### PR TITLE
Bundesagentur: distinguish probe failures from page failures (Codex #12 review)

### DIFF
--- a/src/jobhive/scrapers/bundesagentur.py
+++ b/src/jobhive/scrapers/bundesagentur.py
@@ -143,9 +143,22 @@ class BundesagenturScraper(BaseScraper):
         unused subdivision facet and split. ``depth`` bounds the
         recursion: berufsfeld → arbeitszeit → zeitarbeit → befristung.
         """
-        first = await self._fetch_page(
-            client, sem, params={**base_params, "size": 1, "page": 1},
-        )
+        try:
+            first = await self._fetch_page(
+                client, sem, params={**base_params, "size": 1, "page": 1},
+            )
+        except ScraperError as exc:
+            # Probe failed after retries (most likely persistent WAF block).
+            # Probe failures must never silently look like ``maxErgebnisse=0``
+            # — that would drop the whole subtree (and at depth=0 the entire
+            # scrape) without anyone noticing. Log loudly and skip just this
+            # subtree; sibling buckets continue.
+            logger.warning(
+                "Bundesagentur probe failed for params=%s depth=%d — "
+                "subtree skipped, output will undercount: %s",
+                base_params, depth, exc,
+            )
+            return
         total = int(first.get("maxErgebnisse") or 0)
         if total == 0:
             return
@@ -216,7 +229,20 @@ class BundesagenturScraper(BaseScraper):
         # saw at concurrency=3.
         for page in range(1, page_count + 1):
             params = {**base_params, "size": PAGE_SIZE, "page": page}
-            payload = await self._fetch_page(client, sem, params=params)
+            try:
+                payload = await self._fetch_page(client, sem, params=params)
+            except ScraperError as exc:
+                # Page-level soft-fail: lose at most ``PAGE_SIZE`` jobs from
+                # this one page; keep working on the rest of the leaf and
+                # the rest of the tree. (Page failures are bounded; probe
+                # failures are not, which is why ``_exhaust_query`` handles
+                # them separately.)
+                logger.warning(
+                    "Bundesagentur page %d/%d failed for params=%s — "
+                    "page skipped (~%d jobs lost): %s",
+                    page, page_count, base_params, PAGE_SIZE, exc,
+                )
+                continue
             await absorb(payload.get("stellenangebote") or [])
 
     async def _fetch_page(
@@ -257,16 +283,18 @@ class BundesagenturScraper(BaseScraper):
             # auth failure (the API key never expires); back off and retry.
             if r.status_code in (403, 429) or 500 <= r.status_code < 600:
                 if attempt == MAX_RETRIES:
-                    # Soft-fail: log + drop this leaf so the scraper still
-                    # completes the rest. Crashing on a single persistent
-                    # WAF block would lose ~95% of the work the recursion
-                    # already finished.
-                    logger.warning(
-                        "Bundesagentur returned %s after %d retries for %s — "
-                        "skipping this leaf (output will undercount).",
-                        r.status_code, MAX_RETRIES, params,
+                    # Persistent WAF/server failure — raise so callers can
+                    # decide what to do. ``_exhaust_query`` treats this as
+                    # a subtree-loss (logs + skips); ``_fan_out_pages``
+                    # treats it as a page-loss (logs + continues). We must
+                    # NOT silently return an empty payload here: that would
+                    # be indistinguishable from a real ``maxErgebnisse=0``
+                    # response and would silently abandon the whole subtree
+                    # whenever a probe gets WAF-blocked.
+                    raise ScraperError(
+                        f"Bundesagentur returned {r.status_code} for {params} "
+                        f"after {MAX_RETRIES} retries"
                     )
-                    return {"stellenangebote": [], "maxErgebnisse": 0}
                 retry_after = r.headers.get("Retry-After")
                 base = (
                     float(retry_after) if retry_after and retry_after.isdigit()

--- a/tests/test_bundesagentur.py
+++ b/tests/test_bundesagentur.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import logging
 import re
+from urllib.parse import parse_qs, urlparse
 
+import httpx
 import pytest
 
 from jobhive.scrapers import BundesagenturScraper
@@ -104,32 +106,14 @@ def test_page_failure_logs_page_skip_not_subtree_skip(
     # the per-page failure path deterministically.
     monkeypatch.setattr(ba, "PAGE_SIZE", 1)
 
-    callback_calls = {"n": 0}
-
-    def serve(request):
-        from urllib.parse import parse_qs, urlparse
+    def serve(request: httpx.Request) -> httpx.Response:
         params = parse_qs(urlparse(str(request.url)).query)
-        size = params.get("size", ["1"])[0]
         page = int(params.get("page", ["1"])[0])
-        callback_calls["n"] += 1
-        # The probe (size=1, page=1) and page 1 of fan-out (also size=1,
-        # page=1) succeed.
-        if page == 1:
-            from pytest_httpx import IteratorStream  # noqa: F401  (typing only)
-            import httpx as _h
-            return _h.Response(
-                200,
-                json={
-                    "stellenangebote": [_job(str(page), f"Page-{page} row")],
-                    "maxErgebnisse": 3,
-                },
-            )
+        # The probe (page=1) and page 1 of fan-out succeed; page 2
+        # persistently 403s; page 3 succeeds.
         if page == 2:
-            import httpx as _h
-            return _h.Response(403)
-        # Page 3 succeeds again.
-        import httpx as _h
-        return _h.Response(
+            return httpx.Response(403)
+        return httpx.Response(
             200,
             json={
                 "stellenangebote": [_job(str(page), f"Page-{page} row")],

--- a/tests/test_bundesagentur.py
+++ b/tests/test_bundesagentur.py
@@ -1,0 +1,158 @@
+"""Tests for the Bundesagentur scraper.
+
+Focused on the failure-mode contract: probe failures must skip the affected
+subtree (and shout about it), page failures must skip just one page, and
+neither may silently look like a clean ``maxErgebnisse=0`` response.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import pytest
+
+from jobhive.scrapers import BundesagenturScraper
+
+_API_RE = re.compile(
+    r"^https://rest\.arbeitsagentur\.de/jobboerse/jobsuche-service/pc/v4/jobs"
+)
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.bundesagentur as ba
+    monkeypatch.setattr(ba, "MAX_RETRIES", 2)
+    monkeypatch.setattr(ba, "RETRY_BASE_DELAY", 0.0)
+    monkeypatch.setattr(ba, "RETRY_JITTER", 0.0)
+
+
+def _job(refnr: str, titel: str, ort: str | None = None) -> dict:
+    return {
+        "refnr": refnr,
+        "titel": titel,
+        "arbeitsort": {"ort": ort or "Berlin", "land": "Deutschland"},
+        "arbeitgeber": "ACME",
+        "aktuelleVeroeffentlichungsdatum": "2026-05-01",
+    }
+
+
+# --- Happy path -------------------------------------------------------------
+
+
+def test_simple_run_under_pagination_cap(httpx_mock) -> None:
+    """A small dataset (≤10k) just paginates and returns everything."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        json={"stellenangebote": [_job("1", "Probe")], "maxErgebnisse": 1},
+        is_reusable=True,
+    )
+    jobs = BundesagenturScraper("any").fetch()
+    assert {j.ats_id for j in jobs} == {"1"}
+
+
+# --- Probe failure: must NOT silently look like maxErgebnisse=0 -------------
+
+
+def test_root_probe_persistent_403_skips_subtree(httpx_mock, caplog) -> None:
+    """If the very first probe (no facets) keeps returning 403 the entire
+    scrape must NOT just return an empty list silently — that would publish
+    a wholesale undercount as a successful run. We log loudly and return
+    whatever was collected (here: nothing)."""
+    httpx_mock.add_response(url=_API_RE, status_code=403, is_reusable=True)
+    with caplog.at_level(logging.WARNING, logger="jobhive.scrapers.bundesagentur"):
+        jobs = BundesagenturScraper("any").fetch()
+    assert jobs == []
+    # The warning must say "subtree skipped" so an operator can spot the
+    # undercount in the logs. The previous soft-fail returned a fake
+    # ``maxErgebnisse=0`` payload that produced no warning at all.
+    assert any(
+        "subtree skipped" in rec.getMessage().lower()
+        for rec in caplog.records
+    ), "expected 'subtree skipped' warning, got: " + "\n".join(
+        rec.getMessage() for rec in caplog.records
+    )
+
+
+def test_probe_500_after_retries_skips_with_warning(
+    httpx_mock, caplog
+) -> None:
+    """Same pattern for 500 — the previous code returned empty and looked
+    like a clean zero-result query. Now the failure is logged."""
+    httpx_mock.add_response(url=_API_RE, status_code=500, is_reusable=True)
+    with caplog.at_level(logging.WARNING, logger="jobhive.scrapers.bundesagentur"):
+        jobs = BundesagenturScraper("any").fetch()
+    assert jobs == []
+    assert any(
+        "subtree skipped" in rec.getMessage().lower()
+        for rec in caplog.records
+    )
+
+
+# --- Page failure: skip just the page, keep going ---------------------------
+
+
+def test_page_failure_logs_page_skip_not_subtree_skip(
+    httpx_mock, monkeypatch, caplog
+) -> None:
+    """A page-level failure inside ``_fan_out_pages`` must log a *page*
+    skip (bounded loss) — not a subtree skip — and must not silently
+    look like a clean response.
+    """
+    import jobhive.scrapers.bundesagentur as ba
+    # Tiny page size so a 3-row dataset spans 3 pages and we can exercise
+    # the per-page failure path deterministically.
+    monkeypatch.setattr(ba, "PAGE_SIZE", 1)
+
+    callback_calls = {"n": 0}
+
+    def serve(request):
+        from urllib.parse import parse_qs, urlparse
+        params = parse_qs(urlparse(str(request.url)).query)
+        size = params.get("size", ["1"])[0]
+        page = int(params.get("page", ["1"])[0])
+        callback_calls["n"] += 1
+        # The probe (size=1, page=1) and page 1 of fan-out (also size=1,
+        # page=1) succeed.
+        if page == 1:
+            from pytest_httpx import IteratorStream  # noqa: F401  (typing only)
+            import httpx as _h
+            return _h.Response(
+                200,
+                json={
+                    "stellenangebote": [_job(str(page), f"Page-{page} row")],
+                    "maxErgebnisse": 3,
+                },
+            )
+        if page == 2:
+            import httpx as _h
+            return _h.Response(403)
+        # Page 3 succeeds again.
+        import httpx as _h
+        return _h.Response(
+            200,
+            json={
+                "stellenangebote": [_job(str(page), f"Page-{page} row")],
+                "maxErgebnisse": 3,
+            },
+        )
+
+    httpx_mock.add_callback(serve, url=_API_RE, is_reusable=True)
+
+    with caplog.at_level(logging.WARNING, logger="jobhive.scrapers.bundesagentur"):
+        jobs = BundesagenturScraper("any").fetch()
+
+    # Pages 1 and 3 made it through; page 2 was lost. The leaf and the
+    # subtree both kept going.
+    ats_ids = {j.ats_id for j in jobs}
+    assert "1" in ats_ids and "3" in ats_ids
+    assert "2" not in ats_ids
+
+    page_warnings = [
+        r for r in caplog.records if "page skipped" in r.getMessage().lower()
+    ]
+    subtree_warnings = [
+        r for r in caplog.records if "subtree skipped" in r.getMessage().lower()
+    ]
+    assert page_warnings, "expected page-level warning"
+    assert not subtree_warnings, "page failure must NOT escalate to subtree skip"


### PR DESCRIPTION
Addresses [Codex review on #12](https://github.com/stapply-ai/ats-scrapers/pull/12#issuecomment-4390607418).

## The bug Codex caught

The persistent-WAF soft-fail in ``_fetch_page`` returned an empty payload
``{\"stellenangebote\": [], \"maxErgebnisse\": 0}`` that callers couldn't
tell apart from a clean zero-result response.

``_exhaust_query`` reads ``maxErgebnisse`` from that payload to decide
whether to descend — and a fake ``0`` from a *probe* failure made it skip
the subtree silently. Worst case: the **root probe** (no facets) gets
WAF-blocked → ``maxErgebnisse=0`` → the entire scrape returns ``[]`` and
exits ``0`` like nothing happened.

The single warning the old code logged said ``\"skipping this leaf\"``,
which was wrong: the same return path served both probe failures and
page failures, and only the page case is actually leaf-bounded.

## Fix

``_fetch_page`` now always raises ``ScraperError`` on persistent WAF
failure (no silent empty payload). The soft-fail logic moves to the call
sites where there's enough context to decide what was lost:

- **``_exhaust_query``** catches probe failures, logs ``\"subtree
  skipped\"``, and returns. Sibling buckets keep going (they have their
  own probes); everything under this ``base_params`` is lost. The warning
  includes ``base_params`` and ``depth`` so an operator can see scope.
- **``_fan_out_pages``** catches per-page failures, logs ``\"page
  skipped\"``, and continues to the next page. Bounded loss of at most
  ``PAGE_SIZE=100`` jobs per occurrence.

The 400 (past-pagination-cap) return path is untouched — that's a real
\"we're done with this query\" signal, not a failure mode.

## Tests

New ``tests/test_bundesagentur.py`` covers all three branches:

| Test | What it pins |
|---|---|
| ``test_simple_run_under_pagination_cap`` | happy path — small dataset paginates cleanly, no failures |
| ``test_root_probe_persistent_403_skips_subtree`` | regression for the silent-undercount: persistent root-probe 403 must produce ``[]`` *and* a ``\"subtree skipped\"`` warning |
| ``test_probe_500_after_retries_skips_with_warning`` | same contract for 5xx |
| ``test_page_failure_logs_page_skip_not_subtree_skip`` | page-2 fails → pages 1 + 3 still returned, ``\"page skipped\"`` logged but ``\"subtree skipped\"`` never |

All 640 tests pass.

## Test plan

- [x] ``pytest tests/test_bundesagentur.py`` — 4 passed
- [x] ``pytest`` — 640 passed
- [ ] Live re-run on the same Akamai-prone tenant to confirm operator-visible warnings now distinguish lost subtrees from lost pages