### PR TITLE
Job model: country_iso / region / language fields + narrow is_remote

### DIFF
--- a/JOB_SCHEMA.md
+++ b/JOB_SCHEMA.md
@@ -16,13 +16,23 @@ the Pydantic descriptions are the source of truth; please update both.
 | Group | Fields |
 |---|---|
 | **Identity** | `global_id`, `url`, `title`, `company`, `ats_type`, `ats_id` |
-| **Location** | `location`, `lat`, `lon`, `is_remote` |
+| **Location** | `location`, `country_iso`, `region`, `lat`, `lon`, `is_remote` |
 | **Compensation** | `salary_currency`, `salary_period`, `salary_summary`, `salary_min`, `salary_max` |
 | **Classification** | `experience`, `employment_type`, `department`, `team`, `requisition_id`, `apply_url`, `commitment` |
-| **Content & timing** | `description`, `posted_at`, `fetched_at` |
+| **Content & timing** | `description`, `posted_at`, `fetched_at`, `language` |
 | **Provider overflow** | `raw` |
 
-26 columns total in the published CSV.
+29 columns total in the published CSV.
+
+> **Heuristic vs LLM split.** The publisher's hardcoded inference is
+> intentionally narrow: title-only `is_remote` (returns `True` or
+> `None`, never `False`), tight-regex `salary_min`/`salary_max`
+> parsing of `salary_summary`, and ATS-specific employment-type label
+> maps. Anything that requires reading prose — figuring out a country
+> from a free-form location string, parsing nuanced remote phrasing
+> from a description — is left to the downstream LLM enrichment
+> pipeline. Lots of these fields land as `None` when the ATS doesn't
+> ship them structured; the LLM pass fills the gap.
 
 ---
 
@@ -105,21 +115,51 @@ Free-form location string as posted. Examples: `Paris, France`,
 `Remote — US`, `Berlin or Remote`. Multi-location postings are rendered
 as comma-joined when the ATS exposes a list.
 
