### PR TITLE
Workday: resolve 'N Locations' rollup → real city list (Oracle/SF/Amazon investigated, no parser fix needed)

### DIFF
--- a/src/jobhive/scrapers/workday.py
+++ b/src/jobhive/scrapers/workday.py
@@ -56,6 +56,15 @@ MAX_CONCURRENCY = 10
 MAX_RETRIES = 3
 RETRY_BACKOFF = 1.5
 
+# When a Workday job spans multiple offices, the search endpoint returns a
+# rollup string in ``locationsText`` like "2 Locations" / "5 Locations"
+# instead of the actual list — the underlying ``locations`` array is not
+# included in the search payload. We detect those and fetch the per-job
+# detail endpoint (which DOES expose ``jobPostingInfo.location`` plus
+# ``additionalLocations``) to recover the real cities. About 9% of typical
+# Workday rows hit this code path on multi-tenant runs.
+_LOCATION_ROLLUP_RE = re.compile(r"^\s*\d+\s+Locations?\s*$", re.IGNORECASE)
+
 # Facets we'll try as subdivision dimensions, in priority order. After
 # `jobFamilyGroup` (which usually covers level 1 well), `timeType`
 # partitions further into Full/Part-time. `workerSubType` (Skills) is
@@ -82,11 +91,20 @@ class WorkdayScraper(BaseScraper):
         instance = match.group("instance")
         site = match.group("site")
         api = f"https://{company}.{instance}.myworkdayjobs.com/wday/cxs/{company}/{site}/jobs"
+        # The detail endpoint shares the cxs prefix but takes a job-relative
+        # path: GET /wday/cxs/{co}/{site}{externalPath}.
+        detail_prefix = f"https://{company}.{instance}.myworkdayjobs.com/wday/cxs/{company}/{site}"
         base = self.company_slug.split("/wday/")[0].rstrip("/")
 
-        return asyncio.run(self._fetch_async(api, base, company))
+        return asyncio.run(self._fetch_async(api, base, company, detail_prefix))
 
-    async def _fetch_async(self, api: str, base: str, company: str) -> list[Job]:
+    async def _fetch_async(
+        self,
+        api: str,
+        base: str,
+        company: str,
+        detail_prefix: str,
+    ) -> list[Job]:
         async with httpx.AsyncClient(
             timeout=self.timeout, follow_redirects=True
         ) as client:
@@ -107,7 +125,65 @@ class WorkdayScraper(BaseScraper):
                 client, api, sem,
                 applied_facets={}, absorb=absorb, depth=0,
             )
+
+            await self._resolve_location_rollups(
+                client, sem, detail_prefix, all_jobs,
+            )
         return all_jobs
