### PR TITLE
publisher: ship all.csv alongside all.parquet

### DIFF
--- a/src/jobhive/storage/publisher.py
+++ b/src/jobhive/storage/publisher.py
@@ -3,7 +3,7 @@
 Layout produced under ``<prefix>`` (default ``jobhive/v1``):
 
     jobhive/v1/manifest.json
-    jobhive/v1/all.parquet           # full snapshot, parquet only
+    jobhive/v1/all.{csv,parquet}     # full snapshot, both formats
     jobhive/v1/<ats>/jobs.csv        # per-ATS jobs slice
     jobhive/v1/<ats>/jobs.parquet    # idem in parquet
 
@@ -81,9 +81,13 @@ logger = logging.getLogger(__name__)
 DEFAULT_PREFIX = "jobhive/v1"
 CACHE_CONTROL_LATEST = "public, max-age=300"  # manifest + latest data files
 
-# `all` is parquet-only — the CSV equivalent would be ~150 MB and there's
-# no consumer for it that wouldn't prefer parquet.
-FORMATS_ALL = ("parquet",)
+# ``all`` ships both formats — parquet for typed pandas / DuckDB
+# consumers, CSV (~2.3 GB at the current ~4M-row corpus) for
+# spreadsheet, ``grep``, and tools that don't speak parquet. The CSV
+# is built by streaming the merged parquet back through polars, so
+# the per-row data lives on disk in two places but never both in
+# RAM.
+FORMATS_ALL = ("csv", "parquet")
 FORMATS_PER_ATS = ("csv", "parquet")
 
 # Common pl.scan_csv options across every read path. ``ignore_errors``
@@ -149,7 +153,7 @@ class DatasetPublisher:
         1. Per-ATS slice ``<prefix>/<ats>/jobs.{csv,parquet}`` (raw —
            no cross-ATS dedup, so single-ATS consumers see what that
            ATS exposes).
-        2. Cross-ATS deduped global snapshot ``<prefix>/all.parquet``.
+        2. Cross-ATS deduped global snapshot ``<prefix>/all.{csv,parquet}``.
         3. Patched ``<prefix>/manifest.json`` with refreshed
            ``all`` and ``by_ats`` jobs entries; ``companies`` and
            ``by_ats_companies`` (CI-owned) are preserved untouched.
@@ -369,23 +373,25 @@ class DatasetPublisher:
     ) -> dict[str, object]:
         """Stream the global ``all.parquet`` from the per-ATS temp CSVs.
 
-        Two stages, both streaming:
+        Three stages, all streaming:
 
         1. Per-ATS — ``scan_csv`` + ``semi``-join against its
            survivor index frame, sunk to a per-ATS temp parquet via
            ``sink_parquet``. Polars's semi-join on a small RHS is
            hash-probe, so the LHS streams.
 
-        2. Merge — the per-ATS temp parquets are concatenated into the
-           global ``all.parquet`` via pyarrow's batch-iteration writer
-           with a unified schema (different ATSes can have different
-           columns; pyarrow promotes to the union and fills missing
-           with null). Peak memory in the merge is one Arrow batch
-           (~64 k rows, tens of MB), not the full corpus.
+        2. Merge parquet — the per-ATS temp parquets are concatenated
+           into the global ``all.parquet`` via polars' lazy
+           ``concat(diagonal_relaxed)`` + ``sink_parquet``, so
+           heterogeneous per-ATS schemas are unified and peak memory
+           is one Arrow batch.
+
+        3. Convert to CSV — the merged parquet is re-scanned and
+           ``sink_csv``'d for the ``all.csv`` artifact (~2.3 GB at
+           current corpus size). Polars streams batches; nothing is
+           materialized whole.
         """
         all_entry: dict[str, object] = {"rows": rows_total}
-        if "parquet" not in FORMATS_ALL or not self._write_parquet:
-            return all_entry
 
         with ExitStack() as stage_stack:
             per_ats_parquets: list[Path] = []
@@ -409,14 +415,19 @@ class DatasetPublisher:
                 )
                 per_ats_parquets.append(pq_temp)
 
