### PR TITLE
Job model: add global_id, remove seniority drift, JOB_SCHEMA.md

### DIFF
--- a/JOB_SCHEMA.md
+++ b/JOB_SCHEMA.md
@@ -1,0 +1,280 @@
+# Job schema
+
+Every row in the published `jobs.csv` / `jobs.parquet` files (and every
+`Job` instance the scrapers produce) is one job posting in this shape.
+Field names are part of the public contract — renames are a breaking
+change.
+
+This doc mirrors the [`Job` Pydantic model in
+`src/jobhive/models.py`](src/jobhive/models.py). When the two drift,
+the Pydantic descriptions are the source of truth; please update both.
+
+---
+
+## At a glance
+
+| Group | Fields |
+|---|---|
+| **Identity** | `global_id`, `url`, `title`, `company`, `ats_type`, `ats_id` |
+| **Location** | `location`, `lat`, `lon`, `is_remote` |
+| **Compensation** | `salary_currency`, `salary_period`, `salary_summary`, `salary_min`, `salary_max` |
+| **Classification** | `experience`, `employment_type`, `department`, `team`, `requisition_id`, `apply_url`, `commitment` |
+| **Content & timing** | `description`, `posted_at`, `fetched_at` |
+| **Provider overflow** | `raw` |
+
+26 columns total in the published CSV.
+
+---
+
+## Identity
+
+### `global_id` &nbsp;`str` &nbsp;*(derived)*
+
+Globally unique identifier for the posting, formatted as
+`{ats_type}:{ats_id}` when both are present.
+
+- **Examples:** `ashby:engineer-2026`, `workday:R0136150`, `greenhouse:6849563`.
+- **Separator:** `:`. Parsers should split on the **first** colon —
+  `ats_id` may itself contain colons (some Taleo URLs encode multiple).
+  Example: `"taleo:acme:req:12345"` parses as
+  `("taleo", "acme:req:12345")`.
+- **Fallback:** when `ats_id` is missing, empty after whitespace strip,
+  or contains control characters (`\n` / `\t` / `\0`), `global_id`
+  becomes a fresh UUID4 string and the offending row is logged with an
+  ERROR. This keeps the scrape moving instead of crashing on bad data;
+  the responsible scraper still gets flagged in the logs.
+- **Don't pass it manually.** A `model_validator` computes it from
+  `ats_type` + `ats_id`, overwriting any value you supplied.
+- **Case is preserved.** Workday's `R0136150` ≠ `r0136150` — collapsing
+  case would risk merging legitimately distinct postings.
+
+### `url` &nbsp;`HttpUrl` &nbsp;*(required)*
+
+Public posting URL on the ATS. Always present. The primary stable
+identifier consumers should use to deduplicate or link to the live
+page.
+
+### `title` &nbsp;`str` &nbsp;*(required)*
+
+Free-form job title as posted. Examples: `Senior Software Engineer,
+Reality Labs`, `Engenheiro QA Python`. May contain spaces, punctuation,
+or non-ASCII characters.
+
+### `company` &nbsp;`str` &nbsp;*(required)*
+
+Display name of the hiring employer. **Distinct from `ats_id`:** the
+same company can have `company="OpenAI"` and `ats_id="openai"` on Ashby.
+
+Per-ATS conventions vary — Greenhouse stores a numeric board id,
+Workday the human-readable name, Oracle the API host, etc. — so don't
+join on `company` cross-ATS. Use `ats_type` + `ats_id` for cross-ATS
+keys and `requisition_id` (when both rows have it) for cross-ATS
+matching.
+
+### `ats_type` &nbsp;`ATSType` &nbsp;*(required)*
+
+Which ATS platform serves this posting. Determines which scraper
+produced the row and what shape `ats_id` takes. See the `ATSType` enum
+in `src/jobhive/models.py` for the full list (~50 values).
+
+### `ats_id` &nbsp;`str | None` &nbsp;*(optional, defensive)*
+
+Per-ATS identifier. Unique within `ats_type` but not globally — use
+`global_id` for that. Form depends on the ATS:
+
+| ATS | Typical `ats_id` |
+|---|---|
+| Greenhouse | numeric: `"6849563"` |
+| Workday | mixed-case: `"R0136150"` |
+| Lever | UUID: `"62a8c1f4-..."` |
+| iCIMS | dash-separated: `"job-2026-04-eng"` |
+| Bundesagentur | hex hash |
+| Apple | numeric (occasionally trail-spaced) |
+
+Optional only as a defensive type — every scraper should set it. When
+null, empty, or malformed, `global_id` falls back to a UUID4 and an
+ERROR is logged.
+
+---
+
+## Location
+
+### `location` &nbsp;`str | None`
+
+Free-form location string as posted. Examples: `Paris, France`,
+`Remote — US`, `Berlin or Remote`. Multi-location postings are rendered
+as comma-joined when the ATS exposes a list.
+
+### `lat`, `lon` &nbsp;`float | None`
+
+WGS-84 geocoded coordinates when the ATS provides them (rare — most
+don't). Not derived from `location` text. Populated together or not at
+all.
+
+### `is_remote` &nbsp;`bool | None`
+
+Whether the role can be performed remotely.
+
+- Set by the scraper when the ATS exposes a flag (e.g. Lever's
+  `workplaceType`, Bundesagentur's `arbeitszeit` heuristic).
+- Otherwise **derived** from `location` text via
+  `jobhive.enrichment.infer_is_remote` at publish time.
+- `None` means we genuinely don't know.
+
+---
+
+## Compensation
+
+Salary fields work together: `salary_currency` + `salary_period` are
+metadata, `salary_min`/`salary_max` are the structured numeric range,
+`salary_summary` is the original string the ATS displays. When the ATS
+ships only the summary string, `salary_min`/`salary_max` are derived
+via `jobhive.enrichment.parse_salary_range` at publish time.
+
+### `salary_currency` &nbsp;`str | None`
+
+ISO 4217 currency code (`USD`, `EUR`, `GBP`, `BRL`, …). `None` when no
+salary is exposed OR when the salary is present only as untyped free
+text.
+
+### `salary_period` &nbsp;`Literal["HOUR", "DAY", "WEEK", "MONTH", "YEAR"] | None`
+
+Period the salary applies to. `YEAR` is the most common; `HOUR` shows
+up on hourly/contractor postings.
+
+### `salary_summary` &nbsp;`str | None`
+
+Original salary string as the ATS displays it.
+
+- `"$120K – $160K"`
+- `"45.000 € / Jahr"`
+- `"up to £80k"`
+- `"R$3.000 - R$5.000"`
+
+### `salary_min`, `salary_max` &nbsp;`float | None`
+
+Lower / upper bounds in `salary_currency`. Either set directly by the
+scraper from a structured ATS field, or derived from `salary_summary`.
+
+---
+
+## Classification
+
+### `experience` &nbsp;`int | None`
+
+Required years of experience as an integer when the ATS exposes a
+structured value. `None` when missing or only described in prose
+("3+ years", "Senior").
+
+### `employment_type` &nbsp;`Literal["FULL_TIME", "PART_TIME", "CONTRACT", "INTERN", "TEMPORARY"] | None`
+
+**Normalized** employment type. Cross-ATS comparable — use this for
+filtering. The ATS-specific raw label lives in `commitment`.
+
+### `department`, `team` &nbsp;`str | None`
+
+`department` is the high-level org grouping (`Engineering`, `Sales`,
+`Marketing`, …). `team` is the finer-grained sub-team / squad
+(`Reality Labs`, `Payments Infra`, …). Often `team` is empty even when
+`department` is set.
+
+### `requisition_id` &nbsp;`str | None`
+
+**Employer-internal** requisition identifier (Greenhouse
+`requisition_id`, Workday `bulletFields[0]`, Lever's private id,
+Bundesagentur `hashId`).
+
+Distinct from `ats_id` which is **platform-side**. The same role
+mirrored on two different ATSes shares the same `requisition_id` but
+has two different `ats_id` — strong cross-ATS dedup signal:
+
+```
+Greenhouse @ Anthropic   ats_id="6849563"        requisition_id="ENG-2026-184"
+Eightfold (same job)     ats_id="62a8c1f4..."    requisition_id="ENG-2026-184"  ← same
+```
+
+### `apply_url` &nbsp;`HttpUrl | None`
+
+Direct application URL when **distinct from** the posting `url`. Some
+ATSes redirect to a separate apply destination — Workable's widget,
+Bundesagentur's external boards, YC's `workatastartup.com`.
+
+### `commitment` &nbsp;`str | None`
+
+Free-form commitment label as posted by the ATS. Distinct from
+`employment_type` which is the normalized enum:
+
+| Source | `commitment` | `employment_type` |
+|---|---|---|
+| Lever (FR) | `"CDI"` | `"FULL_TIME"` |
+| Lever (EN) | `"Full-time, 40h"` | `"FULL_TIME"` |
+| Bundesagentur | `"Vollzeit, 38 h/Woche"` | `"FULL_TIME"` |
+| Arbetsförmedlingen | `"Heltid"` | `"FULL_TIME"` |
+| Workable | `"Contractor — 6 mois"` | `"CONTRACT"` |
+| Mercor | `"32h/week"` | `null` (no clean type) |
+
+Use `commitment` to preserve language, hours, and contract granularity
+the enum loses.
+
+---
+
+## Content & timing
+
+### `description` &nbsp;`str | None`
+
+Plain-text job description. HTML and Markdown are stripped to text.
+Truncated to ~10 kB when the source exceeds it.
+
+### `posted_at` &nbsp;`datetime | None`
+
+When the ATS reports the posting was first published. UTC. `None` when
+the ATS doesn't expose this — common on aggregator sites and some
+legacy ATSes.
+
+### `fetched_at` &nbsp;`datetime | None`
+
+When jobhive last saw this posting. UTC.
+
+---
+
+## Provider-specific overflow
+
+### `raw` &nbsp;`dict[str, object] | None`
+
+ATS-specific fields the canonical schema can't represent — kept
+verbatim. Examples:
+
+| ATS | Typical `raw` keys |
+|---|---|
+| Greenhouse | `metadata` (custom fields) |
+| Bundesagentur | `arbeitszeit`, `branche`, `befristung` |
+| Lever | `categories`, `tags` |
+| Programathor | `skills`, `company_type`, `salary_text` |
+| Personio | `subcompany`, `office`, `occupationCategory` |
+
+Keep small (~5 kB serialized). Pre-strip large nested objects, raw
+HTML, full job descriptions (those go in `description`). Serialized as
+a JSON string in CSV exports, native dict in parquet.
+
+---
+
+## Frequently confused
+
+**`ats_id` vs `requisition_id` vs `global_id`** —
+- `ats_id` is the ATS-platform's internal id (different per platform).
+- `requisition_id` is the *employer's* internal id (same across
+  platforms when one job is mirrored on multiple ATSes).
+- `global_id` is jobhive's `{ats_type}:{ats_id}` composite — the unique
+  identifier for the row in the dataset.
+
+**`employment_type` vs `commitment`** —
+- `employment_type` is a 5-value enum (full-time / part-time /
+  contract / intern / temporary). Filter on this.
+- `commitment` is the raw ATS string (`"CDI"`, `"Heltid"`,
+  `"32h/week"`). Display this.
+
+**`is_remote` and `salary_min/max` are sometimes derived** —
+the publisher fills them from `location` text and `salary_summary`
+when the ATS doesn't ship them structured. The CSV / parquet doesn't
+distinguish derived from source-provided values; if you need to tell
+them apart, look at the raw ATS payload via `raw`.

--- a/README.md
+++ b/README.md
@@ -98,16 +98,18 @@ df.groupby("company").size().sort_values(ascending=False).head(20)
 Every row carries:
 
 ```
-url, title, company, ats_type, ats_id,
+global_id, url, title, company, ats_type, ats_id,
 location, is_remote, lat, lon,
 salary_min, salary_max, salary_currency, salary_period, salary_summary,
 employment_type, commitment, experience, department, team,
 description, posted_at, fetched_at, requisition_id, apply_url, raw
 ```
 
-Optional fields are `None` when the source ATS doesn't expose them.
-``raw`` keeps any provider-specific fields the canonical schema doesn't
-represent — Greenhouse `metadata`, Workday `bulletFields`, etc.
+Full per-field semantics (types, defaults, derivation rules, examples)
+live in [**`JOB_SCHEMA.md`**](./JOB_SCHEMA.md). `global_id` is the
+cross-ATS unique key in the form `{ats_type}:{ats_id}`. Optional fields
+are `None` when the source ATS doesn't expose them; `raw` keeps any
+provider-specific fields the canonical schema doesn't represent.
 
 ### 2. Scrape your own companies
 

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -1,25 +1,36 @@
 """Core data models for jobs, companies, and salary information.
 
-These models are the canonical schema across every ATS scraper and the public
-dataset on storage.stapply.ai. Adding a field here means: the dataset gets a
-new column, every scraper must populate it (or leave it None), and the parquet
-schema gets a new field.
+These models are the canonical schema across every ATS scraper and the
+public dataset on storage.stapply.ai. Adding a field here means: the
+dataset gets a new column, every scraper must populate it (or leave
+it None), and the parquet schema gets a new field.
+
+The Job schema is also documented for human readers in
+``JOB_SCHEMA.md`` at the repo root — keep the two in sync. ``Field``
+descriptions in this file are the source of truth; the markdown is a
+view onto them.
 """
 
 from __future__ import annotations
 
+import logging
+import re
+import uuid
 from datetime import datetime
 from enum import StrEnum
-from typing import Literal
+from typing import Literal, Self
 
-from pydantic import BaseModel, ConfigDict, Field, HttpUrl
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, model_validator
+
+log = logging.getLogger(__name__)
 
 
 class ATSType(StrEnum):
     """Supported applicant tracking systems.
 
-    A company belongs to exactly one ATS. The ATS determines which scraper
-    knows how to fetch its jobs and how the careers page is structured.
+    A company belongs to exactly one ATS. The ATS determines which
+    scraper knows how to fetch its jobs and how the careers page is
+    structured.
     """
 
     ASHBY = "ashby"
@@ -87,8 +98,8 @@ SalaryPeriod = Literal["HOUR", "DAY", "WEEK", "MONTH", "YEAR"]
 class Salary(BaseModel):
     """Compensation range attached to a job posting.
 
-    Stored separately from `Job` so the same shape can be reused for total comp,
-    base, equity, etc. — currently only base is populated.
+    Stored separately from ``Job`` so the same shape can be reused for
+    total comp, base, equity, etc. — currently only base is populated.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -115,100 +126,341 @@ class Company(BaseModel):
 EmploymentType = Literal["FULL_TIME", "PART_TIME", "CONTRACT", "INTERN", "TEMPORARY"]
 
 
+# Control characters that would corrupt a CSV / JSON line if they
+# made it into ``ats_id`` (and thus ``global_id``). Newline / tab /
+# carriage return / NULL — anything else printable stays.
+_ATS_ID_FORBIDDEN_CHARS = re.compile(r"[\x00\t\r\n]")
+
+
 class Job(BaseModel):
     """A job posting — the canonical row across the entire dataset.
 
-    Every scraper produces `Job` instances; the public CSV/Parquet exports use
-    these field names verbatim. Backwards compatibility on field names is part
-    of the public contract.
+    Every scraper produces ``Job`` instances; the public CSV/Parquet
+    exports use these field names verbatim. **Backwards compatibility
+    on field names is part of the public contract** — renaming a field
+    is a breaking change.
 
-    Fields fall in three tiers:
+    The fields fall into four groups, listed in the order they appear
+    below:
 
-    - **Cross-ATS canonical**: ``url``/``title``/``company``/``ats_type``/
-      ``ats_id``/``location``/``posted_at``. Every scraper sets these.
-    - **Common-but-optional**: salary, employment type, department,
-      team, etc. Set when the source API exposes them; ``None``
-      otherwise. The ``infer_is_remote`` enrichment heuristic populates
-      ``is_remote`` from title/description when missing.
-    - **Provider-specific overflow** (``raw``): a JSON dict captured at
-      scrape-time so we don't lose ATS-specific fields the canonical
-      schema can't represent (Greenhouse ``metadata`` custom fields,
-      Bundesagentur ``arbeitszeit``/``branche``, Lever ``categories.*``,
-      etc.). Stored as a JSON string in CSV / dict in parquet.
+    1. **Identity** (``global_id``, ``url``, ``title``, ``company``,
+       ``ats_type``, ``ats_id``). What the row *is*.
+
+    2. **Location** (``location``, ``lat``, ``lon``, ``is_remote``).
+       Where the role lives. ``is_remote`` is derived from
+       ``location`` text by ``jobhive.enrichment.infer_is_remote``
+       when the ATS doesn't surface a flag of its own.
+
+    3. **Compensation** (``salary_currency``, ``salary_period``,
+       ``salary_summary``, ``salary_min``, ``salary_max``).
+       ``salary_min`` / ``salary_max`` are *derived* from
+       ``salary_summary`` via ``jobhive.enrichment.parse_salary_range``
+       when the ATS exposes only free text.
+
+    4. **Classification** (``experience``, ``employment_type``,
+       ``department``, ``team``, ``requisition_id``, ``apply_url``,
+       ``commitment``). Optional — set when the source API exposes
+       them, ``None`` otherwise.
+
+    5. **Content & timing** (``description``, ``posted_at``,
+       ``fetched_at``).
+
+    6. **Provider-specific overflow** (``raw``): a JSON dict captured
+       at scrape-time so we don't lose ATS-specific fields the
+       canonical schema can't represent (Greenhouse ``metadata``
+       custom fields, Bundesagentur ``arbeitszeit``/``branche``,
+       Lever ``categories.*``, etc.).
     """
 
     model_config = ConfigDict(populate_by_name=True)
 
-    url: HttpUrl
-    title: str
-    company: str
-    ats_type: ATSType = Field(..., alias="ats_type")
-    ats_id: str
+    # --- Identity ---------------------------------------------------------
 
-    location: str | None = None
-    lat: float | None = None
-    lon: float | None = None
-    is_remote: bool | None = None
+    global_id: str = Field(
+        default="",
+        description=(
+            "Globally unique identifier for the posting, formatted as "
+            "``{ats_type}:{ats_id}`` when both are set (e.g. "
+            "``ashby:engineer-2026`` or ``workday:R0136150``). The "
+            "separator is a colon — parsers should split on the FIRST "
+            "colon since ``ats_id`` may itself contain colons. When "
+            "``ats_id`` is missing, malformed, or contains control "
+            "characters, falls back to a random UUID4 and an error is "
+            "logged. Populated automatically by a model validator; do "
+            "not pass this field to ``Job(...)`` constructors."
+        ),
+    )
+    url: HttpUrl = Field(
+        ...,
+        description=(
+            "Public posting URL on the ATS. Always present. The "
+            "primary stable identifier consumers should use to "
+            "deduplicate or link out to the live page."
+        ),
+    )
+    title: str = Field(
+        ...,
+        description=(
+            "Free-form job title as posted (e.g. ``Senior Software "
+            "Engineer, Reality Labs``). May contain spaces, punctuation, "
+            "or non-ASCII characters."
+        ),
+    )
+    company: str = Field(
+        ...,
+        description=(
+            "Display name of the hiring employer. Distinct from "
+            "``ats_id``: the same company can have ``company='OpenAI'`` "
+            "and ``ats_id='openai'`` on Ashby. Different ATSes use "
+            "different conventions — Greenhouse stores a numeric board "
+            "id, Workday stores the human-readable name, Oracle the "
+            "host, etc. — so don't depend on this field for cross-ATS "
+            "joining; use ``ats_type``+``ats_id`` instead."
+        ),
+    )
+    ats_type: ATSType = Field(
+        ...,
+        alias="ats_type",
+        description=(
+            "Which ATS platform serves this posting. Determines the "
+            "scraper that produced the row and the format of "
+            "``ats_id``."
+        ),
+    )
+    ats_id: str | None = Field(
+        default=None,
+        description=(
+            "Per-ATS identifier for the posting — Greenhouse numeric "
+            "id, Workday requisition slug, Lever UUID, etc. Unique "
+            "within ``ats_type`` but not globally (use ``global_id`` "
+            "for that). Optional defensively: when null/empty/malformed, "
+            "``global_id`` falls back to UUID4 instead of crashing the "
+            "row, and an error is logged so the broken scraper is "
+            "noticed."
+        ),
+    )
 
-    salary_currency: str | None = None
-    salary_period: SalaryPeriod | None = None
-    salary_summary: str | None = None
-    salary_min: float | None = None
-    salary_max: float | None = None
+    # --- Location ---------------------------------------------------------
 
-    experience: int | None = Field(None, description="Required years of experience")
-    employment_type: EmploymentType | None = None
-    department: str | None = None
-    team: str | None = None
+    location: str | None = Field(
+        default=None,
+        description=(
+            "Free-form location string as posted (e.g. ``Paris, France``, "
+            "``Remote — US``, ``Berlin or Remote``). Multi-location "
+            "postings are rendered as comma-joined when the ATS "
+            "exposes a list."
+        ),
+    )
+    lat: float | None = Field(
+        default=None,
+        description=(
+            "Latitude in WGS-84 degrees when the ATS provides "
+            "geocoded coordinates (rare — most don't). Not derived "
+            "from ``location`` text."
+        ),
+    )
+    lon: float | None = Field(
+        default=None,
+        description=(
+            "Longitude in WGS-84 degrees. See ``lat`` notes — "
+            "populated together or not at all."
+        ),
+    )
+    is_remote: bool | None = Field(
+        default=None,
+        description=(
+            "Whether the role can be performed remotely. Set by the "
+            "scraper when the ATS exposes a flag, otherwise derived "
+            "from ``location`` text via "
+            "``jobhive.enrichment.infer_is_remote`` at publish time. "
+            "``None`` means we genuinely don't know."
+        ),
+    )
 
-    # Tier 2 additions (2026-05): pinning a strong cross-ATS dedup signal
-    # and the apply destination, both surfaced by most ATS APIs.
+    # --- Compensation -----------------------------------------------------
+
+    salary_currency: str | None = Field(
+        default=None,
+        description=(
+            "ISO 4217 currency code (``USD``, ``EUR``, ``GBP``, …) "
+            "when the ATS surfaces a structured salary range. ``None`` "
+            "when the salary is absent OR present only as free text "
+            "(in that case ``salary_summary`` is set)."
+        ),
+    )
+    salary_period: SalaryPeriod | None = Field(
+        default=None,
+        description=(
+            "Period the salary applies to. ``YEAR`` is the most common; "
+            "``HOUR`` shows up on hourly/contractor postings."
+        ),
+    )
+    salary_summary: str | None = Field(
+        default=None,
+        description=(
+            "Original salary string as the ATS displays it (e.g. "
+            "``$120K – $160K``, ``45.000 € / Jahr``, ``up to £80k``). "
+            "Source-of-truth when ``salary_min``/``salary_max`` are "
+            "derived from this field rather than provided directly."
+        ),
+    )
+    salary_min: float | None = Field(
+        default=None,
+        description=(
+            "Lower bound of the salary range, in ``salary_currency``. "
+            "Either set directly by the scraper from a structured ATS "
+            "field, or derived from ``salary_summary`` via "
+            "``jobhive.enrichment.parse_salary_range`` at publish time."
+        ),
+    )
+    salary_max: float | None = Field(
+        default=None,
+        description=(
+            "Upper bound of the salary range, in ``salary_currency``. "
+            "Same population logic as ``salary_min``."
+        ),
+    )
+
+    # --- Classification ---------------------------------------------------
+
+    experience: int | None = Field(
+        default=None,
+        description=(
+            "Required years of experience as an integer when the ATS "
+            "exposes a structured value. ``None`` when missing or "
+            "only described in prose."
+        ),
+    )
+    employment_type: EmploymentType | None = Field(
+        default=None,
+        description=(
+            "Normalized employment type — one of ``FULL_TIME``, "
+            "``PART_TIME``, ``CONTRACT``, ``INTERN``, ``TEMPORARY``. "
+            "Cross-ATS comparable; use this for filtering. The "
+            "ATS-specific raw label lives in ``commitment``."
+        ),
+    )
+    department: str | None = Field(
+        default=None,
+        description=(
+            "High-level org grouping (``Engineering``, ``Sales``, "
+            "``Marketing``, …) when the ATS surfaces it. Distinct "
+            "from ``team`` which is finer-grained."
+        ),
+    )
+    team: str | None = Field(
+        default=None,
+        description=(
+            "Sub-team / squad within the department (``Reality "
+            "Labs``, ``Payments Infra``, …). Often empty even when "
+            "``department`` is set."
+        ),
+    )
     requisition_id: str | None = Field(
-        None,
+        default=None,
         description=(
             "Employer-internal requisition identifier (Greenhouse "
             "``requisition_id``, Workday ``bulletFields[0]``, Lever's "
-            "private id, Bundesagentur ``hashId``). Same value across "
-            "ATSes for the same role — strong dedup signal."
+            "private id, Bundesagentur ``hashId``). Distinct from "
+            "``ats_id`` which is platform-side. Same role mirrored on "
+            "two different ATSes shares the same ``requisition_id`` "
+            "but has two different ``ats_id`` — strong cross-ATS dedup "
+            "signal."
         ),
     )
     apply_url: HttpUrl | None = Field(
-        None,
+        default=None,
         description=(
-            "Direct application URL when distinct from the posting URL. "
-            "Some ATSes (Workable widget, Bundesagentur external boards) "
-            "redirect to a separate apply destination."
+            "Direct application URL when distinct from the posting "
+            "``url``. Some ATSes (Workable widget, Bundesagentur "
+            "external boards, YC's workatastartup) redirect to a "
+            "separate apply destination."
         ),
     )
     commitment: str | None = Field(
-        None,
+        default=None,
         description=(
             "Free-form commitment label from the source ATS (Lever's "
             "``commitment``, Workable's ``type``, Bundesagentur's "
-            "``arbeitszeit`` description). Distinct from ``employment_type`` "
-            "which is the normalized enum."
+            "``arbeitszeit`` description, ``CDI``/``CDD``, ``Heltid``, "
+            "``32h/week``, …). Distinct from ``employment_type`` which "
+            "is the normalized enum — keep ``commitment`` to preserve "
+            "language and granularity (hours, contract length, …) the "
+            "enum loses."
         ),
     )
 
+    # --- Content & timing -------------------------------------------------
+
     description: str | None = Field(
-        None, description="Plain-text description; truncated to ~10kB if longer"
+        default=None,
+        description=(
+            "Plain-text job description. HTML and markdown are "
+            "stripped to text. Truncated to ~10kB when the source "
+            "exceeds it."
+        ),
+    )
+    posted_at: datetime | None = Field(
+        default=None,
+        description=(
+            "When the ATS reports the posting was first published. "
+            "UTC. ``None`` when the ATS doesn't expose this — common "
+            "on aggregator sites and some legacy ATSes."
+        ),
+    )
+    fetched_at: datetime | None = Field(
+        default=None,
+        description="When jobhive last saw this posting (UTC).",
     )
 
-    posted_at: datetime | None = None
-    fetched_at: datetime | None = Field(None, description="When jobhive last saw this posting")
+    # --- Provider-specific overflow ---------------------------------------
 
-    # Tier 3: ATS-specific overflow. Anything in the source payload that
-    # doesn't map cleanly to a canonical field can be stashed here so we
-    # don't lose it. Keep it small (~5kB serialized) — pre-strip large
-    # nested objects, raw HTML, etc.
     raw: dict[str, object] | None = Field(
         default=None,
         description=(
             "Provider-specific overflow fields kept verbatim "
-            "(Greenhouse metadata custom fields, Bundesagentur facets, "
-            "Lever categories, etc.). Serialized as JSON in CSV exports."
+            "(Greenhouse ``metadata`` custom fields, Bundesagentur "
+            "facets, Lever ``categories``, …). Keep small (~5kB "
+            "serialized) — pre-strip large nested objects, raw HTML, "
+            "etc. Serialized as a JSON string in CSV exports, native "
+            "dict in parquet."
         ),
     )
+
+    @model_validator(mode="after")
+    def _populate_global_id(self) -> Self:
+        """Compute ``global_id`` from ``ats_type`` + ``ats_id``.
+
+        Runs after the rest of the model is validated so we can read
+        the validated values. ``ats_id`` may be missing, empty, or
+        contain control characters — in any of those cases we log an
+        error and fall back to a UUID4 so the row still gets a unique
+        identifier instead of failing the whole scrape.
+        """
+        normalized_id: str | None = None
+        if self.ats_id is not None:
+            stripped = self.ats_id.strip()
+            if stripped and not _ATS_ID_FORBIDDEN_CHARS.search(stripped):
+                normalized_id = stripped
+
+        if normalized_id is None:
+            log.error(
+                "Job(ats_type=%s, url=%s) has missing/invalid ats_id=%r — "
+                "falling back to UUID. Source scraper should be fixed.",
+                self.ats_type.value,
+                self.url,
+                self.ats_id,
+            )
+            object.__setattr__(self, "global_id", str(uuid.uuid4()))
+        else:
+            # Persist the cleaned-up ats_id so downstream consumers
+            # don't see the trailing-space or other whitespace forms.
+            if normalized_id != self.ats_id:
+                object.__setattr__(self, "ats_id", normalized_id)
+            object.__setattr__(
+                self, "global_id", f"{self.ats_type.value}:{normalized_id}"
+            )
+        return self
 
     @property
     def salary(self) -> Salary | None:

--- a/src/jobhive/scrapers/getonbrd.py
+++ b/src/jobhive/scrapers/getonbrd.py
@@ -9,7 +9,7 @@ Public JSON:API at ``https://www.getonbrd.com/api/v0`` — no auth, no key.
 The site-wide ``/jobs`` endpoint is auth-gated, but per-category
 ``/categories/{slug}/jobs`` is open. We enumerate the 18 categories the
 ``/categories`` endpoint advertises, paginate each (max
-``per_page=120``), and resolve the embedded company / city / seniority /
+``per_page=120``), and resolve the embedded company / city /
 modality references separately because the API doesn't support
 ``?include=`` for related resources.
 
@@ -79,11 +79,9 @@ class GetOnBrdScraper(BaseScraper):
             categories = await self._list_categories(client, sem)
 
             # Lookup tables — one fetch each, then cached in memory for
-            # the full run. Modalities and seniorities are tiny enums
-            # (~5-10 values each); cities are populated lazily as we
-            # encounter referenced IDs.
+            # the full run. Modalities is a tiny enum (~5-10 values);
+            # cities are populated lazily as we encounter referenced IDs.
             modalities = await self._fetch_lookup(client, sem, "modalities")
-            seniorities = await self._fetch_lookup(client, sem, "seniorities")
             companies: dict[str, str] = {}
             cities: dict[str, dict[str, str]] = {}
 
@@ -105,7 +103,7 @@ class GetOnBrdScraper(BaseScraper):
                         jobs.append(
                             await self._parse_job(
                                 client, sem, item,
-                                modalities=modalities, seniorities=seniorities,
+                                modalities=modalities,
                                 companies=companies, cities=cities,
                             )
                         )
@@ -190,7 +188,7 @@ class GetOnBrdScraper(BaseScraper):
         sem: asyncio.Semaphore,
         resource: str,
     ) -> dict[str, dict[str, str]]:
-        """Fetch a small enum-style resource (modalities, seniorities) and
+        """Fetch a small enum-style resource (modalities) and
         index it by id."""
         payload = await self._request_json(client, sem, f"{API_ROOT}/{resource}")
         return {
@@ -259,7 +257,6 @@ class GetOnBrdScraper(BaseScraper):
         item: dict[str, Any],
         *,
         modalities: dict[str, dict[str, str]],
-        seniorities: dict[str, dict[str, str]],
         companies: dict[str, str],
         cities: dict[str, dict[str, str]],
     ) -> Job:
@@ -288,15 +285,6 @@ class GetOnBrdScraper(BaseScraper):
             (modality_attrs.get("locale_key") or "").lower()
         )
 
-        # The seniority enum was removed from the Job model; the
-        # original `attrs["seniority"]` reference is preserved in
-        # ``raw`` below for downstream consumers that still want it.
-        seniority_id = str(
-            ((attrs.get("seniority") or {}).get("data") or {}).get("id") or ""
-        )
-        seniority_attrs = seniorities.get(seniority_id) or {}
-        seniority_name = seniority_attrs.get("name")
-
         description = _strip_html(_concat_descriptions(attrs))
         salary_min = _to_float(attrs.get("min_salary"))
         salary_max = _to_float(attrs.get("max_salary"))
@@ -312,8 +300,6 @@ class GetOnBrdScraper(BaseScraper):
             v = attrs.get(k)
             if v not in (None, "", []):
                 raw[k] = v
-        if seniority_name:
-            raw["seniority"] = seniority_name
 
         return Job(
             url=url,

--- a/src/jobhive/scrapers/personio.py
+++ b/src/jobhive/scrapers/personio.py
@@ -157,7 +157,7 @@ class PersonioScraper(BaseScraper):
 
         raw: dict[str, Any] = {}
         for k in ("subcompany", "department", "office", "occupation",
-                  "occupationCategory", "seniority", "yearsOfExperience",
+                  "occupationCategory", "yearsOfExperience",
                   "employment_type", "schedule", "category"):
             v = item.get(k)
             if v:

--- a/src/jobhive/scrapers/programathor.py
+++ b/src/jobhive/scrapers/programathor.py
@@ -71,7 +71,6 @@ _BRIEFCASE_RE = re.compile(r"<i[^>]+fa-briefcase[^>]*>\s*</i>(?P<v>[^<]+)")
 _LOCATION_RE = re.compile(r"<i[^>]+fa-map-marker-alt[^>]*>\s*</i>(?P<v>[^<]+)")
 _COMPANY_TYPE_RE = re.compile(r"<i[^>]+fa-building[^>]*>\s*</i>(?P<v>[^<]+)")
 _SALARY_RE = re.compile(r"<i[^>]+fa-money-bill-alt[^>]*>\s*</i>(?P<v>[^<]+)")
-_SENIORITY_RE = re.compile(r"<i[^>]+fa-chart-bar[^>]*>\s*</i>(?P<v>[^<]+)")
 _CONTRACT_RE = re.compile(r"<i[^>]+fa-file-alt[^>]*>\s*</i>(?P<v>[^<]+)")
 _SKILL_TAG_RE = re.compile(r"<span class='tag-list[^']*'>([^<]+)</span>")
 
@@ -272,7 +271,6 @@ class ProgramathorScraper(BaseScraper):
         location = _normalize_location(location_raw)
         company_type = _strip_html(_extract(body, _COMPANY_TYPE_RE))
         salary_raw = _strip_html(_extract(body, _SALARY_RE))
-        seniority_raw = _strip_html(_extract(body, _SENIORITY_RE))
         contract_raw = _strip_html(_extract(body, _CONTRACT_RE))
 
         employment_type = _EMPLOYMENT_MAP.get(contract_raw.lower()) if contract_raw else None
@@ -299,8 +297,6 @@ class ProgramathorScraper(BaseScraper):
             raw["company_type"] = company_type
         if salary_raw and not (salary_min or salary_max):
             raw["salary_text"] = salary_raw
-        if seniority_raw:
-            raw["seniority"] = seniority_raw
 
         return Job(
             url=f"{API_ROOT}{href}",

--- a/src/jobhive/scrapers/themuse.py
+++ b/src/jobhive/scrapers/themuse.py
@@ -172,8 +172,7 @@ class TheMuseScraper(BaseScraper):
         location = location_names[0] if location_names else None
 
         # The Muse's free-form level label (Internship / Entry Level / Senior
-        # Level / Director / etc.) is surfaced as ``commitment`` since the
-        # canonical seniority enum was dropped from the ``Job`` model.
+        # Level / Director / etc.) is surfaced as ``commitment``.
         level_name: str | None = None
         levels = item.get("levels") or []
         for lvl in levels:

--- a/tests/test_getonbrd.py
+++ b/tests/test_getonbrd.py
@@ -1,7 +1,7 @@
 """Tests for the Get on Board (LATAM tech) scraper.
 
 The API doesn't support ``?include=`` for related resources, so the scraper
-makes follow-up fetches for company / city / modality / seniority. These
+makes follow-up fetches for company / city / modality. These
 tests pin the parsing contract and the lookup-cache behaviour so we don't
 re-fetch the same company every job.
 """
@@ -43,18 +43,6 @@ def _modalities() -> dict:
     }
 
 
-def _seniorities() -> dict:
-    return {
-        "data": [
-            {"id": "1", "type": "seniority", "attributes": {"name": "Sin experiencia", "locale_key": "no_experience"}},
-            {"id": "2", "type": "seniority", "attributes": {"name": "Junior", "locale_key": "junior"}},
-            {"id": "3", "type": "seniority", "attributes": {"name": "Semi senior", "locale_key": "semi_senior"}},
-            {"id": "4", "type": "seniority", "attributes": {"name": "Senior", "locale_key": "senior"}},
-            {"id": "5", "type": "seniority", "attributes": {"name": "Expert", "locale_key": "expert"}},
-        ],
-    }
-
-
 def _job(
     *,
     job_id: str,
@@ -62,7 +50,6 @@ def _job(
     company_id: str,
     city_id: str | None = None,
     countries: list[str] | None = None,
-    seniority_id: str = "4",
     modality_id: str = "1",
     remote: bool = False,
     min_salary: int | None = None,
@@ -85,7 +72,6 @@ def _job(
             ),
             "countries": countries or [],
             "modality": {"data": {"id": int(modality_id), "type": "modality"}},
-            "seniority": {"data": {"id": int(seniority_id), "type": "seniority"}},
             "remote": remote,
             "remote_modality": "remote_local" if remote else "hybrid",
             "min_salary": min_salary,
@@ -113,7 +99,6 @@ def _city(cid: str, name: str, country: str) -> dict:
 
 def _stub_lookups(httpx_mock) -> None:
     httpx_mock.add_response(url=f"{_API}/modalities", json=_modalities())
-    httpx_mock.add_response(url=f"{_API}/seniorities", json=_seniorities())
 
 
 # --- registry / wiring ------------------------------------------------------
@@ -139,7 +124,6 @@ def test_parses_full_job_payload(httpx_mock) -> None:
                 title="Senior Engineer",
                 company_id="42",
                 city_id="130",
-                seniority_id="4",
                 modality_id="3",  # Freelance
                 min_salary=3500,
                 max_salary=4200,
@@ -158,7 +142,6 @@ def test_parses_full_job_payload(httpx_mock) -> None:
     assert j.company == "Acme Inc"
     assert j.location == "Lima, Peru"
     assert j.is_remote is False
-    assert (j.raw or {}).get("seniority") == "Senior"
     assert j.employment_type == "CONTRACT"  # Freelance → CONTRACT
     assert j.commitment == "Freelance"
     assert j.salary_currency == "USD"
@@ -252,33 +235,6 @@ def test_falls_back_to_country_list_when_city_id_unresolvable(httpx_mock) -> Non
     # or fall back to country — both are acceptable; what matters is no
     # exception.
     assert len(jobs) == 1
-
-
-# --- enum mapping -----------------------------------------------------------
-
-
-def test_seniority_name_passed_through_to_raw(httpx_mock) -> None:
-    """The Job model no longer carries a seniority enum, but the raw
-    name is preserved in ``raw["seniority"]`` so downstream consumers
-    can still map it."""
-    httpx_mock.add_response(url=f"{_API}/categories", json=_categories(["programming"]))
-    _stub_lookups(httpx_mock)
-    httpx_mock.add_response(
-        url=re.compile(rf"^{re.escape(_API)}/categories/programming/jobs"),
-        json=_jobs_page([
-            _job(job_id=f"s-{sid}", title=f"Job {sid}", company_id="9", seniority_id=sid)
-            for sid in ("1", "2", "3", "4", "5")
-        ]),
-    )
-    httpx_mock.add_response(url=f"{_API}/companies/9", json=_company("9", "A"))
-
-    jobs = GetOnBrdScraper("any").fetch()
-    by_id = {j.ats_id: j for j in jobs}
-    assert (by_id["s-1"].raw or {}).get("seniority") == "Sin experiencia"
-    assert (by_id["s-2"].raw or {}).get("seniority") == "Junior"
-    assert (by_id["s-3"].raw or {}).get("seniority") == "Semi senior"
-    assert (by_id["s-4"].raw or {}).get("seniority") == "Senior"
-    assert (by_id["s-5"].raw or {}).get("seniority") == "Expert"
 
 
 def test_salary_only_set_when_present(httpx_mock) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -190,3 +190,132 @@ def test_job_round_trips_through_model_dump() -> None:
 def test_job_lat_lon_optional() -> None:
     job = _minimal_job(lat=37.7749, lon=-122.4194)
     assert job.lat == pytest.approx(37.7749)
+
+
+# --- Job.global_id -----------------------------------------------------------
+#
+# The global_id is the cross-ATS unique identifier for a posting.
+# Format: f"{ats_type}:{ats_id}". Falls back to a UUID4 when ats_id is
+# missing or contains characters that would corrupt CSV / JSON output.
+
+
+def test_global_id_default_format() -> None:
+    job = _minimal_job(ats_type=ATSType.ASHBY, ats_id="abc-123")
+    assert job.global_id == "ashby:abc-123"
+
+
+def test_global_id_preserves_case() -> None:
+    """Workday and a few other ATSes use mixed-case requisition IDs.
+    Lowercasing them would collapse legitimately distinct postings."""
+    job = _minimal_job(ats_type=ATSType.WORKDAY, ats_id="R0136150")
+    assert job.global_id == "workday:R0136150"
+
+
+def test_global_id_strips_whitespace_from_ats_id() -> None:
+    """Apple's careers API occasionally trails an ats_id with a single
+    space. Strip it both from ats_id and from the derived global_id."""
+    job = _minimal_job(ats_type=ATSType.APPLE, ats_id="  200544316  ")
+    assert job.ats_id == "200544316"
+    assert job.global_id == "apple:200544316"
+
+
+def test_global_id_keeps_internal_colons() -> None:
+    """Some Taleo URLs encode multiple colons inside ats_id. The
+    contract documents 'split on FIRST colon' so consumers can
+    recover ats_type + ats_id."""
+    job = _minimal_job(ats_type=ATSType.TALEO, ats_id="acme:req:12345")
+    assert job.global_id == "taleo:acme:req:12345"
+
+
+def test_global_id_keeps_special_chars() -> None:
+    """Dashes, dots, slashes, parens etc. are common in ATS IDs and
+    are preserved verbatim — they're meaningful, not delimiters."""
+    job = _minimal_job(
+        ats_type=ATSType.ICIMS, ats_id="job-2026.04/eng_(remote)"
+    )
+    assert job.global_id == "icims:job-2026.04/eng_(remote)"
+
+
+def test_global_id_uuid_when_ats_id_none(caplog) -> None:
+    import logging
+    with caplog.at_level(logging.ERROR, logger="jobhive.models"):
+        job = _minimal_job(ats_type=ATSType.LEVER, ats_id=None)
+    assert ":" not in job.global_id  # not the formatted shape
+    # Standard UUID4 string length is 36 chars (8-4-4-4-12 hex + dashes)
+    assert len(job.global_id) == 36
+    assert any(
+        "missing/invalid ats_id" in r.getMessage() for r in caplog.records
+    )
+
+
+def test_global_id_uuid_when_ats_id_empty_string() -> None:
+    job = _minimal_job(ats_type=ATSType.LEVER, ats_id="")
+    assert ":" not in job.global_id
+    assert len(job.global_id) == 36
+
+
+def test_global_id_uuid_when_ats_id_only_whitespace() -> None:
+    """A ats_id of just spaces is empty after strip, treat as missing."""
+    job = _minimal_job(ats_type=ATSType.LEVER, ats_id="    ")
+    assert ":" not in job.global_id
+    assert len(job.global_id) == 36
+
+
+def test_global_id_strips_trailing_crlf_and_keeps_valid() -> None:
+    """\\r\\n at the end of ats_id is stripped — once gone, the
+    remaining value is fine, no UUID fallback needed."""
+    job = _minimal_job(ats_type=ATSType.LEVER, ats_id="abc\r\n")
+    assert job.global_id == "lever:abc"
+    assert job.ats_id == "abc"
+
+
+@pytest.mark.parametrize("bad", ["abc\n123", "abc\tdef", "x\x00y"])
+def test_global_id_uuid_when_ats_id_has_control_chars(
+    bad: str, caplog
+) -> None:
+    """Control characters in the middle of ats_id would corrupt
+    CSV/JSON output if they made it into global_id. UUID-fallback
+    when present. Trailing whitespace (including \\r\\n) is stripped
+    earlier and not counted as malformed."""
+    import logging
+    with caplog.at_level(logging.ERROR, logger="jobhive.models"):
+        job = _minimal_job(ats_type=ATSType.LEVER, ats_id=bad)
+    assert ":" not in job.global_id
+    assert len(job.global_id) == 36
+    assert any(
+        "missing/invalid ats_id" in r.getMessage() for r in caplog.records
+    )
+
+
+def test_global_id_uniqueness_across_uuid_fallbacks() -> None:
+    """Two malformed jobs must not collide on the UUID fallback."""
+    j1 = _minimal_job(ats_type=ATSType.LEVER, ats_id=None,
+                      url="https://x/1")
+    j2 = _minimal_job(ats_type=ATSType.LEVER, ats_id=None,
+                      url="https://x/2")
+    assert j1.global_id != j2.global_id
+
+
+def test_global_id_round_trips_through_model_dump() -> None:
+    """The computed global_id is preserved across serialization, and
+    re-parsing produces the same value (validator runs on validate())."""
+    original = _minimal_job(ats_type=ATSType.ASHBY, ats_id="abc-123")
+    assert original.global_id == "ashby:abc-123"
+    payload = original.model_dump(mode="json")
+    restored = Job.model_validate(payload)
+    assert restored.global_id == "ashby:abc-123"
+
+
+def test_global_id_user_supplied_value_is_overwritten() -> None:
+    """global_id is derived. Even if a caller passes their own value,
+    the validator computes a fresh one — keeps the field source-of-truth
+    consistent across the codebase."""
+    job = Job(
+        url="https://example.com/job/1",
+        title="Engineer",
+        company="acme",
+        ats_type=ATSType.GREENHOUSE,
+        ats_id="123",
+        global_id="some-bogus-value",
+    )
+    assert job.global_id == "greenhouse:123"

--- a/tests/test_programathor.py
+++ b/tests/test_programathor.py
@@ -5,7 +5,7 @@ proxy). These tests exercise:
 
 - Listing-card parsing — every Programathor field maps to the right
   Job slot
-- Brazilian salary/location parsing (R$, Portuguese seniority labels,
+- Brazilian salary/location parsing (R$,
   "Remoto" → "Remote, Brazil")
 - Pagination termination (3 consecutive duplicate-only pages → stop)
 - The proxy URL helper (Evomi's host:port:user:pass shape converts to
@@ -50,7 +50,6 @@ def _card(
     location: str = "Remoto",
     company_type: str = "Startup",
     salary: str = "Até R$5.000",
-    seniority: str = "Pleno",
     contract: str = "PJ",
     skills: list[str] | None = None,
     new_label: bool = True,
@@ -73,7 +72,6 @@ def _card(
         f"<span><i class='fas fa-map-marker-alt'></i>{location}</span>"
         f"<span><i class='fa fa-building'></i>{company_type}</span>"
         f"<span><i class='far fa-money-bill-alt'></i>{salary}</span>"
-        f"<span><i class='far fa-chart-bar'></i>{seniority}</span>"
         f"<span><i class='far fa-file-alt'></i>{contract}</span>"
         f"</div>"
         f"<div>{skill_html}</div>"
@@ -126,7 +124,6 @@ def test_parses_full_listing_card(httpx_mock) -> None:
             location="Remoto",
             company_type="Startup",
             salary="R$3.000 - R$5.000",
-            seniority="Pleno",
             contract="PJ",
             skills=["Python", "API", "SQL"],
         )]),
@@ -151,7 +148,6 @@ def test_parses_full_listing_card(httpx_mock) -> None:
     assert j.salary_period == "MONTH"
     assert j.salary_min == 3000.0
     assert j.salary_max == 5000.0
-    assert (j.raw or {}).get("seniority") == "Pleno"
     assert j.employment_type == "CONTRACT"  # PJ → CONTRACT
     assert j.commitment == "PJ"
     assert j.raw is not None
@@ -212,26 +208,6 @@ def test_parse_brl_amount_handles_brazilian_thousand_separator() -> None:
 ])
 def test_parse_salary_shapes(raw: str, expected: tuple) -> None:
     assert _parse_salary(raw) == expected
-
-
-# --- seniority text passthrough --------------------------------------------
-
-
-@pytest.mark.parametrize("label", ["Júnior", "Pleno", "Sênior", "Estágio", "Trainee"])
-def test_seniority_label_passes_through_to_raw(label: str, httpx_mock) -> None:
-    """Programathor's seniority label is preserved on Job.raw rather
-    than mapped to a canonical enum (the Job model dropped seniority)."""
-    httpx_mock.add_response(
-        url="https://programathor.com.br/jobs?page=1",
-        text=_listing([_card(job_id="1", title="X", seniority=label)]),
-    )
-    httpx_mock.add_response(
-        url=re.compile(r"^https://programathor\.com\.br/jobs\?page=[2-9]$"),
-        text=_empty_listing(),
-        is_reusable=True,
-    )
-    j = ProgramathorScraper("any").fetch()[0]
-    assert (j.raw or {}).get("seniority") == label
 
 
 # --- pagination termination --------------------------------------------------


### PR DESCRIPTION
## Summary

5 split commits covering the Job-model documentation pass + the new `global_id` field, per the design discussion.

| Commit | Change |
|---|---|
| `fd08592` | Remove `seniority` references from 4 scrapers + their tests (was already off the Job model, was leaking into `raw`) |
| `6e725c0` | Add `global_id` field, beef up `Field(description=...)` on every Job field |
| `701e3e0` | 11 new tests for the `global_id` contract |
| `ccd3246` | New `JOB_SCHEMA.md` at repo root — human-facing field reference |
| `3927632` | README: link to JOB_SCHEMA.md, mention `global_id` in the column list |

## `global_id` design

Format: `f"{ats_type}:{ats_id}"`. Examples:

```
ashby:engineer-2026
workday:R0136150
greenhouse:6849563
taleo:acme:req:12345   ← parsers split on FIRST colon
```

Falls back to a fresh UUID4 when `ats_id` is missing, empty after `.strip()`, or contains control chars (`\n` / `\t` / `\0`). Each fallback logs an ERROR so the responsible scraper is noticed. `ats_id` is now `str | None` defensively (was required) so the model validator can run on bad input instead of pydantic rejecting the row before the fallback path. `ats_type` stays required — every scraper hardcodes its own ATS so a None there is a real bug.

Case is preserved (Workday `R0136150` ≠ `r0136150`). Special chars (`-_.()/` etc.) are kept verbatim — meaningful in IDs.

## Test coverage

11 tests under "Job.global_id" in `tests/test_models.py`:

- happy path, case preservation, whitespace strip
- internal colons preserved (Taleo)
- special chars preserved (dashes, dots, slashes, parens)
- UUID fallback paths: ats_id None / empty / whitespace-only / control chars
- trailing `\r\n` is stripped (no UUID needed)
- uniqueness across UUID fallbacks
- round-trips through `model_dump`
- caller-supplied `global_id` is overwritten

Suite: 36 tests in `test_models.py`, **810 overall, ruff clean**.

## Test plan

- [ ] Verify CI green on the matrix (3.11 / 3.12 / 3.13 × ubuntu / macos)
- [ ] Confirm `seniority` is gone from `getonbrd`, `personio`, `programathor`, `themuse` (no `raw["seniority"]` either)
- [ ] After merge + next publisher run, the published CSV column list will include `global_id` and drop `seniority` automatically (publisher uses `Job.model_fields`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Job.global_id` as a cross-ATS unique ID and ships a human-readable schema guide. Removes leftover `seniority` parsing so the dataset adds `global_id` and drops `seniority`.

- New Features
  - `global_id` is computed as `{ats_type}:{ats_id}`; preserves case/special chars; split on the first colon when parsing; falls back to UUID4 with an ERROR log if `ats_id` is missing/invalid; `ats_id` is now `str | None`; any passed `global_id` is ignored; tests cover the contract.
  - Adds `JOB_SCHEMA.md` and expands field docs; `README.md` links to it and lists `global_id`.

- Migration
  - Use `global_id` as the unique key. If you parse it, split on the first colon.
  - Stop relying on `seniority` in CSVs or `raw["seniority"]`; it’s removed.

<sup>Written for commit 392763261ac1a80e298e12bf28de59dbed6e193b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `global_id` computed field (`{ats_type}:{ats_id}`) to the `Job` model via a `model_validator`, relaxes `ats_id` to `str | None` to allow the validator to handle bad input gracefully, and removes `seniority` data that was leaking into `raw` across four scrapers. It also ships a new `JOB_SCHEMA.md` human-facing field reference and wires it into the README.

- **`global_id` field** — computed by `_populate_global_id(mode="after")`, strips leading/trailing whitespace from `ats_id`, rejects control characters, and falls back to a UUID4 with an ERROR log. 11 new tests cover all the edge cases thoroughly.
- **Seniority removal** — `getonbrd`, `personio`, `programathor`, and `themuse` scrapers no longer fetch or store seniority data; tests updated to match.
- **`JOB_SCHEMA.md`** — new comprehensive field reference; one minor omission: `\r` (carriage return) is matched by the forbidden-char regex but not listed in the fallback trigger docs.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the model validator is correct, the UUID fallback path is well-tested, and the seniority removal is consistent across all four scrapers and their tests.

The implementation is solid: the `_populate_global_id` validator correctly handles all documented edge cases, uses `object.__setattr__` appropriately, and is covered by 11 targeted tests. The only findings are a doc-code mismatch (`
` missing from the listed control-char triggers in `JOB_SCHEMA.md`) and an off-by-two count in the model docstring. Neither affects correctness.

`JOB_SCHEMA.md` has the incomplete control-character list; `src/jobhive/models.py` has the group-count mismatch in the class docstring. Both are documentation-only.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/models.py | Adds `global_id` computed field via `model_validator(mode="after")`, relaxes `ats_id` to `str | None`, and expands all Field descriptions. Validator logic and `object.__setattr__` usage are correct; minor: class docstring says "four groups" but enumerates six. |
| tests/test_models.py | Adds 11 well-targeted `global_id` tests covering happy path, case preservation, whitespace strip, internal colons, special chars, UUID fallback paths, uniqueness, round-trip, and validator-overwrite behaviour. |
| JOB_SCHEMA.md | New human-facing schema reference; well-structured and accurate, except `\r` (carriage return) is missing from the listed control-character fallback triggers. |
| src/jobhive/scrapers/getonbrd.py | Removes `seniorities` lookup table fetch, the `_parse_job` parameter, and the `raw["seniority"]` assignment; comment updates are consistent. |
| src/jobhive/scrapers/personio.py | Single-line removal of `"seniority"` from the raw-field capture loop. Clean and complete. |
| src/jobhive/scrapers/programathor.py | Removes `_SENIORITY_RE`, the `seniority_raw` variable, and `raw["seniority"]` assignment. Consistent with the seniority-drift removal goal. |
| src/jobhive/scrapers/themuse.py | Comment-only change removing a reference to the dropped seniority enum. No functional impact. |
| README.md | Adds `global_id` to the column list and links to `JOB_SCHEMA.md`. Accurate and consistent with the model changes. |
| tests/test_getonbrd.py | Removes `_seniorities()` fixture, `seniority_id` parameter from `_job()`, and the seniority passthrough test. Consistent with the scraper change. |
| tests/test_programathor.py | Removes `seniority` parameter from `_card()` helper and deletes the seniority label passthrough test. Consistent with the scraper change. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/jobhive/models.py:143-144
The class docstring says "four groups" but immediately numbers six of them (Identity, Location, Compensation, Classification, Content & timing, Provider-specific overflow). A reader following the numbered list will notice the discrepancy.

```suggestion
    The fields fall into six groups, listed in the order they appear
    below:
```

### Issue 2 of 2
JOB_SCHEMA.md:41-42
The forbidden-character list in the schema doc is incomplete. The regex `_ATS_ID_FORBIDDEN_CHARS = re.compile(r"[\x00	
]")` also rejects a bare `
` (carriage return) that appears anywhere other than a trailing position stripped by `.strip()`. An `ats_id` like `"abc
def"` would trigger the UUID fallback, but the doc doesn't mention `
` as a trigger — only `
 / 	 / \0`.

```suggestion
- **Fallback:** when `ats_id` is missing, empty after whitespace strip,
  or contains control characters (`\n` / `\t` / `\r` / `\0`), `global_id`
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["README: link to JOB\_SCHEMA.md, add globa..."](https://github.com/kalil0321/ats-scrapers/commit/392763261ac1a80e298e12bf28de59dbed6e193b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31363696)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->