### PR TITLE
builtin + jobs.ch: fall back to httpcloak / Evomi proxy on 403

### DIFF
--- a/src/jobhive/scrapers/builtin.py
+++ b/src/jobhive/scrapers/builtin.py
@@ -127,13 +127,27 @@ class BuiltInScraper(BaseScraper):
             consecutive_empty = 0
             page = 1
             while page <= self.max_pages and consecutive_empty < 3:
-                page_jobs = await self._fetch_listing_page(client, sem, page)
+                try:
+                    page_jobs = await self._fetch_listing_page(client, sem, page)
+                except ScraperError as exc:
+                    # Cloudflare and httpcloak both rate-limit deep
+                    # pagination — once we hit a hard wall we keep what
+                    # we already collected rather than throw it all out.
+                    # Page 1 failures are still fatal (nothing to keep).
+                    if page == 1:
+                        raise
+                    log.warning(
+                        "Built In: stopping pagination at page %d (%s); "
+                        "keeping %d jobs collected so far.",
+                        page, exc, len(jobs),
+                    )
+                    break
                 new = sum(1 for j in page_jobs if j.ats_id not in seen)
                 await absorb(page_jobs)
                 consecutive_empty = 0 if new else consecutive_empty + 1
                 page += 1
 
-            if self.firecrawl_api_key:
+            if self.firecrawl_api_key and jobs:
                 await self._enrich_via_firecrawl(client, jobs)
 
         return jobs
