### PR TITLE
apple: retry transient timeouts + return partial jobs on exhaustion

### DIFF
--- a/src/jobhive/scrapers/apple.py
+++ b/src/jobhive/scrapers/apple.py
@@ -10,6 +10,8 @@ The CSRF flow is held in a single httpx.Client session.
 
 from __future__ import annotations
 
+import logging
+import time
 from datetime import datetime
 from typing import TYPE_CHECKING
 
@@ -26,6 +28,10 @@ BASE_URL = "https://jobs.apple.com"
 CSRF_URL = f"{BASE_URL}/api/v1/CSRFToken"
 SEARCH_URL = f"{BASE_URL}/api/v1/search"
 PAGE_SIZE = 20
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1.0
+
+_LOG = logging.getLogger(__name__)
 
 
 @ScraperRegistry.register(ATSType.APPLE)
@@ -71,14 +77,43 @@ class AppleScraper(BaseScraper):
                         "mediumDate": "MMM D, YYYY",
                     },
                 }
-                try:
-                    response = client.post(SEARCH_URL, json=payload)
-                except httpx.HTTPError as exc:
-                    raise ScraperError(f"Apple search failed: {exc}") from exc
-                if response.status_code != 200:
+                # Apple's catalog (~5 k jobs / 250 pages) means a single
+                # mid-fetch ``ReadTimeout`` or transient 5xx must not
+                # discard the dozens of pages already accumulated. Retry
+                # transient failures with exponential backoff; if all
+                # retries are exhausted, log a warning and break out
+                # of the pagination loop, returning ``all_jobs`` so far.
+                response: httpx.Response | None = None
+                last_exc: Exception | None = None
+                last_status: int | None = None
+                for attempt in range(1, MAX_RETRIES + 1):
+                    try:
+                        r = client.post(SEARCH_URL, json=payload)
+                    except httpx.HTTPError as exc:
+                        last_exc = exc
+                        if attempt < MAX_RETRIES:
+                            time.sleep(RETRY_BASE_DELAY * (2 ** (attempt - 1)))
+                        continue
+                    if r.status_code == 200:
+                        response = r
+                        break
+                    last_status = r.status_code
+                    if r.status_code == 429 or 500 <= r.status_code < 600:
+                        if attempt < MAX_RETRIES:
+                            time.sleep(RETRY_BASE_DELAY * (2 ** (attempt - 1)))
+                        continue
                     raise ScraperError(
-                        f"Apple search returned {response.status_code}: {response.text[:120]}"
+                        f"Apple search returned {r.status_code}: {r.text[:120]}"
                     )
+                if response is None:
+                    _LOG.warning(
+                        "Apple search page %d failed after %d retries "
+                        "(last_status=%s last_exc=%s); returning %d "
+                        "partial jobs",
+                        page, MAX_RETRIES, last_status, last_exc,
+                        len(all_jobs),
+                    )
+                    break
                 data = response.json()
                 postings = (data.get("res") or {}).get("searchResults") or []
                 if not postings:

