### PR TITLE
tesla: fetch per-job descriptions via legacy /cua-api/careers/job/{id}

### DIFF
--- a/src/jobhive/scrapers/tesla.py
+++ b/src/jobhive/scrapers/tesla.py
@@ -23,6 +23,7 @@ pipeline keeps moving (per the optional-browser-fallback contract).
 from __future__ import annotations
 
 import asyncio
+import html
 import json
 import logging
 import re
@@ -44,6 +45,9 @@ _STATE_ENDPOINT = "/cua-api/apps/careers/state"
 # ``jobResponsibilities``, ``jobRequirements``,
 # ``jobCompensationAndBenefits``, ``department``, ``timeType``.
 # Pattern lifted from the legacy scraper at ``legacy/tesla/main.py``.
+# Passed into the in-page fetch as a JS template-arg (see
+# ``_fetch_details``) so this constant is the single source of truth
+# and the path can't drift between Python and JS.
 _JOB_DETAIL_ENDPOINT = "/cua-api/careers/job/{job_id}"
 
 # Page-load waits that let Akamai's risk-score settle before the
@@ -165,11 +169,11 @@ class TeslaScraper(BaseScraper):
             batch = job_ids[i : i + _DETAIL_CONCURRENCY]
             try:
                 results = await page.evaluate(
-                    """async (ids) => {
+                    """async ({ids, pathTpl}) => {
                         return await Promise.all(ids.map(async (id) => {
                             try {
                                 const r = await fetch(
-                                    `/cua-api/careers/job/${id}`,
+                                    pathTpl.replace('{job_id}', id),
                                     {credentials: 'include',
                                      headers: {'Accept': 'application/json'}},
                                 );
@@ -182,7 +186,7 @@ class TeslaScraper(BaseScraper):
                             }
                         }));
                     }""",
-                    batch,
+                    {"ids": batch, "pathTpl": _JOB_DETAIL_ENDPOINT},
                 )
             except Exception as exc:
                 # Whole-batch failure (e.g. page crashed). Log and
@@ -194,7 +198,10 @@ class TeslaScraper(BaseScraper):
             for item in results or []:
                 if item.get("status") == 200 and item.get("data"):
                     out[str(item["id"])] = item["data"]
-            await asyncio.sleep(_DETAIL_BATCH_DELAY_S)
+            # Sleep only between batches, not after the last one — saves
+            # a needless ~300 ms per scraper run on the tail batch.
+            if i + _DETAIL_CONCURRENCY < len(job_ids):
+                await asyncio.sleep(_DETAIL_BATCH_DELAY_S)
         log.info(
             "Tesla: fetched %d/%d job descriptions",
             len(out), len(job_ids),
@@ -238,6 +245,39 @@ class TeslaScraper(BaseScraper):
         return f"{slug}-{job_id}" if slug else job_id
 
 
+_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RUN_RE = re.compile(r"[ \t]+")
+_BLANK_LINES_RE = re.compile(r"\n{3,}")
+
+
+def _html_to_text(raw: str) -> str:
+    """Strip HTML tags + unescape entities + normalise whitespace.
+
+    Tesla's detail endpoint ships ``jobResponsibilities`` /
+    ``jobRequirements`` with embedded ``<li>``, ``<ul>``, ``<p>``
+    markup; ``Job.description`` is documented as plain text and
+    several downstream consumers assume that. A simple
+    regex-strip is sufficient here — these payloads are
+    well-formed snippets, not arbitrary HTML.
+    """
+    # Replace block-level tags with newlines before stripping so we
+    # don't glue list items together. ``<br>`` and ``</li>`` /
+    # ``</p>`` / ``</div>`` etc. become line breaks; opening tags
+    # of those elements are stripped without a newline.
+    text = re.sub(
+        r"<\s*(?:br\s*/?|/li|/p|/div|/h[1-6]|/tr|/ul|/ol)\s*>",
+        "\n",
+        raw,
+        flags=re.IGNORECASE,
+    )
+    text = _TAG_RE.sub("", text)
+    text = html.unescape(text)
+    # Collapse runs of horizontal whitespace; squash 3+ newlines.
+    text = _WS_RUN_RE.sub(" ", text)
+    text = _BLANK_LINES_RE.sub("\n\n", text)
+    return text.strip()
+
+
 def _format_description(detail: dict[str, Any]) -> str:
     """Concatenate the four description-bearing fields from the
     Tesla per-job detail payload into a single string.
@@ -246,7 +286,10 @@ def _format_description(detail: dict[str, Any]) -> str:
     description column reads with section headers (Description /
     Responsibilities / Requirements / Compensation & Benefits) — Tesla
     surfaces those as distinct fields and the structure is worth
-    preserving for downstream consumers.
+    preserving for downstream consumers. Each section value is run
+    through ``_html_to_text`` first because Tesla mixes HTML markup
+    (``<li>``, ``<ul>``, ``<p>``) into these fields and
+    ``Job.description`` must be plain text.
     """
     sections = (
         ("Description", detail.get("jobDescription")),
@@ -255,9 +298,11 @@ def _format_description(detail: dict[str, Any]) -> str:
         ("Compensation & Benefits",
          detail.get("jobCompensationAndBenefits")),
     )
-    parts = [
-        f"{label}:\n{value.strip()}"
-        for label, value in sections
-        if isinstance(value, str) and value.strip()
-    ]
+    parts = []
+    for label, value in sections:
+        if not isinstance(value, str):
+            continue
+        cleaned = _html_to_text(value)
+        if cleaned:
+            parts.append(f"{label}:\n{cleaned}")
     return "\n\n".join(parts)

--- a/src/jobhive/scrapers/tesla.py
+++ b/src/jobhive/scrapers/tesla.py
@@ -259,20 +259,28 @@ def _html_to_text(raw: str) -> str:
     several downstream consumers assume that. A simple
     regex-strip is sufficient here — these payloads are
     well-formed snippets, not arbitrary HTML.
+
+    Order matters: unescape entities *first*, then strip tags. If
+    we stripped tags before unescaping, an encoded tag like
+    ``&lt;script&gt;...`` would survive the strip pass and then
+    unescape back into a literal ``<script>`` in the output —
+    leaking real HTML into ``Job.description``. Doing the unescape
+    first means any decoded tags get caught by the strip pass.
     """
-    # Replace block-level tags with newlines before stripping so we
-    # don't glue list items together. ``<br>`` and ``</li>`` /
-    # ``</p>`` / ``</div>`` etc. become line breaks; opening tags
-    # of those elements are stripped without a newline.
+    # 1. Unescape entities so any encoded tags surface as real
+    #    angle-brackets that the strip pass below will then remove.
+    text = html.unescape(raw)
+    # 2. Replace block-level closing/self-closing tags with newlines
+    #    before stripping so list items stay on separate lines.
     text = re.sub(
         r"<\s*(?:br\s*/?|/li|/p|/div|/h[1-6]|/tr|/ul|/ol)\s*>",
         "\n",
-        raw,
+        text,
         flags=re.IGNORECASE,
     )
+    # 3. Strip any remaining tags.
     text = _TAG_RE.sub("", text)
-    text = html.unescape(text)
-    # Collapse runs of horizontal whitespace; squash 3+ newlines.
+    # 4. Collapse runs of horizontal whitespace; squash 3+ newlines.
     text = _WS_RUN_RE.sub(" ", text)
     text = _BLANK_LINES_RE.sub("\n\n", text)
     return text.strip()

--- a/src/jobhive/scrapers/tesla.py
+++ b/src/jobhive/scrapers/tesla.py
@@ -39,6 +39,12 @@ log = logging.getLogger(__name__)
 _BASE_URL = "https://www.tesla.com"
 _CAREERS_HOME = "/careers/search/"
 _STATE_ENDPOINT = "/cua-api/apps/careers/state"
+# Per-job detail endpoint — note the path differs from state
+# (no ``apps/`` segment). Yields ``jobDescription``,
+# ``jobResponsibilities``, ``jobRequirements``,
+# ``jobCompensationAndBenefits``, ``department``, ``timeType``.
+# Pattern lifted from the legacy scraper at ``legacy/tesla/main.py``.
+_JOB_DETAIL_ENDPOINT = "/cua-api/careers/job/{job_id}"
 
 # Page-load waits that let Akamai's risk-score settle before the
 # ``cua-api`` call. Tuned to ~10 s total wall — long enough to look
@@ -46,6 +52,13 @@ _STATE_ENDPOINT = "/cua-api/apps/careers/state"
 _INITIAL_SETTLE_S = 5
 _POST_SCROLL_S = 2
 _POST_MOUSE_S = 2
+
+# Description-fetch knobs. We fan out N detail requests via
+# Promise.all inside the warmed-up page (so they share Akamai
+# cookies + risk-score), then sleep between batches so we don't
+# trip the per-IP rate limiter.
+_DETAIL_CONCURRENCY = 10
+_DETAIL_BATCH_DELAY_S = 0.3
 
 
 @ScraperRegistry.register(ATSType.TESLA)
@@ -97,22 +110,96 @@ class TeslaScraper(BaseScraper):
                 }""",
                 _STATE_ENDPOINT,
             )
+
+            if resp["status"] != 200:
+                raise ScraperError(
+                    f"Tesla cua-api returned status {resp['status']} "
+                    f"(body preview: {resp['body'][:200]!r})"
+                )
+            try:
+                payload = json.loads(resp["body"])
+            except json.JSONDecodeError as exc:
+                raise ScraperError(
+                    f"Tesla: response did not parse as JSON ({exc})."
+                ) from exc
+
+            jobs = list(self._parse_payload(payload))
+
+            # Per-job descriptions — fetched in-session from inside
+            # the warmed-up page so we keep cookies + risk-score. The
+            # state-endpoint listings are description-less, so without
+            # this step every Tesla row ships with an empty
+            # ``description`` (violates the
+            # always-include-descriptions invariant).
+            ids = [j.ats_id for j in jobs]
+            details = await self._fetch_details(page, ids)
+            for j in jobs:
+                d = details.get(j.ats_id)
+                if d:
+                    j.description = _format_description(d) or None
+                    if not j.department:
+                        j.department = d.get("department") or None
         finally:
             await browser.close()
 
-        if resp["status"] != 200:
-            raise ScraperError(
-                f"Tesla cua-api returned status {resp['status']} "
-                f"(body preview: {resp['body'][:200]!r})"
-            )
-        try:
-            payload = json.loads(resp["body"])
-        except json.JSONDecodeError as exc:
-            raise ScraperError(
-                f"Tesla: response did not parse as JSON ({exc})."
-            ) from exc
+        return jobs
 
-        return list(self._parse_payload(payload))
+    async def _fetch_details(
+        self,
+        page: Any,
+        job_ids: list[str],
+    ) -> dict[str, dict[str, Any]]:
+        """Fetch ``/cua-api/careers/job/{id}`` for every id, batched.
+
+        Uses Promise.all inside the page so the cookies set during
+        warm-up are reused. Errors per job are swallowed and the id
+        is simply absent from the returned dict — the caller treats
+        a missing entry as "no description available" so a partial
+        Akamai trip doesn't drop the whole listings payload we
+        already paid for.
+        """
+        if not job_ids:
+            return {}
+        out: dict[str, dict[str, Any]] = {}
+        for i in range(0, len(job_ids), _DETAIL_CONCURRENCY):
+            batch = job_ids[i : i + _DETAIL_CONCURRENCY]
+            try:
+                results = await page.evaluate(
+                    """async (ids) => {
+                        return await Promise.all(ids.map(async (id) => {
+                            try {
+                                const r = await fetch(
+                                    `/cua-api/careers/job/${id}`,
+                                    {credentials: 'include',
+                                     headers: {'Accept': 'application/json'}},
+                                );
+                                if (r.status !== 200) {
+                                    return {id, status: r.status, data: null};
+                                }
+                                return {id, status: 200, data: await r.json()};
+                            } catch (e) {
+                                return {id, status: -1, error: String(e)};
+                            }
+                        }));
+                    }""",
+                    batch,
+                )
+            except Exception as exc:
+                # Whole-batch failure (e.g. page crashed). Log and
+                # keep going — partial coverage beats zero.
+                log.warning(
+                    "Tesla: detail batch %d failed: %s", i, exc,
+                )
+                continue
+            for item in results or []:
+                if item.get("status") == 200 and item.get("data"):
+                    out[str(item["id"])] = item["data"]
+            await asyncio.sleep(_DETAIL_BATCH_DELAY_S)
+        log.info(
+            "Tesla: fetched %d/%d job descriptions",
+            len(out), len(job_ids),
+        )
+        return out
 
     def _parse_payload(self, payload: dict[str, Any]) -> list[Job]:
         listings = payload.get("listings") or []
@@ -149,3 +236,28 @@ class TeslaScraper(BaseScraper):
     def _url_slug(title: str, job_id: str) -> str:
         slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
         return f"{slug}-{job_id}" if slug else job_id
+
+
+def _format_description(detail: dict[str, Any]) -> str:
+    """Concatenate the four description-bearing fields from the
+    Tesla per-job detail payload into a single string.
+
+    Mirrors the legacy formatter at ``legacy/tesla/main.py`` so the
+    description column reads with section headers (Description /
+    Responsibilities / Requirements / Compensation & Benefits) — Tesla
+    surfaces those as distinct fields and the structure is worth
+    preserving for downstream consumers.
+    """
+    sections = (
+        ("Description", detail.get("jobDescription")),
+        ("Responsibilities", detail.get("jobResponsibilities")),
+        ("Requirements", detail.get("jobRequirements")),
+        ("Compensation & Benefits",
+         detail.get("jobCompensationAndBenefits")),
+    )
+    parts = [
+        f"{label}:\n{value.strip()}"
+        for label, value in sections
+        if isinstance(value, str) and value.strip()
+    ]
+    return "\n\n".join(parts)

--- a/tests/test_tesla.py
+++ b/tests/test_tesla.py
@@ -1,16 +1,18 @@
 """Tests for the Tesla scraper.
 
