### PR TITLE
phenom: docstring points at canonical ats-companies/phenom.csv

### DIFF
--- a/src/jobhive/scrapers/phenom.py
+++ b/src/jobhive/scrapers/phenom.py
@@ -83,9 +83,10 @@ class PhenomScraper(BaseScraper):
     site (e.g. ``"https://jobs.bell.ca"``). ``locale`` and ``country`` are
     tenant-specific and typically appear in the public URL path.
 
-    Legacy-discovered configurations (``data/phenom/companies.csv``) ship the
-    correct ``locale``/``country`` per tenant. For brand-new tenants, default
-    ``"en_us"``/``"us"`` works for the majority of US sites."""
+    The canonical tenant list at ``ats-companies/phenom.csv`` ships the
+    correct ``locale``/``country`` per tenant (columns:
+    ``url,name,company_code,locale,country``). For brand-new tenants the
+    default ``"en_us"``/``"us"`` works for the majority of US sites."""
 
     ats = ATSType.PHENOM
 


### PR DESCRIPTION
Doc-only follow-up to the 2026-05 `ats-companies/` migration. The `PhenomScraper` class docstring still mentioned the legacy `data/phenom/companies.csv` path that was deleted as part of the cleanup; rewords to name the canonical `ats-companies/phenom.csv` (columns `url,name,company_code,locale,country`). No runtime change.

## Test plan
- [x] No behavioural surface modified — pure docstring edit
- [ ] VPS pull picks this up so the on-disk source comment matches reality

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Doc-only follow-up to the May 2026 `ats-companies/` migration: update `PhenomScraper` docstring to point to the canonical `ats-companies/phenom.csv` (columns: `url,name,company_code,locale,country`) instead of the removed `data/phenom/companies.csv`. No runtime change.

<sup>Written for commit 4868543b8a24d598a6aaaa0c9ef4221b4ca0c0e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the `PhenomScraper` class docstring to reference the canonical `ats-companies/phenom.csv` tenant list instead of the deleted `data/phenom/companies.csv` path, and adds the column schema for clarity. No runtime behaviour is changed.

- Replaces the stale legacy path reference with the post-migration canonical path; the target file and its header (`url,name,company_code,locale,country`) match the docstring exactly.
- Slightly rewrites the surrounding prose for conciseness while preserving the guidance on default locale/country values for new tenants.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change touches only a docstring and the updated path and column list are accurate.

The edit corrects a stale file path and adds a column schema in a class docstring. The referenced CSV exists at the stated location with the exact header listed. No logic, configuration, or runtime behaviour is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/phenom.py | Pure docstring update replacing the legacy `data/phenom/companies.csv` path with the canonical `ats-companies/phenom.csv` path and listing the correct CSV columns; verified against the actual file header. |

</details>

<sub>Reviews (1): Last reviewed commit: ["phenom: docstring points at canonical at..."](https://github.com/kalil0321/ats-scrapers/commit/4868543b8a24d598a6aaaa0c9ef4221b4ca0c0e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31625866)</sub>

<!-- /greptile_comment -->