### PR TITLE
eures: tolerate partial sub-query failures instead of cancelling the tree

### DIFF
--- a/src/jobhive/scrapers/eures.py
+++ b/src/jobhive/scrapers/eures.py
@@ -31,6 +31,7 @@ the publisher's cross-ATS dedup still works.
 from __future__ import annotations
 
 import asyncio
+import logging
 from datetime import datetime
 from typing import TYPE_CHECKING
 
@@ -42,6 +43,8 @@ from jobhive.scrapers.base import BaseScraper, ScraperRegistry
 
 if TYPE_CHECKING:
     from typing import Any
+
+log = logging.getLogger(__name__)
 
 API_URL = (
     "https://europa.eu/eures/api/jv-searchengine/public/jv-search/search"
@@ -149,7 +152,10 @@ class EuresScraper(BaseScraper):
                     depth=0, used_dims=set(),
                     absorb=absorb,
                 )
-            await asyncio.gather(*(per_country(c) for c in _COUNTRIES))
+            await _gather_tolerant(
+                (per_country(c) for c in _COUNTRIES),
+                label="country",
+            )
         return all_jobs
 
     async def _exhaust_query(
@@ -200,7 +206,10 @@ class EuresScraper(BaseScraper):
                         used_dims=used_dims | {"region"},
                         absorb=absorb,
                     )
-                await asyncio.gather(*(child_region(c) for c in children))
+                await _gather_tolerant(
+                    (child_region(c) for c in children),
+                    label="region",
+                )
                 return
 
         if "sector" not in used_dims:
@@ -217,7 +226,10 @@ class EuresScraper(BaseScraper):
                     used_dims=used_dims | {"sector"},
                     absorb=absorb,
                 )
-            await asyncio.gather(*(child_sector(c) for c in sectors))
+            await _gather_tolerant(
+                (child_sector(c) for c in sectors),
+                label="sector",
+            )
             return
 
         if "schedule" not in used_dims:
@@ -229,7 +241,10 @@ class EuresScraper(BaseScraper):
                     used_dims=used_dims | {"schedule"},
                     absorb=absorb,
                 )
-            await asyncio.gather(*(child_sched(c) for c in _SCHEDULES))
+            await _gather_tolerant(
+                (child_sched(c) for c in _SCHEDULES),
+                label="schedule",
+            )
             return
 
         # Exhausted dimensions — accept the cap loss for this slice.
@@ -255,7 +270,10 @@ class EuresScraper(BaseScraper):
             payload = await self._search(client, sem, base=base, page=page)
             await absorb(payload.get("jvs") or [])
 