--- a/tests/test_apple.py
+++ b/tests/test_apple.py
@@ -1,0 +1,125 @@
+"""Tests for Apple scraper retry / partial-result behaviour.
+
+Apple's catalog is ~5 k jobs spread across ~250 paginated requests.
+A single mid-fetch ``httpx.ReadTimeout`` (or transient 5xx) must not
+discard the dozens of pages already accumulated — that was the
+2026-05-11 regression where the cron yielded 0 rows instead of ~5 k.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import httpx
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import AppleScraper, ScraperRegistry
+
+_CSRF_URL = "https://jobs.apple.com/api/v1/CSRFToken"
+_SEARCH_URL = "https://jobs.apple.com/api/v1/search"
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drop sleep delay so retry tests run in <1 s instead of seconds."""
+    import jobhive.scrapers.apple as m
+    monkeypatch.setattr(m, "RETRY_BASE_DELAY", 0.0)
+
+
+def _csrf_mock(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_CSRF_URL,
+        method="GET",
+        headers={"x-apple-csrf-token": "tok-123"},
+        json={},
+    )
+
+
+def _posting(req_id: str = "1", location: str = "Cupertino, California, United States") -> dict[str, Any]:
+    return {
+        "reqId": req_id,
+        "positionId": req_id,
+        "postingTitle": "Software Engineer",
+        "transformedPostingTitle": "software-engineer",
+        "jobSummary": "Build things.",
+        "team": {"teamName": "Apple", "teamCode": "APL"},
+        "postDateInGMT": "2026-05-01T10:00:00Z",
+        "standardWeeklyHours": 40,
+        "homeOffice": False,
+        "locations": [{"name": location}],
+    }
+
+
+def _envelope(postings: list[dict], total: int | None = None) -> dict:
+    return {
+        "res": {
+            "searchResults": postings,
+            "totalRecords": total if total is not None else len(postings),
+        }
+    }
+
+
+def test_registry_resolves_apple() -> None:
+    assert ScraperRegistry.get(ATSType.APPLE) is AppleScraper
+
+
+def test_transient_read_timeout_is_retried_to_success(httpx_mock) -> None:
+    """Single ReadTimeout on first attempt must not abort — retry succeeds."""
+    _csrf_mock(httpx_mock)
+    httpx_mock.add_exception(httpx.ReadTimeout("boom"), url=_SEARCH_URL)
+    httpx_mock.add_response(url=_SEARCH_URL, json=_envelope([_posting("a")], total=1))
+
+    jobs = AppleScraper("apple").fetch()
+    assert len(jobs) == 1
+    assert jobs[0].title == "Software Engineer"
+
+
+def test_5xx_is_retried_to_success(httpx_mock) -> None:
+    """Transient 503 (e.g. behind Cloudflare hiccup) must be retried."""
+    _csrf_mock(httpx_mock)
+    httpx_mock.add_response(url=_SEARCH_URL, status_code=503, text="upstream")
+    httpx_mock.add_response(url=_SEARCH_URL, json=_envelope([_posting("b")], total=1))
+
+    jobs = AppleScraper("apple").fetch()
+    assert len(jobs) == 1
+
+
+def test_retry_exhaustion_returns_partial_jobs(httpx_mock) -> None:
+    """When all retries on page N are exhausted, return what was already
+    accumulated from pages 1..N-1 instead of raising. This is the
+    central fix: previously a single late timeout wiped the whole run."""
+    _csrf_mock(httpx_mock)
+    # Page 1: succeeds, full page (PAGE_SIZE=20 postings, totalRecords
+    # tells the loop more pages exist).
+    page1 = [_posting(str(i)) for i in range(20)]
+    httpx_mock.add_response(url=_SEARCH_URL, json=_envelope(page1, total=40))
+    # Page 2: timeout three times in a row (MAX_RETRIES=3).
+    for _ in range(3):
+        httpx_mock.add_exception(httpx.ReadTimeout("page 2 down"), url=_SEARCH_URL)
+
+    jobs = AppleScraper("apple").fetch()
+    # 20 rows from page 1 survived even though page 2 never landed.
+    assert len(jobs) == 20
+
+
+def test_non_retryable_4xx_still_raises(httpx_mock) -> None:
+    """A 4xx other than 429 (e.g. 401 = stale CSRF, 400 = bad payload)
+    must surface as ScraperError — retrying won't help, and silently
+    breaking would mask an integration bug."""
+    _csrf_mock(httpx_mock)
+    httpx_mock.add_response(url=_SEARCH_URL, status_code=401, text="auth")
+
+    with pytest.raises(ScraperError, match="returned 401"):
+        AppleScraper("apple").fetch()
+
+
+def test_429_is_retried(httpx_mock) -> None:
+    _csrf_mock(httpx_mock)
+    httpx_mock.add_response(url=_SEARCH_URL, status_code=429, text="slow down")
+    httpx_mock.add_response(url=_SEARCH_URL, json=_envelope([_posting("c")], total=1))
+
+    jobs = AppleScraper("apple").fetch()
+    assert len(jobs) == 1

--- a/tests/test_apple.py
+++ b/tests/test_apple.py
@@ -8,7 +8,6 @@ discard the dozens of pages already accumulated — that was the
 
 from __future__ import annotations
 
-import re
 from typing import Any
 
 import httpx