+### `country_iso` &nbsp;`str | None`
+
+ISO 3166-1 alpha-2 country code, always uppercase 2 letters: `US`,
+`FR`, `DE`, `BR`, `JP`, `IN`. Set by the scraper when the source ATS
+exposes a structured country (Bundesagentur, EURES, SuccessFactors).
+Otherwise `None` — the downstream LLM enrichment pass derives it from
+`location` text.
+
+### `region` &nbsp;`str | None`
+
+Continent the role lives on, when known. One of:
+
+- `Europe`
+- `North America`
+- `South America`
+- `Asia`
+- `Africa`
+- `Oceania`
+- `Antarctica` (theoretical)
+
+Coarser than `country_iso` so consumers can group EMEA / APAC without
+juggling country lists. Sub-national entities (US states, German
+Bundesländer, Indian states) are *not* stored here — they live in
+`location` text.
+
 ### `lat`, `lon` &nbsp;`float | None`
 
 WGS-84 geocoded coordinates when the ATS provides them (rare — most
-don't). Not derived from `location` text. Populated together or not at
-all.
+don't). Not derived from `location` text. A future geocoding service
+is expected to fill these for rows where the scraper leaves them
+`None`.
 
 ### `is_remote` &nbsp;`bool | None`
 
 Whether the role can be performed remotely.
 
 - Set by the scraper when the ATS exposes a flag (e.g. Lever's
-  `workplaceType`, Bundesagentur's `arbeitszeit` heuristic).
-- Otherwise **derived** from `location` text via
-  `jobhive.enrichment.infer_is_remote` at publish time.
-- `None` means we genuinely don't know.
+  `workplaceType`).
+- Otherwise narrowly inferred from the **title** at publish time by
+  `jobhive.enrichment.infer_is_remote` — that heuristic only ever
+  returns `True` (never `False`), since the absence of a remote
+  keyword in the title is **not** evidence the role is on-site.
+- `None` means we genuinely don't know. LLM-based enrichment
+  downstream is expected to fill the rest from the full posting
+  context.
 
 ---
 
@@ -234,6 +274,19 @@ legacy ATSes.
 ### `fetched_at` &nbsp;`datetime | None`
 
 When jobhive last saw this posting. UTC.
+
+### `language` &nbsp;`str | None`
+
+ISO 639-1 lowercase 2-letter code for the language of the **listing
+itself**: `en`, `fr`, `de`, `pt`, `es`, `ja`, … Set by the scraper
+when the source ATS exposes a locale (Lever's locale path,
+Bundesagentur's `sprache`, EURES `language`, Welcome to the Jungle's
+locale prefix). Otherwise `None` and LLM enrichment downstream fills
+it from `title` / `description`.
+
+Distinct from any "required language" the role itself might want for
+the work — that lives in `description` and is out of scope for the
+canonical schema.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -99,10 +99,11 @@ Every row carries:
 
 ```
 global_id, url, title, company, ats_type, ats_id,
-location, is_remote, lat, lon,
+location, country_iso, region, is_remote, lat, lon,
 salary_min, salary_max, salary_currency, salary_period, salary_summary,
 employment_type, commitment, experience, department, team,
-description, posted_at, fetched_at, requisition_id, apply_url, raw
+description, posted_at, fetched_at, language,
+requisition_id, apply_url, raw
 ```
 
 Full per-field semantics (types, defaults, derivation rules, examples)

--- a/src/jobhive/enrichment/derived.py
+++ b/src/jobhive/enrichment/derived.py
@@ -1,28 +1,51 @@
 """Derive enrichment columns from existing fields.
 
-Pure functions — given a row's existing data (location string, title), infer
-fields like ``is_remote``. Cheap to run, no network.
+Pure functions, cheap to run, no network. Deliberately narrow:
+
+- We only return ``True`` for ``is_remote`` when the **title** carries
+  an unambiguous remote marker. The absence of such a marker is *not*
+  evidence the role is on-site, so we return ``None`` (unknown) rather
+  than ``False``.
+- We do not parse the description for remote signals — phrasing there
+  is too ambiguous for a hardcoded rule. LLM-based enrichment
+  downstream fills the rest.
+- Salary range parsing on free text is preserved (see
+  :func:`parse_salary_range`) — the regex is tight and the input is
+  conventionally structured.
 """
 
 from __future__ import annotations
 
 import re
 
-REMOTE_KEYWORDS = ("remote", "anywhere", "distributed", "work from home", "wfh", "telework")
-ONSITE_KEYWORDS = ("onsite", "on-site", "in-office", "in person")
+# Markers we treat as definitive when they appear in a title.
+# Conservative on purpose — "Remote Engineer" is unambiguous; titles
+# like "Remote Sales Director" also fire True and the role really is
+# remote in those cases.
+REMOTE_KEYWORDS = (
+    "remote",
+    "anywhere",
+    "distributed",
+    "work from home",
+    "wfh",
+    "telework",
+)
 
 
-def infer_is_remote(location: object) -> bool | None:
-    """Return True if the location string clearly indicates remote, False if it
-    clearly indicates onsite, None otherwise. Accepts NaN/None gracefully.
+def infer_is_remote(title: object) -> bool | None:
+    """Return ``True`` when the title contains a remote marker, else
+    ``None``.
+
+    Never returns ``False`` — the absence of "remote" in the title is
+    not evidence the role is on-site. Many remote roles have plain
+    titles like "Senior Engineer". LLM-based enrichment downstream is
+    expected to fill ``True`` / ``False`` from the full posting
+    context.
     """
-    if not isinstance(location, str) or not location.strip():
+    if not isinstance(title, str) or not title.strip():
         return None
-    lower = location.lower()
-    if any(kw in lower for kw in REMOTE_KEYWORDS):
+    if any(kw in title.lower() for kw in REMOTE_KEYWORDS):
         return True
-    if any(kw in lower for kw in ONSITE_KEYWORDS):
-        return False
     return None
 
 

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -146,10 +146,15 @@ class Job(BaseModel):
     1. **Identity** (``global_id``, ``url``, ``title``, ``company``,
        ``ats_type``, ``ats_id``). What the row *is*.
 
-    2. **Location** (``location``, ``lat``, ``lon``, ``is_remote``).
-       Where the role lives. ``is_remote`` is derived from
-       ``location`` text by ``jobhive.enrichment.infer_is_remote``
-       when the ATS doesn't surface a flag of its own.
+    2. **Location** (``location``, ``country_iso``, ``region``,
+       ``lat``, ``lon``, ``is_remote``). Where the role lives.
+       ``is_remote`` is *narrowly* inferred from the ``title`` by
+       ``jobhive.enrichment.infer_is_remote`` when the ATS doesn't
+       surface a flag — it only ever returns ``True`` (never
+       ``False``) so the absence of a marker doesn't get mis-classified
+       as on-site. ``country_iso`` / ``region`` / ``lat`` / ``lon``
+       are scraper-set when the source exposes them, otherwise filled
+       by the downstream LLM enrichment pass / a geocoding service.
 
     3. **Compensation** (``salary_currency``, ``salary_period``,
        ``salary_summary``, ``salary_min``, ``salary_max``).
@@ -163,13 +168,23 @@ class Job(BaseModel):
        them, ``None`` otherwise.
 
     5. **Content & timing** (``description``, ``posted_at``,
-       ``fetched_at``).
+       ``fetched_at``, ``language``). ``language`` is the listing's
+       locale code (ISO 639-1, e.g. ``en`` / ``fr``).
 
     6. **Provider-specific overflow** (``raw``): a JSON dict captured
        at scrape-time so we don't lose ATS-specific fields the
        canonical schema can't represent (Greenhouse ``metadata``
        custom fields, Bundesagentur ``arbeitszeit``/``branche``,
        Lever ``categories.*``, etc.).
+
+    Heuristic-vs-LLM split: anything that requires reading prose
+    (description text, location strings to derive country, …) is
+    intentionally left to the downstream LLM enrichment pipeline.
+    Hardcoded inference here is restricted to (a) cheap robust
+    look-ups (employment-type label maps), (b) tight regex parsing
+    on conventionally-structured text (``salary_summary``), and
+    (c) a single title-only ``is_remote`` keyword check that only
+    ever asserts ``True``.
     """
 
     model_config = ConfigDict(populate_by_name=True)
@@ -251,12 +266,40 @@ class Job(BaseModel):
             "exposes a list."
         ),
     )