@@ -264,30 +278,52 @@ class BuiltInScraper(BaseScraper):
     async def _request_via_httpcloak(self, url: str) -> str:
         """TLS+h2 impersonation fallback used when builtin.com 403's
         the direct httpx user-agent. Verified live 2026-05-09: 200 with
-        full ~390 KB HTML where direct returns 403/919 B."""
-        try:
-            import httpcloak
-        except ImportError as exc:
+        full ~390 KB HTML where direct returns 403/919 B.
+
+        Cloudflare also rate-limits deep pagination via httpcloak — the
+        first 403 here is treated as transient (retry with backoff) and
+        only escalates to a hard ``ScraperError`` if it survives every
+        retry. The caller in :meth:`_fetch_async` then keeps the jobs
+        collected so far rather than throwing them away.
+        """
+        from importlib.util import find_spec
+
+        if find_spec("httpcloak") is None:
             raise ScraperError(
                 "Built In's 403 fallback needs httpcloak — "
                 "`pip install jobhive[scrapers]`."
-            ) from exc
+            )
 
-        def _get() -> str:
-            r = httpcloak.get(url, timeout=self.timeout)
-            if r.status_code != 200:
-                raise ScraperError(
-                    f"Built In httpcloak fallback returned "
-                    f"{r.status_code} for {url}"
-                )
-            # httpcloak returns bytes — decode as UTF-8 with replacement
-            # so a stray non-UTF-8 byte never tanks a whole page.
-            content = r.content
-            if isinstance(content, bytes):
-                return content.decode("utf-8", errors="replace")
-            return content
+        last_status: int | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            text = await asyncio.to_thread(self._httpcloak_get_sync, url)
+            if isinstance(text, str):
+                return text
+            # ``_httpcloak_get_sync`` returned the int status on non-200
+            # so we can decide here whether to retry or escalate.
+            last_status = text
+            if last_status != 403 or attempt == MAX_RETRIES:
+                break
+            await asyncio.sleep(RETRY_BASE_DELAY * (2 ** (attempt - 1)))
+        raise ScraperError(
+            f"Built In httpcloak fallback returned {last_status} for "
+            f"{url} after {MAX_RETRIES} retries"
+        )
 
-        return await asyncio.to_thread(_get)
+    @staticmethod
+    def _httpcloak_get_sync(url: str) -> str | int:
+        """Sync fetch via httpcloak. Returns the page text on 200, the
+        bare status int otherwise so the async caller can decide
+        retry/escalate without raising for transient blocks."""
+        import httpcloak
+
+        r = httpcloak.get(url, timeout=30)
+        if r.status_code != 200:
+            return int(r.status_code)
+        content = r.content
+        if isinstance(content, bytes):
+            return content.decode("utf-8", errors="replace")
+        return content
 
     # --- optional Firecrawl enrichment --------------------------------------
 

--- a/src/jobhive/scrapers/builtin.py
+++ b/src/jobhive/scrapers/builtin.py
@@ -6,9 +6,14 @@ a schema.org ``ItemList`` with the visible 30 jobs (per page) — title,
 URL, and a one-line description for each — which we parse without any
 JS rendering.
 
-The library defaults to direct ``httpx`` fetching and pulls only what
-the listing JSON-LD contains: title, URL, ats_id, and description. To
-recover company / location / salary on the per-job detail pages
+The scraper tries direct ``httpx`` first; on the 403 that builtin.com
+serves to bare httpx user-agents (post-Cloudflare hardening, observed
+2026-05-09) it switches to ``httpcloak`` for the rest of the fetch.
+``httpcloak`` is a TLS+h2 fingerprint impersonator already shipped in
+the ``scrapers`` extra and used by Avature/JazzHR/Eightfold; no extra
+config or paid service involved.
+
+To recover company / location / salary on the per-job detail pages
 (which Built In renders client-side and is therefore invisible to a
 plain HTTP GET) the user can opt into Firecrawl-based enrichment by
 passing ``firecrawl_api_key="…"`` to the constructor or setting the
@@ -23,6 +28,7 @@ from __future__ import annotations
 import asyncio
 import html
 import json
+import logging
 import os
 import re
 from datetime import datetime
@@ -33,6 +39,8 @@ import httpx
 from jobhive.exceptions import ScraperError
 from jobhive.models import ATSType, Job
 from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from typing import Any
@@ -91,6 +99,10 @@ class BuiltInScraper(BaseScraper):
             or os.environ.get("FIRECRAWL_API_KEY")
             or None
         )
+        # Flipped to True the first time the direct ``httpx`` path
+        # returns 403; subsequent requests in this scraper instance
+        # then go through ``httpcloak``. Reset by re-instantiating.
+        self._use_httpcloak = False
 
     def fetch(self) -> list[Job]:
         return asyncio.run(self._fetch_async())
@@ -192,6 +204,11 @@ class BuiltInScraper(BaseScraper):
         sem: asyncio.Semaphore,
         url: str,
     ) -> str:
+        # Once a 403 has flipped the instance to httpcloak mode, every
+        # subsequent request skips the wasted direct attempt.
+        if self._use_httpcloak:
+            return await self._request_via_httpcloak(url)
+
         last_exc: Exception | None = None
         for attempt in range(1, MAX_RETRIES + 1):
             async with sem:
@@ -214,6 +231,16 @@ class BuiltInScraper(BaseScraper):
                     continue
             if response.status_code == 200:
                 return response.text
+            if response.status_code == 403:
+                # Cloudflare-style block on the bare httpx fingerprint.
+                # Flip the scraper into httpcloak mode and retry; every
+                # subsequent page in this fetch reuses the cheap path.
+                log.info(
+                    "Built In: 403 on %s — switching to httpcloak fallback",
+                    url,
+                )
+                self._use_httpcloak = True
+                return await self._request_via_httpcloak(url)
             if response.status_code in (429,) or 500 <= response.status_code < 600:
                 if attempt == MAX_RETRIES:
                     raise ScraperError(
@@ -233,6 +260,34 @@ class BuiltInScraper(BaseScraper):
         raise ScraperError(
             f"Built In exhausted retries for {url}: {last_exc}"
         )
+
+    async def _request_via_httpcloak(self, url: str) -> str:
+        """TLS+h2 impersonation fallback used when builtin.com 403's
+        the direct httpx user-agent. Verified live 2026-05-09: 200 with
+        full ~390 KB HTML where direct returns 403/919 B."""
+        try:
+            import httpcloak
+        except ImportError as exc:
+            raise ScraperError(
+                "Built In's 403 fallback needs httpcloak — "
+                "`pip install jobhive[scrapers]`."
+            ) from exc
+
+        def _get() -> str:
+            r = httpcloak.get(url, timeout=self.timeout)
+            if r.status_code != 200:
+                raise ScraperError(
+                    f"Built In httpcloak fallback returned "
+                    f"{r.status_code} for {url}"
+                )
+            # httpcloak returns bytes — decode as UTF-8 with replacement
+            # so a stray non-UTF-8 byte never tanks a whole page.
+            content = r.content
+            if isinstance(content, bytes):
+                return content.decode("utf-8", errors="replace")
+            return content
+
+        return await asyncio.to_thread(_get)
 
     # --- optional Firecrawl enrichment --------------------------------------
 

--- a/src/jobhive/scrapers/jobsch.py
+++ b/src/jobhive/scrapers/jobsch.py
@@ -12,12 +12,24 @@ at 20; >20 → 422). Each entry has ``company_name`` embedded so no
 separate company-resolution fetch is needed. The detail-page URL
 template is in ``_links.detail_*`` (German is the canonical default).
 
+The API geo-fences off datacenter IPs — bare httpx from a Hetzner /
+DigitalOcean / AWS machine returns 403 with a 919-byte block page
+(verified 2026-05-09 from Hetzner). The scraper tries direct first
+and, on 403, falls back to a residential proxy pulled from the
+``PROXY`` env var (Evomi 4-colon shape ``http://host:port:user:pass``,
+matching the Tesla / Meta pattern). With the proxy active, the same
+endpoint returns 200 + ~200 KB HTML and the public REST API works.
+When ``PROXY`` is not set the scraper raises a clear error rather
+than silently 0-scraping.
+
 Single-source scraper: ``company_slug`` is informational and ignored.
 """
 
 from __future__ import annotations
 
 import asyncio
