### PR TITLE
apple: raise on page-1 retry exhaustion + use MAX_RETRIES constant in tests

### DIFF
--- a/src/jobhive/scrapers/apple.py
+++ b/src/jobhive/scrapers/apple.py
@@ -106,6 +106,20 @@ class AppleScraper(BaseScraper):
                         f"Apple search returned {r.status_code}: {r.text[:120]}"
                     )
                 if response is None:
+                    # When page 1 exhausts retries we have no partial
+                    # data — returning ``[]`` would silently masquerade
+                    # as a successful zero-result scrape and let cron
+                    # / downstream consumers treat an outage as
+                    # "Apple has no jobs today." Only the
+                    # partial-result fallback (page ≥ 2) is safe; for
+                    # page 1 raise so the failure surfaces as a non-
+                    # zero exit code.
+                    if not all_jobs:
+                        raise ScraperError(
+                            f"Apple search page {page} failed after "
+                            f"{MAX_RETRIES} retries (last_status="
+                            f"{last_status} last_exc={last_exc})"
+                        )
                     _LOG.warning(
                         "Apple search page %d failed after %d retries "
                         "(last_status=%s last_exc=%s); returning %d "

--- a/tests/test_apple.py
+++ b/tests/test_apple.py
@@ -16,6 +16,7 @@ import pytest
 from jobhive.exceptions import ScraperError
 from jobhive.models import ATSType
 from jobhive.scrapers import AppleScraper, ScraperRegistry
+from jobhive.scrapers.apple import MAX_RETRIES
 
 _CSRF_URL = "https://jobs.apple.com/api/v1/CSRFToken"
 _SEARCH_URL = "https://jobs.apple.com/api/v1/search"
@@ -86,22 +87,48 @@ def test_5xx_is_retried_to_success(httpx_mock) -> None:
     assert len(jobs) == 1
 
 
-def test_retry_exhaustion_returns_partial_jobs(httpx_mock) -> None:
-    """When all retries on page N are exhausted, return what was already
-    accumulated from pages 1..N-1 instead of raising. This is the
-    central fix: previously a single late timeout wiped the whole run."""
+def test_retry_exhaustion_after_partial_returns_those_jobs(httpx_mock) -> None:
+    """When all retries on page N (N≥2) are exhausted, return what was
+    already accumulated from pages 1..N-1 instead of raising. This is
+    the central fix: previously a single late timeout wiped the whole
+    run."""
     _csrf_mock(httpx_mock)
     # Page 1: succeeds, full page (PAGE_SIZE=20 postings, totalRecords
     # tells the loop more pages exist).
     page1 = [_posting(str(i)) for i in range(20)]
     httpx_mock.add_response(url=_SEARCH_URL, json=_envelope(page1, total=40))
-    # Page 2: timeout three times in a row (MAX_RETRIES=3).
-    for _ in range(3):
+    # Page 2: timeout MAX_RETRIES times in a row. Use the constant so
+    # this test does not drift if the retry budget changes.
+    for _ in range(MAX_RETRIES):
         httpx_mock.add_exception(httpx.ReadTimeout("page 2 down"), url=_SEARCH_URL)
 
     jobs = AppleScraper("apple").fetch()
     # 20 rows from page 1 survived even though page 2 never landed.
     assert len(jobs) == 20
+
+
+def test_page_1_exhaustion_raises_instead_of_masking_outage(httpx_mock) -> None:
+    """When page 1 itself fails every retry, ``all_jobs`` is empty.
+    Returning ``[]`` would let cron / downstream consumers treat a full
+    outage as "Apple has no jobs today." Raise so the failure surfaces
+    as a non-zero exit code."""
+    _csrf_mock(httpx_mock)
+    for _ in range(MAX_RETRIES):
+        httpx_mock.add_exception(httpx.ReadTimeout("apple down"), url=_SEARCH_URL)
+
+    with pytest.raises(ScraperError, match=r"page 1 failed after \d+ retries"):
+        AppleScraper("apple").fetch()
+
+
+def test_page_1_exhaustion_with_5xx_raises(httpx_mock) -> None:
+    """Same invariant via 5xx exhaustion path rather than exception
+    path — both must funnel to the same raise."""
+    _csrf_mock(httpx_mock)
+    for _ in range(MAX_RETRIES):
+        httpx_mock.add_response(url=_SEARCH_URL, status_code=503, text="upstream")
+
+    with pytest.raises(ScraperError, match=r"page 1 failed after \d+ retries"):
+        AppleScraper("apple").fetch()
 
 
 def test_non_retryable_4xx_still_raises(httpx_mock) -> None:


### PR DESCRIPTION
Follow-up to PR #38 that addresses two reviewer comments which landed before merge but were not addressed (I admin-merged on green checks alone — won't repeat).

## Codex P1 — \"Do not return an empty scrape when page 1 fails\"
[Link](https://github.com/kalil0321/ats-scrapers/pull/38#discussion_r…)

Previously, if every retry for page 1 hit a timeout / 429 / 5xx, \`fetch()\` broke out of the loop and returned \`[]\`. From cron's point of view that's indistinguishable from \"Apple has no jobs today\" and silently masks a full outage.

Now: when \`response is None\` **and** \`all_jobs\` is empty, raise \`ScraperError\` so the failure surfaces as a non-zero exit code. The partial-result fallback only kicks in for page ≥ 2 (where we have rows worth keeping).

## Greptile P2 — hardcoded \`range(3)\` in tests
[Link](https://github.com/kalil0321/ats-scrapers/pull/38#discussion_r…)

The exhaustion test had \`for _ in range(3)\` to register 3 mock exceptions. If \`MAX_RETRIES\` is bumped later, pytest-httpx would raise a confusing \"no more registered exceptions\" error rather than a clean test failure. Switched to \`from jobhive.scrapers.apple import MAX_RETRIES\` and \`range(MAX_RETRIES)\`.

## Test plan
- [x] 2 new tests cover the page-1-raise invariant:
  - \`test_page_1_exhaustion_raises_instead_of_masking_outage\` (ReadTimeout path)
  - \`test_page_1_exhaustion_with_5xx_raises\` (5xx status path)
- [x] Renamed existing exhaustion test to \`test_retry_exhaustion_after_partial_returns_those_jobs\` for clarity
- [x] Local run: \`8 passed in 0.23s\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise `ScraperError` when the Apple scraper exhausts retries on page 1 so outages don’t look like a successful empty result. Tests now use `MAX_RETRIES` and cover the new behavior.

- **Bug Fixes**
  - If page 1 fails after `MAX_RETRIES` with no accumulated jobs, raise `ScraperError`. Partial-result fallback remains only for pages ≥2.

- **Refactors**
  - Tests import `MAX_RETRIES` instead of hardcoding `range(3)` and add two cases for page-1 exhaustion (timeout and 5xx).

<sup>Written for commit b293b2112dd24adae78e0ee3970cd34d554ba30f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a focused follow-up that raises `ScraperError` when page-1 retries are fully exhausted and no jobs have been collected, preventing a silent empty-result masquerade as "no jobs today." It also replaces the hardcoded `range(3)` in the retry-exhaustion test with `range(MAX_RETRIES)` to keep the test in sync with the retry budget constant.

- **`apple.py`**: Inserts an `if not all_jobs: raise ScraperError(...)` guard just before the existing `_LOG.warning` + `break` path; the partial-result fallback is preserved for page ≥ 2, where accumulated rows are worth returning.
- **`tests/test_apple.py`**: Imports `MAX_RETRIES`, renames the partial-result test for accuracy, and adds two new tests (`ReadTimeout` path and `5xx` path) verifying the page-1 raise invariant.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is small, well-tested, and strictly improves failure visibility with no behavioural regressions.

The guard condition (not all_jobs) correctly discriminates page-1 exhaustion from later-page exhaustion because page only increments after a successful response with non-empty postings. Both failure paths (exception and 5xx) are covered by new tests whose regex matches the exact error format. The MAX_RETRIES import in tests eliminates the previously hardcoded magic number. No existing behaviour is changed for the partial-result (page ≥ 2) path.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/apple.py | Adds a guard before the partial-result fallback: raises ScraperError when page-1 retries are exhausted and all_jobs is still empty, surfacing full outages instead of silently returning [] |
| tests/test_apple.py | Imports MAX_RETRIES to eliminate magic-number drift, renames the partial-result test for clarity, and adds two new tests covering the page-1 raise path (ReadTimeout and 5xx exhaustion variants) |

</details>

<sub>Reviews (1): Last reviewed commit: ["apple: raise on page-1 retry exhaustion ..."](https://github.com/kalil0321/ats-scrapers/commit/b293b2112dd24adae78e0ee3970cd34d554ba30f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31591678)</sub>

<!-- /greptile_comment -->