### PR TITLE
[codex] Add mercor slugs and canonical URLs

### DIFF
--- a/ats-companies/mercor.csv
+++ b/ats-companies/mercor.csv
@@ -1,2 +1,2 @@
-name,url
-Mercor,https://work.mercor.com
+name,slug,url
+Mercor,mercor,https://work.mercor.com


### PR DESCRIPTION
## Summary

- Migrate `ats-companies/mercor.csv` from `name,url` to `name,slug,url`.
- Keep `slug` as the scraper/API identifier and `url` as the canonical public careers URL.

## Pipeline note

Any scraping pipeline that reads these CSVs should pass `row["slug"]` to slug-based scrapers when the column exists. `url` is now intended for public/canonical company career links and may no longer be a valid scraper input for slug-only providers.

## Validation

- CSV schema validation: `name,slug,url`, non-empty values, `https://` URLs, no whitespace in URLs.
- Sample URL check: `Mercor` -> `200` at `https://work.mercor.com`, no `/login`, `/signin`, or `/auth` final redirect.
- Full non-Phenom sample check: 25/25 providers OK.
- Scraper tests: `392 passed` with the ATS-focused pytest suite.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `slug` column to `ats-companies/mercor.csv` and set Mercor’s slug to `mercor`. `url` stays the canonical public careers page (`https://work.mercor.com`), and scrapers should read `slug` for slug-based providers.

<sup>Written for commit 11a6b50c8082c2ae0dda783c4daf184922bd144b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