+import logging
+import os
 from datetime import datetime
 from typing import TYPE_CHECKING
 
@@ -30,6 +42,8 @@ from jobhive.scrapers.base import BaseScraper, ScraperRegistry
 if TYPE_CHECKING:
     from typing import Any
 
+log = logging.getLogger(__name__)
+
 API_URL = "https://www.jobs.ch/api/v1/public/search"
 PER_PAGE = 20  # API hard-caps ``rows`` at 20 (>20 → 422).
 MAX_CONCURRENCY = 4
@@ -38,6 +52,12 @@ RETRY_BASE_DELAY = 1.5
 # Default cap on total pages to fetch — 2,500 pages × 20 jobs = full
 # 50k inventory. Set lower via ``max_pages`` for incremental runs.
 DEFAULT_MAX_PAGES = 2500
+
+
+class _BlockedError(Exception):
+    """Internal marker — the API returned 403, retry the whole fetch
+    via the residential-proxy fallback. Not raised at the public
+    boundary."""
 
 
 @ScraperRegistry.register(ATSType.JOBSCH)
@@ -66,6 +86,28 @@ class JobsChScraper(BaseScraper):
         return asyncio.run(self._fetch_async())
 
     async def _fetch_async(self) -> list[Job]:
+        # Try direct first; on 403 from the datacenter-blocked API,
+        # restart the whole fetch through the Evomi residential proxy.
+        try:
+            return await self._run_fetch(proxy_url=None)
+        except _BlockedError:
+            pass
+
+        proxy_url = _evomi_proxy_url_from_env()
+        if proxy_url is None:
+            raise ScraperError(
+                "jobs.ch returned 403 (likely datacenter IP block) and "
+                "no PROXY env var is set. Set PROXY=http://host:port:user:pass "
+                "to a residential proxy (Evomi or similar) to enable the "
+                "fallback path."
+            )
+        log.info(
+            "jobs.ch: direct request 403'd — retrying via PROXY "
+            "residential fallback."
+        )
+        return await self._run_fetch(proxy_url=proxy_url)
+
+    async def _run_fetch(self, *, proxy_url: str | None) -> list[Job]:
         seen: set[str] = set()
         jobs: list[Job] = []
         lock = asyncio.Lock()
@@ -79,9 +121,14 @@ class JobsChScraper(BaseScraper):
                     seen.add(job.ats_id)
                     jobs.append(job)
 
-        async with httpx.AsyncClient(
-            timeout=self.timeout, follow_redirects=True,
-        ) as client:
+        client_kwargs: dict[str, Any] = {
+            "timeout": self.timeout,
+            "follow_redirects": True,
+        }
+        if proxy_url is not None:
+            client_kwargs["proxy"] = proxy_url
+
+        async with httpx.AsyncClient(**client_kwargs) as client:
             sem = asyncio.Semaphore(MAX_CONCURRENCY)
 
             # First request to learn the real total. The API doesn't
@@ -139,6 +186,13 @@ class JobsChScraper(BaseScraper):
                     raise ScraperError(
                         f"jobs.ch returned non-JSON at start={start}: {exc}"
                     ) from exc
+            if response.status_code == 403:
+                # Datacenter IP block — escalate to ``_fetch_async`` so
+                # it can retry the whole fetch through the residential
+                # proxy. Don't burn retries here.
+                raise _BlockedError(
+                    f"jobs.ch returned 403 at start={start}"
+                )
             if response.status_code == 422:
                 # Past the search-engine cap (rare; API caps deep
                 # pagination differently per query). Treat as exhausted.
@@ -242,3 +296,28 @@ def _parse_iso(value: object) -> datetime | None:
         return datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
         return None
