### PR TITLE
ci: bump manifest version to 2.0

### DIFF
--- a/.github/scripts/publish_companies.py
+++ b/.github/scripts/publish_companies.py
@@ -238,8 +238,10 @@ def main() -> None:
     manifest["updated_at"] = datetime.now(tz=UTC).isoformat(
         timespec="seconds"
     ).replace("+00:00", "Z")
-    if "version" not in manifest:
-        manifest["version"] = "1.0"
+    # The companies-side moved to the new per-ATS layout in this PR
+    # series; bump the manifest version to advertise it. The publisher
+    # also sets "2.0" once it runs against the jobs side.
+    manifest["version"] = "2.0"
     # Drop the legacy companies-side field. It pointed at
     # `<prefix>/companies/by-ats/<ats>.csv` URLs that we deleted in
     # `delete_legacy(...)` below, and its name is one underscore away


### PR DESCRIPTION
Companies-side fully migrated to the new layout. Marks the v1→v2 boundary in the manifest. Both publisher and CI now agree on `version="2.0"`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the manifest version to 2.0 in CI to mark the companies-side switch to the new per-ATS layout and keep it in sync with the publisher. This makes the v1→v2 boundary explicit for consumers.

- **Migration**
  - Manifest now always sets `"version": "2.0"`.
  - Use `<ats>/companies.csv` and aggregated `companies.{csv,parquet}`.
  - Stop using `companies/by-ats/*`, `companies/all.csv`, and the `companies_by_ats` manifest field.

<sup>Written for commit c0152fe44296fcec7487f2b4f17fdae6781308b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the manifest `version` field from `"1.0"` to `"2.0"` in the companies-side CI publisher script, marking the completion of the migration to the new per-ATS layout. The change is a one-liner replacing a conditional assignment (only fill if absent) with an unconditional one.

- The hard-coded `"2.0"` will be written on every CI run, which is fine while both the CI script and `DatasetPublisher` agree on that value, but removes the guard that previously allowed the publisher to own the version field independently.
- If the publisher is ever advanced to a higher version without updating this script in the same PR, the next companies-side CI run will silently downgrade the manifest version back to `"2.0"`.

<h3>Confidence Score: 4/5</h3>

Safe to merge as-is given both sides are currently aligned on "2.0", but the unconditional write creates a latent maintenance hazard for the next version bump.

The change is intentional and coordinated for the v1→v2 boundary. The only concern is that switching from a conditional to an unconditional version assignment means CI will always win the race, potentially overwriting a future publisher-set version. No data is lost today, and the script is otherwise unchanged.

.github/scripts/publish_companies.py — specifically the unconditional manifest["version"] = "2.0" write on line 244.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/scripts/publish_companies.py | Replaces the conditional v1.0 version guard with an unconditional v2.0 write; correct for the current coordinated bump, but removes the safety net that prevented CI from overwriting a publisher-set higher version. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/scripts/publish_companies.py:244
**Unconditional version write can silently downgrade the manifest**

This now hard-codes `"2.0"` on every CI run regardless of what the manifest already contains. If the jobs-side `DatasetPublisher` is ever bumped to `"3.0"` (or any future version) before this script is updated, the next companies-side CI run will overwrite it back to `"2.0"`. The original conditional (`if "version" not in manifest`) was precisely designed to avoid this: it only filled in a missing version, leaving a publisher-set one intact. The comment acknowledges that both scripts now agree on `"2.0"`, but that agreement is implicit and doesn't survive independent version bumps on either side.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: bump manifest version to 2.0"](https://github.com/kalil0321/ats-scrapers/commit/c0152fe44296fcec7487f2b4f17fdae6781308b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31355674)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->