### PR TITLE
ats-companies: publisher preserves slug column; README documents new schema

### DIFF
--- a/.github/scripts/publish_companies.py
+++ b/.github/scripts/publish_companies.py
@@ -21,7 +21,11 @@ Notes:
 - Hashes are computed locally (sha256) so consumers can verify
   downloads without trusting the bucket's ETag.
 - Parquet is generated with ``pandas.to_parquet`` (snappy by default).
-  Schema: ``ats,name,url`` — same simple shape as the CSVs.
+  Schema: ``ats,name,slug,url``. The ``slug`` column was introduced in
+  the 2026-05 migration as the scraper/API identifier; ``url`` holds
+  the canonical public careers URL. Per-ATS files that haven't been
+  migrated yet (still ``name,url``) get an empty ``slug`` column in
+  the aggregate so the published schema stays uniform.
 
 Known limitation — manifest read-modify-write race:
   This script and ``DatasetPublisher`` both read+modify+write
@@ -117,21 +121,32 @@ def file_entry(url: str, *, data: bytes, parquet_url: str | None = None) -> dict
 
 def build_aggregated(ats_files: dict[str, bytes]) -> tuple[bytes, bytes, int]:
     """Concatenate per-ATS CSVs adding an ``ats`` column. Returns
-    ``(csv_bytes, parquet_bytes, row_count)``."""
+    ``(csv_bytes, parquet_bytes, row_count)``.
+
+    Aggregated schema is ``ats,name,slug,url``. The ``slug`` column was
+    introduced in the 2026-05 migration as the scraper/API identifier;
+    ``url`` is now the canonical public careers URL. CSVs that haven't
+    been migrated yet (still ``name,url``) get an empty ``slug`` value
+    so the published schema is uniform across all ATSes.
+    """
     frames: list[pd.DataFrame] = []
     for ats, raw in sorted(ats_files.items()):
         df = pd.read_csv(io.BytesIO(raw), dtype=str, keep_default_na=False)
         # Some legacy phenom rows carry a 5-column schema (url, name,
         # company_code, locale, country). For the aggregate we keep
-        # only the universal pair to match the documented schema.
+        # only the universal trio to match the documented schema.
         if not {"name", "url"}.issubset(df.columns):
             print(f"  WARN: {ats} CSV missing name/url columns: {df.columns.tolist()}")
             continue
-        df = df[["name", "url"]].copy()
+        if "slug" in df.columns:
+            df = df[["name", "slug", "url"]].copy()
+        else:
+            df = df[["name", "url"]].copy()
+            df.insert(1, "slug", "")
         df.insert(0, "ats", ats)
         frames.append(df)
     combined = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame(
-        columns=["ats", "name", "url"]
+        columns=["ats", "name", "slug", "url"]
     )
     csv_buf = io.BytesIO()
     combined.to_csv(csv_buf, index=False)

--- a/ats-companies/README.md
+++ b/ats-companies/README.md
@@ -3,18 +3,28 @@
 Tenant lists per ATS — every company that **jobhive** scrapes lives in
 one of the CSVs here. New rows here = new companies in the dataset.
 
-One file per ATS, named `{ats}.csv`. Schema is uniform across all of
-them:
+One file per ATS, named `{ats}.csv`. The canonical schema is
+`name,slug,url`:
 
 ```csv
-name,url
-Acme Corp,https://acme.greenhouse.io
+name,slug,url
+Acme Corp,acme,https://acme.greenhouse.io
 ```
 
 - `name` — display name. Free-form. Used as `Job.company` until the
   scraper resolves a richer value from the live page.
-- `url` — the URL or slug the matching scraper accepts. Format depends
-  on the ATS (see examples below).
+- `slug` — the scraper/API identifier the matching scraper accepts
+  (lowercase, deterministic). Pipelines should prefer this column when
+  reading the CSV.
+- `url` — the canonical public careers URL. User-facing — safe to
+  ship to consumers as a link. **Not** guaranteed to be a valid
+  scraper input on its own; scraper code parses/rejects case-by-case.
+
+> **Schema migration in flight.** A few files still use the legacy
+> two-column shape (`name,url`) where `url` is the bare slug. The
+> publisher tolerates both: legacy files get an empty `slug` in the
+> aggregated R2 output so the published schema (`ats,name,slug,url`)
+> stays uniform.
 
 ## URL formats by ATS
 
@@ -46,10 +56,12 @@ Acme Corp,https://acme.greenhouse.io
 | workable | `https://apply.workable.com/<slug>` |
 | workday | `https://<host>.myworkdayjobs.com/<board>` |
 
-> **Phenom is the one exception to the 2-column schema.**
+> **Phenom is the exception.**
 > `phenom.csv` carries `url,name,company_code,locale,country` because
 > Phenom search endpoints are scoped per `(locale, country)` and we
-> want to keep that wiring close to the tenant list.
+> want to keep that wiring close to the tenant list. The publisher
+> aggregate keeps only `name`/`slug`/`url` from this file (the rest
+> stays in the per-ATS CSV).
 
 When in doubt, look at the existing rows in the file you're editing —
 the scraper accepts whatever shape is already there.


### PR DESCRIPTION
## Why

Kind AI Tests is failing on 13 of the codex slug-migration PRs (#41, #43, #44, #46, #51, #53, #56, #58, #59, #60, #61, #63, #64) with the same root cause:

> *\"The publisher keeps only ``ats,name,url`` in aggregated output and ignores the extra ``slug`` column. The migrated CSV is valid, but supporting repo metadata is not updated for the migration.\"*

So Kind correctly refuses to bless those PRs until the publisher and README catch up with the data files.

## What this PR does

1. **\`.github/scripts/publish_companies.py\` \`build_aggregated()\`** now keeps \`slug\` from every per-ATS CSV when present, and fills it with an empty string for CSVs still on the legacy \`name,url\` shape — uniform aggregated schema \`ats,name,slug,url\` regardless of migration state.

2. **\`ats-companies/README.md\`** updates the canonical schema docs to \`name,slug,url\` with explicit semantics:
   - \`slug\` = scraper/API identifier (preferred input)
   - \`url\` = canonical user-facing careers URL (not necessarily a valid scraper input)
   Plus a migration-in-flight note so contributors editing legacy files don't get confused.

Phenom keeps its 5-column per-ATS shape; the aggregate now picks \`name,slug,url\` from it (slug empty since phenom has no slug column) — schema stays uniform.

## Smoke test

```python
csv_out, _, n = build_aggregated({
    'greenhouse': b'name,slug,url\\nAcme,acme,https://acme.greenhouse.io\\n',
    'legacy_ats': b'name,url\\nFoo,foo\\n',
    'phenom':     b'url,name,company_code,locale,country\\nhttps://bell.ca,bell,,en_us,us\\n',
})
# Output:
# ats,name,slug,url
# greenhouse,Acme,acme,https://acme.greenhouse.io
# legacy_ats,Foo,,foo
# phenom,bell,,https://bell.ca
```

## After merge

The 13 failing Kind runs on the codex PRs should pass (or improve to a clean rating) on rerun because the metadata they checked against (README + publisher schema) is now aligned with the migrated data.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publisher now preserves the slug column and publishes a uniform `ats,name,slug,url` schema; README documents the new schema and semantics. This aligns publisher output with migrated per-ATS files to unblock slug-migration PRs.

- **Bug Fixes**
  - Updated `.github/scripts/publish_companies.py:build_aggregated()` to keep `slug` when present and insert empty `slug` for legacy `name,url`; outputs `ats,name,slug,url` for CSV and Parquet.
  - `ats-companies/README.md` now defines `name,slug,url`, clarifies `slug` (scraper identifier) vs `url` (public careers URL), and notes migration tolerance.
  - For Phenom, aggregate keeps only `name`/`slug`/`url` (slug empty) and ignores extra columns.

<sup>Written for commit d57bf23f5b79a8b18bd5c1f1cc47cbec7ff6685a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the publisher's aggregation logic so the `slug` column introduced during the 2026-05 migration is carried through to the published output, and updates the README to document the new canonical schema.

- `build_aggregated()` now emits a uniform `ats,name,slug,url` schema: migrated CSVs keep their `slug` value; legacy `name,url` CSVs and the 5-column Phenom file receive an empty `slug` so downstream consumers always see the same shape.
- The README's schema section, field definitions, and Phenom exception note are all updated to match the new reality, including a migration-in-flight callout for contributors editing legacy files.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The logic change is small and well-scoped, and code, docs, and smoke-test output are mutually consistent.

The diff touches two paths: the aggregation function and the README. In build_aggregated(), column selection is explicit (positional insert and list-based [] selection), so the slug column always lands in the right slot regardless of the source CSV's column order. Legacy files get a typed empty-string column rather than a NaN, which is safe because keep_default_na=False is already set. The empty-frame fallback was updated to match. The Phenom 5-column case continues to work correctly because the existing {name, url} guard still filters it through the else branch. No existing callers of build_aggregated() are affected beyond gaining the extra column. README content is accurate and internally consistent with the code.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/scripts/publish_companies.py | build_aggregated() now normalises every per-ATS frame to ats,name,slug,url — adding an empty slug column for legacy name,url CSVs — and the empty-frame fallback columns are updated to match. |
| ats-companies/README.md | Schema docs updated from name,url to name,slug,url with field semantics, a migration-in-flight note for legacy files, and a clarified Phenom exception note. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ats-companies: publisher preserves slug ..."](https://github.com/kalil0321/ats-scrapers/commit/d57bf23f5b79a8b18bd5c1f1cc47cbec7ff6685a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31631075)</sub>

<!-- /greptile_comment -->