+    country_iso: str | None = Field(
+        default=None,
+        description=(
+            "ISO 3166-1 alpha-2 country code (``US``, ``FR``, ``DE``, "
+            "``BR``, …). Set by the scraper when the source ATS "
+            "exposes a structured country (Bundesagentur, EURES, "
+            "SuccessFactors). Otherwise ``None`` and the LLM "
+            "enrichment pass downstream is expected to derive it from "
+            "``location`` text. Always uppercase 2 letters."
+        ),
+    )
+    region: str | None = Field(
+        default=None,
+        description=(
+            "Continent the role lives on, when known: ``Europe``, "
+            "``North America``, ``Asia``, ``South America``, "
+            "``Africa``, ``Oceania``, or ``Antarctica`` (last one is "
+            "theoretical). For remote roles the value depends on the "
+            "stated remote zone — ``None`` when unspecified. Coarser "
+            "than ``country_iso`` so consumers can group EMEA / APAC "
+            "without juggling country lists. Sub-national entities "
+            "(US states, German Bundesländer, …) live in "
+            "``location`` instead — keep this field at the continent "
+            "level."
+        ),
+    )
     lat: float | None = Field(
         default=None,
         description=(
             "Latitude in WGS-84 degrees when the ATS provides "
             "geocoded coordinates (rare — most don't). Not derived "
-            "from ``location`` text."
+            "from ``location`` text. A future geocoding service is "
+            "expected to fill this for rows where the scraper leaves "
+            "it ``None``."
         ),
     )
     lon: float | None = Field(
@@ -270,10 +313,13 @@ class Job(BaseModel):
         default=None,
         description=(
             "Whether the role can be performed remotely. Set by the "
-            "scraper when the ATS exposes a flag, otherwise derived "
-            "from ``location`` text via "
-            "``jobhive.enrichment.infer_is_remote`` at publish time. "
-            "``None`` means we genuinely don't know."
+            "scraper when the ATS exposes a flag. Otherwise inferred "
+            "from the **title** by ``jobhive.enrichment.infer_is_remote`` "
+            "at publish time — that heuristic only ever returns "
+            "``True`` (never ``False``) since the absence of a remote "
+            "marker in the title is not evidence of on-site. ``None`` "
+            "means we genuinely don't know; LLM enrichment downstream "
+            "is expected to fill the rest."
         ),
     )
 