-            pq_key = f"{self._prefix}/all.parquet"
-            with _temp_file(".parquet") as all_pq:
-                if per_ats_parquets:
-                    _merge_parquets_streaming(per_ats_parquets, all_pq)
-                else:
-                    pl.DataFrame(
-                        schema=dict.fromkeys(schema_union, pl.String)
-                    ).write_parquet(all_pq, compression="zstd")
+            # Build the merged parquet first — both ``all.parquet`` and
+            # ``all.csv`` (when configured) source from this file so the
+            # CSV path doesn't re-do the per-ATS semi-joins.
+            all_pq = stage_stack.enter_context(_temp_file(".parquet"))
+            if per_ats_parquets:
+                _merge_parquets_streaming(per_ats_parquets, all_pq)
+            else:
+                pl.DataFrame(
+                    schema=dict.fromkeys(schema_union, pl.String)
+                ).write_parquet(all_pq, compression="zstd")
+
+            if "parquet" in FORMATS_ALL and self._write_parquet:
+                pq_key = f"{self._prefix}/all.parquet"
                 pq_sha, pq_size = _file_sha_size(all_pq)
                 self._r2.upload(
                     all_pq,
@@ -424,11 +435,30 @@ class DatasetPublisher:
                     content_type="application/vnd.apache.parquet",
                     cache_control=CACHE_CONTROL_LATEST,
                 )
