### PR TITLE
ci: drop legacy companies_by_ats from manifest

### DIFF
--- a/.github/scripts/publish_companies.py
+++ b/.github/scripts/publish_companies.py
@@ -240,6 +240,13 @@ def main() -> None:
     ).replace("+00:00", "Z")
     if "version" not in manifest:
         manifest["version"] = "1.0"
+    # Drop the legacy companies-side field. It pointed at
+    # `<prefix>/companies/by-ats/<ats>.csv` URLs that we deleted in
+    # `delete_legacy(...)` below, and its name is one underscore away
+    # from `by_ats_companies` so leaving it behind invites confusion.
+    # Jobs-side legacy fields (`by_date`) are publisher-owned — that
+    # cleanup happens in DatasetPublisher.
+    manifest.pop("companies_by_ats", None)
     manifest_bytes = json.dumps(manifest, indent=2, sort_keys=True).encode("utf-8")
     upload(
         client,


### PR DESCRIPTION
Removes the leftover `companies_by_ats` field from the manifest on every CI publish. See commit message for rationale (legacy field, name collision with the new `by_ats_companies`, underlying objects already gone).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the legacy manifest field `companies_by_ats` during CI publish to avoid stale metadata and confusion with `by_ats_companies`.
The old `companies/by-ats/*.csv` files are already gone; this is idempotent and needs no migration.

<sup>Written for commit 90230ba4fce56d8259212a87795489b35d433631. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the legacy `companies_by_ats` key from the manifest JSON on every CI publish run, using a safe `dict.pop` with a default of `None` so the call is idempotent whether or not the key is already absent.

- Adds `manifest.pop("companies_by_ats", None)` immediately after the manifest is built and before it is serialized, ensuring the legacy field is stripped on every publish without risk of a `KeyError`.
- The comment clearly explains the motivation: the underlying CSV URLs were already deleted and the key name is one underscore away from the new `by_ats_companies` field, making confusion likely.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single, idempotent key removal with no side-effects on the rest of the publish pipeline.

The only change is `manifest.pop("companies_by_ats", None)`, which is a no-op if the key is already absent and silently drops it when present. It runs after all new fields are written and before serialization, so the published manifest is always clean. No data is lost and no downstream paths are affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/scripts/publish_companies.py | Adds a safe, idempotent `manifest.pop("companies_by_ats", None)` to drop the legacy field before the manifest is uploaded; no logic issues found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: drop legacy companies\_by\_ats from ma..."](https://github.com/kalil0321/ats-scrapers/commit/90230ba4fce56d8259212a87795489b35d433631) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31355451)</sub>

<!-- /greptile_comment -->