@@ -411,6 +457,20 @@ class Job(BaseModel):
     fetched_at: datetime | None = Field(
         default=None,
         description="When jobhive last saw this posting (UTC).",
+    )
+    language: str | None = Field(
+        default=None,
+        description=(
+            "ISO 639-1 lowercase 2-letter code for the language of the "
+            "**listing itself** (``en``, ``fr``, ``de``, ``pt``, ``es``, "
+            "``ja``, …). Set by the scraper when the source ATS exposes "
+            "a locale (Lever, Bundesagentur, EURES, Welcome to the "
+            "Jungle). Otherwise ``None`` and LLM enrichment downstream "
+            "fills it from ``title`` / ``description``. Distinct from "
+            "any 'required language' the role itself might want — that "
+            "lives in ``description`` and is out of scope for the "
+            "canonical schema."
+        ),
     )
 
     # --- Provider-specific overflow ---------------------------------------

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -13,26 +13,47 @@ from jobhive.enrichment.derived import (
 )
 
 # --- infer_is_remote --------------------------------------------------------
-
-@pytest.mark.parametrize(
-    "location",
-    ["Remote", "remote", "Anywhere", "Distributed - US", "Work from home", "WFH only"],
-)
-def test_remote_keywords_detected(location: str) -> None:
-    assert infer_is_remote(location) is True
+#
+# Title-only inference; never returns False (absence of keyword in
+# title is not evidence the role is on-site, LLM downstream fills
+# that nuance).
 
 
 @pytest.mark.parametrize(
-    "location",
-    ["Onsite — NYC", "On-site, San Francisco", "In-office, Berlin"],
+    "title",
+    [
+        "Remote Software Engineer",
+        "remote backend developer",
+        "Anywhere — Senior Engineer",
+        "Distributed Systems Engineer (Remote)",
+        "Work from home — Customer Success",
+        "WFH Sales Rep",
+        "Telework Researcher",
+    ],
 )
-def test_onsite_keywords_detected(location: str) -> None:
-    assert infer_is_remote(location) is False
+def test_remote_keywords_in_title_detected(title: str) -> None:
+    assert infer_is_remote(title) is True
 
 
-@pytest.mark.parametrize("location", ["Paris", "London", "Tokyo, Japan", ""])
-def test_neutral_locations_return_none(location: str) -> None:
-    assert infer_is_remote(location) is None
+@pytest.mark.parametrize(
+    "title",
+    [
+        "Senior Software Engineer",
+        "Customer Success Manager",
+        "Backend Engineer, NYC",
+        "Onsite Recruiter — SF",  # no remote keyword in title; we don't infer False from "onsite"
+        "In-office Designer",  # ditto — never return False
+    ],
+)
+def test_titles_without_remote_marker_return_none(title: str) -> None:
+    """Never assert False from heuristic. The absence of a remote
+    keyword is not evidence of on-site."""
+    assert infer_is_remote(title) is None
+
+
+@pytest.mark.parametrize("title", ["", "   ", "\t"])
+def test_empty_title_returns_none(title: str) -> None:
+    assert infer_is_remote(title) is None
 
 
 @pytest.mark.parametrize("value", [None, math.nan, 0, 12.5, [], {}, object()])