+
+
+def _evomi_proxy_url_from_env() -> str | None:
+    """Parse the ``PROXY`` env var into an httpx-compatible proxy URL.
+
+    Evomi ships ``PROXY`` in the 4-colon
+    ``http://host:port:user:pass`` shape (same shape the
+    ``_browserbase`` helper consumes for patchright). We rebuild it
+    into the standard ``http://user:pass@host:port`` form that httpx
+    accepts. Returns ``None`` when no env var is set so the caller can
+    surface a clear error instead of silently no-op'ing.
+    """
+    raw = os.getenv("PROXY")
+    if not raw:
+        return None
+    rest = raw.replace("http://", "").replace("https://", "")
+    parts = rest.split(":")
+    if len(parts) != 4:
+        log.warning(
+            "PROXY env var doesn't match host:port:user:pass shape; "
+            "skipping jobs.ch fallback."
+        )
+        return None
+    host, port, user, password = parts
+    return f"http://{user}:{password}@{host}:{port}"

--- a/src/jobhive/scrapers/jobsch.py
+++ b/src/jobhive/scrapers/jobsch.py
@@ -112,6 +112,12 @@ class JobsChScraper(BaseScraper):
         jobs: list[Job] = []
         lock = asyncio.Lock()
 
+        # Track whether we've already escalated to the proxy. After
+        # that, any further 403 mid-pagination is treated as a
+        # rate-limit / regional dropout — we keep what we have and
+        # stop, rather than re-raising and throwing away the slice.
+        already_in_proxy_mode = proxy_url is not None
+
         async def absorb(items: list[dict[str, Any]]) -> None:
             async with lock:
                 for it in items:
@@ -131,9 +137,9 @@ class JobsChScraper(BaseScraper):
         async with httpx.AsyncClient(**client_kwargs) as client:
             sem = asyncio.Semaphore(MAX_CONCURRENCY)
 
-            # First request to learn the real total. The API doesn't
-            # ship total in a single field on every response shape; we
-            # use ``total_hits`` from page 1 as the planning anchor.
+            # First request to learn the real total. A 403 here on the
+            # first page (no proxy yet) escalates so the caller can
+            # retry through the residential proxy fallback.
             first = await self._fetch_page(client, sem, start=0)
             total = int(first.get("total_hits") or 0)
             await absorb(first.get("documents") or [])
@@ -147,7 +153,15 @@ class JobsChScraper(BaseScraper):
             offsets = [PER_PAGE * i for i in range(1, page_count)]
 
             async def one(offset: int) -> None:
-                payload = await self._fetch_page(client, sem, start=offset)
+                try:
+                    payload = await self._fetch_page(client, sem, start=offset)
+                except _BlockedError:
+                    if not already_in_proxy_mode:
+                        raise  # let _fetch_async escalate to proxy
+                    # Already on the proxy — different node may have
+                    # hit a per-IP rate limit. Drop this page silently
+                    # so partial pagination returns what we have.
+                    return
                 await absorb(payload.get("documents") or [])
 
             await asyncio.gather(*(one(o) for o in offsets))

--- a/src/jobhive/scrapers/jobsch.py
+++ b/src/jobhive/scrapers/jobsch.py
@@ -12,15 +12,27 @@ at 20; >20 → 422). Each entry has ``company_name`` embedded so no
 separate company-resolution fetch is needed. The detail-page URL
 template is in ``_links.detail_*`` (German is the canonical default).
 
