### PR TITLE
[codex] Add oracle slugs and canonical URLs

### DIFF
--- a/ats-companies/oracle.csv
+++ b/ats-companies/oracle.csv
@@ -1,557 +1,366 @@
-name,url
-ABM US,https://eiqg.fa.us2.oraclecloud.com
-ADES Global,https://epgv.fa.em3.oraclecloud.com
-ADIB Candidate Experience site,https://hciq.fa.em2.oraclecloud.com
-ADNIC Career Portal,https://eoro.fa.em8.oraclecloud.com
-AEO,https://hcml.fa.us2.oraclecloud.com
-AFW,https://ejqy.fa.us6.oraclecloud.com
-AICC External Site,https://iaarkf.fa.ocs.oraclecloud.com
-AL Gihaz Holding,https://efva.fa.em3.oraclecloud.com
-APP Recruitment,https://eify.fa.us6.oraclecloud.com
-AWR Career Site,https://iacpey.fa.ocs.oraclecloud.com
-Abdulla-Fouad Career Site Minimal,https://hdgp.fa.em3.oraclecloud.com
-Abt Global,https://egpy.fa.us2.oraclecloud.com
-Abu Dhabi Airports,https://hcts.fa.em2.oraclecloud.com
-Adani Career Site,https://eibd.fa.em2.oraclecloud.com
-Adventist Health,https://ecvz.fa.us2.oraclecloud.com
-Al Ghurair,https://iaaxey.fa.ocs.oraclecloud.com
-Al Moosa Career Portal,https://edns.fa.em2.oraclecloud.com
-Al-Othman Holding Company,https://eknh.fa.em2.oraclecloud.com
-Albertsons Companies,https://eofd.fa.us6.oraclecloud.com
-Allegheny Intermediate Unit Career Site,https://einj.fa.us6.oraclecloud.com
-American Bureau of Shipping Career Site,https://hbbq.fa.us2.oraclecloud.com
-American Tower Global,https://hdsn.fa.us6.oraclecloud.com
-Anywhere,https://ibmqjb.fa.ocs.oraclecloud.com
-Apollo Hospitals,https://cgs.fa.ap2.oraclecloud.com
-Apparel Career Site,https://ediu.fa.em2.oraclecloud.com
-Arcadis,https://ebcs.fa.em2.oraclecloud.com
-ArcelorMittal,https://emfg.fa.em4.oraclecloud.com
-Arconic,https://hdnn.fa.us6.oraclecloud.com
-Arcor Global,https://emqm.fa.us6.oraclecloud.com
-Aspire Zone Candidate Experience site,https://eipb.fa.em2.oraclecloud.com
-Aster DM Healthcare,https://hcdt.fa.us2.oraclecloud.com
-At Home,https://hdiy.fa.us2.oraclecloud.com
-BCBSM Career Section,https://ejko.fa.us2.oraclecloud.com
-BDO USA Experienced Career Site,https://ebqb.fa.us2.oraclecloud.com
-BE Careers,https://iadygs.fa.ocs.oraclecloud.com
-BNY External Career Site,https://eofe.fa.us2.oraclecloud.com
-BSC,https://ecge.fa.us2.oraclecloud.com
-Badger,https://ejlj.fa.us2.oraclecloud.com
-Bank Negara Malaysia - Professional Career Site,https://iaartj.fa.ocs.oraclecloud.com
-Barrick Mining Corporation,https://ehkn.fa.ca2.oraclecloud.com
-Baylor Careers,https://ejof.fa.us2.oraclecloud.com
-Black Box Careers,https://eoje.fa.us2.oraclecloud.com
-Brazos County Career Site,https://ekzl.fa.us2.oraclecloud.com
-Bristlecone,https://iaagiz.fa.ocs.oraclecloud.com
-Brookdale Senior Living Inc.,https://ibmwjb.fa.ocs.oraclecloud.com
-CECONY Career Site,https://ejcu.fa.us6.oraclecloud.com
-CIMB Group Malaysia,https://ejox.fa.ap1.oraclecloud.com
-CLP,https://iabhtj.fa.ocs.oraclecloud.com
-CORSAIR,https://edix.fa.us2.oraclecloud.com
-COTTON ON Careers,https://ekxm.fa.ap1.oraclecloud.com
-CRS,https://eipn.fa.us2.oraclecloud.com
-CSC,https://hczw.fa.us2.oraclecloud.com
-"CTB, Inc.",https://emsl.fa.us2.oraclecloud.com
-Caesars Entertainment,https://edmn.fa.us2.oraclecloud.com
-Calderys Career Opportunities,https://egmk.fa.us6.oraclecloud.com
-Camden,https://ehap.fa.us2.oraclecloud.com
-Candidate Experience Site - Campus,https://hdpc.fa.us2.oraclecloud.com
-Canon,https://ejqe.fa.em2.oraclecloud.com
-Cantor Fitzgerald/BGC,https://hdow.fa.us6.oraclecloud.com
-Career Site,https://iaceiz.fa.ocs.oraclecloud.com
-Careers at Atlantic Health System,https://erqh.fa.us2.oraclecloud.com
-Careers at CBIZ,https://ebez.fa.us2.oraclecloud.com
-Careers at Heathrow,https://encd.fa.em3.oraclecloud.com
-Careers at Marriott,https://ejwl.fa.us2.oraclecloud.com
-Careers | BXP,https://edxn.fa.us2.oraclecloud.com
-Careers|CURIA,https://hcug.fa.us2.oraclecloud.com
-Carnival Corporation,https://eicl.fa.em5.oraclecloud.com
-Carrington,https://emvo.fa.us2.oraclecloud.com
-Cbzp,https://cbzp.fa.ap1.oraclecloud.com
-Cedars-Sinai,https://hdkk.fa.us6.oraclecloud.com
-Centrus Global Career Site,https://eese.fa.us8.oraclecloud.com
-Cherokee Federal,https://ibtcjb.fa.ocs.oraclecloud.com
-Cherokee Nation Businesses Corporate,https://ejvp.fa.us2.oraclecloud.com
-Choctaw Nation of Oklahoma,https://egoh.fa.us2.oraclecloud.com
-Church,https://epej.fa.us2.oraclecloud.com
-Citizens,https://eeab.fa.us2.oraclecloud.com
-City Of Atlanta,https://ehxr.fa.us2.oraclecloud.com
-Clean Harbors External Career Site,https://epyc.fa.us2.oraclecloud.com
-ClubCorp,https://ecwl.fa.us2.oraclecloud.com
-Coherent Corp. US,https://hcwp.fa.us2.oraclecloud.com
-Cohu Careers,https://hcbo.fa.us2.oraclecloud.com
-Conduent,https://egua.fa.us2.oraclecloud.com
-CooperCompanies,https://hcjy.fa.us2.oraclecloud.com
-Corporate Careers | Trueblue,https://ehnn.fa.us2.oraclecloud.com
-Cottage Health,https://eglz.fa.us2.oraclecloud.com
-Cummins Arabia External Career Site,https://hdjd.fa.em3.oraclecloud.com
-Cytel,https://iblyjb.fa.ocs.oraclecloud.com
-DAMAC,https://ejwe.fa.em2.oraclecloud.com
-DC Water Candidate Experience site,https://elxb.fa.us2.oraclecloud.com
-DLL Group,https://iabcbn.fa.ocs.oraclecloud.com
-DNV careers,https://ecyq.fa.em2.oraclecloud.com
-DP World,https://ehpv.fa.em2.oraclecloud.com
-DTCC Candidate Experience Site,https://ebxr.fa.us2.oraclecloud.com
-DTU Career Site,https://efzu.fa.em2.oraclecloud.com
-Dallah Recruitment System,https://eniy.fa.em3.oraclecloud.com
-Datavail Career Site,https://eifn.fa.us6.oraclecloud.com
-Deplerp Iabkcp Test,https://deplerp iabkcp test
-Diebold Nixdorf,https://eeug.fa.us6.oraclecloud.com
-Digital Realty Global,https://hdep.fa.us2.oraclecloud.com
-Dubai Holding,https://esbe.fa.em8.oraclecloud.com
-Dubai World Trade Centre -,https://bun.fa.em2.oraclecloud.com
-ELCA Global Career site,https://iaaras.fa.ocs.oraclecloud.com
-EMAAR,https://emhm.fa.em2.oraclecloud.com
-EMSS,https://eism.fa.em2.oraclecloud.com
-EMkan,https://iafckf.fa.ocs.oraclecloud.com
-ESEC Experience site,https://ebfi.fa.em2.oraclecloud.com
-ESF Career Site-External,https://eoix.fa.ap1.oraclecloud.com
-EXP,https://elcn.fa.us2.oraclecloud.com
-Eccd,https://eccd.fa.em2.oraclecloud.com
-Ecnf,https://ecnf.fa.us2.oraclecloud.com
-Ecwr,https://ecwr.fa.us2.oraclecloud.com
-Edel,https://edel.fa.us2.oraclecloud.com
-Edyo,https://edyo.fa.us2.oraclecloud.com
-Eega,https://eega.fa.ap1.oraclecloud.com
-Eexi,https://eexi.fa.em3.oraclecloud.com
-Efoa,https://efoa.fa.us6.oraclecloud.com
-Egge,https://egge.fa.ap1.oraclecloud.com
-Egpa,https://egpa.fa.em3.oraclecloud.com
-Egrh,https://egrh.fa.ap1.oraclecloud.com
-Ehfo,https://ehfo.fa.em2.oraclecloud.com
-Eiek,https://eiek.fa.em2.oraclecloud.com
-Eigf,https://eigf.fa.us8.oraclecloud.com
-Eigu,https://eigu.fa.em2.oraclecloud.com
-Eijc,https://eijc.fa.em2.oraclecloud.com
-Eims,https://eims.fa.us2.oraclecloud.com
-Eisq,https://eisq.fa.us6.oraclecloud.com
-Ejbr,https://ejbr.fa.us6.oraclecloud.com
-Ejep,https://ejep.fa.us2.oraclecloud.com
-Ejis,https://ejis.fa.us6.oraclecloud.com
-Ejov,https://ejov.fa.ca2.oraclecloud.com
-Ejyf,https://ejyf.fa.us2.oraclecloud.com
-Ekcm,https://ekcm.fa.us6.oraclecloud.com
-Ekcn,https://ekcn.fa.us6.oraclecloud.com
-Ekkt,https://ekkt.fa.us2.oraclecloud.com
-Ekxv,https://ekxv.fa.ap1.oraclecloud.com
-Elaj,https://elaj.fa.us2.oraclecloud.com
-Elhr,https://elhr.fa.us2.oraclecloud.com
-Eloc,https://eloc.fa.em3.oraclecloud.com
-Emerson Career Site,https://hdjq.fa.us2.oraclecloud.com
-Emirates Healthcare,https://hcbh.fa.em2.oraclecloud.com
-England Rugby,https://ecer.fa.em2.oraclecloud.com
-Enxa,https://enxa.fa.em8.oraclecloud.com
-Eohs,https://eohs.fa.ap2.oraclecloud.com
-Equity Residential,https://hcjm.fa.us2.oraclecloud.com
-Erey,https://erey.fa.em3.oraclecloud.com
-Etihadrail Iaalbv,https://etihadrail iaalbv
-Euroclear,https://don.fa.em2.oraclecloud.com
-Ewrh Dev1,https://ewrh dev1
-Explore RH Careers,https://hcqq.fa.us2.oraclecloud.com
-External Site,https://ekez.fa.em2.oraclecloud.com
-FAB |,https://ehjd.fa.em2.oraclecloud.com
-Fa Efds Dev16 Saasfaprod1,https://fa efds dev16 saasfaprod1
-Fa Elhu Saasfaprod1,https://fa elhu saasfaprod1
-Fa Elxu Saasfaprod1,https://fa elxu saasfaprod1
-Fa Emkq Saasfaprod1,https://fa emkq saasfaprod1
-Fa Emqf Saasfaprod1,https://fa emqf saasfaprod1
-Fa Emqh Saasfaprod1,https://fa emqh saasfaprod1
-Fa Emza Saasfaprod1,https://fa emza saasfaprod1
-Fa Eneh Saasfaprod1,https://fa eneh saasfaprod1
-Fa Engp Saasfaprod1,https://fa engp saasfaprod1
-Fa Enor Saasfaprod1,https://fa enor saasfaprod1
-Fa Eolw Saasfaprod1,https://fa eolw saasfaprod1
-Fa Eoqj Saasfaprod1,https://fa eoqj saasfaprod1
-Fa Eosd Saasfaprod1,https://fa eosd saasfaprod1
-Fa Eowa Saasfaprod1,https://fa eowa saasfaprod1
-Fa Epcb Saasfaprod1,https://fa epcb saasfaprod1
-Fa Epoc Saasfaprod1,https://fa epoc saasfaprod1
-Fa Epod Saasfaprod1,https://fa epod saasfaprod1
-Fa Epom Saasfaprod1,https://fa epom saasfaprod1
-Fa Epph Saasfaprod1,https://fa epph saasfaprod1
-Fa Epss Saasfaprod1,https://fa epss saasfaprod1
-Fa Epuh Saasfaprod1,https://fa epuh saasfaprod1
-Fa Epvs Saasfaprod1,https://fa epvs saasfaprod1
-Fa Epxn Saasfaprod1,https://fa epxn saasfaprod1
-Fa Eqai Saasfaprod1,https://fa eqai saasfaprod1
-Fa Eqcd Saasfaprod1,https://fa eqcd saasfaprod1
-Fa Eqdg Saasfaprod1,https://fa eqdg saasfaprod1
-Fa Eqfc Saasfaprod1,https://fa eqfc saasfaprod1
-Fa Eqfz Saasfaprod1,https://fa eqfz saasfaprod1
-Fa Eqgp Saasfaprod1,https://fa eqgp saasfaprod1
-Fa Eqid Saasfaprod1,https://fa eqid saasfaprod1
-Fa Eqlf Saasfaprod1,https://fa eqlf saasfaprod1
-Fa Eqnk Saasfaprod1,https://fa eqnk saasfaprod1
-Fa Eqnr Saasfaprod1,https://fa eqnr saasfaprod1
-Fa Eqpz Saasfaprod1,https://fa eqpz saasfaprod1
-Fa Eqva Saasfaprod1,https://fa eqva saasfaprod1
-Fa Eqvg Saasfaprod1,https://fa eqvg saasfaprod1
-Fa Eqzh Saasfaprod1,https://fa eqzh saasfaprod1
-Fa Eqzr Saasfaprod1,https://fa eqzr saasfaprod1
-Fa Erqf Saasfaprod1,https://fa erqf saasfaprod1
-Fa Errt Saasfaprod1,https://fa errt saasfaprod1
-Fa Ertb Saasfaprod1,https://fa ertb saasfaprod1
-Fa Eryk Saasfaprod1,https://fa eryk saasfaprod1
-Fa Esaq Saasfaprod1,https://fa esaq saasfaprod1
-Fa Esau Saasfaprod1,https://fa esau saasfaprod1
-Fa Escq Saasfaprod1,https://fa escq saasfaprod1
-Fa Esgk Saasfaprod1,https://fa esgk saasfaprod1
-Fa Esiu Saasfaprod1,https://fa esiu saasfaprod1
-Fa Esiv Saasfaprod1,https://fa esiv saasfaprod1
-Fa Eskh Saasfaprod1,https://fa eskh saasfaprod1
-Fa Espx Saasfaprod1,https://fa espx saasfaprod1
-Fa Essf Saasfaprod1,https://fa essf saasfaprod1
-Fa Esti Saasfaprod1,https://fa esti saasfaprod1
-Fa Estl Saasfaprod1,https://fa estl saasfaprod1
-Fa Etbm Saasfaprod1,https://fa etbm saasfaprod1
-Fa Etbx Saasfaprod1,https://fa etbx saasfaprod1
-Fa Etgw Saasfaprod1,https://fa etgw saasfaprod1
-Fa Etiv Saasfaprod1,https://fa etiv saasfaprod1
-Fa Etjb Saasfaprod1,https://fa etjb saasfaprod1
-Fa Etjg Saasfaprod1,https://fa etjg saasfaprod1
-Fa Etnv Saasfaprod1,https://fa etnv saasfaprod1
-Fa Etny Saasfaprod1,https://fa etny saasfaprod1
-Fa Etol Saasfaprod1,https://fa etol saasfaprod1
-Fa Etqd Saasfaprod1,https://fa etqd saasfaprod1
-Fa Etsr Saasfaprod1,https://fa etsr saasfaprod1
-Fa Etum Saasfaprod1,https://fa etum saasfaprod1
-Fa Etvc Saasfaprod1,https://fa etvc saasfaprod1
-Fa Etvl Saasfaprod1,https://fa etvl saasfaprod1
-Fa Etwq Saasfaprod1,https://fa etwq saasfaprod1
-Fa Etxx Saasfaprod1,https://fa etxx saasfaprod1
-Fa Etyi Saasfaprod1,https://fa etyi saasfaprod1
-Fa Etyr Saasfaprod1,https://fa etyr saasfaprod1
-Fa Etzd Saasfaprod1,https://fa etzd saasfaprod1
-Fa Eubm Saasfaprod1,https://fa eubm saasfaprod1
-Fa Eufk Saasfaprod1,https://fa eufk saasfaprod1
-Fa Eugx Saasfaprod1,https://fa eugx saasfaprod1
-Fa Euha Saasfaprod1,https://fa euha saasfaprod1
-Fa Euhy Saasfaprod1,https://fa euhy saasfaprod1
-Fa Eujk Saasfaprod1,https://fa eujk saasfaprod1
-Fa Eukk Saasfaprod1,https://fa eukk saasfaprod1
-Fa Eumz Saasfaprod1,https://fa eumz saasfaprod1
-Fa Eups Saasfaprod1,https://fa eups saasfaprod1
-Fa Euqk Saasfaprod1,https://fa euqk saasfaprod1
-Fa Euru Saasfaprod1,https://fa euru saasfaprod1
-Fa Eutv Saasfaprod1,https://fa eutv saasfaprod1
-Fa Euud Saasfaprod1,https://fa euud saasfaprod1
-Fa Euuy Saasfaprod1,https://fa euuy saasfaprod1
-Fa Euwp Saasfaprod1,https://fa euwp saasfaprod1
-Fa Euxc Saasfaprod1,https://fa euxc saasfaprod1
-Fa Euxw Saasfaprod1,https://fa euxw saasfaprod1
-Fa Euyb Saasfaprod1,https://fa euyb saasfaprod1
-Fa Euyk Saasfaprod1,https://fa euyk saasfaprod1
-Fa Euzi Saasfaprod1,https://fa euzi saasfaprod1
-Fa Evax Saasfaprod1,https://fa evax saasfaprod1
-Fa Evcm Saasfaprod1,https://fa evcm saasfaprod1
-Fa Evdq Saasfaprod1,https://fa evdq saasfaprod1
-Fa Evfm Saasfaprod1,https://fa evfm saasfaprod1
-Fa Evfw Saasfaprod1,https://fa evfw saasfaprod1
-Fa Evge Saasfaprod1,https://fa evge saasfaprod1
-Fa Evgg Saasfaprod1,https://fa evgg saasfaprod1
-Fa Evkz Saasfaprod1,https://fa evkz saasfaprod1
-Fa Evlf Dev5 Saasfaprod1,https://fa evlf dev5 saasfaprod1
-Fa Evlf Saasfaprod1,https://fa evlf saasfaprod1
-Fa Evlj Saasfaprod1,https://fa evlj saasfaprod1
-Fa Evlo Saasfaprod1,https://fa evlo saasfaprod1
-Fa Evmr Saasfaprod1,https://fa evmr saasfaprod1
-Fa Evra Saasfaprod1,https://fa evra saasfaprod1
-Fa Evrg Saasfaprod1,https://fa evrg saasfaprod1
-Fa Evtx Saasfaprod1,https://fa evtx saasfaprod1
-Fa Evue Saasfaprod1,https://fa evue saasfaprod1
-Fa Evuf Saasfaprod1,https://fa evuf saasfaprod1
-Fa Evuz Saasfaprod1,https://fa evuz saasfaprod1
-Fa Evxi Saasfaprod1,https://fa evxi saasfaprod1
-Fa Evxn Saasfaukgovprod1,https://fa evxn saasfaukgovprod1
-Fa Evxo Saasfaprod1,https://fa evxo saasfaprod1
-Fa Evxv Saasfaprod1,https://fa evxv saasfaprod1
-Fa Evzn Saasfaukgovprod1,https://fa evzn saasfaukgovprod1
-Fa Evzu Saasfaprod1,https://fa evzu saasfaprod1
-Fa Ewab Saasfaprod1,https://fa ewab saasfaprod1
-Fa Ewbu Saasfaprod1,https://fa ewbu saasfaprod1
-Fa Ewdg Saasfaprod1,https://fa ewdg saasfaprod1
-Fa Ewdp Test Saasfaprod1,https://fa ewdp test saasfaprod1
-Fa Eweh Saasfaprod1,https://fa eweh saasfaprod1
-Fa Ewfb Saasfaprod1,https://fa ewfb saasfaprod1
-Fa Ewgu Saasfaprod1,https://fa ewgu saasfaprod1
-Fa Ewik Saasfaprod1,https://fa ewik saasfaprod1
-Fa Ewji Saasfaprod1,https://fa ewji saasfaprod1
-Fa Ewjo Saasfaprod1,https://fa ewjo saasfaprod1
-Fa Ewjt Saasfaprod1,https://fa ewjt saasfaprod1
-Fa Ewkd Saasfaprod1,https://fa ewkd saasfaprod1
-Fa Ewlq Saasfaprod1,https://fa ewlq saasfaprod1
-Fa Ewmy Saasfaprod1,https://fa ewmy saasfaprod1
-Fa Ewnb Saasfaprod1,https://fa ewnb saasfaprod1
-Fa Ewnx Saasfaprod1,https://fa ewnx saasfaprod1
-Fa Ewto Saasfaprod1,https://fa ewto saasfaprod1
-Fa Ewub Saasfaprod1,https://fa ewub saasfaprod1
-Fa Ewur Saasfaprod1,https://fa ewur saasfaprod1
-Fa Ewve Test Saasfaprod1,https://fa ewve test saasfaprod1
-Fa Ewwx Saasfaprod1,https://fa ewwx saasfaprod1
-Fa Ewzx Saasfaprod1,https://fa ewzx saasfaprod1
-Fa Exbd Saasfaprod1,https://fa exbd saasfaprod1
-Fa Exci Saasfaprod1,https://fa exci saasfaprod1
-Fa Exde Saasfaprod1,https://fa exde saasfaprod1
-Fa Exdv Saasfaprod1,https://fa exdv saasfaprod1
-Fa Exea Saasfaprod1,https://fa exea saasfaprod1
-Fa Exer Saasfaprod1,https://fa exer saasfaprod1
-Fa Exew Saasfaprod1,https://fa exew saasfaprod1
-Fa Exfs Saasfaprod1,https://fa exfs saasfaprod1
-Fa Exhh Saasfaprod1,https://fa exhh saasfaprod1
-Fa Exjs Saasfaprod1,https://fa exjs saasfaprod1
-Fa Exki Saasfaprod1,https://fa exki saasfaprod1
-Fa Exkk Saasfaprod1,https://fa exkk saasfaprod1
-Fa Exmi Saasfaprod1,https://fa exmi saasfaprod1
-Fa Exow Saasfaprod1,https://fa exow saasfaprod1
-Fa Expc Saasfaprod1,https://fa expc saasfaprod1
-Fa Exrr Saasfaprod1,https://fa exrr saasfaprod1
-Fa Exsx Saasfaprod1,https://fa exsx saasfaprod1
-Fa Exts Saasfaprod1,https://fa exts saasfaprod1
-Fa Exty Saasfaprod1,https://fa exty saasfaprod1
-Fa Exvu Saasfaprod1,https://fa exvu saasfaprod1
-Fa Exxi Saasfaprod1,https://fa exxi saasfaprod1
-Fa Eyau Saasfaprod1,https://fa eyau saasfaprod1
-Fa Eygo Saasfaprod1,https://fa eygo saasfaprod1
-Fa Eykz Saasfaprod1,https://fa eykz saasfaprod1
-Faulkner Iccjjb Dev2,https://faulkner iccjjb dev2
-Fife Council Jobs and Careers,https://ekmu.fa.em3.oraclecloud.com
-Ford Global Career Site,https://efds.fa.em5.oraclecloud.com
-Fortive Careers,https://ejta.fa.us6.oraclecloud.com
-Forward,https://eguq.fa.us2.oraclecloud.com
-GCAA,https://elon.fa.em8.oraclecloud.com
-GCI Careers,https://edqv.fa.us2.oraclecloud.com
-GP Strategies Career Site,https://eetz.fa.us6.oraclecloud.com
-Galadari Brothers,https://efcs.fa.em3.oraclecloud.com
-Galliford Try,https://cbct.fa.em2.oraclecloud.com
-Garrett Advancing Motion,https://ehth.fa.em2.oraclecloud.com
-Global,https://hcwx.fa.us2.oraclecloud.com
-Global Careers,https://ekpl.fa.us6.oraclecloud.com
-Golden Goose,https://iaagmj.fa.ocs.oraclecloud.com
-Grant Thornton - US,https://ehzq.fa.us2.oraclecloud.com
-Guthrie Careers,https://elfw.fa.us2.oraclecloud.com
-HBL People,https://hdcs.fa.ap1.oraclecloud.com
-Hand Protection,https://emdm.fa.ap1.oraclecloud.com
-Harrah's Cherokee Casino Resort,https://epgr.fa.us6.oraclecloud.com
-Hcbt,https://hcbt.fa.em2.oraclecloud.com
-Hccz,https://hccz.fa.em3.oraclecloud.com
-Hcdtgccprod Iayeqy,https://hcdtgccprod iayeqy
-Hcgn,https://hcgn.fa.us2.oraclecloud.com
-Hdbc,https://hdbc.fa.em2.oraclecloud.com
-Hdhe,https://hdhe.fa.em3.oraclecloud.com
-Hearst,https://eevd.fa.us6.oraclecloud.com
-Heriot-Watt University,https://enzj.fa.em3.oraclecloud.com
-Hill Minimal 112022,https://hcib.fa.us2.oraclecloud.com
-Hillside,https://ebrf.fa.us2.oraclecloud.com
-Hilton Grand Vacations,https://efuq.fa.us6.oraclecloud.com
-Hoag,https://iaucqy.fa.ocs.oraclecloud.com
-Hoffman Construction Company,https://efsp.fa.us6.oraclecloud.com
-Hologic Careers,https://ebwb.fa.us2.oraclecloud.com
-Home Page,https://hdhy.fa.em3.oraclecloud.com
-Honeywell,https://ibqbjb.fa.ocs.oraclecloud.com
-IB,https://ejst.fa.em3.oraclecloud.com
-INSEAD,https://iablgs.fa.ocs.oraclecloud.com
-INTEGRIS Health,https://ertr.fa.us2.oraclecloud.com
-IP Global Career Site,https://iazbqy.fa.ocs.oraclecloud.com
-IRENA Employment,https://eexh.fa.em3.oraclecloud.com
-Iaajkf,https://iaajkf.fa.ocs.oraclecloud.com
-Iaatiz Test,https://iaatiz test
-Iaavbk,https://iaavbk.fa.ocs.oraclecloud.com
-Iabezv,https://iabezv.fa.ocs.oraclecloud.com
-Iabzey Test,https://iabzey test
-Iacmiz Dev1,https://iacmiz dev1
-Iacvkf,https://iacvkf.fa.ocs.oraclecloud.com
-Iadbkf,https://iadbkf.fa.ocs.oraclecloud.com
-Iaeukf,https://iaeukf.fa.ocs.oraclecloud.com
-Iajmgs Test,https://iajmgs test
-Iamxme,https://iamxme.fa.ocs.oraclecloud.com
-Iaogqy,https://iaogqy.fa.ocs.oraclecloud.com
-Ibarqy,https://ibarqy.fa.ocs.oraclecloud.com
-Ibyijb,https://ibyijb.fa.ocs.oraclecloud.com
-Icertis,https://iaaviz.fa.ocs.oraclecloud.com
-Infoblox Careers,https://efpv.fa.us6.oraclecloud.com
-Inova,https://elar.fa.us2.oraclecloud.com
-Inspira Health,https://ernh.fa.us2.oraclecloud.com
-Intertek US,https://hcog.fa.em2.oraclecloud.com
-Ipsos,https://ecqf.fa.em2.oraclecloud.com
-Jefferies,https://hdid.fa.us2.oraclecloud.com
-Job Opportunities | MCB Group,https://ekbd.fa.em2.oraclecloud.com
-Jobs at Acosta,https://eczy.fa.us2.oraclecloud.com
-KPMG,https://elzw.fa.em8.oraclecloud.com
-KPMG India,https://ejgk.fa.em2.oraclecloud.com
-Kroll,https://hcxs.fa.us2.oraclecloud.com
-LANDMARK GROUP,https://efhi.fa.em3.oraclecloud.com
-Lewisham Career Site,https://efuy.fa.em3.oraclecloud.com
-Libertygroup Iaaybv,https://libertygroup iaaybv
-LifeView Group,https://etud.fa.us8.oraclecloud.com
-Login Emza Saasfaprod1,https://login emza saasfaprod1
-Login Enmi Saasfaprod1,https://login enmi saasfaprod1
-Login Epod Saasfaprod1,https://login epod saasfaprod1
-Login Epph Saasfaprod1,https://login epph saasfaprod1
-Login Epwg Saasfaprod1,https://login epwg saasfaprod1
-Login Eqdg Saasfaprod1,https://login eqdg saasfaprod1
-Loma Linda,https://egln.fa.us2.oraclecloud.com
-Lucy Group,https://hdga.fa.em3.oraclecloud.com
-MAS Holdings,https://egmh.fa.us6.oraclecloud.com
-MBC Group,https://ehff.fa.em2.oraclecloud.com
-MHRA,https://eckx.fa.em2.oraclecloud.com
-MTN EXTERNAL CAREER SITE,https://ehle.fa.em2.oraclecloud.com
-MX Career Site,https://ehtc.fa.ca2.oraclecloud.com
-Macy's,https://ebwh.fa.us2.oraclecloud.com
-Mafi Iammgs Test,https://mafi iammgs test
-Mashreq Careers,https://hcld.fa.em2.oraclecloud.com
-Masimo,https://egcu.fa.us6.oraclecloud.com
-Mauser Packaging Solutions,https://hdpn.fa.us6.oraclecloud.com
-McDermott External Career Site,https://edsv.fa.us2.oraclecloud.com
-McLeod Careers Section,https://erym.fa.us6.oraclecloud.com
-Medusind Ibzajb,https://medusind ibzajb
-Messiah Ibvrjb,https://messiah ibvrjb
-Metalsa Career Site,https://hcun.fa.us2.oraclecloud.com
-Michael Baker International,https://ebxs.fa.us2.oraclecloud.com
-Milaha,https://ejqa.fa.em2.oraclecloud.com
-Misk Foundation New Career Site Splash Page,https://ejpi.fa.em2.oraclecloud.com
-"Mission Support & Test Services, LLC (MSTS)",https://ewij.fa.us8.oraclecloud.com
-Monro,https://ibqmjb.fa.ocs.oraclecloud.com
-Motherson_North America Careers,https://hcnh.fa.us2.oraclecloud.com
-Mountaire Jobs,https://ebtg.fa.us2.oraclecloud.com
-Mouser,https://eabw.fa.us2.oraclecloud.com
-NFL Career Site,https://hdmm.fa.us6.oraclecloud.com
-NMC,https://eiby.fa.em2.oraclecloud.com
-NOV,https://egay.fa.us6.oraclecloud.com
-NRC NORCAP Careers,https://ekum.fa.em2.oraclecloud.com
-NSF,https://hcnz.fa.us2.oraclecloud.com
-Nahdi,https://efan.fa.em3.oraclecloud.com
-Napco Careers,https://iaeegs.fa.ocs.oraclecloud.com
-National Bank of Kenya,https://eoin.fa.em3.oraclecloud.com
-NemoursCareerSite,https://epyz.fa.us2.oraclecloud.com
-Northwell Career Site,https://eppr.fa.us2.oraclecloud.com
-Notified,https://eclz.fa.us2.oraclecloud.com
-Onity External Career Site,https://ebhz.fa.us2.oraclecloud.com
-Online @ Air Selangor,https://egek.fa.ap1.oraclecloud.com
-Opus,https://iaaxiz.fa.ocs.oraclecloud.com
-Oracle,https://eeho.fa.us2.oraclecloud.com
-Osumc Iborjb,https://osumc iborjb
-Oxford Nanopore Technologies,https://ejnh.fa.em2.oraclecloud.com
-Piramal,https://hcwf.fa.ap1.oraclecloud.com
-Proskauer,https://dfa.fa.us1.oraclecloud.com
-Providence,https://evac.fa.us2.oraclecloud.com
-Pyxus,https://iahome.fa.ocs.oraclecloud.com
-Quest Diagnostics Careers,https://hdox.fa.us6.oraclecloud.com
-R+L Carriers,https://erhk.fa.us2.oraclecloud.com
-REDCON - Candidate Career site,https://eiej.fa.em2.oraclecloud.com
-Resideo,https://ehtl.fa.us6.oraclecloud.com
-Rice University Minimal Template External Career Site,https://emdz.fa.us2.oraclecloud.com
-Ricoh Careers,https://cbha.fa.us2.oraclecloud.com
-S&C Minimal Career Site,https://ejia.fa.us6.oraclecloud.com
-SAIL BSL,https://iabaiz.fa.ocs.oraclecloud.com
-SALIC Career Site,https://hen.fa.em2.oraclecloud.com
-SBH Careers,https://eigx.fa.us6.oraclecloud.com
-SCI Career Site,https://hcri.fa.em2.oraclecloud.com
-SHANER,https://ebwv.fa.us2.oraclecloud.com
-SPL - Career Site,https://iaazkf.fa.ocs.oraclecloud.com
-Safaricom Candidate Experience site,https://egjd.fa.us6.oraclecloud.com
-Samsonite,https://ekkf.fa.em2.oraclecloud.com
-Schroders,https://ekbq.fa.em2.oraclecloud.com
-Seaspan,https://hckz.fa.us2.oraclecloud.com
-Securitas Security Services,https://ekaw.fa.us2.oraclecloud.com
-Sherwin-Williams,https://ejhp.fa.us6.oraclecloud.com
-Sinch,https://iaings.fa.ocs.oraclecloud.com
-Sinclair Broadcast Group,https://edyy.fa.us2.oraclecloud.com
-Sitio de Carrera Banregio,https://ehyn.fa.us6.oraclecloud.com
-Sotera Health,https://eftx.fa.us6.oraclecloud.com
-Southern Company,https://emje.fa.us6.oraclecloud.com
-Squareroot Iadzkf,https://squareroot iadzkf
-Standard Aero,https://cva.fa.us1.oraclecloud.com
-Stantec,https://hdhl.fa.us6.oraclecloud.com
-Station Casinos,https://ejfh.fa.us6.oraclecloud.com
-Stats Perform,https://eobe.fa.em2.oraclecloud.com
-Stmichaels Ibukjb,https://stmichaels ibukjb
-Stolt-Nielsen,https://eclo.fa.em2.oraclecloud.com
-Subaru,https://hcal.fa.us2.oraclecloud.com
-Suffolk Jobs Direct,https://eoce.fa.em3.oraclecloud.com
-Sun River Health,https://edvy.fa.us2.oraclecloud.com
-Sundt Careers,https://eewl.fa.us6.oraclecloud.com
-T.EN Career Site,https://hcxg.fa.em2.oraclecloud.com
-TG_WFSJobs,https://iaboey.fa.ocs.oraclecloud.com
-TTX,https://ejjc.fa.us6.oraclecloud.com
-TWE Global Careers,https://ebpm.fa.us2.oraclecloud.com
-Talent Acquisition,https://enpk.fa.em8.oraclecloud.com
-Tamaki Health Careers,https://iaantz.fa.ocs.oraclecloud.com
-Tamer Group Site,https://eenp.fa.em3.oraclecloud.com
-Tata Capital,https://eofh.fa.em2.oraclecloud.com
-Teekay,https://eipv.fa.us6.oraclecloud.com
-Tenet Healthcare Corporation,https://eodr.fa.us2.oraclecloud.com
-Texas Children's Careers,https://eohh.fa.us2.oraclecloud.com
-Texas Instruments,https://edbz.fa.us2.oraclecloud.com
-The Arab Energy Fund,https://iaebkf.fa.ocs.oraclecloud.com
-The City of Edinburgh Council,https://iaghme.fa.ocs.oraclecloud.com
-The Fedcap Group,https://eckb.fa.us2.oraclecloud.com
-The Kroger Co.,https://eluq.fa.us2.oraclecloud.com
-Tiffany,https://eljs.fa.us2.oraclecloud.com
-Tmbhcm Iacciz,https://tmbhcm iacciz
-Trillium Health Partners,https://iadyup.fa.ocs.oraclecloud.com
-Trincore Ibvxjb,https://trincore ibvxjb
-UC Health Career Site,https://eswt.fa.us6.oraclecloud.com
-UNDP,https://estm.fa.em2.oraclecloud.com
-URUS Group,https://hdjm.fa.ca2.oraclecloud.com
-USS,https://icbajb.fa.ocs.oraclecloud.com
-UW Health,https://eimy.fa.us6.oraclecloud.com
-Ublcloud Iaanbv,https://ublcloud iaanbv
-UnitedLex,https://ekkk.fa.us6.oraclecloud.com
-University of Edinburgh,https://elxw.fa.em3.oraclecloud.com
-Utulsa Ibvjjb,https://utulsa ibvjjb
-VDOT Careers Site,https://etgi.fa.us8.oraclecloud.com
-VITAS Healthcare,https://ejrz.fa.us2.oraclecloud.com
-Vanderbilt University,https://ecsr.fa.us2.oraclecloud.com
-Vertiv,https://egup.fa.us2.oraclecloud.com
-Vodafone Qatar,https://elat.fa.em2.oraclecloud.com
-WM,https://emcm.fa.us2.oraclecloud.com
-WSP,https://emit.fa.ca3.oraclecloud.com
-WTW External Careers Site,https://eedu.fa.em3.oraclecloud.com
-Well Enterprises - Career Site,https://hcsb.fa.us2.oraclecloud.com
-Wesco,https://eklm.fa.us2.oraclecloud.com
-West Midlands Police,https://ecwz.fa.em3.oraclecloud.com
-Westpac Group,https://ebuu.fa.ap1.oraclecloud.com
-Williams-Sonoma,https://ehac.fa.us6.oraclecloud.com
-Winning Form Careers Site,https://iagjme.fa.ocs.oraclecloud.com
-Wood,https://ehif.fa.em2.oraclecloud.com
-Working at Signature Aviation,https://hdbt.fa.us2.oraclecloud.com
-Www.Fa Eufr Saasfaprod1,https://www.fa eufr saasfaprod1
-Www.Fa Ewuu Saasfaprod1,https://www.fa ewuu saasfaprod1
-Yum!,https://eczd.fa.us2.oraclecloud.com
-Zeus,https://cbhm.fa.us2.oraclecloud.com
-ebtw.fa.us2.oraclecloud.com,https://ebtw.fa.us2.oraclecloud.com
-ectf.fa.us2.oraclecloud.com,https://ectf.fa.us2.oraclecloud.com
-eduu.fa.us2.oraclecloud.com,https://eduu.fa.us2.oraclecloud.com
-eees.fa.us2.oraclecloud.com,https://eees.fa.us2.oraclecloud.com
-eexs.fa.us2.oraclecloud.com,https://eexs.fa.us2.oraclecloud.com
-egvv.fa.us6.oraclecloud.com,https://egvv.fa.us6.oraclecloud.com
-ehgv.fa.em2.oraclecloud.com,https://ehgv.fa.em2.oraclecloud.com
-ehwy.fa.us2.oraclecloud.com,https://ehwy.fa.us2.oraclecloud.com
-ejql.fa.us6.oraclecloud.com,https://ejql.fa.us6.oraclecloud.com
-ekcf.fa.us6.oraclecloud.com,https://ekcf.fa.us6.oraclecloud.com
-ekkh.fa.us2.oraclecloud.com,https://ekkh.fa.us2.oraclecloud.com
-ekug.fa.us6.oraclecloud.com,https://ekug.fa.us6.oraclecloud.com
-enmv.fa.us2.oraclecloud.com,https://enmv.fa.us2.oraclecloud.com
-enno.fa.ap1.oraclecloud.com,https://enno.fa.ap1.oraclecloud.com
-enqn.fa.us2.oraclecloud.com,https://enqn.fa.us2.oraclecloud.com
-enxp.fa.us6.oraclecloud.com,https://enxp.fa.us6.oraclecloud.com
-eubt.fa.us6.oraclecloud.com,https://eubt.fa.us6.oraclecloud.com
-gka.fa.us1.oraclecloud.com,https://gka.fa.us1.oraclecloud.com
-hcfa.fa.us2.oraclecloud.com,https://hcfa.fa.us2.oraclecloud.com
-hckd.fa.us2.oraclecloud.com,https://hckd.fa.us2.oraclecloud.com
-hctz.fa.us2.oraclecloud.com,https://hctz.fa.us2.oraclecloud.com
-hcut.fa.ap2.oraclecloud.com,https://hcut.fa.ap2.oraclecloud.com
-hcwt.fa.us2.oraclecloud.com,https://hcwt.fa.us2.oraclecloud.com
-hdbg.fa.us2.oraclecloud.com,https://hdbg.fa.us2.oraclecloud.com
-hdrc.fa.ca3.oraclecloud.com,https://hdrc.fa.ca3.oraclecloud.com
-hza.fa.us1.oraclecloud.com,https://hza.fa.us1.oraclecloud.com
-iabqiz.fa.ocs.oraclecloud.com,https://iabqiz.fa.ocs.oraclecloud.com
-iaccgs.fa.ocs.oraclecloud.com,https://iaccgs.fa.ocs.oraclecloud.com
-iahbme.fa.ocs.oraclecloud.com,https://iahbme.fa.ocs.oraclecloud.com
-iawmqy.fa.ocs.oraclecloud.com,https://iawmqy.fa.ocs.oraclecloud.com
-iazuqy.fa.ocs.oraclecloud.com,https://iazuqy.fa.ocs.oraclecloud.com
-ibmljb.fa.ocs.oraclecloud.com,https://ibmljb.fa.ocs.oraclecloud.com
-ibnjjb.fa.ocs.oraclecloud.com,https://ibnjjb.fa.ocs.oraclecloud.com
-icfcjb.fa.ocs.oraclecloud.com,https://icfcjb.fa.ocs.oraclecloud.com
-ooba,https://ejuu.fa.em2.oraclecloud.com
-the Myriad Genetics Candidate site,https://ekgn.fa.us6.oraclecloud.com
+name,slug,url
+ABM US,eiqg,https://eiqg.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+ADES Global,epgv,https://epgv.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+ADIB Candidate Experience site,hciq,https://hciq.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+ADNIC Career Portal,eoro,https://eoro.fa.em8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+AEO,hcml,https://hcml.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+AFW,ejqy,https://ejqy.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+AICC External Site,iaarkf,https://iaarkf.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+AL Gihaz Holding,efva,https://efva.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+APP Recruitment,eify,https://eify.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+AWR Career Site,iacpey,https://iacpey.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Abdulla-Fouad Career Site Minimal,hdgp,https://hdgp.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Abt Global,egpy,https://egpy.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Abu Dhabi Airports,hcts,https://hcts.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Adani Career Site,eibd,https://eibd.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Adventist Health,ecvz,https://ecvz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Al Ghurair,iaaxey,https://iaaxey.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Al Moosa Career Portal,edns,https://edns.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Al-Othman Holding Company,eknh,https://eknh.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Albertsons Companies,eofd,https://eofd.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Allegheny Intermediate Unit Career Site,einj,https://einj.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+American Bureau of Shipping Career Site,hbbq,https://hbbq.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+American Tower Global,hdsn,https://hdsn.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Anywhere,ibmqjb,https://ibmqjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Apollo Hospitals,cgs,https://cgs.fa.ap2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Apparel Career Site,ediu,https://ediu.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Arcadis,ebcs,https://ebcs.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+ArcelorMittal,emfg,https://emfg.fa.em4.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Arconic,hdnn,https://hdnn.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Arcor Global,emqm,https://emqm.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Aspire Zone Candidate Experience site,eipb,https://eipb.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Aster DM Healthcare,hcdt,https://hcdt.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+At Home,hdiy,https://hdiy.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+BCBSM Career Section,ejko,https://ejko.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+BDO USA Experienced Career Site,ebqb,https://ebqb.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+BE Careers,iadygs,https://iadygs.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+BNY External Career Site,eofe,https://eofe.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+BSC,ecge,https://ecge.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Badger,ejlj,https://ejlj.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Bank Negara Malaysia - Professional Career Site,iaartj,https://iaartj.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Barrick Mining Corporation,ehkn,https://ehkn.fa.ca2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Baylor Careers,ejof,https://ejof.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Black Box Careers,eoje,https://eoje.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Brazos County Career Site,ekzl,https://ekzl.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Bristlecone,iaagiz,https://iaagiz.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Brookdale Senior Living Inc.,ibmwjb,https://ibmwjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+CECONY Career Site,ejcu,https://ejcu.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+CIMB Group Malaysia,ejox,https://ejox.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+CLP,iabhtj,https://iabhtj.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+CORSAIR,edix,https://edix.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+COTTON ON Careers,ekxm,https://ekxm.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+CRS,eipn,https://eipn.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+CSC,hczw,https://hczw.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+"CTB, Inc.",emsl,https://emsl.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Caesars Entertainment,edmn,https://edmn.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Calderys Career Opportunities,egmk,https://egmk.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Camden,ehap,https://ehap.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Candidate Experience Site - Campus,hdpc,https://hdpc.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Canon,ejqe,https://ejqe.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Cantor Fitzgerald/BGC,hdow,https://hdow.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Career Site,iaceiz,https://iaceiz.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Careers at Atlantic Health System,erqh,https://erqh.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Careers at CBIZ,ebez,https://ebez.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Careers at Heathrow,encd,https://encd.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Careers at Marriott,ejwl,https://ejwl.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Careers | BXP,edxn,https://edxn.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Careers|CURIA,hcug,https://hcug.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Carnival Corporation,eicl,https://eicl.fa.em5.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Carrington,emvo,https://emvo.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Cbzp,cbzp,https://cbzp.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Cedars-Sinai,hdkk,https://hdkk.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Centrus Global Career Site,eese,https://eese.fa.us8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Cherokee Federal,ibtcjb,https://ibtcjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Cherokee Nation Businesses Corporate,ejvp,https://ejvp.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Choctaw Nation of Oklahoma,egoh,https://egoh.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Church,epej,https://epej.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Citizens,eeab,https://eeab.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+City Of Atlanta,ehxr,https://ehxr.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Clean Harbors External Career Site,epyc,https://epyc.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+ClubCorp,ecwl,https://ecwl.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Coherent Corp. US,hcwp,https://hcwp.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Cohu Careers,hcbo,https://hcbo.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Conduent,egua,https://egua.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+CooperCompanies,hcjy,https://hcjy.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Corporate Careers | Trueblue,ehnn,https://ehnn.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Cottage Health,eglz,https://eglz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Cummins Arabia External Career Site,hdjd,https://hdjd.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Cytel,iblyjb,https://iblyjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+DAMAC,ejwe,https://ejwe.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+DC Water Candidate Experience site,elxb,https://elxb.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+DLL Group,iabcbn,https://iabcbn.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+DNV careers,ecyq,https://ecyq.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+DP World,ehpv,https://ehpv.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+DTCC Candidate Experience Site,ebxr,https://ebxr.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+DTU Career Site,efzu,https://efzu.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Dallah Recruitment System,eniy,https://eniy.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Datavail Career Site,eifn,https://eifn.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Diebold Nixdorf,eeug,https://eeug.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Digital Realty Global,hdep,https://hdep.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Dubai Holding,esbe,https://esbe.fa.em8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Dubai World Trade Centre -,bun,https://bun.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+ELCA Global Career site,iaaras,https://iaaras.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+EMAAR,emhm,https://emhm.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+EMSS,eism,https://eism.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+EMkan,iafckf,https://iafckf.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+ESEC Experience site,ebfi,https://ebfi.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+ESF Career Site-External,eoix,https://eoix.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+EXP,elcn,https://elcn.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Eccd,eccd,https://eccd.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Ecnf,ecnf,https://ecnf.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Ecwr,ecwr,https://ecwr.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Edel,edel,https://edel.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Edyo,edyo,https://edyo.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Eega,eega,https://eega.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Eexi,eexi,https://eexi.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Efoa,efoa,https://efoa.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Egge,egge,https://egge.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Egpa,egpa,https://egpa.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Egrh,egrh,https://egrh.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Ehfo,ehfo,https://ehfo.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Eiek,eiek,https://eiek.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Eigf,eigf,https://eigf.fa.us8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Eigu,eigu,https://eigu.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Eijc,eijc,https://eijc.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Eims,eims,https://eims.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Eisq,eisq,https://eisq.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Ejbr,ejbr,https://ejbr.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Ejep,ejep,https://ejep.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Ejis,ejis,https://ejis.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Ejov,ejov,https://ejov.fa.ca2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Ejyf,ejyf,https://ejyf.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Ekcm,ekcm,https://ekcm.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Ekcn,ekcn,https://ekcn.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Ekkt,ekkt,https://ekkt.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Ekxv,ekxv,https://ekxv.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Elaj,elaj,https://elaj.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Elhr,elhr,https://elhr.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Eloc,eloc,https://eloc.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Emerson Career Site,hdjq,https://hdjq.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Emirates Healthcare,hcbh,https://hcbh.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+England Rugby,ecer,https://ecer.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Enxa,enxa,https://enxa.fa.em8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Eohs,eohs,https://eohs.fa.ap2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Equity Residential,hcjm,https://hcjm.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Erey,erey,https://erey.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Euroclear,don,https://don.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Explore RH Careers,hcqq,https://hcqq.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+External Site,ekez,https://ekez.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+FAB |,ehjd,https://ehjd.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fife Council Jobs and Careers,ekmu,https://ekmu.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Ford Global Career Site,efds,https://efds.fa.em5.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fortive Careers,ejta,https://ejta.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Forward,eguq,https://eguq.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+GCAA,elon,https://elon.fa.em8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+GCI Careers,edqv,https://edqv.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+GP Strategies Career Site,eetz,https://eetz.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Galadari Brothers,efcs,https://efcs.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Galliford Try,cbct,https://cbct.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Garrett Advancing Motion,ehth,https://ehth.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Global,hcwx,https://hcwx.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Global Careers,ekpl,https://ekpl.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Golden Goose,iaagmj,https://iaagmj.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Grant Thornton - US,ehzq,https://ehzq.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Guthrie Careers,elfw,https://elfw.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+HBL People,hdcs,https://hdcs.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hand Protection,emdm,https://emdm.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Harrah's Cherokee Casino Resort,epgr,https://epgr.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hcbt,hcbt,https://hcbt.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hccz,hccz,https://hccz.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hcgn,hcgn,https://hcgn.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hdbc,hdbc,https://hdbc.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hdhe,hdhe,https://hdhe.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hearst,eevd,https://eevd.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Heriot-Watt University,enzj,https://enzj.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hill Minimal 112022,hcib,https://hcib.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hillside,ebrf,https://ebrf.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hilton Grand Vacations,efuq,https://efuq.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hoag,iaucqy,https://iaucqy.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hoffman Construction Company,efsp,https://efsp.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hologic Careers,ebwb,https://ebwb.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Home Page,hdhy,https://hdhy.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Honeywell,ibqbjb,https://ibqbjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+IB,ejst,https://ejst.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+INSEAD,iablgs,https://iablgs.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+INTEGRIS Health,ertr,https://ertr.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+IP Global Career Site,iazbqy,https://iazbqy.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+IRENA Employment,eexh,https://eexh.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Iaajkf,iaajkf,https://iaajkf.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Iaavbk,iaavbk,https://iaavbk.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Iabezv,iabezv,https://iabezv.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Iacvkf,iacvkf,https://iacvkf.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Iadbkf,iadbkf,https://iadbkf.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Iaeukf,iaeukf,https://iaeukf.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Iamxme,iamxme,https://iamxme.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Iaogqy,iaogqy,https://iaogqy.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Ibarqy,ibarqy,https://ibarqy.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Ibyijb,ibyijb,https://ibyijb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Icertis,iaaviz,https://iaaviz.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Infoblox Careers,efpv,https://efpv.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Inova,elar,https://elar.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Inspira Health,ernh,https://ernh.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Intertek US,hcog,https://hcog.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Ipsos,ecqf,https://ecqf.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Jefferies,hdid,https://hdid.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Job Opportunities | MCB Group,ekbd,https://ekbd.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Jobs at Acosta,eczy,https://eczy.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+KPMG,elzw,https://elzw.fa.em8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+KPMG India,ejgk,https://ejgk.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Kroll,hcxs,https://hcxs.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+LANDMARK GROUP,efhi,https://efhi.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Lewisham Career Site,efuy,https://efuy.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+LifeView Group,etud,https://etud.fa.us8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Loma Linda,egln,https://egln.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Lucy Group,hdga,https://hdga.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+MAS Holdings,egmh,https://egmh.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+MBC Group,ehff,https://ehff.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+MHRA,eckx,https://eckx.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+MTN EXTERNAL CAREER SITE,ehle,https://ehle.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+MX Career Site,ehtc,https://ehtc.fa.ca2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Macy's,ebwh,https://ebwh.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Mashreq Careers,hcld,https://hcld.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Masimo,egcu,https://egcu.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Mauser Packaging Solutions,hdpn,https://hdpn.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+McDermott External Career Site,edsv,https://edsv.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+McLeod Careers Section,erym,https://erym.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Metalsa Career Site,hcun,https://hcun.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Michael Baker International,ebxs,https://ebxs.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Milaha,ejqa,https://ejqa.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Misk Foundation New Career Site Splash Page,ejpi,https://ejpi.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+"Mission Support & Test Services, LLC (MSTS)",ewij,https://ewij.fa.us8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Monro,ibqmjb,https://ibqmjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Motherson_North America Careers,hcnh,https://hcnh.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Mountaire Jobs,ebtg,https://ebtg.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Mouser,eabw,https://eabw.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+NFL Career Site,hdmm,https://hdmm.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+NMC,eiby,https://eiby.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+NOV,egay,https://egay.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+NRC NORCAP Careers,ekum,https://ekum.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+NSF,hcnz,https://hcnz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Nahdi,efan,https://efan.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Napco Careers,iaeegs,https://iaeegs.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+National Bank of Kenya,eoin,https://eoin.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+NemoursCareerSite,epyz,https://epyz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Northwell Career Site,eppr,https://eppr.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Notified,eclz,https://eclz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Onity External Career Site,ebhz,https://ebhz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Online @ Air Selangor,egek,https://egek.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Opus,iaaxiz,https://iaaxiz.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Oracle,eeho,https://eeho.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Oxford Nanopore Technologies,ejnh,https://ejnh.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Piramal,hcwf,https://hcwf.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Proskauer,dfa,https://dfa.fa.us1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Providence,evac,https://evac.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Pyxus,iahome,https://iahome.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Quest Diagnostics Careers,hdox,https://hdox.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+R+L Carriers,erhk,https://erhk.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+REDCON - Candidate Career site,eiej,https://eiej.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Resideo,ehtl,https://ehtl.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Rice University Minimal Template External Career Site,emdz,https://emdz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Ricoh Careers,cbha,https://cbha.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+S&C Minimal Career Site,ejia,https://ejia.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+SAIL BSL,iabaiz,https://iabaiz.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+SALIC Career Site,hen,https://hen.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+SBH Careers,eigx,https://eigx.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+SCI Career Site,hcri,https://hcri.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+SHANER,ebwv,https://ebwv.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+SPL - Career Site,iaazkf,https://iaazkf.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Safaricom Candidate Experience site,egjd,https://egjd.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Samsonite,ekkf,https://ekkf.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Schroders,ekbq,https://ekbq.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Seaspan,hckz,https://hckz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Securitas Security Services,ekaw,https://ekaw.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Sherwin-Williams,ejhp,https://ejhp.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Sinch,iaings,https://iaings.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Sinclair Broadcast Group,edyy,https://edyy.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Sitio de Carrera Banregio,ehyn,https://ehyn.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Sotera Health,eftx,https://eftx.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Southern Company,emje,https://emje.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Standard Aero,cva,https://cva.fa.us1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Stantec,hdhl,https://hdhl.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Station Casinos,ejfh,https://ejfh.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Stats Perform,eobe,https://eobe.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Stolt-Nielsen,eclo,https://eclo.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Subaru,hcal,https://hcal.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Suffolk Jobs Direct,eoce,https://eoce.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Sun River Health,edvy,https://edvy.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Sundt Careers,eewl,https://eewl.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+T.EN Career Site,hcxg,https://hcxg.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+TG_WFSJobs,iaboey,https://iaboey.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+TTX,ejjc,https://ejjc.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+TWE Global Careers,ebpm,https://ebpm.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Talent Acquisition,enpk,https://enpk.fa.em8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Tamaki Health Careers,iaantz,https://iaantz.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Tamer Group Site,eenp,https://eenp.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Tata Capital,eofh,https://eofh.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Teekay,eipv,https://eipv.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Tenet Healthcare Corporation,eodr,https://eodr.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Texas Children's Careers,eohh,https://eohh.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Texas Instruments,edbz,https://edbz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+The Arab Energy Fund,iaebkf,https://iaebkf.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+The City of Edinburgh Council,iaghme,https://iaghme.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+The Fedcap Group,eckb,https://eckb.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+The Kroger Co.,eluq,https://eluq.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Tiffany,eljs,https://eljs.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Trillium Health Partners,iadyup,https://iadyup.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+UC Health Career Site,eswt,https://eswt.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+UNDP,estm,https://estm.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+URUS Group,hdjm,https://hdjm.fa.ca2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+USS,icbajb,https://icbajb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+UW Health,eimy,https://eimy.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+UnitedLex,ekkk,https://ekkk.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+University of Edinburgh,elxw,https://elxw.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+VDOT Careers Site,etgi,https://etgi.fa.us8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+VITAS Healthcare,ejrz,https://ejrz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Vanderbilt University,ecsr,https://ecsr.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Vertiv,egup,https://egup.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Vodafone Qatar,elat,https://elat.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+WM,emcm,https://emcm.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+WSP,emit,https://emit.fa.ca3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+WTW External Careers Site,eedu,https://eedu.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Well Enterprises - Career Site,hcsb,https://hcsb.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Wesco,eklm,https://eklm.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+West Midlands Police,ecwz,https://ecwz.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Westpac Group,ebuu,https://ebuu.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Williams-Sonoma,ehac,https://ehac.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Winning Form Careers Site,iagjme,https://iagjme.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Wood,ehif,https://ehif.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Working at Signature Aviation,hdbt,https://hdbt.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Yum!,eczd,https://eczd.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Zeus,cbhm,https://cbhm.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+ebtw.fa.us2.oraclecloud.com,ebtw,https://ebtw.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+ectf.fa.us2.oraclecloud.com,ectf,https://ectf.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+eduu.fa.us2.oraclecloud.com,eduu,https://eduu.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+eees.fa.us2.oraclecloud.com,eees,https://eees.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+eexs.fa.us2.oraclecloud.com,eexs,https://eexs.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+egvv.fa.us6.oraclecloud.com,egvv,https://egvv.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+ehgv.fa.em2.oraclecloud.com,ehgv,https://ehgv.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+ehwy.fa.us2.oraclecloud.com,ehwy,https://ehwy.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+ejql.fa.us6.oraclecloud.com,ejql,https://ejql.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+ekcf.fa.us6.oraclecloud.com,ekcf,https://ekcf.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+ekkh.fa.us2.oraclecloud.com,ekkh,https://ekkh.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+ekug.fa.us6.oraclecloud.com,ekug,https://ekug.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+enmv.fa.us2.oraclecloud.com,enmv,https://enmv.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+enno.fa.ap1.oraclecloud.com,enno,https://enno.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+enqn.fa.us2.oraclecloud.com,enqn,https://enqn.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+enxp.fa.us6.oraclecloud.com,enxp,https://enxp.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+eubt.fa.us6.oraclecloud.com,eubt,https://eubt.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+gka.fa.us1.oraclecloud.com,gka,https://gka.fa.us1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+hcfa.fa.us2.oraclecloud.com,hcfa,https://hcfa.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+hckd.fa.us2.oraclecloud.com,hckd,https://hckd.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+hctz.fa.us2.oraclecloud.com,hctz,https://hctz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+hcut.fa.ap2.oraclecloud.com,hcut,https://hcut.fa.ap2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+hcwt.fa.us2.oraclecloud.com,hcwt,https://hcwt.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+hdbg.fa.us2.oraclecloud.com,hdbg,https://hdbg.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+hdrc.fa.ca3.oraclecloud.com,hdrc,https://hdrc.fa.ca3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+hza.fa.us1.oraclecloud.com,hza,https://hza.fa.us1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+iabqiz.fa.ocs.oraclecloud.com,iabqiz,https://iabqiz.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+iaccgs.fa.ocs.oraclecloud.com,iaccgs,https://iaccgs.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+iahbme.fa.ocs.oraclecloud.com,iahbme,https://iahbme.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+iawmqy.fa.ocs.oraclecloud.com,iawmqy,https://iawmqy.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+iazuqy.fa.ocs.oraclecloud.com,iazuqy,https://iazuqy.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+ibmljb.fa.ocs.oraclecloud.com,ibmljb,https://ibmljb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+ibnjjb.fa.ocs.oraclecloud.com,ibnjjb,https://ibnjjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+icfcjb.fa.ocs.oraclecloud.com,icfcjb,https://icfcjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+ooba,ejuu,https://ejuu.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+the Myriad Genetics Candidate site,ekgn,https://ekgn.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1