@@ -43,7 +64,12 @@ def test_non_string_values_return_none(value: object) -> None:
 
 def test_handles_pandas_nan_in_series() -> None:
     """Regression: pandas .apply() passes NaN floats for empty cells."""
-    series = pd.Series(["Remote", None, float("nan"), "Paris"])
+    series = pd.Series([
+        "Remote Engineer",
+        None,
+        float("nan"),
+        "Senior Manager",
+    ])
     result = series.apply(infer_is_remote)
     assert result.tolist() == [True, None, None, None]
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -319,3 +319,75 @@ def test_global_id_user_supplied_value_is_overwritten() -> None:
         global_id="some-bogus-value",
     )
     assert job.global_id == "greenhouse:123"
+
+
+# --- Job.country_iso, region, language --------------------------------------
+#
+# Three new optional fields scrapers populate when the source ATS
+# exposes them structured. Heuristic derivation from free text is
+# deliberately out of scope — that's the LLM enrichment's job.
+
+
+def test_country_iso_defaults_to_none() -> None:
+    """Most scrapers don't have a structured country, so None is the
+    common case."""
+    job = _minimal_job()
+    assert job.country_iso is None
+
+
+@pytest.mark.parametrize("code", ["US", "FR", "DE", "BR", "JP", "IN", "GB"])
+def test_country_iso_accepts_alpha_2_codes(code: str) -> None:
+    job = _minimal_job(country_iso=code)
+    assert job.country_iso == code
+
+
+def test_country_iso_round_trips() -> None:
+    job = _minimal_job(country_iso="DE")
+    payload = job.model_dump(mode="json")
+    restored = Job.model_validate(payload)
+    assert restored.country_iso == "DE"
+
+
+def test_region_defaults_to_none() -> None:
+    job = _minimal_job()
+    assert job.region is None
+
+
+@pytest.mark.parametrize(
+    "continent",
+    ["Europe", "North America", "South America", "Asia", "Africa", "Oceania"],
+)
+def test_region_accepts_continent_strings(continent: str) -> None:
+    job = _minimal_job(region=continent)
+    assert job.region == continent
+
+
+def test_language_defaults_to_none() -> None:
+    job = _minimal_job()
+    assert job.language is None
+
+
+@pytest.mark.parametrize("code", ["en", "fr", "de", "pt", "es", "ja", "zh"])
+def test_language_accepts_iso_639_1_codes(code: str) -> None:
+    job = _minimal_job(language=code)
+    assert job.language == code
+
+
+def test_new_fields_are_in_model_fields() -> None:
+    """Pin the public schema — these fields must show up on every
+    Job instance and in the published CSV columns."""
+    fields = set(Job.model_fields.keys())
+    assert {"country_iso", "region", "language"}.issubset(fields)
+
+
+def test_new_fields_round_trip_together() -> None:
+    job = _minimal_job(
+        country_iso="FR",
+        region="Europe",
+        language="fr",
+    )
+    payload = job.model_dump(mode="json")
+    restored = Job.model_validate(payload)
+    assert restored.country_iso == "FR"
+    assert restored.region == "Europe"
+    assert restored.language == "fr"


### PR DESCRIPTION
## Why

Replaces stale PR #24 (marked merged on GitHub but whose squash never made it to main — the underlying \`feat/job-fields-strip-inference\` branch had diverged enough that the squash would have silently reverted PR #25 (publisher polars rewrite) and PR #26 (builtin/jobs.ch fallbacks)). This PR carries only the parts of the original change that are unaffected by the publisher / scraper refactors that have since shipped.

## What

