### PR TITLE
tesla + meta: switch from Browserbase to cloakbrowser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,11 @@ scrapers = [
     # load balancer 406-blocks plain httpx (Avature, JazzHR, Eightfold).
     # 1.6.x ships fingerprint refreshes that fix recent breakages.
     "httpcloak>=1.6",
+    # Stealth-patched Chromium used by Tesla / Meta (Akamai bot manager
+    # blocks every cheaper fingerprint — httpcloak, curl_cffi, even
+    # Browserbase Sessions). cloakbrowser ships its own binary and
+    # caches under ~/.cache/cloakbrowser, no separate playwright install.
+    "cloakbrowser>=0.3",
 ]
 parquet = [
     "pyarrow>=15.0",

--- a/src/jobhive/scrapers/_cloakbrowser.py
+++ b/src/jobhive/scrapers/_cloakbrowser.py
@@ -1,0 +1,113 @@
+"""Shared helpers for ``cloakbrowser``-backed scrapers.
+
+``cloakbrowser`` is a stealth-patched Chromium fork that ships its own
+binary and bypasses every fingerprint check (Akamai, Cloudflare bot
+manager, PerimeterX, …). Drop-in Playwright API: same ``page.goto`` /
+``page.evaluate`` / ``page.mouse`` surface, just imported from
+``cloakbrowser`` instead of ``playwright``. The library auto-downloads
+the patched Chromium on first ``launch()`` and caches it under
+``~/.cache/cloakbrowser`` — no separate ``playwright install`` step.
+
+Two scrapers use cloakbrowser today:
+
+  - ``tesla.py``: Akamai is aggressive on ``tesla.com``. Even
+    Browserbase Sessions over residential proxies return 403/429.
+    cloakbrowser + ``humanize=True`` + a behavioural warm-up clears
+    the bot manager. From a datacenter IP the warm-up is still
+    rate-limited so we route through the Evomi residential proxy
+    when ``PROXY`` is set; on a residential machine ``PROXY`` is
+    typically unset and the warm-up alone suffices.
+
+  - ``meta.py``: GraphQL-driven SPA that needs a real browser to
+    issue ``fb_dtsg`` tokens. cloakbrowser handles the cookie
+    initialisation transparently; ``humanize`` is optional but
+    cheap, so we keep it on for parity with the Tesla path.
+
+Helpers below mirror the structure of :mod:`_browserbase` (which
+Avature still uses as its last-resort fallback): ``is_enabled`` /
+``require_cloakbrowser`` / ``warn_disabled`` / ``evomi_proxy_from_env``.
+The graceful degradation contract is preserved — when ``cloakbrowser``
+isn't installed, the scraper logs a warning and returns ``[]`` instead
+of crashing the publish pipeline.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from jobhive.exceptions import ScraperError
+
+log = logging.getLogger(__name__)
+
+
+def is_enabled() -> bool:
+    """Return True if cloakbrowser is importable.
+
+    Treated as the on/off switch for cloakbrowser-backed scrapers —
+    when the public library is installed without the ``scrapers``
+    extra, this returns ``False`` and the scrapers no-op.
+    """
+    try:
+        import cloakbrowser  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def require_cloakbrowser() -> None:
+    """Raise :class:`ScraperError` with a clear install hint when
+    cloakbrowser isn't available. Use after :func:`is_enabled` has
+    been checked (the caller decides whether the absence is fatal)."""
+    try:
+        import cloakbrowser  # noqa: F401
+    except ImportError as exc:
+        raise ScraperError(
+            "cloakbrowser is required for Tesla / Meta scrapers. "
+            "Install with `pip install jobhive[scrapers]`."
+        ) from exc
+
+
+def warn_disabled(scraper_name: str) -> None:
+    """Log a one-line warning the operator will see in the pipeline
+    log when a scraper is skipped because cloakbrowser is missing."""
+    log.warning(
+        "%s: browser required — install cloakbrowser "
+        "(`pip install jobhive[scrapers]`) to enable. Skipping.",
+        scraper_name,
+    )
+
+
+def evomi_proxy_from_env() -> dict[str, Any] | None:
+    """Parse the ``PROXY`` env var into the dict shape cloakbrowser /
+    Playwright accept under ``launch(proxy=...)``.
+
+    Evomi ships ``PROXY`` in the 4-colon
+    ``http://host:port:user:pass`` shape (same convention the rest of
+    the codebase uses — Tesla's old patchright path, jobs.ch). Returns
+    ``None`` when no env var is set so the caller passes it straight
+    through without a branch.
+
+    Used by Tesla on the datacenter VPS to avoid an immediate
+    rate-limit on the first ``cua-api`` call. On a residential
+    machine ``PROXY`` is typically unset and cloakbrowser warms up
+    directly.
+    """
+    raw = os.getenv("PROXY")
+    if not raw:
+        return None
+    rest = raw.replace("http://", "").replace("https://", "")
+    parts = rest.split(":")
+    if len(parts) != 4:
+        log.warning(
+            "PROXY env var doesn't match host:port:user:pass shape; "
+            "ignoring.",
+        )
+        return None
+    host, port, user, password = parts
+    return {
+        "server": f"http://{host}:{port}",
+        "username": user,
+        "password": password,
+    }

--- a/src/jobhive/scrapers/meta.py
+++ b/src/jobhive/scrapers/meta.py
@@ -1,4 +1,4 @@
-"""Meta careers scraper — Browserbase-backed.
+"""Meta careers scraper — cloakbrowser-backed.
 
 ``metacareers.com`` is a single-page React app whose listing UI is fed
 by GraphQL queries that require browser-issued tokens (``fb_dtsg`` and
@@ -6,14 +6,13 @@ friends). There's no public REST endpoint to call directly: the only
 reliable path is to load the page in a real browser and intercept the
 GraphQL responses.
 
-We use Browserbase as the remote browser host so the public library
-doesn't ship its own Chrome binary. Set ``JOBHIVE_USE_BROWSERBASE=1``
-together with ``BROWSERBASE_API_KEY`` / ``BROWSERBASE_PROJECT_ID`` to
-enable. Without the flag, this scraper logs a warning and returns
-``[]`` so a full-pipeline run keeps moving.
+``cloakbrowser`` (stealth-patched Chromium) ships its own binary and
+bypasses Meta's bot-detection without a paid browser-as-a-service.
+When the package isn't installed the scraper logs a warning and
+returns ``[]`` so the rest of the publish pipeline keeps moving.
 
 Listings only — per-job descriptions would need a second pass (one
-navigation per job) and aren't worth the Browserbase minutes for v1.
+navigation per job) and aren't worth the wall-clock for v1.
 """
 
 from __future__ import annotations
@@ -24,7 +23,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from jobhive.models import ATSType, Job
-from jobhive.scrapers import _browserbase as bb
+from jobhive.scrapers import _cloakbrowser as cb
 from jobhive.scrapers.base import BaseScraper, ScraperRegistry
 
 log = logging.getLogger(__name__)
@@ -45,25 +44,18 @@ class MetaScraper(BaseScraper):
     ats = ATSType.META
 
     def fetch(self) -> list[Job]:
-        if not bb.is_enabled():
-            bb.warn_disabled("Meta")
+        if not cb.is_enabled():
+            cb.warn_disabled("Meta")
             return []
-        # Order matters: creds is a cheap env-var check, playwright is a
-        # module import. Surface the more likely misconfig (missing
-        # creds) first.
-        api_key, project_id = bb.require_creds()
-        bb.require_playwright()
-        return asyncio.run(self._fetch_via_browserbase(api_key, project_id))
+        return asyncio.run(self._fetch_via_cloakbrowser())
 
-    async def _fetch_via_browserbase(
-        self, api_key: str, project_id: str
-    ) -> list[Job]:
-        from playwright.async_api import Response, async_playwright
+    async def _fetch_via_cloakbrowser(self) -> list[Job]:
+        from cloakbrowser import launch_async
 
-        ws_url = await bb.create_session_ws_url(api_key, project_id)
+        proxy = cb.evomi_proxy_from_env()
         captured: list[dict[str, Any]] = []
 
-        async def on_response(resp: Response) -> None:
+        async def on_response(resp: Any) -> None:
             if "graphql" not in resp.url:
                 return
             try:
@@ -74,23 +66,23 @@ class MetaScraper(BaseScraper):
                 return
             captured.append(payload)
 
-        async with async_playwright() as p:
-            browser = await p.chromium.connect_over_cdp(ws_url)
+        browser = await launch_async(
+            headless=True, humanize=True, proxy=proxy,
+        )
+        try:
+            page = await browser.new_page()
+            page.on("response", on_response)
             try:
-                ctx = browser.contexts[0]
-                page = ctx.pages[0] if ctx.pages else await ctx.new_page()
-                page.on("response", on_response)
-                try:
-                    await page.goto(
-                        _LISTING_URL,
-                        wait_until="domcontentloaded",
-                        timeout=60_000,
-                    )
-                    await page.wait_for_timeout(_GRAPHQL_SETTLE_MS)
-                except Exception as exc:
-                    log.warning("Meta: page load failed (%s)", exc)
-            finally:
-                await browser.close()
+                await page.goto(
+                    _LISTING_URL,
+                    wait_until="domcontentloaded",
+                    timeout=60_000,
+                )
+                await page.wait_for_timeout(_GRAPHQL_SETTLE_MS)
+            except Exception as exc:
+                log.warning("Meta: page load failed (%s)", exc)
+        finally:
+            await browser.close()
 
         return list(self._parse_responses(captured))
 

--- a/src/jobhive/scrapers/tesla.py
+++ b/src/jobhive/scrapers/tesla.py
@@ -1,47 +1,51 @@
-"""Tesla careers scraper — Browserbase-backed.
+"""Tesla careers scraper — cloakbrowser-backed.
 
-Tesla's public listings live behind ``/cua-api/apps/careers/state``,
-which returns the entire job catalog as one JSON document. Direct
-``httpx`` calls are 403'd by Akamai bot detection — a real browser is
-required, with cookies + JS challenges from a prior visit to
-``tesla.com``.
+Tesla's public listings live at
+``https://www.tesla.com/cua-api/apps/careers/state``, which returns
+the entire job catalog as one JSON document. Direct ``httpx`` calls
+are 403'd by Akamai bot management — TLS-impersonation libraries
+(``httpcloak``, ``curl_cffi``) and even Browserbase Sessions get
+"Access Denied" because Akamai pins the IP / TLS fingerprint /
+JavaScript challenge stack together.
 
-We use Browserbase as the remote browser host so the public library
-doesn't ship its own Chrome binary. Set ``JOBHIVE_USE_BROWSERBASE=1``
-together with ``BROWSERBASE_API_KEY`` / ``BROWSERBASE_PROJECT_ID`` to
-enable. Without the flag, this scraper logs a warning and returns
-``[]`` so a full-pipeline run keeps moving.
+``cloakbrowser`` (stealth-patched Chromium) clears the bot manager
+in our 2026-05-11 retesting. From a datacenter VPS the unproxied
+request to ``cua-api`` gets rate-limited (429) even via cloakbrowser,
+so we route the whole flow through the Evomi residential proxy when
+``PROXY`` is set. The behavioural warm-up (scroll + mouse moves +
+short waits) primes Akamai's risk-score before we touch the API.
 
-Caveat — Akamai's IP and TLS fingerprinting on ``tesla.com`` is
-aggressive: as of 2026-05, default Browserbase sessions (with or
-without their built-in residential proxies) still get an "Access
-Denied" challenge page. Until the Browserbase project is configured
-with a proxy / fingerprint that Tesla accepts, this scraper will
-raise ``ScraperError`` on the JSON parse. The code path itself is
-correct; only the network frontend needs work.
+Graceful degradation: when ``cloakbrowser`` isn't installed, the
+scraper logs a warning and returns ``[]`` so the rest of the publish
+pipeline keeps moving (per the optional-browser-fallback contract).
 """
 
 from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import re
 from datetime import UTC, datetime
 from typing import Any
 
 from jobhive.exceptions import ScraperError
 from jobhive.models import ATSType, Job
-from jobhive.scrapers import _browserbase as bb
+from jobhive.scrapers import _cloakbrowser as cb
 from jobhive.scrapers.base import BaseScraper, ScraperRegistry
 
+log = logging.getLogger(__name__)
+
 _BASE_URL = "https://www.tesla.com"
-_CAREERS_HOME = "/careers/search/jobs"
+_CAREERS_HOME = "/careers/search/"
 _STATE_ENDPOINT = "/cua-api/apps/careers/state"
 
-# Match the JSON body whether the browser wraps it in <pre>…</pre> or
-# inlines it as plain text. Both forms appear in the wild depending on
-# user-agent / accept headers.
-_PRE_RE = re.compile(r"<pre[^>]*>(.*?)</pre>", re.DOTALL)
+# Page-load waits that let Akamai's risk-score settle before the
+# ``cua-api`` call. Tuned to ~10 s total wall — long enough to look
+# human, short enough to leave headroom for cron's 02:40 budget.
+_INITIAL_SETTLE_S = 5
+_POST_SCROLL_S = 2
+_POST_MOUSE_S = 2
 
 
 @ScraperRegistry.register(ATSType.TESLA)
@@ -51,60 +55,64 @@ class TeslaScraper(BaseScraper):
     ats = ATSType.TESLA
 
     def fetch(self) -> list[Job]:
-        if not bb.is_enabled():
-            bb.warn_disabled("Tesla")
+        if not cb.is_enabled():
+            cb.warn_disabled("Tesla")
             return []
-        # Order matters: creds is a cheap env-var check, playwright is
-        # a module import. Surface the more likely misconfig (missing
-        # creds) first.
-        api_key, project_id = bb.require_creds()
-        bb.require_playwright()
-        return asyncio.run(self._fetch_via_browserbase(api_key, project_id))
+        return asyncio.run(self._fetch_via_cloakbrowser())
 
-    async def _fetch_via_browserbase(
-        self, api_key: str, project_id: str
-    ) -> list[Job]:
-        from playwright.async_api import async_playwright
+    async def _fetch_via_cloakbrowser(self) -> list[Job]:
+        from cloakbrowser import launch_async
 
-        ws_url = await bb.create_session_ws_url(api_key, project_id)
-        async with async_playwright() as p:
-            browser = await p.chromium.connect_over_cdp(ws_url)
-            try:
-                ctx = browser.contexts[0]
-                page = ctx.pages[0] if ctx.pages else await ctx.new_page()
-
-                # Warm up Akamai cookies by visiting the careers page first.
-                await page.goto(
-                    f"{_BASE_URL}{_CAREERS_HOME}",
-                    wait_until="domcontentloaded",
-                    timeout=60_000,
-                )
-
-                # Now hit the JSON endpoint — same browser context, same
-                # cookies, no bot-block.
-                await page.goto(
-                    f"{_BASE_URL}{_STATE_ENDPOINT}",
-                    wait_until="domcontentloaded",
-                    timeout=30_000,
-                )
-                payload = await self._extract_json(page)
-            finally:
-                await browser.close()
-
-        return list(self._parse_payload(payload))
-
-    @staticmethod
-    async def _extract_json(page: Any) -> dict[str, Any]:
-        html = await page.content()
-        match = _PRE_RE.search(html)
-        body = match.group(1) if match else await page.inner_text("body")
+        proxy = cb.evomi_proxy_from_env()
+        browser = await launch_async(
+            headless=True, humanize=True, proxy=proxy,
+        )
         try:
-            return json.loads(body)
+            page = await browser.new_page()
+
+            # Warm up Akamai cookies + risk-score with a real-looking
+            # visit to the careers page.
+            await page.goto(
+                f"{_BASE_URL}{_CAREERS_HOME}",
+                wait_until="domcontentloaded",
+                timeout=60_000,
+            )
+            await asyncio.sleep(_INITIAL_SETTLE_S)
+            await page.mouse.wheel(0, 500)
+            await asyncio.sleep(_POST_SCROLL_S)
+            await page.mouse.wheel(0, -300)
+            await asyncio.sleep(_POST_SCROLL_S)
+            await page.mouse.move(400, 400, steps=20)
+            await page.mouse.move(800, 600, steps=20)
+            await asyncio.sleep(_POST_MOUSE_S)
+
+            # Fetch the state endpoint from inside the page context
+            # so we keep the warm-up cookies. ``fetch`` returns the
+            # raw text — Tesla's endpoint is JSON, not the legacy
+            # ``<pre>``-wrapped form.
+            resp = await page.evaluate(
+                """async (url) => {
+                    const r = await fetch(url, {credentials: 'include'});
+                    return {status: r.status, body: await r.text()};
+                }""",
+                _STATE_ENDPOINT,
+            )
+        finally:
+            await browser.close()
+
+        if resp["status"] != 200:
+            raise ScraperError(
+                f"Tesla cua-api returned status {resp['status']} "
+                f"(body preview: {resp['body'][:200]!r})"
+            )
+        try:
+            payload = json.loads(resp["body"])
         except json.JSONDecodeError as exc:
             raise ScraperError(
-                f"Tesla: response did not parse as JSON ({exc}). "
-                "Akamai may have served a challenge page."
+                f"Tesla: response did not parse as JSON ({exc})."
             ) from exc
+
+        return list(self._parse_payload(payload))
 
     def _parse_payload(self, payload: dict[str, Any]) -> list[Job]:
         listings = payload.get("listings") or []

--- a/tests/test_cloakbrowser_helper.py
+++ b/tests/test_cloakbrowser_helper.py
@@ -1,0 +1,66 @@
+"""Unit tests for the cloakbrowser helper used by Tesla / Meta."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from jobhive.scrapers import _cloakbrowser as cb
+
+
+def test_evomi_proxy_returns_none_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PROXY", raising=False)
+    assert cb.evomi_proxy_from_env() is None
+
+
+def test_evomi_proxy_parses_4_colon_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PROXY", "http://core.evomi.com:1000:myuser:mypass")
+    assert cb.evomi_proxy_from_env() == {
+        "server": "http://core.evomi.com:1000",
+        "username": "myuser",
+        "password": "mypass",
+    }
+
+
+def test_evomi_proxy_accepts_no_scheme_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same env var without ``http://`` must still parse — the
+    library tolerates both shapes for back-compat with hand-edited
+    .env files."""
+    monkeypatch.setenv("PROXY", "host.example.com:1234:user:pwd")
+    assert cb.evomi_proxy_from_env() == {
+        "server": "http://host.example.com:1234",
+        "username": "user",
+        "password": "pwd",
+    }
+
+
+def test_evomi_proxy_returns_none_for_malformed(
+    monkeypatch: pytest.MonkeyPatch, caplog
+) -> None:
+    """Wrong number of colons → warn + return None so callers can
+    decide whether to no-op or fall back to direct."""
+    monkeypatch.setenv("PROXY", "http://just:two:parts")
+    with caplog.at_level(logging.WARNING):
+        assert cb.evomi_proxy_from_env() is None
+    assert any("doesn't match" in r.getMessage() for r in caplog.records)
+
+
+def test_warn_disabled_emits_install_hint(caplog) -> None:
+    with caplog.at_level(logging.WARNING):
+        cb.warn_disabled("TestATS")
+    assert any(
+        "TestATS" in r.getMessage() and "cloakbrowser" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_is_enabled_returns_bool() -> None:
+    """Sanity: ``is_enabled`` returns a real boolean (not raising)."""
+    assert isinstance(cb.is_enabled(), bool)

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,8 +1,9 @@
 """Tests for the Meta scraper.
 
-Scope: flag-gating + GraphQL parsing. The Browserbase / Playwright
-path is exercised with live creds out-of-band — covering it here would
-mean mocking Playwright's surface, which is more brittle than useful.
+Scope: cloakbrowser gating + GraphQL parsing. The cloakbrowser /
+Playwright path is exercised with live creds out-of-band — covering
+it here would mean mocking Playwright's surface, which is more
+brittle than useful.
 """
 
 from __future__ import annotations
@@ -11,42 +12,22 @@ import logging
 
 import pytest
 
-from jobhive.exceptions import ScraperError
 from jobhive.scrapers.meta import MetaScraper
 
 
-@pytest.fixture(autouse=True)
-def _clear_browserbase_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    for key in (
-        "JOBHIVE_USE_BROWSERBASE",
-        "JOBHIVE_DISABLE_BROWSERBASE",
-        "BROWSERBASE_API_KEY",
-        "BROWSERBASE_PROJECT_ID",
-    ):
-        monkeypatch.delenv(key, raising=False)
+def test_returns_empty_with_warning_when_cloakbrowser_missing(
+    monkeypatch: pytest.MonkeyPatch, caplog
+) -> None:
+    """When ``cloakbrowser`` isn't installed, the scraper degrades
+    gracefully — logs a warning and returns ``[]`` so a publish run
+    keeps moving."""
+    from jobhive.scrapers import _cloakbrowser
 
-
-def test_flag_off_returns_empty_with_warning(caplog) -> None:
-    """Default (no flag) skips cleanly so a full pipeline keeps moving."""
+    monkeypatch.setattr(_cloakbrowser, "is_enabled", lambda: False)
     with caplog.at_level(logging.WARNING):
         jobs = MetaScraper("meta").fetch()
     assert jobs == []
     assert any("browser required" in r.getMessage().lower() for r in caplog.records)
-
-
-def test_flag_on_without_creds_raises(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("JOBHIVE_USE_BROWSERBASE", "1")
-    with pytest.raises(ScraperError, match="BROWSERBASE_API_KEY"):
-        MetaScraper("meta").fetch()
-
-
-def test_disable_overrides_use_flag(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Kill-switch wins even when the opt-in is set, matching Avature."""
-    monkeypatch.setenv("JOBHIVE_USE_BROWSERBASE", "1")
-    monkeypatch.setenv("JOBHIVE_DISABLE_BROWSERBASE", "1")
-    monkeypatch.setenv("BROWSERBASE_API_KEY", "x")
-    monkeypatch.setenv("BROWSERBASE_PROJECT_ID", "y")
-    assert MetaScraper("meta").fetch() == []
 
 
 # --- GraphQL parsing -------------------------------------------------------

--- a/tests/test_tesla.py
+++ b/tests/test_tesla.py
@@ -1,7 +1,7 @@
 """Tests for the Tesla scraper.
 
-Scope: flag-gating + ``/cua-api/apps/careers/state`` parsing. The
-Browserbase / Playwright path is verified live, not mocked.
+Scope: cloakbrowser gating + ``/cua-api/apps/careers/state`` parsing.
+The cloakbrowser network path is verified live, not mocked.
 """
 
 from __future__ import annotations
@@ -10,32 +10,22 @@ import logging
 
 import pytest
 
-from jobhive.exceptions import ScraperError
 from jobhive.scrapers.tesla import TeslaScraper
 
 
-@pytest.fixture(autouse=True)
-def _clear_browserbase_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    for key in (
-        "JOBHIVE_USE_BROWSERBASE",
-        "JOBHIVE_DISABLE_BROWSERBASE",
-        "BROWSERBASE_API_KEY",
-        "BROWSERBASE_PROJECT_ID",
-    ):
-        monkeypatch.delenv(key, raising=False)
+def test_returns_empty_with_warning_when_cloakbrowser_missing(
+    monkeypatch: pytest.MonkeyPatch, caplog
+) -> None:
+    """When ``cloakbrowser`` isn't installed, the scraper degrades
+    gracefully — logs a warning and returns ``[]`` so a publish run
+    keeps moving (per the optional-browser-fallback contract)."""
+    from jobhive.scrapers import _cloakbrowser
 
-
-def test_flag_off_returns_empty_with_warning(caplog) -> None:
+    monkeypatch.setattr(_cloakbrowser, "is_enabled", lambda: False)
     with caplog.at_level(logging.WARNING):
         jobs = TeslaScraper("tesla").fetch()
     assert jobs == []
     assert any("browser required" in r.getMessage().lower() for r in caplog.records)
-
-
-def test_flag_on_without_creds_raises(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("JOBHIVE_USE_BROWSERBASE", "1")
-    with pytest.raises(ScraperError, match="BROWSERBASE_API_KEY"):
-        TeslaScraper("tesla").fetch()
 
 
 def test_parses_state_payload() -> None:


### PR DESCRIPTION
## Why

Akamai's bot manager on \`tesla.com\` 403's every cheaper fingerprint — direct httpx, httpcloak (TLS+h2 impersonator), curl_cffi, and (as of 2026-05) even Browserbase Sessions with their built-in residential proxy. The cron-time Tesla scrape has been returning 0 jobs since the latest Akamai update.

\`cloakbrowser\` (stealth-patched Chromium that auto-downloads its own binary on first launch) clears the bot manager in 2026-05-11 retesting. **Tesla pulls 6,086 jobs and Meta still pulls its 454** — both without a paid browser-as-a-service.

## What

- **\`tesla.py\`**: cloakbrowser \`launch_async(humanize=True)\` + a behavioural warm-up (scroll / mouse moves / sleeps) to prime Akamai's risk-score, then in-page fetch of the new \`/cua-api/apps/careers/state\` endpoint (the prior \`/cua-api/state\` path returns 404 since the careers-ui rebuild). On a datacenter VPS the warm-up alone gets rate-limited, so we route through the Evomi residential proxy when \`PROXY\` is set.

- **\`meta.py\`**: same \`launch_async(humanize=True)\` recipe, GraphQL interception unchanged. Drops the paid Browserbase session.

- **\`_cloakbrowser.py\`**: shared helpers (\`is_enabled\` / \`require_cloakbrowser\` / \`warn_disabled\` / \`evomi_proxy_from_env\`) mirroring the existing \`_browserbase\` module. Graceful degradation: when cloakbrowser isn't installed, the scrapers log a warning and return \`[]\` so the publish pipeline keeps moving.

- **\`pyproject\`** scrapers extra adds \`cloakbrowser>=0.3\`.

- **\`_browserbase.py\`** kept untouched — Avature still uses it as a last-resort fallback for the rare tenants where httpcloak also fails. Separate refactor.

## Live results

\`\`\`
=== tesla live test ===
tesla: 6086 jobs
  sample: AI Engineer, Manipulation, Optimus @ Palo Alto, California

=== meta live test ===
meta: 454 jobs
  sample: Software Engineer, Infrastructure @ Sunnyvale, CA, Bellevue, WA, ...
\`\`\`

## Test plan

- [x] \`pytest -q\` → 837 passed.
- [x] cloakbrowser gating tests replace the old \`JOBHIVE_USE_BROWSERBASE\` env-var tests.
- [x] Live VPS run of \`TeslaScraper().fetch()\` and \`MetaScraper().fetch()\` returns non-zero jobs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Tesla and Meta scrapers from Browserbase to `cloakbrowser` to bypass Akamai and restore results. Live tests: Tesla ~6,086 jobs; Meta ~454 — no paid browser service required.

- **Refactors**
  - Tesla: use `cloakbrowser.launch_async(humanize=True)`, add scroll/mouse warm-up, fetch `/cua-api/apps/careers/state` from in-page `fetch`, optional Evomi proxy via `PROXY`.
  - Meta: switch to `cloakbrowser` with the same GraphQL interception; drop Browserbase.
  - New `src/jobhive/scrapers/_cloakbrowser.py`: `is_enabled`, `require_cloakbrowser`, `warn_disabled`, `evomi_proxy_from_env`; scrapers warn and return `[]` when `cloakbrowser` is missing.
  - Keep `_browserbase.py` as-is for Avature fallback; update tests to cover the new gating.

- **Dependencies**
  - Add `cloakbrowser>=0.3` to the `scrapers` extra.

<sup>Written for commit 3e4fd7c3d25cc19045791dda09db2b52cca14aef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Migrates the Tesla and Meta scrapers off Browserbase and onto `cloakbrowser`, a stealth-patched Chromium that clears Akamai's bot manager where all cheaper fingerprint approaches (httpcloak, curl_cffi, Browserbase Sessions) now 403. A new shared `_cloakbrowser.py` helper module mirrors the existing `_browserbase` structure so the graceful-degradation contract is preserved.

- **`tesla.py`**: replaces the Browserbase/Playwright path with `launch_async(humanize=True)`, adds a behavioural warm-up (scroll + mouse moves + sleeps) to prime Akamai's risk score, then fetches the updated `/cua-api/apps/careers/state` endpoint via an in-page `fetch` call to carry warm-up cookies.
- **`meta.py`**: same `launch_async` recipe; GraphQL interception logic is unchanged, Browserbase dependency dropped.
- **`_cloakbrowser.py`**: new helper exposing `is_enabled` / `warn_disabled` / `require_cloakbrowser` / `evomi_proxy_from_env`; tests cover proxy parsing, malformed input, and the warn/is_enabled helpers.

<h3>Confidence Score: 4/5</h3>

Safe to merge; logic changes are well-scoped and the fallback contract is preserved.

The migration is clean and live results confirm it works. The one notable fragility is in `evomi_proxy_from_env`: an Evomi password containing a colon would silently fall back to no proxy, causing Tesla to get rate-limited on a datacenter VPS without a clear diagnostic. The `require_cloakbrowser` function is also dead code with no callers. Both are non-blocking but worth a follow-up before the proxy parsing bites someone.

`src/jobhive/scrapers/_cloakbrowser.py` — proxy parsing robustness and the unused `require_cloakbrowser` function.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/_cloakbrowser.py | New shared helper module mirroring `_browserbase.py`; proxy URL parsing silently drops valid proxies when the password contains a colon, and `require_cloakbrowser()` is defined but never called. |
| src/jobhive/scrapers/tesla.py | Rewrites the browser path from Browserbase/Playwright to cloakbrowser with an Akamai warm-up; `resp` is used after the try/finally block, which is safe at runtime but may trip strict static analysers. |
| src/jobhive/scrapers/meta.py | Drops Browserbase dependency and switches to cloakbrowser; GraphQL interception logic and graceful-degradation contract are unchanged. |
| tests/test_cloakbrowser_helper.py | New unit tests covering proxy parsing (with/without scheme, malformed input) and the warn/is_enabled helpers; good coverage of the happy and edge-case paths. |
| tests/test_tesla.py | Updated to monkeypatch `is_enabled` instead of relying on Browserbase env vars; old credential-error tests removed, payload-parsing tests retained. |
| tests/test_meta.py | Updated gating test patches `is_enabled` via monkeypatch; flag/credential tests removed in favour of the simpler cloakbrowser availability check. |
| pyproject.toml | Adds `cloakbrowser>=0.3` to the `scrapers` optional dependency group with an explanatory comment. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/jobhive/scrapers/_cloakbrowser.py:82-113
`evomi_proxy_from_env` silently drops a valid proxy when the password contains a colon. After stripping the scheme, the value is split on `:`, so a password like `"p:ass"` yields 5 parts, hits the `len(parts) != 4` branch, logs "doesn't match host:port:user:pass shape", and returns `None`. On a datacenter VPS this means Tesla runs without its residential proxy and gets 429'd, but the operator sees only a vague "shape" warning rather than a clear message that a colon in the password is the culprit.

### Issue 2 of 3
src/jobhive/scrapers/_cloakbrowser.py:59-69
`require_cloakbrowser` is defined but never called. Both scrapers use `is_enabled()` + early-return, so this function has no current caller. Either wire it in (e.g., raise instead of returning `[]` in stricter configurations) or remove it to avoid confusion about the intended degradation contract.

### Issue 3 of 3
src/jobhive/scrapers/tesla.py:93-113
`resp` is assigned inside the `try` block but consumed after the `try/finally`. At runtime this is safe — any exception raised before the assignment propagates through `finally` and the post-block code is never reached. However, strict static analysers (mypy with `--warn-possibly-undefined`, pylance in strict mode) will flag `resp` as possibly unbound here, which can become a friction point as the type-checking posture tightens. Moving the status check and JSON parse inside the `try` block would eliminate the concern entirely.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["tesla + meta: switch from Browserbase to..."](https://github.com/kalil0321/ats-scrapers/commit/3e4fd7c3d25cc19045791dda09db2b52cca14aef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31537714)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->