+
+    async def _resolve_location_rollups(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        detail_prefix: str,
+        jobs: list[Job],
+    ) -> None:
+        """Replace 'N Locations' rollup strings with the actual city list.
+
+        The search endpoint returns ``locationsText="2 Locations"`` for any
+        posting that spans multiple offices but does not include the
+        underlying location array in the response. We can recover the real
+        cities from the per-job detail endpoint
+        (``jobPostingInfo.location`` + ``additionalLocations``).
+        """
+        targets = [
+            (i, j) for i, j in enumerate(jobs)
+            if isinstance(j.location, str) and _LOCATION_ROLLUP_RE.match(j.location)
+        ]
+        if not targets:
+            return
+
+        async def resolve(i: int, job: Job) -> None:
+            external_path = (job.raw or {}).get("externalPath") or _external_path(job.url)
+            if not external_path:
+                return
+            url = f"{detail_prefix}{external_path}"
+            async with sem:
+                try:
+                    response = await client.get(
+                        url,
+                        headers={
+                            "Accept": "application/json",
+                            "User-Agent": "Mozilla/5.0",
+                        },
+                    )
+                except httpx.HTTPError:
+                    return
+            if response.status_code != 200:
+                return
+            try:
+                payload = response.json()
+            except ValueError:
+                return
+            jpi = payload.get("jobPostingInfo") or {}
+            primary = jpi.get("location")
+            additional = jpi.get("additionalLocations") or []
+            resolved = _format_locations(primary, additional)
+            if resolved:
+                # Job is frozen — rebuild via model_copy.
+                jobs[i] = job.model_copy(update={"location": resolved})
+
+        await asyncio.gather(*(resolve(i, j) for i, j in targets))
 
     async def _exhaust_query(
         self,
@@ -267,6 +343,10 @@ class WorkdayScraper(BaseScraper):
             v = item.get(k)
             if v:
                 raw[k] = v
+        # Stash externalPath so the post-scrape rollup-resolver can build
+        # the detail URL without re-parsing the job url.
+        if external_path:
+            raw["externalPath"] = external_path
 
         return Job(
             url=f"{base_url}{external_path}" if external_path else base_url,
@@ -287,6 +367,33 @@ def _parse_workday_date(value: str | None) -> datetime | None:
     if not value:
         return None
     return None  # Relative; absolute date requires fetching the per-job detail.
+
+
+def _external_path(url: object) -> str | None:
+    """Extract the Workday external path from a full job URL.
+
+    Workday URLs are ``{base}/{site}{externalPath}`` — externalPath
+    starts with ``/job/...``. We grep for that prefix to stay schema-
+    independent across tenants.
+    """
+    if not url:
+        return None
+    s = str(url)
+    idx = s.find("/job/")
+    return s[idx:] if idx >= 0 else None
+
+
+def _format_locations(primary: object, additional: object) -> str | None:
+    """Combine primary + additional Workday location strings into a single
+    pipe-separated value. Returns None when both are empty or non-string."""
+    locs: list[str] = []
+    if isinstance(primary, str) and primary.strip():
+        locs.append(primary.strip())
+    if isinstance(additional, list):
+        for v in additional:
+            if isinstance(v, str) and v.strip() and v.strip() not in locs:
+                locs.append(v.strip())
+    return " | ".join(locs) if locs else None
 
 
 def _pick_subdivision_facet(

--- a/tests/test_scrapers_extra.py
+++ b/tests/test_scrapers_extra.py
@@ -344,6 +344,83 @@ def test_workday_invalid_url_raises() -> None:
         WorkdayScraper("https://example.com").fetch()
 
 
+def test_workday_resolves_n_locations_rollup(httpx_mock) -> None:
+    """When ``locationsText`` is the 'N Locations' rollup, the search API
+    doesn't include the actual list — we have to fetch the per-job detail
+    endpoint to get them. This was the bug behind 31k Workday rows
+    collapsing to placeholder strings like '2 Locations'."""
+    api = "https://acme.wd1.myworkdayjobs.com/wday/cxs/acme/External/jobs"
+    httpx_mock.add_response(
+        url=api,
+        json={
+            "jobPostings": [
+                {
+                    "title": "Engineer",
+                    "externalPath": "/job/USA-NY-NYC/Engineer_R-1",
+                    "locationsText": "2 Locations",
+                    "bulletFields": ["R-1"],
+                },
+                # A regular single-location job — must be left alone.
+                {
+                    "title": "Manager",
+                    "externalPath": "/job/USA-CA-SF/Manager_R-2",
+                    "locationsText": "San Francisco, CA",
+                    "bulletFields": ["R-2"],
+                },
+            ],
+            "total": 2,
+        },
+    )
+    # Detail endpoint for the rollup job — primary + additionalLocations.
+    detail_url = (
+        "https://acme.wd1.myworkdayjobs.com/wday/cxs/acme/External"
+        "/job/USA-NY-NYC/Engineer_R-1"
+    )
+    httpx_mock.add_response(
+        url=detail_url,
+        json={
+            "jobPostingInfo": {
+                "location": "USA - NY - New York",
+                "additionalLocations": ["USA - CA - San Francisco"],
+            }
+        },
+    )
+
+    jobs = WorkdayScraper("https://acme.wd1.myworkdayjobs.com/External").fetch()
+    by_title = {j.title: j.location for j in jobs}
+    assert by_title["Engineer"] == "USA - NY - New York | USA - CA - San Francisco"
+    # Single-location job untouched — no detail fetch should have been issued
+    # for it (httpx_mock would error on un-stubbed requests).
+    assert by_title["Manager"] == "San Francisco, CA"
+
+
+def test_workday_rollup_resolution_failure_is_silent(httpx_mock) -> None:
+    """If the detail fetch 404s or returns malformed JSON, the original
+    rollup string is kept rather than crashing the whole scrape."""
+    api = "https://acme.wd1.myworkdayjobs.com/wday/cxs/acme/External/jobs"
+    httpx_mock.add_response(
+        url=api,
+        json={
+            "jobPostings": [
+                {
+                    "title": "Engineer",
+                    "externalPath": "/job/USA/Engineer_R-1",
+                    "locationsText": "3 Locations",
+                    "bulletFields": ["R-1"],
+                },
+            ],
+            "total": 1,
+        },
+    )
+    httpx_mock.add_response(
+        url="https://acme.wd1.myworkdayjobs.com/wday/cxs/acme/External/job/USA/Engineer_R-1",
+        status_code=404,
+    )
+    jobs = WorkdayScraper("https://acme.wd1.myworkdayjobs.com/External").fetch()
+    assert len(jobs) == 1
+    assert jobs[0].location == "3 Locations"  # original rollup kept
+
+
 # --- Avature: covered in test_avature.py ------------------------------------
 
 # --- Phenom: covered in test_phenom.py --------------------------------------


### PR DESCRIPTION
## Summary

You asked me to fix the high within-ATS dup rates for Oracle (30%), Amazon
(30%), SuccessFactors (17%), and Workday (16%) — all suspected to be the
same iCIMS-style empty/coarse location bug.

After investigating each one against live API responses, **only Workday
turns out to actually be a parser bug.** The others are tenant-side or
not-actually-duplicates. This PR ships the Workday fix and documents the
investigation findings on the others so we don't re-chase them.

## Workday fix (this PR)

The job-search response returns ``locationsText=\"2 Locations\"`` (a rollup
count) for any posting that spans multiple offices but does **not** include
the underlying location array — the ``locations`` field is empty in the
search payload. The previous parser stored that rollup string verbatim,
which broke downstream dedup keyed on ``(title, company, location)`` and
left users with no useful geographic info for ~9% of all Workday rows.

Affected volume in the published parquet:

| ``location`` value | Rows |
|---|---:|
| ``\"2 Locations\"`` | 31,134 |
| ``\"3 Locations\"`` | 9,339 |
| ``\"4 Locations\"`` | 5,416 |
| ``\"5 Locations\"`` | 3,724 |
| ``\"6 Locations\"`` | 2,159 |
| … (up to ~100 Locations) | … |

**Fix**: after the main paginated scrape finishes, walk every job whose
location matches ``^\\d+ Locations?$`` and fetch the per-job detail
endpoint (``GET /wday/cxs/{co}/{site}{externalPath}``), which exposes
``jobPostingInfo.location`` plus ``jobPostingInfo.additionalLocations``.
We rebuild the location field as ``\"primary | secondary1 | secondary2\"``.

- Detail fetches share the global semaphore (no extra burst).
- 403/404/JSON-decode failure → soft-fail: keep the original rollup
  string instead of crashing the whole run. Regression-tested.

### Verification

Live run against ``capitalone.wd12.myworkdayjobs.com/Capital_One``:

```
1,498 jobs in 60.8s
  remaining 'N Locations' strings: 34
  multi-location strings (pipe-separated): 983
  distinct location values: 302  (was a handful of rollups before)

  ✓ Senior Auditor - Risk Management
    | McLean, VA | Richmond, VA | Chicago, IL | Plano, TX
    | Charlotte, NC | New York, NY | Riverwoods, IL
```

(The 34 remaining are detail-endpoint 404s on a handful of internal
requisition URLs; soft-fail keeps the original rollup string for those.)

### Tests

- ``test_workday_resolves_n_locations_rollup`` — happy path: rollup row
  gets primary + additional locations joined; non-rollup rows untouched
  (verified by httpx_mock erroring on un-stubbed requests).
- ``test_workday_rollup_resolution_failure_is_silent`` — 404 on the
  detail endpoint must not abort the scrape; the original rollup string
  is kept on that one row.
- All 636 existing tests still green.

## Other three ATSes — investigated, no parser fix possible

### Oracle (30% dup rate) — tenant-side

Probed multiple tenants. The largest (``eubt.fa.us6.oraclecloud.com``,
10k rows) returns ``PrimaryLocation: \"United States\"`` — country only,
no city. There is no other location field on these tenants:
``GeographyId`` is a numeric reference with no name resolver,
``WorkLocation`` doesn't exist, and ``expand=requisitionList.secondaryLocations``
returns an empty array.

Other tenants (``emcm.fa.us2.oraclecloud.com``) DO ship full
``\"Vero Beach, FL, United States\"`` and these are already parsed
correctly. The 30% dup rate is a mix of (1) tenants that just don't
publish city, and (2) tenants that have legitimate same-city duplicate
openings (140× ``\"india junior analyst\"`` at one Oracle tenant in
Indore — same role, multiple openings).

**Conclusion**: not a parser bug. Could maybe expand 1-2 percentage
points of coverage by trying ``expand=requisitionList,workLocation`` on
specific tenants but the gain is marginal.

### SuccessFactors (17% dup rate) — tenant-side

The SAP RSS feed (``sitemal.xml``) on tenants like Action only ships:

- title: ``\"Vulploegmedewerker (NL)\"`` — country code in parens
- ``g:location: \"NL\"`` — bare ISO 3166

The current parser correctly extracts ``\"NL\"`` from both, but that's
all the data has. Per-job detail pages would need to be fetched (3,343
extra requests for Action alone), and even then they may not surface
city info.

Other tenants (``karriere.rewe-group.com``) ship full
``\"Weserbergland, Niedersachsen, Deutschland\"`` and parse correctly.

**Conclusion**: SF feed quality is tenant-controlled. Action genuinely
has 310 same-title openings across NL with country-only location in
their feed; we can't manufacture city info that isn't there.

### Amazon (30% dup rate) — not actually a bug

Amazon already returns 100% complete locations
(``\"Wink, Texas, USA\"`` etc.). The 65× ``\"engineering operation
technician in Wink, Texas, USA\"`` is the API's actual output: Amazon
posts multiple identical openings under separate ``ats_id``s for the
same data center. These are real distinct positions, just with the same
public-facing title and city.

**Conclusion**: nothing to fix. The dup-by-(title, location) metric was
misleading for tenants with this hiring pattern.

## Test plan

- [x] ``pytest`` — 636 passed
- [x] Live scrape on capitalone — 983/1,017 rollups resolved
- [ ] Re-run publisher on this branch and confirm ``manifest`` shows
      the rollup count drops from ~57k → near-0