### PR DESCRIPTION
## Summary

- Migrate `ats-companies/oracle.csv` from `name,url` to `name,slug,url`.
- Keep `slug` as the scraper/API identifier and `url` as the canonical public careers URL.
- Drop 191 Oracle rows whose `url` values contained spaces and were not syntactically valid URLs.

## Pipeline note

Any scraping pipeline that reads these CSVs should pass `row["slug"]` to slug-based scrapers when the column exists. `url` is now intended for public/canonical company career links and may no longer be a valid scraper input for slug-only providers.

## Validation

- CSV schema validation: `name,slug,url`, non-empty values, `https://` URLs, no whitespace in URLs.
- Sample URL check: `ABM US` -> `200` at `https://eiqg.fa.us2.oraclecloud.com`, no `/login`, `/signin`, or `/auth` final redirect.
- Full non-Phenom sample check: 25/25 providers OK.
- Scraper tests: `392 passed` with the ATS-focused pytest suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `ats-companies/oracle.csv` to the `name,slug,url` schema and added Oracle slugs (host codes). `url` now points to the canonical Candidate Experience path (`/hcmUI/CandidateExperience/en/sites/CX_1`). Removed 191 rows with invalid URLs.

- **Migration**
  - Pass `row["slug"]` to Oracle scrapers; do not derive it from `url`.
  - Treat `row["url"]` as the public careers link; it now includes the full Candidate Experience path.
  - Expect fewer rows after removing invalid/test entries.

<sup>Written for commit 5112169f37838007ed7fbc1dc95f92d6a26e8b05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

