### PR TITLE
publisher: address PR #33 reviewer feedback (Lausanne, oversize test, test extras)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,11 +86,14 @@ discovery = [
 all = [
     "jobhive-py[scrapers,parquet,publish,discovery]",
 ]
-# Minimal set to run the test suite (covers httpx_mock fixtures used
-# by every scraper test). External CI / reviewers should install this
-# extra (not just ``publish``) — Kind AI flagged on PR #33 that
-# ``pytest -q`` fails out of the box otherwise.
+# Set to run the test suite cleanly. Pulls in every runtime extra
+# (``all``) so ``pytest`` can collect ``test_publisher.py`` (which
+# imports ``polars`` / ``boto3`` / ``rapidfuzz`` via the publisher
+# module). External CI / reviewers should install this extra rather
+# than ``publish`` alone — Kind AI flagged on PR #33 / #34 that the
+# minimal extras left the suite uncollectable.
 test = [
+    "jobhive-py[all]",
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "pytest-httpx>=0.30",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,10 +86,17 @@ discovery = [
 all = [
     "jobhive-py[scrapers,parquet,publish,discovery]",
 ]
-dev = [
+# Minimal set to run the test suite (covers httpx_mock fixtures used
+# by every scraper test). External CI / reviewers should install this
+# extra (not just ``publish``) — Kind AI flagged on PR #33 that
+# ``pytest -q`` fails out of the box otherwise.
+test = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "pytest-httpx>=0.30",
+]
+dev = [
+    "jobhive-py[test]",
     "ruff>=0.5",
     "mypy>=1.10",
     "pandas-stubs",

--- a/src/jobhive/storage/publisher.py
+++ b/src/jobhive/storage/publisher.py
@@ -589,6 +589,24 @@ _COUNTRY_PATTERNS: tuple[tuple[str, tuple[str, ...]], ...] = (
 # ``location`` during harvest.
 _NUTS_PREFIX_RE = re.compile(r"^\s*([a-z]{2})\s*\(", re.IGNORECASE)
 
+# Word-boundary-anchored country needle patterns. Substring matching
+# false-positived on common European place names — e.g. ``"usa"``
+# inside ``"Lausanne"`` (CH) had Lausanne jobs ending up tagged as
+# US. ``\b`` flanks every needle so the match requires non-word
+# context on each side; the multi-character needles (``"u.s.a"``,
+# ``"new zealand"``) still work because ``re.escape`` keeps the
+# internal punctuation literal.
+_COUNTRY_PATTERNS_RE: tuple[tuple[str, re.Pattern[str]], ...] = tuple(
+    (
+        code,
+        re.compile(
+            "|".join(rf"\b{re.escape(n)}\b" for n in needles),
+            re.IGNORECASE,
+        ),
+    )
+    for code, needles in _COUNTRY_PATTERNS
+)
+
 
 def _country_iso_from_location(loc: object) -> str:
     """Heuristic ISO 3166-1 alpha-2 extraction from a free-form
@@ -597,12 +615,14 @@ def _country_iso_from_location(loc: object) -> str:
     Covers the patterns observed across the duplicate-prone EU
     aggregators: full country names in DE/FR/EN, NUTS-region prefixes
     (``DE (DEA58)``), and ``"<City>, <Country>"`` suffixes.
+    Word-boundary-anchored so ``"Lausanne"`` doesn't get tagged as US
+    via a substring match on ``"usa"``.
     """
     if not isinstance(loc, str) or not loc.strip():
         return ""
     lowered = loc.strip().lower()
-    for code, needles in _COUNTRY_PATTERNS:
-        if any(n in lowered for n in needles):
+    for code, pat in _COUNTRY_PATTERNS_RE:
+        if pat.search(lowered):
             return code
     m = _NUTS_PREFIX_RE.match(loc.strip())
     if m:

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -647,58 +647,47 @@ def test_phase2_respects_priority_when_dedupping(tmp_path, fake_r2):
     assert "workday.example" in df.iloc[0]["url"]
 
 
-def test_phase2_oversize_block_skipped(tmp_path, fake_r2, caplog):
+def test_phase2_oversize_block_skipped(caplog):
     """A block with more rows than ``fuzzy_max_block_size`` must be
     skipped (rather than blowing up the wall clock with n² fuzz
-    calls); a warning is logged so the operator can investigate."""
-    eures_dir = tmp_path / "eures"
-    eures_dir.mkdir()
-    bundes_dir = tmp_path / "bundesagentur"
-    bundes_dir.mkdir()
+    calls); a warning is logged so the operator can investigate.
 
-    # 20 rows × 2 ATSes = 40-row block (> the test cap of 30 below).
-    rows_e = [{
-        "url": f"https://eures.example/{i}",
-        "title": f"Engineer {i:03d}",
-        "company": "Mega GmbH",
-        "location": "Berlin, Deutschland",
-        "ats_id": f"e{i}",
-    } for i in range(20)]
-    rows_b = [{
-        "url": f"https://arbeitsagentur.example/{i}",
-        "title": f"Engineer {i:03d}",  # identical, would normally dedup
-        "company": "Mega GmbH",
-        "location": "München, Deutschland",
-        "ats_id": f"b{i}",
-    } for i in range(20)]
-    pd.DataFrame(rows_e).to_csv(eures_dir / "jobs.csv", index=False)
-    pd.DataFrame(rows_b).to_csv(bundes_dir / "jobs.csv", index=False)
-
+    Titles are made *distinct* between the two ATS slices so Phase 1
+    (exact ``(company_norm, title_core, country)`` collapse) doesn't
+    eat the rows before Phase 2 sees them — otherwise the oversize
+    code path is never exercised.
+    """
     import polars as pl
 
     from jobhive.storage.publisher import _decide_dedup_survivors_polars
 
-    # Smaller cap forces the warning path. We test the inner function
-    # directly because the publisher's top-level call uses the default
-    # 5000 cap, which our 40-row block doesn't reach.
-
-    # Build a fake keys frame matching the harvest schema.
+    # 20 + 20 = 40-row block. Each ATS uses a different role family per
+    # row so no two rows across slices share the same ``title_core``
+    # (Phase 1 stays a no-op). The titles are still close enough that
+    # rapidfuzz's ``token_set_ratio`` would fire if Phase 2 reached
+    # them — which is exactly what the oversize guard prevents.
     keys_rows = []
-    for i, r in enumerate(rows_e):
+    for i in range(20):
         keys_rows.append({
             "_local_idx": i, "_orig_idx": i,
             "_priority": 6, "ats_type": "eures",
-            "url": r["url"], "title_raw": r["title"],
-            "title": r["title"].lower(), "company": "mega gmbh",
-            "location": r["location"].lower(), "ats_id": r["ats_id"],
+            "url": f"https://eures.example/{i}",
+            "title_raw": f"Backend Engineer Role {i:03d}",
+            "title": f"backend engineer role {i:03d}",
+            "company": "mega gmbh",
+            "location": "berlin, deutschland",
+            "ats_id": f"e{i}",
         })
-    for i, r in enumerate(rows_b):
+    for i in range(20):
         keys_rows.append({
             "_local_idx": i, "_orig_idx": 20 + i,
             "_priority": 6, "ats_type": "bundesagentur",
-            "url": r["url"], "title_raw": r["title"],
-            "title": r["title"].lower(), "company": "mega gmbh",
-            "location": r["location"].lower(), "ats_id": r["ats_id"],
+            "url": f"https://arbeitsagentur.example/{i}",
+            "title_raw": f"Senior Frontend Engineer Role {i:03d}",
+            "title": f"senior frontend engineer role {i:03d}",
+            "company": "mega gmbh",
+            "location": "münchen, deutschland",
+            "ats_id": f"b{i}",
         })
     keys = pl.DataFrame(keys_rows)
 
@@ -707,12 +696,16 @@ def test_phase2_oversize_block_skipped(tmp_path, fake_r2, caplog):
             keys, fuzzy_threshold=90, fuzzy_max_block_size=30,
         )
 
-    # Phase 1 collapses the 20 (company, title_core, country) pairs
-    # cleanly so the eures slice keeps all 20 and bundes keeps 0 here
-    # — the block never reaches Phase 2. So we trigger oversize by
-    # using a fuzzy-only test on a more degenerate block below.
-    # For this test we just assert no crash and a sane survivor count.
-    assert sum(s.height for s in survivors.values()) >= 20
+    # The warning is the contract: this block is skipped, not silently
+    # dedupped past the cap.
+    assert any(
+        "Phase-2 fuzzy" in r.getMessage() and "oversize" in r.getMessage()
+        for r in caplog.records
+    ), f"expected oversize warning in {[r.getMessage() for r in caplog.records]}"
+
+    # And the skip means nothing got dropped: all 40 rows survive
+    # (eures 20 + bundesagentur 20).
+    assert sum(s.height for s in survivors.values()) == 40
 
 
 # --- helper-function unit tests ---------------------------------------------
@@ -726,6 +719,32 @@ def test_country_iso_extracts_common_eu_patterns():
     assert f("Paris, France") == "FR"
     assert f("Wien, Österreich") == "AT"
     assert f("Brussels, Belgium") == "BE"
+
+
+def test_country_iso_uses_word_boundaries():
+    """``"usa"`` is a substring of common European place names like
+    ``"Lausanne"`` (CH). The earlier substring-match implementation
+    tagged Lausanne jobs as US — cubic #1 on PR #33. The fix
+    word-boundary-anchors every needle so the substring no longer
+    matches."""
+    from jobhive.storage.publisher import _country_iso_from_location as f
+
+    # Lausanne (CH) standalone — no country suffix. The bare city name
+    # used to false-positive on US via the ``usa`` substring; now it
+    # returns empty until something else identifies the country.
+    assert f("Lausanne") == ""
+    assert f("Lausanne (Vaud)") == ""
+    assert f("Lausanne, Vaud") == ""
+    # With the country suffix the CH match wins because CH appears
+    # before US in the patterns list.
+    assert f("Lausanne, Suisse") == "CH"
+    assert f("Lausanne, Switzerland") == "CH"
+    # Other word-fragment false positives that used to fire:
+    assert f("Glausage") == ""
+    assert f("usable") == ""
+    # Real US strings still match.
+    assert f("New York, USA") == "US"
+    assert f("U.S.A. office") == "US"
 
     # NUTS-prefix style (eures)
     assert f("DE (DEA58)") == "DE"


### PR DESCRIPTION
## Why

Three issues flagged by reviewers on PR #33 (cross-source fuzzy dedup) landed without follow-up. Fixed here.

## What

**1. cubic P2 (publisher.py): \`\"usa\"\` substring false-positive on \"Lausanne\".**
The country pattern matching was raw substring. ``"usa"`` is literally inside ``"Lausanne"`` (l-**a-u-s-a-**n-n-e), so Lausanne jobs without an explicit country suffix were classified as US instead of unknown. Cross-country fuzzy dedup would then incorrectly cluster Lausanne with Lausanne-tagged-US.

Fix: word-boundary-anchored regex. Every needle now matches as \`\\bneedle\\b\`. Multi-word patterns (``"u.s.a"``, ``"new zealand"``, etc.) still match because ``re.escape`` keeps internal punctuation literal.

**2. cubic P2 (test_publisher.py): oversize-block test never exercised the warning path.**
The fixture had 20 + 20 identical titles, so Pass 4 (Phase 1) collapsed every pair on the exact ``(company_norm, title_core, country_iso)`` key before Phase 2 fuzzy ever ran. The ``fuzzy_max_block_size=30`` cap never fired and the warning never logged.

Fix: distinct title cores between the two slices so Phase 1 stays a no-op and Phase 2 sees the full 40-row block. Assert on the actual warning message and the skip-all-rows behaviour.

**3. Kind AI Tests P1: full regression suite errored on missing \`httpx_mock\` fixture.**
The fixture lives in ``pytest-httpx``, which was only declared in the ``[dev]`` extra. Kind AI's clean env installed ``[publish]`` and the broader test suite (every scraper test imports the fixture) refused to collect.

Fix: split ``[dev]`` into ``[test]`` (just the pytest plugins) + ``[dev]`` (lint / typecheck on top of ``[test]``). External CI / reviewers can now install ``-e '.[test]'`` to run the suite without pulling the full dev toolchain.

## Test plan

- [x] Lausanne regression check: ``f(\"Lausanne\") == \"\"``, ``f(\"Lausanne, Suisse\") == \"CH\"``.
- [x] Oversize-block test now asserts the actual warning fires and survivor count == 40.
- [x] \`pytest -q\` → 845 passed (was 844).
- [x] \`ruff check\` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes country detection that misclassified “Lausanne” as US and updates the oversized fuzzy-dedup test to hit the warning path. Also updates the `test` extra so the suite collects in clean environments.

- **Bug Fixes**
  - Country detection: use word-boundary regex for needles to avoid “usa” matching inside “Lausanne”; multi-word patterns (e.g., “u.s.a”, “new zealand”) still match.
  - Oversize fuzzy block: titles are distinct across slices so Phase 1 doesn’t collapse; assert the oversize warning and keep all 40 rows.

- **Dependencies**
  - `test` extra now pulls `jobhive-py[all]` plus `pytest`, `pytest-asyncio`, `pytest-httpx` so imports like `polars`/`boto3`/`rapidfuzz` are present during collection; `dev` depends on `jobhive-py[test]`. Use `-e '.[test]'` to run the suite without the full dev toolchain.

<sup>Written for commit 032d505628dff9e114f1826ae7f40383cdaaddc0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses three issues raised in the review of PR #33: a word-boundary fix for country-pattern matching to prevent "Lausanne" from being tagged as US, a corrected oversize-block test that now actually exercises the warning path, and a `pyproject.toml` split that lets CI install just `[test]` to get `pytest-httpx` without the full dev toolchain.

- **`publisher.py`**: `_COUNTRY_PATTERNS` needles are now compiled into `_COUNTRY_PATTERNS_RE` using `\b{needle}\b` anchors via `re.escape`; `_country_iso_from_location` switches from `any(n in lowered …)` to `pat.search(lowered)`. The approach is sound — `\busa\b` cannot fire inside "lausanne" because 'a' immediately precedes 'u' with no word boundary, and multi-word / dot-punctuated patterns ("u.s.a", "new zealand") still match correctly.
- **`tests/test_publisher.py`**: The oversize test now builds the keys frame in-memory with distinct title families per ATS slice, so Phase 1 (exact-key collapse) stays a no-op and Phase 2 sees the full 40-row block, triggering the `fuzzy_max_block_size=30` guard. The new `test_country_iso_uses_word_boundaries` regression test directly validates the Lausanne fix and several other false-positive cases.
- **`pyproject.toml`**: The `[test]` / `[dev]` split is clean; `dev` explicitly depends on `jobhive-py[test]`, so nothing is accidentally dropped.

<h3>Confidence Score: 5/5</h3>

All three targeted changes are correct and well-tested; no regressions or missing edge cases found.

The regex fix is mechanically sound (word boundaries prevent the substring collision, and `re.escape` keeps internal punctuation literal so "u.s.a" and "new zealand" still resolve), the oversize test now actually reaches the guarded code path and makes a precise assertion, and the extras split is straightforward. No logic gaps or new failure modes were introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/storage/publisher.py | Introduces `_COUNTRY_PATTERNS_RE` pre-compiled with `\b`-anchored patterns, replacing the raw substring `any(n in lowered ...)` check in `_country_iso_from_location`. Fix is correct: `\busa\b` cannot match inside "lausanne" since 'a' precedes 'u' with no word boundary. |
| tests/test_publisher.py | Fixes `test_phase2_oversize_block_skipped` to use distinct title prefixes across slices so Phase 1 stays a no-op, dropping unneeded `tmp_path`/`fake_r2` fixtures; adds `test_country_iso_uses_word_boundaries` with Lausanne regression cases. Both tests are correct and cover the intended contract. |
| pyproject.toml | Splits `[dev]` into `[test]` (pytest plugins including `pytest-httpx`) and `[dev]` (lint/typecheck on top of `[test]`), allowing external CI to install just `[test]` to run the full suite without the dev toolchain. |

</details>

<sub>Reviews (1): Last reviewed commit: ["publisher: address PR #33 reviewer feedb..."](https://github.com/kalil0321/ats-scrapers/commit/a1a48e70594fd8fa9f778820d8b9bc4d3eecb60c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31540678)</sub>

<!-- /greptile_comment -->