### PR TITLE
publisher: route is_remote inference through title (not location)

### DIFF
--- a/JOB_SCHEMA.md
+++ b/JOB_SCHEMA.md
@@ -327,7 +327,8 @@ a JSON string in CSV exports, native dict in parquet.
   `"32h/week"`). Display this.
 
 **`is_remote` and `salary_min/max` are sometimes derived** —
-the publisher fills them from `location` text and `salary_summary`
-when the ATS doesn't ship them structured. The CSV / parquet doesn't
-distinguish derived from source-provided values; if you need to tell
-them apart, look at the raw ATS payload via `raw`.
+the publisher fills them from `title` text (narrow, title-only) and
+`salary_summary` when the ATS doesn't ship them structured. The CSV
+/ parquet doesn't distinguish derived from source-provided values;
+if you need to tell them apart, look at the raw ATS payload via
+`raw`.

--- a/src/jobhive/enrichment/derived.py
+++ b/src/jobhive/enrichment/derived.py
@@ -22,10 +22,16 @@ import re
 # Conservative on purpose — "Remote Engineer" is unambiguous; titles
 # like "Remote Sales Director" also fire True and the role really is
 # remote in those cases.
+#
+# ``distributed`` is intentionally excluded: titles like
+# "Distributed Systems Engineer" / "Senior Engineer, Distributed
+# Storage" use the word as a technical-domain qualifier (distributed
+# computing) rather than a workforce-placement signal. The downstream
+# LLM enrichment pipeline can still classify such roles as remote
+# from the full posting context if they actually are.
 REMOTE_KEYWORDS = (
     "remote",
     "anywhere",
-    "distributed",
     "work from home",
     "wfh",
     "telework",

--- a/src/jobhive/storage/publisher.py
+++ b/src/jobhive/storage/publisher.py
@@ -61,19 +61,15 @@ from jobhive.enrichment import infer_is_remote, parse_salary_range
 from jobhive.exceptions import StorageError
 from jobhive.models import ATSType
 
-# Pull the keyword lists used by ``infer_is_remote`` so the lazy
+# Pull the keyword list used by ``infer_is_remote`` so the lazy
 # enrichment path can express the rule as vectorized polars
-# expressions. Both lists are optional — if a deploy has the narrowed
-# (title-only, True/None) variant of ``derived.py`` that ships without
-# ``ONSITE_KEYWORDS``, we still build a usable ``is_remote`` column.
+# expressions. The list is optional — if a deploy ships a stripped
+# variant of ``derived.py`` that doesn't export it, the publisher
+# falls back to the Python callback via ``map_elements``.
 try:
     from jobhive.enrichment.derived import REMOTE_KEYWORDS as _REMOTE_KEYWORDS
 except ImportError:
     _REMOTE_KEYWORDS = ()
-try:
-    from jobhive.enrichment.derived import ONSITE_KEYWORDS as _ONSITE_KEYWORDS
-except ImportError:
-    _ONSITE_KEYWORDS = ()
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -704,7 +700,7 @@ def _enrich_lazy(lf: pl.LazyFrame) -> pl.LazyFrame:
     """
     schema_names = lf.collect_schema().names()
 
-    if "location" in schema_names and "is_remote" not in schema_names:
+    if "title" in schema_names and "is_remote" not in schema_names:
         lf = lf.with_columns(_is_remote_expr().alias("is_remote"))
 
     if "salary_summary" in schema_names and "salary_min" not in schema_names:
@@ -728,38 +724,30 @@ def _enrich_lazy(lf: pl.LazyFrame) -> pl.LazyFrame:
 def _is_remote_expr() -> pl.Expr:
     """Vectorized polars version of :func:`infer_is_remote`.
 
-    Falls back to a constant ``None`` expression when the deploy lacks
-    keyword lists entirely; never raises so the publisher stays usable
-    on ``derived.py`` variants that don't export them.
+    Reads ``title`` (not ``location``) — the canonical heuristic
+    in :mod:`jobhive.enrichment.derived` is intentionally narrow and
+    only treats title-level remote markers as definitive. Free-form
+    location text is left for the downstream LLM enrichment pipeline.
+
+    Falls back to the eager ``map_elements`` callback when the deploy
+    ships a stripped variant of ``derived.py`` that doesn't export
+    ``REMOTE_KEYWORDS`` — the publisher stays usable, but that branch
+    breaks lazy streaming for the slice that needs it.
     """
-    if not _REMOTE_KEYWORDS and not _ONSITE_KEYWORDS:
-        # No keywords — every row gets None. The publisher passed
-        # ``infer_is_remote`` via ``map_elements`` in the eager path,
-        # but here we want to stay lazy. Defer to a Python callback
-        # only when neither keyword list is importable.
+    if not _REMOTE_KEYWORDS:
         return (
-            pl.col("location")
+            pl.col("title")
             .map_elements(infer_is_remote, return_dtype=pl.Boolean)
         )
 
-    loc_lower = (
-        pl.col("location").cast(pl.String, strict=False).str.to_lowercase()
+    title_lower = (
+        pl.col("title").cast(pl.String, strict=False).str.to_lowercase()
     )
     remote_match: pl.Expr = pl.lit(False)
     for kw in _REMOTE_KEYWORDS:
-        remote_match = remote_match | loc_lower.str.contains(kw, literal=True)
-    if _ONSITE_KEYWORDS:
-        onsite_match: pl.Expr = pl.lit(False)
-        for kw in _ONSITE_KEYWORDS:
-            onsite_match = onsite_match | loc_lower.str.contains(kw, literal=True)
-        return (
-            pl.when(remote_match)
-            .then(pl.lit(True))
-            .when(onsite_match)
-            .then(pl.lit(False))
-            .otherwise(None)
-        )
-    # Narrow heuristic — no onsite keywords, only True / None.
+        remote_match = remote_match | title_lower.str.contains(kw, literal=True)
+    # Narrow heuristic — never returns False; absence of a remote
+    # marker in the title is not evidence the role is on-site.
     return pl.when(remote_match).then(pl.lit(True)).otherwise(None)
 
 


### PR DESCRIPTION
## Why

Follow-up to #27 (Job model: country_iso/region/language fields + narrow is_remote). Three reviewer issues from #27 that landed before merge but went unaddressed:

- **codex P1**: \`infer_is_remote\` switched to title-only, but the publisher's vectorized \`_is_remote_expr\` still read \`pl.col(\"location\")\`. Any scraper CSV that didn't already populate \`is_remote\` got marked from free-form location text — contradicting the canonical heuristic.

- **cubic #1**: \`\"distributed\"\` is too ambiguous to live in \`REMOTE_KEYWORDS\` under a title-only contract. Common titles like \"Distributed Systems Engineer\" / \"Senior Engineer, Distributed Storage\" use the word as a technical-domain qualifier rather than a workforce signal — they shouldn't fire \`is_remote=True\`.

- **cubic #2**: The very last paragraph of \`JOB_SCHEMA.md\` still said \`is_remote\` was filled from \`location\` text — stale after the title-only switch.

## What

- \`publisher.py\`:
  - \`_enrich_lazy\` trigger flips from \`\"location\" in schema\` to \`\"title\" in schema\`.
  - \`_is_remote_expr\` reads \`pl.col(\"title\")\` instead of \`pl.col(\"location\")\`.
  - \`ONSITE_KEYWORDS\` branch removed (the canonical narrow heuristic no longer returns False).
  - The map_elements fallback also reads \`title\` now.

- \`derived.py\`: drop \`\"distributed\"\` from \`REMOTE_KEYWORDS\`. Updated the comment to explain why.

- \`JOB_SCHEMA.md\`: fix the stale closing paragraph to say \"title text\" instead of \"location text\".

## Test plan

- [x] \`pytest -q\` → 834 passed (same as #27, no test changes needed — \`test_enrichment.py\` already covers the title-only narrow heuristic and \`test_publisher.py\` is dtype-agnostic on the lazy chain).
- [x] \`ruff check\` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes `is_remote` inference through job titles instead of location to align with the title-only heuristic and avoid false positives. Drops the ambiguous `"distributed"` keyword and updates schema docs.

- **Bug Fixes**
  - `publisher.py`: `_enrich_lazy` now checks `"title"`; `_is_remote_expr` reads `title`, removes `ONSITE_KEYWORDS`, and falls back to `map_elements` if `REMOTE_KEYWORDS` is unavailable.
  - `derived.py`: removes `"distributed"` from `REMOTE_KEYWORDS` with a clarifying comment.
  - `JOB_SCHEMA.md`: updates the final paragraph to say `is_remote` is derived from title text.

<sup>Written for commit 45b2077c90e8f9ee777d7e6ccc445de652c1ec96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This follow-up PR aligns the publisher's vectorized Polars path with the title-only `is_remote` heuristic that was established in #27, closing three reviewer issues that slipped through before that merge.

- `publisher.py`: `_enrich_lazy` now triggers on `\"title\"` instead of `\"location\"`, and `_is_remote_expr` reads `pl.col(\"title\")` throughout — including the `map_elements` fallback — with the `ONSITE_KEYWORDS` import and its `when/then` branch removed entirely.
- `derived.py`: `\"distributed\"` is dropped from `REMOTE_KEYWORDS` with an explanatory comment, since it fires on technical-domain titles like \"Distributed Systems Engineer\" rather than actual remote-work signals.
- `JOB_SCHEMA.md`: closing paragraph updated to say `title` text instead of `location` text.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the three touched locations are internally consistent and the test suite covers the title-only heuristic.

All three changes are tightly scoped and mutually reinforcing: the vectorized Polars path, the Python fallback, the keyword list, and the documentation all now agree on the same title-only contract. No new edge cases are introduced; scrapers without a `title` column simply skip `is_remote` enrichment rather than populating it from unreliable location text, which is the intended design.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/storage/publisher.py | Flipped `_enrich_lazy` trigger and `_is_remote_expr` column reference from `location` to `title`; removed `ONSITE_KEYWORDS` import and its `when/then` branch — all consistent with the canonical narrow heuristic. |
| src/jobhive/enrichment/derived.py | Dropped `"distributed"` from `REMOTE_KEYWORDS` with a clear explanatory comment; no logic changes beyond that. |
| JOB_SCHEMA.md | Updated closing paragraph to say `title` text instead of `location` text, matching the current implementation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["publisher: route is\_remote inference thr..."](https://github.com/kalil0321/ats-scrapers/commit/45b2077c90e8f9ee777d7e6ccc445de652c1ec96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31495368)</sub>

<!-- /greptile_comment -->