-Scope: cloakbrowser gating + ``/cua-api/apps/careers/state`` parsing.
-The cloakbrowser network path is verified live, not mocked.
+Scope: cloakbrowser gating + ``/cua-api/apps/careers/state`` parsing
++ per-job detail description formatting. The cloakbrowser network
+path is verified live, not mocked.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 import pytest
 
-from jobhive.scrapers.tesla import TeslaScraper
+from jobhive.scrapers.tesla import TeslaScraper, _format_description
 
 
 def test_returns_empty_with_warning_when_cloakbrowser_missing(
@@ -84,3 +86,161 @@ def test_handles_unknown_location_key() -> None:
 def test_url_slug_handles_titles_with_punctuation() -> None:
     slug = TeslaScraper._url_slug("C++ / GPU Engineer (Optimus)", "999")
     assert slug == "c-gpu-engineer-optimus-999"
+
+
+# --- _format_description ---------------------------------------------
+
+
+def test_format_description_concatenates_all_four_sections() -> None:
+    detail = {
+        "jobDescription": "Build a car",
+        "jobResponsibilities": "Drive it",
+        "jobRequirements": "Hands",
+        "jobCompensationAndBenefits": "Equity",
+    }
+    out = _format_description(detail)
+    # Order is fixed and matches the legacy formatter at
+    # ``legacy/tesla/main.py``.
+    assert out == (
+        "Description:\nBuild a car\n\n"
+        "Responsibilities:\nDrive it\n\n"
+        "Requirements:\nHands\n\n"
+        "Compensation & Benefits:\nEquity"
+    )
+
+
+def test_format_description_skips_missing_or_blank_sections() -> None:
+    detail = {
+        "jobDescription": "Body",
+        "jobResponsibilities": "",       # explicit empty
+        "jobRequirements": None,         # null
+        "jobCompensationAndBenefits": "   ",  # whitespace-only
+    }
+    assert _format_description(detail) == "Description:\nBody"
+
+
+def test_format_description_strips_surrounding_whitespace() -> None:
+    detail = {"jobDescription": "  \n  Real text  \n  "}
+    assert _format_description(detail) == "Description:\nReal text"
+
+
+def test_format_description_empty_for_empty_detail() -> None:
+    assert _format_description({}) == ""
+
+
+def test_format_description_ignores_non_string_values() -> None:
+    """Tesla occasionally ships a non-string (e.g. dict shape change);
+    treat anything that isn't a non-empty string as missing rather
+    than crashing the per-job loop."""
+    detail = {
+        "jobDescription": ["body in array"],
+        "jobResponsibilities": 42,
+        "jobRequirements": "Real",
+    }
+    assert _format_description(detail) == "Requirements:\nReal"
+
+
+# --- _fetch_details (per-job description fetch) ----------------------
+
+
+class _FakePage:
+    """Minimal stand-in for the cloakbrowser Page object.
+
+    The real page exposes an async ``evaluate`` that hands a JS source
+    + arg into the renderer. We don't run JS here — we just record
+    which job-id batches were dispatched and return canned per-id
+    payloads."""
+
+    def __init__(self, responses: dict[str, dict | None]) -> None:
+        self._responses = responses
+        self.batches: list[list[str]] = []
+
+    async def evaluate(self, _js: str, batch: list[str]) -> list[dict]:
+        self.batches.append(list(batch))
+        results = []
+        for job_id in batch:
+            data = self._responses.get(job_id)
+            if data is None:
+                results.append({"id": job_id, "status": 403, "data": None})
+            else:
+                results.append({"id": job_id, "status": 200, "data": data})
+        return results
+
+
+@pytest.fixture(autouse=True)
+def _fast_batches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drop the inter-batch sleep so detail tests run instantly."""
+    import jobhive.scrapers.tesla as t
+    monkeypatch.setattr(t, "_DETAIL_BATCH_DELAY_S", 0.0)
+
+
+def test_fetch_details_batches_and_collects_successes() -> None:
+    """Every successful per-id payload must land in the output dict;
+    missing/blocked ids are absent (caller treats as no description)."""
+    responses = {
+        "1": {"jobDescription": "A"},
+        "2": {"jobDescription": "B"},
+        # id 3 deliberately missing → Akamai blocked / 403
+    }
+    page = _FakePage(responses)
+    out = asyncio.run(TeslaScraper("tesla")._fetch_details(page, ["1", "2", "3"]))
+    assert set(out) == {"1", "2"}
+    assert out["1"]["jobDescription"] == "A"
+    # All 3 ids dispatched in a single batch (concurrency=10 default).
+    assert page.batches == [["1", "2", "3"]]
+
+
+def test_fetch_details_empty_input_no_calls() -> None:
+    page = _FakePage({})
+    out = asyncio.run(TeslaScraper("tesla")._fetch_details(page, []))
+    assert out == {}
+    assert page.batches == []
+
+
+def test_fetch_details_chunks_by_concurrency_limit() -> None:
+    """A larger id list should be split into ``_DETAIL_CONCURRENCY``-sized
+    batches so we don't open thousands of in-page parallel requests."""
+    import jobhive.scrapers.tesla as t
+
+    n = t._DETAIL_CONCURRENCY * 2 + 3  # 23 default → 2 full + 1 partial
+    ids = [str(i) for i in range(n)]
+    responses = {i: {"jobDescription": f"d-{i}"} for i in ids}
+    page = _FakePage(responses)
+    out = asyncio.run(TeslaScraper("tesla")._fetch_details(page, ids))
+    assert len(out) == n
+    assert [len(b) for b in page.batches] == [
+        t._DETAIL_CONCURRENCY,
+        t._DETAIL_CONCURRENCY,
+        3,
+    ]
+
+
+def test_fetch_details_swallows_whole_batch_exception(caplog) -> None:
+    """If the page itself raises during ``evaluate`` (browser crash,
+    cookie wipe, …), the helper must keep going on later batches
+    rather than abort the whole description pass."""
+    import jobhive.scrapers.tesla as t
+
+    class _FlakyPage(_FakePage):
+        def __init__(self, responses, fail_on_batch_index):
+            super().__init__(responses)
+            self._fail_at = fail_on_batch_index
+            self._call_count = 0
+
+        async def evaluate(self, js, batch):
+            i = self._call_count
+            self._call_count += 1
+            if i == self._fail_at:
+                raise RuntimeError("page crashed")
+            return await super().evaluate(js, batch)
+
+    n = t._DETAIL_CONCURRENCY + 1  # forces a second batch
+    ids = [str(i) for i in range(n)]
+    responses = {i: {"jobDescription": f"d-{i}"} for i in ids}
+    page = _FlakyPage(responses, fail_on_batch_index=0)
+    with caplog.at_level(logging.WARNING):
+        out = asyncio.run(TeslaScraper("tesla")._fetch_details(page, ids))
+    # First batch raised → nothing from it. Second batch yields its
+    # single id.
+    assert set(out) == {str(t._DETAIL_CONCURRENCY)}
+    assert any("detail batch" in r.getMessage().lower() for r in caplog.records)

--- a/tests/test_tesla.py
+++ b/tests/test_tesla.py
@@ -180,6 +180,27 @@ def test_html_to_text_empty_passthrough() -> None:
     assert _html_to_text("   ") == ""
 
 
+def test_html_to_text_unescapes_before_stripping_tags() -> None:
+    """Order matters. If we stripped tags first, then unescaped, an
+    encoded tag like ``&lt;script&gt;alert(1)&lt;/script&gt;`` would
+    survive the strip pass and then unescape into a literal
+    ``<script>...`` in the output — leaking HTML into
+    ``Job.description``. Doing the unescape first means any decoded
+    tags get caught by the subsequent strip."""
+    raw = "Salary range &lt;script&gt;alert(1)&lt;/script&gt; 100k"
+    out = _html_to_text(raw)
+    # The encoded tag must be GONE — not just decoded.
+    assert "<script>" not in out
+    assert "</script>" not in out
+    assert "<" not in out
+    assert ">" not in out
+    # The surrounding text and the literal payload inside the tag
+    # remain (we strip tags but keep their text content).
+    assert "Salary range" in out
+    assert "alert(1)" in out
+    assert "100k" in out
+
+
 def test_format_description_strips_tesla_html_in_sections() -> None:
     """End-to-end: Tesla's real-world payload has HTML in
     Responsibilities/Requirements — the formatter must yield plain

--- a/tests/test_tesla.py
+++ b/tests/test_tesla.py
@@ -12,7 +12,11 @@ import logging
 
 import pytest
 
-from jobhive.scrapers.tesla import TeslaScraper, _format_description
+from jobhive.scrapers.tesla import (
+    TeslaScraper,
+    _format_description,
+    _html_to_text,
+)
 
 
 def test_returns_empty_with_warning_when_cloakbrowser_missing(
@@ -140,6 +144,64 @@ def test_format_description_ignores_non_string_values() -> None:
     assert _format_description(detail) == "Requirements:\nReal"
 
 
+# --- _html_to_text ---------------------------------------------------
+
+
+def test_html_to_text_strips_simple_tags() -> None:
+    assert _html_to_text("<p>Hello <b>world</b></p>") == "Hello world"
+
+
+def test_html_to_text_converts_list_items_to_newlines() -> None:
+    """The whole point of the helper: an ``<li>`` list must not collapse
+    into a single glued line. Each ``</li>`` becomes a newline."""
+    raw = "<ul><li>Lead the team</li><li>Ship code</li><li>Drink coffee</li></ul>"
+    out = _html_to_text(raw)
+    # All three items present, separated by newlines (order
+    # preserved). Empty leading line from </ul> stripped.
+    assert out.split("\n") == ["Lead the team", "Ship code", "Drink coffee"]
+
+
+def test_html_to_text_unescapes_entities() -> None:
+    assert _html_to_text("Salary &amp; equity &lt;&gt; bonus") == "Salary & equity <> bonus"
+
+
+def test_html_to_text_collapses_excess_whitespace() -> None:
+    raw = "<p>Lots   of    spaces</p>\n\n\n<p>And gaps</p>"
+    out = _html_to_text(raw)
+    assert out == "Lots of spaces\n\nAnd gaps"
+
+
+def test_html_to_text_handles_br() -> None:
+    assert _html_to_text("Line A<br>Line B<br/>Line C") == "Line A\nLine B\nLine C"
+
+
+def test_html_to_text_empty_passthrough() -> None:
+    assert _html_to_text("") == ""
+    assert _html_to_text("   ") == ""
+
+
+def test_format_description_strips_tesla_html_in_sections() -> None:
+    """End-to-end: Tesla's real-world payload has HTML in
+    Responsibilities/Requirements — the formatter must yield plain
+    text without raw tags leaking through to ``Job.description``."""
+    detail = {
+        "jobDescription": "Be a wizard at Tesla.",
+        "jobResponsibilities": "<ul><li>Build optimus</li><li>Test it</li></ul>",
+        "jobRequirements": "<p>10y experience &amp; <b>passion</b></p>",
+        "jobCompensationAndBenefits": None,
+    }
+    out = _format_description(detail)
+    # No raw HTML tags anywhere.
+    assert "<" not in out and ">" not in out
+    # Entities decoded.
+    assert "&amp;" not in out
+    assert "&" in out
+    # Section structure preserved.
+    assert out.startswith("Description:\nBe a wizard at Tesla.")
+    assert "Responsibilities:\nBuild optimus\nTest it" in out
+    assert "Requirements:\n10y experience & passion" in out
+
+
 # --- _fetch_details (per-job description fetch) ----------------------
 
 
@@ -149,14 +211,19 @@ class _FakePage:
     The real page exposes an async ``evaluate`` that hands a JS source
     + arg into the renderer. We don't run JS here — we just record
     which job-id batches were dispatched and return canned per-id
-    payloads."""
+    payloads. The scraper now passes ``{"ids": [...], "pathTpl":
+    "/cua-api/careers/job/{job_id}"}`` so the path template is the
+    single source of truth (see PR #65 review comment from Greptile)."""
 
     def __init__(self, responses: dict[str, dict | None]) -> None:
         self._responses = responses
         self.batches: list[list[str]] = []
+        self.path_tpls: list[str] = []
 
-    async def evaluate(self, _js: str, batch: list[str]) -> list[dict]:
-        self.batches.append(list(batch))
+    async def evaluate(self, _js: str, arg: dict) -> list[dict]:
+        batch = list(arg["ids"])
+        self.batches.append(batch)
+        self.path_tpls.append(arg["pathTpl"])
         results = []
         for job_id in batch:
             data = self._responses.get(job_id)
@@ -213,6 +280,65 @@ def test_fetch_details_chunks_by_concurrency_limit() -> None:
         t._DETAIL_CONCURRENCY,
         3,
     ]
+
+
+def test_fetch_details_passes_path_template_to_js() -> None:
+    """The path template lives in Python as a single source of truth;
+    the helper hands it to ``page.evaluate`` so JS never hard-codes
+    the path. Catches the drift Greptile flagged on PR #65."""
+    import jobhive.scrapers.tesla as t
+
+    page = _FakePage({"1": {"jobDescription": "x"}})
+    asyncio.run(TeslaScraper("tesla")._fetch_details(page, ["1"]))
+    assert page.path_tpls == [t._JOB_DETAIL_ENDPOINT]
+
+
+def test_fetch_details_no_trailing_sleep_after_last_batch(monkeypatch) -> None:
+    """The inter-batch sleep must fire only between batches, not after
+    the final one. Catches the wasted ~300 ms tail Greptile flagged."""
+    import jobhive.scrapers.tesla as t
+
+    sleeps: list[float] = []
+    real_sleep = asyncio.sleep
+
+    async def tracker(seconds):
+        sleeps.append(seconds)
+        await real_sleep(0)
+
+    monkeypatch.setattr(t.asyncio, "sleep", tracker)
+    # 0.0 fast-retries fixture also sets _DETAIL_BATCH_DELAY_S=0.0,
+    # restore so the tracker actually records the configured delay.
+    monkeypatch.setattr(t, "_DETAIL_BATCH_DELAY_S", 0.5)
+
+    # 2 batches → exactly 1 inter-batch sleep (after batch 0).
+    n = t._DETAIL_CONCURRENCY + 1
+    ids = [str(i) for i in range(n)]
+    page = _FakePage({i: {"jobDescription": "x"} for i in ids})
+    asyncio.run(TeslaScraper("tesla")._fetch_details(page, ids))
+
+    assert sleeps == [0.5]
+
+
+def test_fetch_details_no_sleep_at_all_for_single_batch(monkeypatch) -> None:
+    """Single batch → zero inter-batch sleeps. The last-batch optimization
+    matters most when the catalog fits in one batch (small ATSes / mocked
+    tests / smoke runs)."""
+    import jobhive.scrapers.tesla as t
+
+    sleeps: list[float] = []
+    real_sleep = asyncio.sleep
+
+    async def tracker(seconds):
+        sleeps.append(seconds)
+        await real_sleep(0)
+
+    monkeypatch.setattr(t.asyncio, "sleep", tracker)
+    monkeypatch.setattr(t, "_DETAIL_BATCH_DELAY_S", 0.5)
+
+    ids = [str(i) for i in range(t._DETAIL_CONCURRENCY)]  # exactly fits 1 batch
+    page = _FakePage({i: {"jobDescription": "x"} for i in ids})
+    asyncio.run(TeslaScraper("tesla")._fetch_details(page, ids))
+    assert sleeps == []
 
 
 def test_fetch_details_swallows_whole_batch_exception(caplog) -> None:


### PR DESCRIPTION
## Summary
Tesla's state endpoint (\`/cua-api/apps/careers/state\`) returns the listings catalog but no description fields. Every Tesla row in our dataset has shipped with an empty \`description\` since the cloakbrowser rewrite (PR #32) — violates the always-include-descriptions invariant in memory.

The legacy scraper at \`legacy/tesla/main.py\` documents the per-job detail endpoint: **\`/cua-api/careers/job/{id}\`** (note: no \`apps/\` segment — different from the state path). It returns \`jobDescription\`, \`jobResponsibilities\`, \`jobRequirements\`, \`jobCompensationAndBenefits\`, \`department\`, \`timeType\`.

## Implementation
- After the warm-up + state fetch, dispatch detail requests **from inside the same warmed-up page** via \`Promise.all\` batches (concurrency=10, 0.3 s inter-batch sleep). Keeps Akamai cookies/risk-score from the warm-up; avoids re-launching the browser per job.
- Per-job failures are swallowed: the id is simply absent from the returned dict, and the row keeps \`description=None\`. A partial Akamai trip on detail requests must not discard the catalog we already scraped from state.
- \`_format_description\` concatenates the four description fields with section headers, matching the legacy formatter so downstream consumers see consistent structure.
- Opportunistically backfills \`department\` from the detail payload when the state-side department lookup didn't resolve.

## Test plan
- [x] **14 unit tests** in \`tests/test_tesla.py\`:
  - \`_format_description\`: all-four-sections, missing/blank/whitespace-only/non-string fields, empty dict
  - \`_fetch_details\`: batching, empty input, chunking by \`_DETAIL_CONCURRENCY\`, whole-batch exception tolerance
- [x] Full test suite: **852 passed in 13.21 s**
- [ ] Live VPS run — to validate next time the Akamai window opens (right now Tesla is 403-ing even on the state endpoint, so the description fetch can't be validated end-to-end today). I'll re-check periodically and trigger a manual run + republish once Tesla lets us back in.

## Operational notes
Pattern proven by \`legacy/tesla/main.py\` (battle-tested per the use-legacy-as-reference memory). The cached per-run JSON file is intentionally not added in this PR — keeping the change tight on the description fetch itself. If repeated daily-cron Akamai trips become a problem, a future PR can add a disk cache so re-runs only fetch new ids.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Tesla job descriptions by fetching per‑job details via the legacy `/cua-api/careers/job/{id}` endpoint and formatting them into one plain‑text string. Requests run in-page in small batches to reuse Akamai cookies; also backfills department when available.

- **Bug Fixes**
  - Fetch details from the warmed-up page using `Promise.all` (concurrency=10) with 0.3s pauses between batches; skip the final sleep to avoid tail delay.
  - Tolerate per-id and whole-batch failures so the catalog is kept even if some requests fail.
  - Build the final description by concatenating the four fields; unescape entities before stripping HTML, convert list items/`<br>` to newlines, and normalize whitespace to produce clean plain text matching legacy output.
  - Backfill `department` from the detail payload when the state response lacks it.
  - Pass `_JOB_DETAIL_ENDPOINT` into `page.evaluate` as `pathTpl` so the Python constant is the single source of truth for the JS fetch path.

<sup>Written for commit 041dd488f8d8caee394300b5ccc5c3fbd7d105bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restores per-job descriptions for Tesla by fetching `/cua-api/careers/job/{id}` in batches from the already-warmed-up cloakbrowser page, then formatting the four description fields into a single structured string matching the legacy scraper output.

- Descriptions are fetched in `_DETAIL_CONCURRENCY`-sized batches with `Promise.all` so Akamai cookies from the warm-up are reused; per-id and whole-batch failures are silently dropped so a partial Akamai block never discards the full catalog already fetched from the state endpoint.
- `_format_description` concatenates `jobDescription`, `jobResponsibilities`, `jobRequirements`, and `jobCompensationAndBenefits` with section headers, mirroring the legacy formatter structure.
- Department is opportunistically backfilled from the detail payload when the state-side lookup didn't resolve.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the description fetch is additive and failures are gracefully tolerated.

The `_JOB_DETAIL_ENDPOINT` constant at module level is never referenced in code — the URL lives only inside the JS template literal, so the two can drift on any future endpoint rename. The inter-batch sleep also fires once after the last batch adding an unnecessary delay. Neither issue affects correctness today.

Review the URL embedding in `_fetch_details` in `src/jobhive/scrapers/tesla.py` — the JS hardcodes the path that the module-level constant is meant to centralise.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/tesla.py | Adds `_fetch_details` to fetch per-job descriptions via the legacy `/cua-api/careers/job/{id}` endpoint in batches. Error handling is solid (per-id and whole-batch failures swallowed gracefully). Two minor issues: the `_JOB_DETAIL_ENDPOINT` constant is dead code (the URL is hardcoded in the JS string, not derived from the constant), and the inter-batch sleep fires unnecessarily after the last batch. |
| tests/test_tesla.py | Adds 14 unit tests covering `_format_description` edge cases (blank/null/non-string fields) and `_fetch_details` batching, empty input, concurrency chunking, and whole-batch exception tolerance. Test coverage is thorough and the `_fast_batches` fixture properly eliminates sleep overhead. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/jobhive/scrapers/tesla.py:47
`_JOB_DETAIL_ENDPOINT` is never referenced in Python code — the actual URL is embedded as a JS template literal (`` `/cua-api/careers/job/${id}` ``) on line 172. The two can silently drift if the endpoint path changes; updating only the Python constant has no effect on the fetches. Consider either passing the base path as a `page.evaluate` argument (so the constant is the single source of truth) or removing the constant and leaving only the comment above it.

### Issue 2 of 2
src/jobhive/scrapers/tesla.py:194-197
The inter-batch sleep fires unconditionally after every batch, including the last one, adding an unnecessary ~300 ms delay at the end of every description fetch pass.

```suggestion
            for item in results or []:
                if item.get("status") == 200 and item.get("data"):
                    out[str(item["id"])] = item["data"]
            if i + _DETAIL_CONCURRENCY < len(job_ids):
                await asyncio.sleep(_DETAIL_BATCH_DELAY_S)
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["tesla: fetch per-job descriptions via le..."](https://github.com/kalil0321/ats-scrapers/commit/d47cb0d8a0153d1f6aecbd9e2340fc58addc7f88) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31598330)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->