-        await asyncio.gather(*(one(p) for p in range(2, page_count + 1)))
+        await _gather_tolerant(
+            (one(p) for p in range(2, page_count + 1)),
+            label="page",
+        )
 
     async def _search(
         self,
@@ -432,6 +450,27 @@ def _flatten_location(loc_map: dict[str, Any]) -> str | None:
     if regions:
         return f"{country} ({', '.join(regions[:3])})"
     return country
+
+
+async def _gather_tolerant(
+    coros: Any,
+    *,
+    label: str,
+) -> None:
+    """Run every coroutine concurrently, log + swallow failures instead
+    of cancelling siblings.
+
+    The default ``asyncio.gather`` re-raises the first exception, which
+    cancels every other pending task — one transient network blip in a
+    deep recursion (300+ sub-queries per country) used to abort the
+    whole scrape and leave the CSV at ~12 k of the ~1 M corpus
+    (observed on the 2026-05-11 cron). With this helper, a failed
+    sibling logs a warning and the rest of the tree keeps writing.
+    """
+    results = await asyncio.gather(*coros, return_exceptions=True)
+    for r in results:
+        if isinstance(r, BaseException):
+            log.warning("EURES %s subtask failed: %s", label, r)
 
 
 def _region_children_for(

--- a/tests/test_eures_gather.py
+++ b/tests/test_eures_gather.py
@@ -1,0 +1,78 @@
+"""Unit tests for the EURES partial-failure-tolerant gather helper.
+
+The 2026-05-11 cron run dropped EURES from ~1 M to 12 k rows because
+a deep-recursion sibling raised (network blip under contention) and
+``asyncio.gather`` cancelled every other task. ``_gather_tolerant``
+swaps in ``return_exceptions=True`` + a warning log so the rest of
+the tree keeps writing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from jobhive.scrapers.eures import _gather_tolerant
+
+
+@pytest.mark.asyncio
+async def test_gather_tolerant_runs_every_sibling_when_one_raises(
+    caplog,
+) -> None:
+    """Sibling tasks must complete even if one raises — the default
+    ``asyncio.gather`` would have cancelled them all."""
+    completed: list[int] = []
+
+    async def succeed(i: int) -> None:
+        await asyncio.sleep(0)
+        completed.append(i)
+
+    async def fail() -> None:
+        raise RuntimeError("transient network blip")
+
+    coros = [succeed(1), fail(), succeed(2), succeed(3)]
+
+    with caplog.at_level(logging.WARNING):
+        await _gather_tolerant(coros, label="page")
+
+    assert sorted(completed) == [1, 2, 3]
+    # And the failure surfaced as a logged warning so the operator can
+    # see how much was lost.
+    assert any(
+        "EURES page subtask failed" in r.getMessage()
+        and "transient network blip" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_gather_tolerant_no_failures_is_silent(caplog) -> None:
+    """No warning when every sibling succeeds — the helper must not
+    add noise to the happy path."""
+    async def succeed() -> None:
+        return None
+
+    with caplog.at_level(logging.WARNING):
+        await _gather_tolerant([succeed() for _ in range(5)], label="country")
+
+    assert not any(
+        "subtask failed" in r.getMessage() for r in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_gather_tolerant_label_appears_in_warning(caplog) -> None:
+    """The ``label`` argument distinguishes which recursion level the
+    failure happened at (country / region / sector / schedule / page)."""
+    async def fail() -> None:
+        raise ValueError("boom")
+
+    with caplog.at_level(logging.WARNING):
+        await _gather_tolerant([fail()], label="sector")
+
+    assert any(
+        "EURES sector subtask failed" in r.getMessage()
+        for r in caplog.records
+    )


### PR DESCRIPTION
## Why

The 2026-05-11 cron dropped EURES from ~1 M rows to **12,048** because one sibling task raised mid-recursion and the default \`asyncio.gather\` cancelled every other in-flight subtask. The scraper exited with a small partial dump that the publish then shipped as the day's EURES output.

Manually re-running the same code at 06:33 UTC produced **984,859 jobs in 86 min** — the scraper logic itself is correct, only the contention behaviour at the 01:30 UTC cron slot (running alongside wave-1 long-runners + wave-3 fasts) tripped a transient network / rate-limit blip that the gather propagated to the whole tree.

## What

Wrap every \`asyncio.gather\` call in the scraper (country / region / sector / schedule / page — 5 sites) in a new \`_gather_tolerant\` helper that passes \`return_exceptions=True\` and logs each failure with the recursion-level label. Siblings keep running; the operator sees how many subtasks dropped via the warning log.

## Test plan

- [x] \`test_eures_gather.py\` covers three contract points:
  - siblings finish when one raises (the regression we hit)
  - happy path stays silent (no spurious warnings)
  - level label appears in the warning so the operator can locate the failure in the (country, region, sector, schedule, page) tree
- [x] \`pytest -q\` → 848 passed (was 845).
- [x] \`ruff check\` clean.
- [x] Live VPS run of the *unfixed* scraper just now returned 984 859 jobs in 86 min — proves the recursion logic is sound and the fix is the right shape.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tolerate partial sub-query failures in the EURES scraper so one transient error doesn’t cancel the whole recursion. Prevents large data drops and keeps sibling tasks running with clear warning logs.

- **Bug Fixes**
  - Wrapped all `asyncio.gather` calls with `_gather_tolerant(return_exceptions=True)` across country, region, sector, schedule, and page levels.
  - Log each failed subtask with its recursion label; other subtasks continue.
  - Added `tests/test_eures_gather.py` to verify siblings complete on failure, happy path stays silent, and labels appear in warnings.

<sup>Written for commit cb38060aaa417f66bac955da57d12a5d126feaf6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the 2026-05-11 cron regression where a single transient network failure mid-recursion caused `asyncio.gather` to cancel every sibling subtask, dropping EURES output from ~1 M to ~12 k jobs. The fix is a thin `_gather_tolerant` helper that passes `return_exceptions=True` to all five `asyncio.gather` call sites and logs each failure with its recursion-level label.

- **Core change** (`eures.py`): five call sites (country / region / sector / schedule / page) are replaced with `_gather_tolerant`; siblings now run to completion regardless of a failed peer.
- **Tests** (`test_eures_gather.py`): three focused unit tests verify sibling completion on failure, silence on the happy path, and the label appearing in the warning message.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is narrow, well-tested, and directly addresses the observed regression.

The `BaseException` check in the exception loop silently swallows `asyncio.CancelledError`, which could mask deliberate shutdown signals and make the process harder to stop cleanly. The missing `exc_info` on the warning reduces operator visibility during future incidents. Neither issue affects the happy path or the regression being fixed.

The exception-handling loop in `_gather_tolerant` (lines 471-473 of `eures.py`) is the only spot worth a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/eures.py | Introduces `_gather_tolerant` to replace all five `asyncio.gather` call sites with a `return_exceptions=True` variant; the exception check uses `BaseException` instead of `Exception`, which silently swallows `CancelledError`. |
| tests/test_eures_gather.py | New unit tests cover the three stated contract points (sibling completion on failure, silent happy path, label in warning); clean and correct. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/jobhive/scrapers/eures.py:472-473
The `log.warning` call formats the exception via `%s`, which only captures `str(r)` — no traceback, no chained cause. For a production cron that silently drops jobs, the operator's only signal is the message text. `exc_info=r` tells the logging framework to attach the full stack trace to the log record, making it much easier to distinguish a transient `httpx.ConnectTimeout` from a programming error.

```suggestion
        if isinstance(r, BaseException):
            log.warning("EURES %s subtask failed: %s", label, r, exc_info=r)
```

### Issue 2 of 2
src/jobhive/scrapers/eures.py:472-473
Catching `BaseException` here also intercepts `asyncio.CancelledError` (a `BaseException` since Python 3.8) that arises inside individual child tasks — e.g. when a child coroutine explicitly cancels itself or when the event loop cancels it due to a timeout. The current code would log "EURES … subtask failed: CancelledError()" and silently continue, which can mask a deliberate shutdown signal. Using `Exception` instead narrows the check to ordinary errors and lets `CancelledError` (and `SystemExit`, `KeyboardInterrupt`) propagate naturally.

```suggestion
        if isinstance(r, Exception):
            log.warning("EURES %s subtask failed: %s", label, r)
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["eures: tolerate partial sub-query failur..."](https://github.com/kalil0321/ats-scrapers/commit/cb38060aaa417f66bac955da57d12a5d126feaf6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31558213)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->