-            all_entry["parquet"] = self._public_or_key(pq_key)
-            all_entry["parquet_size_bytes"] = pq_size
-            all_entry["parquet_sha256"] = pq_sha
-            all_entry["size_bytes"] = pq_size
-            all_entry["sha256"] = pq_sha
+                all_entry["parquet"] = self._public_or_key(pq_key)
+                all_entry["parquet_size_bytes"] = pq_size
+                all_entry["parquet_sha256"] = pq_sha
+                all_entry["size_bytes"] = pq_size
+                all_entry["sha256"] = pq_sha
+
+            if "csv" in FORMATS_ALL:
+                csv_key = f"{self._prefix}/all.csv"
+                with _temp_file(".csv") as all_csv:
+                    pl.scan_parquet(all_pq).sink_csv(all_csv)
+                    csv_sha, csv_size = _file_sha_size(all_csv)
+                    self._r2.upload(
+                        all_csv,
+                        csv_key,
+                        content_type="text/csv",
+                        cache_control=CACHE_CONTROL_LATEST,
+                    )
+                all_entry["csv"] = self._public_or_key(csv_key)
+                # CSV's size + sha live in the canonical ``size_bytes``
+                # / ``sha256`` slots (consumers default-fetching the
+                # text format see the matching pair). Parquet keeps its
+                # own ``parquet_*`` fields populated above.
+                all_entry["size_bytes"] = csv_size
+                all_entry["sha256"] = csv_sha
 
         return all_entry
 

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -31,8 +31,8 @@ from jobhive.storage.publisher import (
 
 
 def test_publish_writes_per_ats_and_full_snapshot(ats_csv_dir, fake_r2) -> None:
-    """``all.parquet`` lives at the top level (parquet only); per-ATS
-    slices ship CSV+parquet under ``<ats>/jobs.{csv,parquet}``."""
+    """``all.{csv,parquet}`` live at the top level; per-ATS slices
+    ship CSV+parquet under ``<ats>/jobs.{csv,parquet}``."""
     publisher = DatasetPublisher(fake_r2, write_parquet=True)
     result = publisher.publish_from_directory(ats_csv_dir)
 
@@ -40,7 +40,7 @@ def test_publish_writes_per_ats_and_full_snapshot(ats_csv_dir, fake_r2) -> None:
     assert result.ats_count == 3
     assert "jobhive/v1/manifest.json" in fake_r2.uploads
     assert "jobhive/v1/all.parquet" in fake_r2.uploads
-    assert "jobhive/v1/all.csv" not in fake_r2.uploads  # parquet-only
+    assert "jobhive/v1/all.csv" in fake_r2.uploads
     for ats in ("greenhouse", "lever", "ashby"):
         assert f"jobhive/v1/{ats}/jobs.csv" in fake_r2.uploads
         assert f"jobhive/v1/{ats}/jobs.parquet" in fake_r2.uploads
@@ -77,9 +77,9 @@ def test_manifest_contains_expected_structure(ats_csv_dir, fake_r2) -> None:
     assert manifest["stats"]["ats_count"] == 3
     assert "greenhouse" in manifest["by_ats"]
     assert manifest["by_ats"]["greenhouse"]["rows"] == 3
-    # `all` lives at the top level now, parquet only.
+    # `all` lives at the top level now and ships both formats.
     assert manifest["all"]["parquet"].endswith("/all.parquet")
-    assert manifest["all"].get("csv") is None  # parquet-only
+    assert manifest["all"]["csv"].endswith("/all.csv")
 
 
 def test_manifest_includes_generator_string(ats_csv_dir, fake_r2) -> None:
@@ -417,8 +417,8 @@ def test_result_reports_counts_and_duration(ats_csv_dir, fake_r2) -> None:
     assert result.ats_count == 3
     assert result.duration_seconds >= 0.0
     assert result.manifest_key == "jobhive/v1/manifest.json"
-    # 3 ATS slices × 2 formats + all.parquet + manifest.json = 8 files
-    assert len(result.files) == 8
+    # 3 ATS slices × 2 formats + all.{csv,parquet} + manifest.json = 9 files
+    assert len(result.files) == 9
 
 
 # --- Cross-ATS deduplication ------------------------------------------------


### PR DESCRIPTION
## Why

The aggregate snapshot went parquet-only when PR #25 (polars publisher rewrite) landed — \`FORMATS_ALL = (\"parquet\",)\`. The homepage (and any consumer that doesn't speak parquet) had to fall back to assembling the corpus themselves from per-ATS CSVs. Restores the dual-format \`all\` artifact.

## What

\`FORMATS_ALL\` flips back to \`(\"csv\", \"parquet\")\`. Pass 3 grows a third stage:

1. Per-ATS \`sink_parquet\` after \`semi\`-join (unchanged).
2. Merge per-ATS parquets → \`all.parquet\` via polars lazy concat (unchanged).
3. **New:** \`pl.scan_parquet(merged) | sink_csv(temp_csv)\` → upload as \`all.csv\`. Polars streams batches, so peak RSS is unchanged from the parquet-only version.

The manifest's canonical \`size_bytes\` / \`sha256\` slots map to the CSV (consumers default-fetching the text format see the matching pair); \`parquet_size_bytes\` / \`parquet_sha256\` keep the parquet-side metadata.

## Test plan

- [x] \`pytest -q\` → 834 passed.
- [x] Three \`test_publisher\` assertions flipped: \`all.csv\` now expected in uploads, manifest \`all.csv\` URL set, total file count 8 → 9.
- [x] Per-ATS slices still ship both formats (already correct, untouched).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the dual-format aggregate snapshot by shipping `all.csv` alongside `all.parquet`. Non-parquet consumers can now download a single CSV without rebuilding from per-ATS slices.

- **New Features**
  - Set `FORMATS_ALL = ("csv", "parquet")`; per-ATS slices remain unchanged.
  - Added a streaming CSV stage: read the merged parquet via `pl.scan_parquet(...)` and `sink_csv(...)`; memory usage stays the same.
  - Manifest now uses CSV for `size_bytes`/`sha256`; parquet metadata lives in `parquet_size_bytes`/`parquet_sha256`.
  - Tests updated to expect `all.csv`, manifest `all.csv` URL, and 9 total files.

<sup>Written for commit cd6da8c1efb1190ab84e7cbd1a7eee9a45cb4508. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores dual-format publishing for the aggregate `all` artifact by flipping `FORMATS_ALL` back to `("csv", "parquet")` and adding a third streaming stage that converts the merged parquet to CSV via `pl.scan_parquet → sink_csv`. The approach is sound: the temp parquet is built once and shared by both the upload and the CSV conversion, so no duplicate semi-join work occurs and peak RSS stays bounded by polars' streaming batch size.

- **`FORMATS_ALL`** changes from `("parquet",)` to `("csv", "parquet")`; both formats are now uploaded at `all.{csv,parquet}`.
- **Canonical `size_bytes`/`sha256`** in the manifest's `all` entry map to the CSV (parquet values occupy dedicated `parquet_size_bytes`/`parquet_sha256` fields), with the parquet block writing the canonical slots first and the CSV block overwriting them — intentional and safe since the manifest is only serialised after both blocks complete.
- **Test suite** updates three assertions (file-count 8 → 9, `all.csv` presence, manifest CSV URL) and all 834 tests pass.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge — it restores a previously supported artifact with a minimal, self-contained implementation and full test coverage for the new behaviour.

The streaming pipeline is well-structured: the merged parquet is built once, both upload paths reference the same temp file (kept alive by the ExitStack), and the CSV conversion is correctly fenced inside its own _temp_file context so the file exists for the duration of the upload. The size_bytes/sha256 overwrite ordering is intentional and clearly documented. No logic errors, resource leaks, or edge-case gaps were identified.

No files require special attention; both changed files are straightforward.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/storage/publisher.py | Adds a streaming CSV-conversion stage in `_stream_write_all_polars`; removes the old early-return guard and replaces it with per-format `if` blocks; `all_pq` temp file lifecycle is correctly managed by the enclosing `ExitStack`. |
| tests/test_publisher.py | Three assertions flipped to expect `all.csv` in uploads, manifest CSV URL set, and file count incremented to 9; test coverage for the no-public-URL and public-URL manifest cases could be extended to also assert `manifest["all"]["csv"]`, but this is a minor gap. |

</details>

<sub>Reviews (1): Last reviewed commit: ["publisher: ship all.csv alongside all.pa..."](https://github.com/kalil0321/ats-scrapers/commit/cd6da8c1efb1190ab84e7cbd1a7eee9a45cb4508) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31496061)</sub>

<!-- /greptile_comment -->