-The API geo-fences off datacenter IPs — bare httpx from a Hetzner /
-DigitalOcean / AWS machine returns 403 with a 919-byte block page
-(verified 2026-05-09 from Hetzner). The scraper tries direct first
-and, on 403, falls back to a residential proxy pulled from the
-``PROXY`` env var (Evomi 4-colon shape ``http://host:port:user:pass``,
-matching the Tesla / Meta pattern). With the proxy active, the same
-endpoint returns 200 + ~200 KB HTML and the public REST API works.
-When ``PROXY`` is not set the scraper raises a clear error rather
-than silently 0-scraping.
+Two anti-bot quirks to handle:
+
+  - Datacenter IP geo-fence — bare httpx from a Hetzner / AWS /
+    DigitalOcean machine returns 403 with a 919-byte block page
+    (verified 2026-05-09 from Hetzner). The scraper tries direct
+    first and, on 403, falls back to a residential proxy pulled
+    from the ``PROXY`` env var (Evomi 4-colon shape
+    ``http://host:port:user:pass``, matching Tesla / Meta).
+    Without ``PROXY`` set we raise a clear error rather than
+    silently 0-scraping.
+
+  - Deep-pagination cap — ``start>=2000`` always returns 422
+    regardless of IP. The empty-query view therefore tops out at
+    2 000 of the ~49 000 live postings. To recover the rest we
+    issue the same paginated search under ~35 keyword seeds (the
+    only filter param the API honours; verified 2026-05-09:
+    ``industry_ids`` / ``region_ids`` / ``place`` are all silently
+    ignored — total stays at 48 892 — but ``query=developer``
+    drops it to 707). Seeds span DE / FR / IT / EN to match the
+    four official languages of Swiss job postings; results across
+    seeds are deduped by ``job_id``.
 
 Single-source scraper: ``company_slug`` is informational and ignored.
 """
@@ -49,9 +61,34 @@ PER_PAGE = 20  # API hard-caps ``rows`` at 20 (>20 → 422).
 MAX_CONCURRENCY = 4
 MAX_RETRIES = 4
 RETRY_BASE_DELAY = 1.5
-# Default cap on total pages to fetch — 2,500 pages × 20 jobs = full
-# 50k inventory. Set lower via ``max_pages`` for incremental runs.
-DEFAULT_MAX_PAGES = 2500
+# The API hard-caps deep pagination at start=2000 (==page 100). Any
+# per-query fetch therefore tops out at 2 000 rows.
+MAX_USABLE_OFFSET = 2000
+# Default cap on pages per query — 100 × 20 rows = the API's per-query
+# ceiling. Lower via ``max_pages`` for quick smoke runs.
+DEFAULT_MAX_PAGES = 100
+
+# Keyword seeds covering DE / FR / IT / EN to defeat the per-query
+# 2 000-row pagination cap. Probed live 2026-05-09: each seed below
+# returns at least 36 unique-to-the-seed hits, the broad seeds
+# (``a``, ``manager``, ``verkauf``) hit the 2 000 cap and contribute
+# their newest 2 000 each. After dedup by ``job_id`` we observed
+# ~30 k unique rows across these seeds vs the 2 000 you get with no
+# query.
+_QUERY_SEEDS: tuple[str, ...] = (
+    # English
+    "developer", "manager", "engineer", "sales", "marketing", "finance",
+    "designer", "analyst", "consultant", "support", "operations", "hr",
+    "lead", "senior", "junior", "intern", "specialist", "executive",
+    # German
+    "entwickler", "verkauf", "ingenieur", "buchhaltung", "leiter",
+    "projektleiter", "kundenberater", "fachkraft", "assistent", "praktikant",
+    # French
+    "développeur", "responsable", "vente", "ingénieur", "comptable",
+    "stagiaire", "assistant", "directeur",
+    # Italian
+    "sviluppatore", "vendita", "ingegnere", "responsabile",
+)
 
 
 class _BlockedError(Exception):
@@ -78,18 +115,26 @@ class JobsChScraper(BaseScraper):
         *,
         timeout: float = 30.0,
         max_pages: int = DEFAULT_MAX_PAGES,
+        query_seeds: tuple[str, ...] | None = None,
     ) -> None:
         super().__init__(company_slug, timeout=timeout)
         self.max_pages = max_pages
+        # ``None`` keeps the production default (full seed list); pass
+        # ``()`` to disable seed-segmentation entirely (unit tests, or
+        # callers who only want the most-recent 2 000 rows).
+        self.query_seeds: tuple[str, ...] = (
+            _QUERY_SEEDS if query_seeds is None else tuple(query_seeds)
+        )
 
     def fetch(self) -> list[Job]:
         return asyncio.run(self._fetch_async())
 
     async def _fetch_async(self) -> list[Job]:
-        # Try direct first; on 403 from the datacenter-blocked API,
-        # restart the whole fetch through the Evomi residential proxy.
+        # Probe IP routing on the empty query: if the datacenter IP is
+        # 403-blocked, the same probe-then-proxy escalation runs once,
+        # and every subsequent seed reuses the resulting proxy_url.
         try:
-            return await self._run_fetch(proxy_url=None)
+            return await self._fetch_all_seeds(proxy_url=None)
         except _BlockedError:
             pass
 
@@ -105,17 +150,68 @@ class JobsChScraper(BaseScraper):
             "jobs.ch: direct request 403'd — retrying via PROXY "
             "residential fallback."
         )
-        return await self._run_fetch(proxy_url=proxy_url)
+        return await self._fetch_all_seeds(proxy_url=proxy_url)
 
-    async def _run_fetch(self, *, proxy_url: str | None) -> list[Job]:
+    async def _fetch_all_seeds(self, *, proxy_url: str | None) -> list[Job]:
+        """Run the empty-query fetch followed by every keyword seed,
+        deduping by ``job_id`` across all queries.
+
+        A 403 on the empty query escalates to the caller (proxy
+        fallback). Once that's been handled (or direct works), 403s on
+        individual seeds are demoted to a warning + skip — the rest of
+        the seeds still run and contribute their unique rows.
+        """
+        seen: set[str] = set()
+        all_jobs: list[Job] = []
+
+        # Empty-query first — its 403 is the signal the caller uses
+        # to flip from direct to proxy mode.
+        first_slice = await self._run_fetch(proxy_url=proxy_url, query=None)
+        for job in first_slice:
+            if job.ats_id in seen:
+                continue
+            seen.add(job.ats_id)
+            all_jobs.append(job)
+        log.info(
+            "jobs.ch: empty query → %d rows (%d new)",
+            len(first_slice), len(all_jobs),
+        )
+
+        for seed in self.query_seeds:
+            try:
+                slice_jobs = await self._run_fetch(
+                    proxy_url=proxy_url, query=seed
+                )
+            except _BlockedError:
+                log.warning(
+                    "jobs.ch: query=%s blocked even via PROXY; "
+                    "skipping this seed.", seed,
+                )
+                continue
+            new_count = 0
+            for job in slice_jobs:
+                if job.ats_id in seen:
+                    continue
+                seen.add(job.ats_id)
+                all_jobs.append(job)
+                new_count += 1
+            log.info(
+                "jobs.ch: query=%s → %d rows (%d new, total %d)",
+                seed, len(slice_jobs), new_count, len(all_jobs),
+            )
+
+        return all_jobs
+
+    async def _run_fetch(
+        self, *, proxy_url: str | None, query: str | None
+    ) -> list[Job]:
         seen: set[str] = set()
         jobs: list[Job] = []
         lock = asyncio.Lock()
 
-        # Track whether we've already escalated to the proxy. After
-        # that, any further 403 mid-pagination is treated as a
-        # rate-limit / regional dropout — we keep what we have and
-        # stop, rather than re-raising and throwing away the slice.
+        # After the proxy switch, any further 403 mid-pagination is a
+        # per-IP rate-limit / regional dropout — drop that page so the
+        # rest of the slice survives.
         already_in_proxy_mode = proxy_url is not None
 
         async def absorb(items: list[dict[str, Any]]) -> None:
@@ -137,30 +233,27 @@ class JobsChScraper(BaseScraper):
         async with httpx.AsyncClient(**client_kwargs) as client:
             sem = asyncio.Semaphore(MAX_CONCURRENCY)
 
-            # First request to learn the real total. A 403 here on the
-            # first page (no proxy yet) escalates so the caller can
-            # retry through the residential proxy fallback.
-            first = await self._fetch_page(client, sem, start=0)
+            first = await self._fetch_page(client, sem, start=0, query=query)
             total = int(first.get("total_hits") or 0)
             await absorb(first.get("documents") or [])
 
             if total <= PER_PAGE:
                 return jobs
 
+            usable = min(total, MAX_USABLE_OFFSET)
             page_count = min(
-                (total + PER_PAGE - 1) // PER_PAGE, self.max_pages
+                (usable + PER_PAGE - 1) // PER_PAGE, self.max_pages
             )
             offsets = [PER_PAGE * i for i in range(1, page_count)]
 
             async def one(offset: int) -> None:
                 try:
-                    payload = await self._fetch_page(client, sem, start=offset)
+                    payload = await self._fetch_page(
+                        client, sem, start=offset, query=query
+                    )
                 except _BlockedError:
                     if not already_in_proxy_mode:
-                        raise  # let _fetch_async escalate to proxy
-                    # Already on the proxy — different node may have
-                    # hit a per-IP rate limit. Drop this page silently
-                    # so partial pagination returns what we have.
+                        raise
                     return
                 await absorb(payload.get("documents") or [])
 
@@ -173,8 +266,11 @@ class JobsChScraper(BaseScraper):
         sem: asyncio.Semaphore,
         *,
         start: int,
+        query: str | None = None,
     ) -> dict[str, Any]:
-        params = {"start": start, "rows": PER_PAGE}
+        params: dict[str, Any] = {"start": start, "rows": PER_PAGE}
+        if query:
+            params["query"] = query
         last_exc: Exception | None = None
         for attempt in range(1, MAX_RETRIES + 1):
             async with sem:

--- a/tests/test_jobsch.py
+++ b/tests/test_jobsch.py
@@ -84,7 +84,7 @@ def test_parses_full_doc(httpx_mock) -> None:
             detail_de="https://www.jobs.ch/de/stellenangebote/detail/abc-123/",
         )], total_hits=1),
     )
-    jobs = JobsChScraper("any").fetch()
+    jobs = JobsChScraper("any", query_seeds=()).fetch()
     assert len(jobs) == 1
     j = jobs[0]
     assert j.ats_type is ATSType.JOBSCH
@@ -108,7 +108,7 @@ def test_falls_back_to_canonical_url_when_no_links(httpx_mock) -> None:
         url=_API_RE,
         json=_page([_doc(job_id="xyz-7", title="Engineer")], total_hits=1),
     )
-    j = JobsChScraper("any").fetch()[0]
+    j = JobsChScraper("any", query_seeds=()).fetch()[0]
     assert str(j.url) == "https://www.jobs.ch/en/vacancies/detail/xyz-7/"
 
 
@@ -118,7 +118,7 @@ def test_part_time_employment_type(httpx_mock) -> None:
         url=_API_RE,
         json=_page([_doc(job_id="p1", title="X", grades=[50])], total_hits=1),
     )
-    assert JobsChScraper("any").fetch()[0].employment_type == "PART_TIME"
+    assert JobsChScraper("any", query_seeds=()).fetch()[0].employment_type == "PART_TIME"
 
 
 def test_mixed_grades_no_employment_type(httpx_mock) -> None:
@@ -128,7 +128,7 @@ def test_mixed_grades_no_employment_type(httpx_mock) -> None:
         url=_API_RE,
         json=_page([_doc(job_id="p1", title="X", grades=[80, 100])], total_hits=1),
     )
-    assert JobsChScraper("any").fetch()[0].employment_type is None
+    assert JobsChScraper("any", query_seeds=()).fetch()[0].employment_type is None
 
 
 # --- pagination -------------------------------------------------------------
@@ -153,7 +153,7 @@ def test_paginates_total_hits_into_offsets(httpx_mock) -> None:
         json=_page([_doc(job_id=f"c{i}", title=f"Job {i}") for i in range(10)],
                    total_hits=50),
     )
-    jobs = JobsChScraper("any").fetch()
+    jobs = JobsChScraper("any", query_seeds=()).fetch()
     assert len(jobs) == 50
 
 
@@ -174,7 +174,7 @@ def test_max_pages_truncates(httpx_mock) -> None:
         json=_page([_doc(job_id=f"b{i}", title="X") for i in range(20)],
                    total_hits=1000),
     )
-    jobs = JobsChScraper("any", max_pages=2).fetch()
+    jobs = JobsChScraper("any", max_pages=2, query_seeds=()).fetch()
     assert len(jobs) == 40
 
 
@@ -184,7 +184,7 @@ def test_no_fanout_when_total_under_per_page(httpx_mock) -> None:
         url=_API_RE,
         json=_page([_doc(job_id="solo", title="Only")], total_hits=1),
     )
-    jobs = JobsChScraper("any").fetch()
+    jobs = JobsChScraper("any", query_seeds=()).fetch()
     assert len(jobs) == 1
 
 
@@ -200,11 +200,11 @@ def test_skips_doc_missing_id_or_title(httpx_mock) -> None:
             {"title": "no-id"},
         ], total_hits=3),
     )
-    jobs = JobsChScraper("any").fetch()
+    jobs = JobsChScraper("any", query_seeds=()).fetch()
     assert [j.ats_id for j in jobs] == ["ok"]
 
 
 def test_persistent_500_raises(httpx_mock) -> None:
     httpx_mock.add_response(url=_API_RE, status_code=500, is_reusable=True)
     with pytest.raises(ScraperError):
-        JobsChScraper("any").fetch()
+        JobsChScraper("any", query_seeds=()).fetch()


### PR DESCRIPTION
## Why

The published dataset manifest had two ATSes at 0 rows: `builtin` and `jobsch`. Empty cron logs hid the cause. Manual scraper runs from the Hetzner VPS surfaced two distinct anti-bot blocks on the bare httpx fingerprint:

- **builtin.com** → 403 (Cloudflare-style fingerprint check on the listing page).
- **jobs.ch** → 403 (datacenter-IP geo-fence on the public REST API from Hetzner; works fine over a Swiss residential IP).

## What

Each scraper falls back to the cheapest path that clears its specific block.

**builtin**: switches to `httpcloak` on the first 403 and stays there for the rest of the fetch (no per-page wasted direct probe). `httpcloak` is the TLS+h2 impersonator already shipped in the `scrapers` extra and used by Avature / JazzHR / Eightfold — no extra config or paid service.

**jobs.ch**: routes the whole fetch through the Evomi residential proxy when the direct attempt 403s and `PROXY` is set (4-colon `http://host:port:user:pass` shape, same env var Tesla / Meta consume). When `PROXY` isn't set the scraper raises a clear `ScraperError` instead of silently 0-scraping.

## Verified live (Hetzner VPS, 2026-05-09)

```
=== builtin live test ===
BuiltIn: 52 jobs (was 0)
sample: Manager III Sourcing Fresh

=== jobsch live test ===
HTTP/1.1 403 Forbidden
jobs.ch: direct request 403'd — retrying via PROXY residential fallback.
HTTP/1.1 200 OK
jobs.ch: 40 jobs (was 0) over 2 pages
sample: Sales Engineer / Technischer Verkäufer Region West @ SMC Schweiz AG
```

## Compatibility

- No new dependencies. `httpcloak` was already in the `scrapers` extra; `PROXY` env var was already configured for Tesla / Meta.
- Existing scraper tests (21 cases across `builtin` and `jobsch`) still pass.
- When `PROXY` is unset the public library degrades gracefully — `jobs.ch` raises a clear error rather than failing silently.

## Test plan

- [x] `pytest -k "builtin or jobsch"` → 21 passed
- [x] Live VPS scrape (max_pages=2) returns non-zero rows on both
- [x] Verify schema-correctness (Job model fields populated) — sample rows look correct

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores scraping for `builtin` and `jobs.ch` with 403 fallbacks and resilient pagination, and lifts the `jobs.ch` 2k pagination cap using keyword segmentation. `builtin` now switches to `httpcloak`; `jobs.ch` retries via a residential proxy from `PROXY` and dedupes results across seeds.

- **New Features**
  - jobs.ch: Added query segmentation across DE/FR/IT/EN seeds to bypass the 2k-per-query cap; results are deduped by `job_id`. New `query_seeds` param (defaults to the seed list). Pagination now caps at 100 pages (offset 2000) to match the API.

- **Bug Fixes**
  - builtin: On first 403, switch to `httpcloak` for all remaining requests. The `httpcloak` path retries 403s with backoff; persistent deep-page blocks stop pagination and keep collected jobs.
  - jobs.ch: Detect 403 and re-run via the `PROXY` residential fallback (`http://host:port:user:pass`). If `PROXY` is unset, raise a `ScraperError`. After switching to the proxy, mid-pagination 403s are treated as rate limits and skipped so partial results are preserved.

<sup>Written for commit fa4671eb91b7e19a30a6186d1978bfb64724db59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two scrapers that were silently returning 0 rows by adding anti-bot fallback paths: `builtin.py` switches to `httpcloak` on the first 403, and `jobsch.py` retries the full fetch through a residential proxy when the direct path is geo-fenced.

- **builtin.py**: An instance flag `_use_httpcloak` is flipped on the first 403 so all subsequent pages skip the wasted direct probe and use `httpcloak` for TLS fingerprint impersonation. No new dependencies are introduced.
- **jobsch.py**: A private `_BlockedError` exception bubbles a 403 up from `_fetch_page` to `_fetch_async`, which re-runs the full fetch through the Evomi proxy. When `PROXY` is unset a clear `ScraperError` is raised. The proxy URL is parsed from a 4-colon env var format into the standard credential form that httpx accepts.

<h3>Confidence Score: 3/5</h3>

The jobs.ch proxy fallback can silently fail for credentials with colons in the password, leaving the scraper returning 0 rows just as before this PR.

The proxy password colon-parsing bug in `_evomi_proxy_url_from_env` means the residential proxy fallback — the central fix for jobs.ch — silently breaks for any Evomi credential that includes a colon, which is common in auto-generated passwords. A one-character fix resolves it, but until applied the feature does not work as described.

src/jobhive/scrapers/jobsch.py — specifically `_evomi_proxy_url_from_env`

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/builtin.py | Adds httpcloak fallback on 403 via an instance-level flag; fallback has no retry logic for transient errors from httpcloak itself. |
| src/jobhive/scrapers/jobsch.py | Adds residential proxy fallback on 403; `_evomi_proxy_url_from_env` silently fails for passwords containing colons due to unbounded `split(":")`, breaking the fallback path. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/jobhive/scrapers/jobsch.py:315-316
Password containing a colon silently breaks the proxy fallback. `rest.split(":")` with no limit produces more than 4 parts when the password includes a `:` (common in auto-generated proxy credentials), so `len(parts) != 4` triggers the warning and the function returns `None` — causing `_fetch_async` to raise `ScraperError("no PROXY env var is set")` even though `PROXY` is set correctly. Using `maxsplit=3` pins the split to host/port/user/remainder, preserving colons in the password.

```suggestion
    parts = rest.split(":", 3)
    if len(parts) != 4:
```

### Issue 2 of 2
src/jobhive/scrapers/builtin.py:264-290
`_request_via_httpcloak` has no retry logic — a single transient non-200 (e.g. 429 or 5xx from httpcloak) raises `ScraperError` immediately and kills the whole fetch, while the direct path above it retries up to `MAX_RETRIES` times with backoff. If the httpcloak path hits a momentary rate-limit, the scraper fails completely rather than recovering.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["builtin + jobs.ch: fall back to httpcloa..."](https://github.com/kalil0321/ats-scrapers/commit/3f710eb2624eb18d8a338a11252fe1da29e1d43d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31466092)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->