### PR DESCRIPTION
## Summary
- Wrap the Apple search POST in a 3-attempt retry with exponential backoff (same pattern as \`EuresScraper._search\`).
- On retry exhaustion, log a warning and break the pagination loop, returning the already-accumulated \`all_jobs\` instead of raising \`ScraperError\` and dropping every page collected so far.
- Retry transient signals only: \`httpx.HTTPError\` (timeouts), \`429\`, \`5xx\`. Non-retryable \`4xx\` (e.g. \`401\` stale CSRF) still raises so integration bugs surface.

## Why
| Date | Apple result |
|---|---|
| 2026-05-09 | **5 095 jobs** ✅ |
| 2026-05-10 | **5 096 jobs** ✅ |
| 2026-05-11 | **0 jobs** (1 error in 40 s) ❌ |

Today's manual probe reproduced: ~40 s of 200-OK pages, then \`httpx.ReadTimeout\` raises \`ScraperError(\"Apple search failed: The read operation timed out\")\`, discarding ~40 pages already in \`all_jobs\`. Apple's ~250-page catalog makes a single mid-fetch timeout near-certain on a flaky day — the scraper has no per-request error budget today.

## Test plan
- [x] 6 new pytest cases in \`tests/test_apple.py\` (mocked \`httpx_mock\`):
  - \`test_transient_read_timeout_is_retried_to_success\`
  - \`test_5xx_is_retried_to_success\`
  - \`test_429_is_retried\`
  - \`test_retry_exhaustion_returns_partial_jobs\` — the central fix
  - \`test_non_retryable_4xx_still_raises\`
  - \`test_registry_resolves_apple\`
- [x] Local run: \`6 passed in 0.22s\`
- [ ] After merge: rerun apple manually on VPS and republish to R2.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Apple scraper resilient to transient timeouts and server hiccups by retrying search requests and returning partial results if retries are exhausted. This prevents runs from dropping all collected jobs after a late failure.

- **Bug Fixes**
  - Retry transient errors (`httpx.HTTPError`, `429`, `5xx`) on the search POST with 3 attempts and exponential backoff.
  - If all retries fail, log a warning and stop pagination; return the `all_jobs` collected so far.
  - Non-retryable `4xx` still raise to surface integration issues.

- **Refactors**
  - Removed unused `re` import in tests (ruff F401).

<sup>Written for commit 8912551485b924ccbac63e43ecb7dfd39a8770ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wraps the Apple search POST in a 3-attempt retry loop with exponential backoff, and changes retry exhaustion from raising `ScraperError` to logging a warning and returning already-accumulated jobs. This directly addresses the 2026-05-11 incident where a mid-fetch `ReadTimeout` across ~250 pages discarded all collected results.

- **`src/jobhive/scrapers/apple.py`**: Adds per-page retry state (`last_exc`, `last_status`, `response`) reset each iteration; retries `httpx.HTTPError`, 429, and 5xx with backoff; non-retryable 4xx still raises immediately; exhaustion breaks pagination and returns partial `all_jobs`.
- **`tests/test_apple.py`**: Six new pytest cases covering timeout retry-to-success, 5xx retry, 429 retry, exhaustion-returns-partial, non-retryable-4xx-raises, and registry resolution. `_fast_retries` fixture monkeypatches `RETRY_BASE_DELAY` to 0 so tests run quickly.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the retry logic is correct and well-tested; the only concerns are minor test maintainability issues.

The production change is solid: retry variables are scoped per page, the non-retryable 4xx fast-path is preserved, and exhaustion gracefully returns partial results. The test file has an unused import and hardcodes the value of MAX_RETRIES rather than referencing the constant, which would produce confusing pytest-httpx failures if the constant changes.

tests/test_apple.py — the exhaustion test's hardcoded range(3) should track MAX_RETRIES from the module.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/apple.py | Adds per-page exponential-backoff retry loop (MAX_RETRIES=3) for transient HTTPError, 429, and 5xx, with partial-result return on exhaustion. Logic is correct: variables are reset each page, non-retryable 4xx still raises, and the warning message captures both last_status and last_exc. |
| tests/test_apple.py | Six well-scoped pytest cases covering the new retry paths. Minor: unused `re` import; `range(3)` in the exhaustion test should reference `MAX_RETRIES` to stay in sync with the constant. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
tests/test_apple.py:99-101
The retry-exhaustion test hardcodes `range(3)` instead of using the `MAX_RETRIES` constant from the module. If `MAX_RETRIES` is later changed (e.g. to 4), the registered exception count will be mismatched: `pytest-httpx` will raise a confusing "unused response" or "no more registered exceptions" error rather than a clear test failure, making the regression hard to diagnose.

```suggestion
    # Page 2: timeout on every attempt (MAX_RETRIES times in a row).
    from jobhive.scrapers.apple import MAX_RETRIES as _MAX_RETRIES
    for _ in range(_MAX_RETRIES):
        httpx_mock.add_exception(httpx.ReadTimeout("page 2 down"), url=_SEARCH_URL)
```

### Issue 2 of 2
tests/test_apple.py:11-12
`re` is imported but never used in this file.

```suggestion
from typing import Any
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["apple test: drop unused re import (ruff ..."](https://github.com/kalil0321/ats-scrapers/commit/8912551485b924ccbac63e43ecb7dfd39a8770ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31590728)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->