### PR TITLE
ci: floor manifest version monotonically (greptile #21)

### DIFF
--- a/.github/scripts/publish_companies.py
+++ b/.github/scripts/publish_companies.py
@@ -53,6 +53,11 @@ from botocore.exceptions import ClientError
 REPO_ROOT = Path(__file__).resolve().parents[2]
 ATS_COMPANIES_DIR = REPO_ROOT / "ats-companies"
 PREFIX = "jobhive/v1"
+# Lowest manifest version this script knows how to write. Treat as a
+# floor: bump existing manifests up to it, never down. If the
+# jobs-side publisher independently moves the manifest to a newer
+# version, that wins until this constant catches up.
+MIN_MANIFEST_VERSION = "2.0"
 
 
 def env(name: str) -> str:
@@ -173,6 +178,24 @@ def delete_legacy(client, bucket: str) -> None:
             client.delete_objects(Bucket=bucket, Delete={"Objects": chunk})
 
 
+def _parse_version(value: object) -> tuple[int, ...]:
+    """Parse ``"<int>.<int>..."`` into a comparable int-tuple.
+
+    Anything we can't read (non-string, non-numeric segment, missing)
+    sorts as ``(0,)`` so the floor wins on garbage input rather than
+    silently preserving it.
+    """
+    if not isinstance(value, str):
+        return (0,)
+    parts: list[int] = []
+    for segment in value.split("."):
+        try:
+            parts.append(int(segment))
+        except ValueError:
+            return (0,)
+    return tuple(parts) if parts else (0,)
+
+
 def public_url(bucket: str, key: str) -> str:
     """Build the canonical public URL written into the manifest entries.
 
@@ -238,10 +261,16 @@ def main() -> None:
     manifest["updated_at"] = datetime.now(tz=UTC).isoformat(
         timespec="seconds"
     ).replace("+00:00", "Z")
-    # The companies-side moved to the new per-ATS layout in this PR
-    # series; bump the manifest version to advertise it. The publisher
-    # also sets "2.0" once it runs against the jobs side.
-    manifest["version"] = "2.0"
+    # Monotonic floor: bump up to MIN_MANIFEST_VERSION if absent or
+    # below, leave anything higher untouched. Prevents this script
+    # from silently downgrading a manifest that a newer publisher
+    # has already moved forward (e.g. publisher moves to "3.0",
+    # next companies-side run preserves it).
+    existing_version = manifest.get("version")
+    if existing_version is None or _parse_version(existing_version) < _parse_version(
+        MIN_MANIFEST_VERSION
+    ):
+        manifest["version"] = MIN_MANIFEST_VERSION
     # Drop the legacy companies-side field. It pointed at
     # `<prefix>/companies/by-ats/<ats>.csv` URLs that we deleted in
     # `delete_legacy(...)` below, and its name is one underscore away


### PR DESCRIPTION
Addresses [greptile comment on PR #21](https://github.com/kalil0321/ats-scrapers/pull/21#discussion_r3210109847).

The hardcoded `manifest['version'] = '2.0'` from PR #21 risked silently downgrading any future version (e.g. publisher bumping to `'3.0'` would be reverted on the next companies-side CI run).

Replaced with a monotonic floor: bump up to `MIN_MANIFEST_VERSION = '2.0'` if absent or below, leave anything higher alone. `_parse_version` defangs garbage inputs (non-string, non-numeric segments) to `(0,)` so they get bumped to the floor instead of being preserved.

Verified across 12 parser cases + 8 floor scenarios — all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a monotonic floor for the manifest version in CI to prevent accidental downgrades. The script now bumps to 2.0 if missing or lower and preserves any higher version.

- **Bug Fixes**
  - Replaced unconditional `manifest["version"] = "2.0"` with floor logic via `MIN_MANIFEST_VERSION = "2.0"`.
  - Added `_parse_version` to compare versions as int tuples; invalid or non-string inputs sort as `(0,)` and are bumped to the floor.

<sup>Written for commit ac95e294ffcfef26935efbf0e7625f6ad4e8457d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the hard-coded `manifest['version'] = '2.0'` from PR #21 with a monotonic floor: `_parse_version` converts version strings to comparable int-tuples, and `main()` only writes `MIN_MANIFEST_VERSION` when the existing stored version is absent or lower, preserving any higher value set by a newer publisher.

- `_parse_version` defensively treats non-strings, non-numeric segments, and empty strings as `(0,)`, so garbage inputs are always bumped to the floor rather than silently preserved.
- The floor comparison in `main()` uses a single `manifest.get(\"version\")` lookup and two `_parse_version` calls, keeping the logic self-contained and readable.
- One subtle edge: single-segment versions like `\"2\"` parse to `(2,)`, which Python's tuple ordering considers strictly less than `(2, 0)`, so they get rewritten to `\"2.0\"` — harmless in practice since manifest versions are always `\"X.Y\"` format, but worth being aware of.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is a targeted, well-scoped improvement over the previous hard assignment with no risk of data loss or version downgrade.

The monotonic floor logic is correct and the defensive _parse_version helper handles all garbage inputs. The only noteworthy subtlety is Python's length-sensitive tuple comparison causing "2" (single-segment) to be treated as below "2.0", but this won't fire in practice since manifest versions are always "X.Y" strings.

.github/scripts/publish_companies.py — specifically the _parse_version + tuple-comparison behaviour noted above.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/scripts/publish_companies.py | Adds MIN_MANIFEST_VERSION constant and _parse_version helper to implement a monotonic floor instead of a hard assignment; one subtle edge case with single-segment versions (e.g. "2") compared against "2.0" |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/scripts/publish_companies.py:191-196
**Single-segment version treated as below floor**

Python tuple comparison is length-sensitive: `(2,) < (2, 0)` is `True`, so a stored version of `"2"` parses to `(2,)`, compares as less than `_parse_version("2.0")` = `(2, 0)`, and gets bumped to `"2.0"`. Semantically `"2"` and `"2.0"` are equivalent, so this silently rewrites a version that is arguably already at the floor. In practice manifest versions are always `"X.Y"` strings so this won't trigger, but it's worth noting the behaviour is not strictly "monotonic" for single-segment strings.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: floor manifest version monotonically..."](https://github.com/kalil0321/ats-scrapers/commit/ac95e294ffcfef26935efbf0e7625f6ad4e8457d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31356474)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->