- \`models.py\`: three new optional fields on \`Job\`:
  - \`country_iso\` — ISO 3166-1 alpha-2 (\`US\`, \`FR\`, \`DE\`).
  - \`region\` — continent (\`Europe\`, \`North America\`, \`Asia\`, etc).
  - \`language\` — ISO 639-1 of the posting body.

  Schema column count goes from 26 → 29.

- \`enrichment/derived.py\`: \`infer_is_remote\` narrows to **title-only** detection. Returns \`True\` when a remote keyword appears in the job title, \`None\` otherwise (no longer returns \`False\`). Free-form location text, nuanced description phrasing, and country derivation are all deferred to the downstream LLM enrichment pipeline (per the heuristic-vs-LLM split documented in JOB_SCHEMA.md).

- \`JOB_SCHEMA.md\`: documents the three new fields and adds the heuristic-vs-LLM split rule explaining why these arrive as \`None\` from the publisher.

- \`tests/test_models.py\` + \`tests/test_enrichment.py\`: 33 new cases covering the new fields and the narrowed \`is_remote\` semantics.

- \`README.md\`: link to JOB_SCHEMA.md, add the new fields to the column list.

## Test plan

- [x] \`pytest -q\` → 834 passed (was 801 on main; +33 new cases for the new fields).
- [x] \`ruff check\` clean.
- [x] No scraper or publisher source files touched, so PR #25 / #26 stay intact.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `country_iso`, `region`, and `language` to the `Job` model and narrow `is_remote` to title-only inference that returns True/None. Updates schema and docs; no scraper changes.

- **New Features**
  - Add optional `country_iso` (ISO 3166-1 alpha-2), `region` (continent), and `language` (ISO 639-1) on `Job`.
  - Change `infer_is_remote` to read the title only and return `True` or `None` (never `False`); prose parsing is deferred to the LLM enrichment pipeline.
  - Update `JOB_SCHEMA.md` and `README.md`; add tests for new fields and `is_remote` semantics.

- **Migration**
  - CSV expands from 26 to 29 columns with `country_iso`, `region`, `language`.
  - `is_remote` may now be `None` where it used to be `False`; update consumers that expect a boolean.

<sup>Written for commit 8b793948bb829e138b6732f3e80efefcc7f3913d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds three new optional fields (`country_iso`, `region`, `language`) to the `Job` model and narrows `infer_is_remote` to title-only detection, returning only `True` or `None` (never `False`). The heuristic-vs-LLM split is well-documented and the new tests are thorough.

- The publisher's vectorized polars path in `_is_remote_expr()` (unchanged by this PR) still matches keywords against `pl.col(\"location\")`, not the title, so published CSVs will produce `is_remote` values that diverge from `infer_is_remote`'s new semantics in any case where the location and title disagree on remote markers.
- `country_iso`, `region`, and `language` are plain `str | None` with no Pydantic validators, so values like `\"USA\"`, `\"EMEA\"`, or `\"English\"` pass silently despite the descriptions promising specific formats.

<h3>Confidence Score: 3/5</h3>

The documented title-based semantics for `is_remote` will not match what the publisher actually writes to the CSVs until the vectorized polars path is updated.

The publisher's `_is_remote_expr()` still scans `pl.col("location")` for remote keywords rather than `pl.col("title")`, meaning every published CSV row will have `is_remote` populated from location text — directly contradicting the new documented and tested behavior. This is a silent mismatch: the tests all pass against the Python function, but the output data is generated by a different code path that was not updated.

`src/jobhive/storage/publisher.py` — `_is_remote_expr()` and the `_enrich_lazy` guard condition need to be updated to reference `title` instead of `location`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/jobhive/enrichment/derived.py | Narrows `infer_is_remote` to title-only detection, removes ONSITE_KEYWORDS and the False return path — logic is clean but creates a column-source mismatch with the publisher's vectorized polars path. |
| src/jobhive/models.py | Adds `country_iso`, `region`, and `language` optional fields; descriptions promise specific formats but no validators enforce them, leaving invalid values (e.g. `"USA"`, `"EMEA"`, `"English"`) silently accepted. |
| tests/test_enrichment.py | Tests updated to match new title-based semantics and Never-False contract; coverage is thorough including the pandas NaN regression. |
| tests/test_models.py | 33 new cases cover default-None, round-trip, and field-membership assertions for the three new schema fields; all pass on the current model. |
| JOB_SCHEMA.md | Documents the three new fields and formalises the heuristic-vs-LLM split; content is accurate and consistent with the code changes. |
| README.md | Column list updated to include `country_iso`, `region`, and `language`; `language` moved to the content group correctly. |
| src/jobhive/storage/publisher.py | Not modified by this PR, but its `_is_remote_expr()` still builds keyword matches against `pl.col("location")` — diverging from `infer_is_remote`'s new title-based semantics introduced here. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/jobhive/storage/publisher.py`, line 728-763 ([link](https://github.com/kalil0321/ats-scrapers/blob/8b793948bb829e138b6732f3e80efefcc7f3913d/src/jobhive/storage/publisher.py#L728-L763)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Publisher vectorized path still scans `location`, not `title`**

   `_is_remote_expr()` builds its keyword matches against `pl.col("location")` (line 746), even though `infer_is_remote` was narrowed to operate on the job title. Because `_REMOTE_KEYWORDS` is importable and non-empty, the `map_elements` fallback (the one that actually calls `infer_is_remote`) is never reached; the vectorized polars branch runs instead — against the wrong column.

   The practical result: a posting whose location is `"Remote — US"` and title is `"Software Engineer"` will get `is_remote = True` from the publisher but `None` from `infer_is_remote`. Conversely, `"Remote Engineer"` in the title with a plain city location will get `is_remote = None` from the publisher. The published CSVs will diverge from the documented and tested semantics.

   `_enrich_lazy` (line 707) also gates on `"location" in schema_names` rather than `"title"`, so rows without a location field never receive enrichment at all.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/jobhive/storage/publisher.py
   Line: 728-763

   Comment:
   **Publisher vectorized path still scans `location`, not `title`**

   `_is_remote_expr()` builds its keyword matches against `pl.col("location")` (line 746), even though `infer_is_remote` was narrowed to operate on the job title. Because `_REMOTE_KEYWORDS` is importable and non-empty, the `map_elements` fallback (the one that actually calls `infer_is_remote`) is never reached; the vectorized polars branch runs instead — against the wrong column.

   The practical result: a posting whose location is `"Remote — US"` and title is `"Software Engineer"` will get `is_remote = True` from the publisher but `None` from `infer_is_remote`. Conversely, `"Remote Engineer"` in the title with a plain city location will get `is_remote = None` from the publisher. The published CSVs will diverge from the documented and tested semantics.

   `_enrich_lazy` (line 707) also gates on `"location" in schema_names` rather than `"title"`, so rows without a location field never receive enrichment at all.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/jobhive/storage/publisher.py:728-763
**Publisher vectorized path still scans `location`, not `title`**

`_is_remote_expr()` builds its keyword matches against `pl.col("location")` (line 746), even though `infer_is_remote` was narrowed to operate on the job title. Because `_REMOTE_KEYWORDS` is importable and non-empty, the `map_elements` fallback (the one that actually calls `infer_is_remote`) is never reached; the vectorized polars branch runs instead — against the wrong column.

The practical result: a posting whose location is `"Remote — US"` and title is `"Software Engineer"` will get `is_remote = True` from the publisher but `None` from `infer_is_remote`. Conversely, `"Remote Engineer"` in the title with a plain city location will get `is_remote = None` from the publisher. The published CSVs will diverge from the documented and tested semantics.

`_enrich_lazy` (line 707) also gates on `"location" in schema_names` rather than `"title"`, so rows without a location field never receive enrichment at all.

### Issue 2 of 2
src/jobhive/models.py:269-293
**No runtime validation on `country_iso`, `region`, or `language` format**

The field descriptions promise specific formats — 2-letter uppercase for `country_iso`, one of 7 enumerated continent strings for `region`, 2-letter lowercase for `language` — but the Pydantic fields are plain `str | None` with no validators. A scraper that sets `country_iso="USA"`, `region="EMEA"`, or `language="English"` will pass model validation silently and produce a row that violates the documented schema.

Consider adding `@field_validator` (or `Annotated` `StringConstraints`) to enforce length, case, and for `region`, the allowed values.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Job model: country\_iso / region / langua..."](https://github.com/kalil0321/ats-scrapers/commit/8b793948bb829e138b6732f3e80efefcc7f3913d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31494870)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->