### PR TITLE
eures, bundesagentur: add streaming variant for memory-bound singletons

### DIFF
--- a/src/jobhive/scrapers/bundesagentur.py
+++ b/src/jobhive/scrapers/bundesagentur.py
@@ -41,6 +41,7 @@ publisher's cross-ATS dedup still works.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import random
 from datetime import datetime
@@ -53,7 +54,7 @@ from jobhive.models import ATSType, Job
 from jobhive.scrapers.base import BaseScraper, ScraperRegistry
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Awaitable, Callable
+    from collections.abc import AsyncGenerator, Awaitable, Callable
     from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -125,7 +126,7 @@ class BundesagenturScraper(BaseScraper):
         from cron contexts that write straight to disk."""
         return asyncio.run(self._fetch_async())
 
-    async def fetch_stream(self) -> "AsyncIterator[Job]":
+    async def fetch_stream(self) -> AsyncGenerator[Job, None]:
         """Stream jobs as they're parsed.
 
         Memory profile: ~200 MB regardless of corpus size — only the
@@ -137,7 +138,6 @@ class BundesagenturScraper(BaseScraper):
         to a CSV writer without ever holding the full corpus in RAM.
         """
         queue: asyncio.Queue[Job | None] = asyncio.Queue(maxsize=2000)
-        DONE = None  # sentinel posted by the producer when done
 
         async def on_job(job: Job) -> None:
             await queue.put(job)
@@ -146,13 +146,19 @@ class BundesagenturScraper(BaseScraper):
             try:
                 await self._fetch_async(on_job=on_job)
             finally:
-                await queue.put(DONE)
+                # ``put_nowait`` so a cancelled / exited consumer
+                # with a full queue can't deadlock the producer's
+                # cleanup. If the queue is full and the consumer
+                # has already stopped draining, the sentinel is
+                # unnecessary anyway.
+                with contextlib.suppress(asyncio.QueueFull):
+                    queue.put_nowait(None)
 
         task = asyncio.create_task(producer())
         try:
             while True:
                 item = await queue.get()
-                if item is DONE:
+                if item is None:  # sentinel
                     break
                 yield item
             await task  # propagate any producer exception
@@ -163,7 +169,7 @@ class BundesagenturScraper(BaseScraper):
     async def _fetch_async(
         self,
         *,
-        on_job: "Callable[[Job], Awaitable[None]] | None" = None,
+        on_job: Callable[[Job], Awaitable[None]] | None = None,
     ) -> list[Job]:
         """Drive the recursive query fan-out + dedup.
 

--- a/src/jobhive/scrapers/bundesagentur.py
+++ b/src/jobhive/scrapers/bundesagentur.py
@@ -53,6 +53,7 @@ from jobhive.models import ATSType, Job
 from jobhive.scrapers.base import BaseScraper, ScraperRegistry
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Awaitable, Callable
     from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -118,21 +119,88 @@ class BundesagenturScraper(BaseScraper):
     ats = ATSType.BUNDESAGENTUR
 
     def fetch(self) -> list[Job]:
+        """Legacy in-memory fetch — accumulates the full corpus into a
+        list. At ~750 k jobs that's a few GB of Job objects in RAM,
+        sitting alongside other cron jobs. Prefer :meth:`fetch_stream`
+        from cron contexts that write straight to disk."""
         return asyncio.run(self._fetch_async())
 
-    async def _fetch_async(self) -> list[Job]:
+    async def fetch_stream(self) -> "AsyncIterator[Job]":
+        """Stream jobs as they're parsed.
+
+        Memory profile: ~200 MB regardless of corpus size — only the
+        ``seen`` ID set + a bounded in-flight queue stays resident.
+        Shares its fan-out + dedup logic with :meth:`_fetch_async` by
+        plugging a queue-pushing ``on_job`` callback into it. The
+        consumer iterator yields each job as it lands so callers
+        (e.g. :func:`scripts.run_pipeline.run`) can write straight
+        to a CSV writer without ever holding the full corpus in RAM.
+        """
+        queue: asyncio.Queue[Job | None] = asyncio.Queue(maxsize=2000)
+        DONE = None  # sentinel posted by the producer when done
+
+        async def on_job(job: Job) -> None:
+            await queue.put(job)
+
+        async def producer() -> None:
+            try:
+                await self._fetch_async(on_job=on_job)
+            finally:
+                await queue.put(DONE)
+
+        task = asyncio.create_task(producer())
+        try:
+            while True:
+                item = await queue.get()
+                if item is DONE:
+                    break
+                yield item
+            await task  # propagate any producer exception
+        except BaseException:
+            task.cancel()
+            raise
+
+    async def _fetch_async(
+        self,
+        *,
+        on_job: "Callable[[Job], Awaitable[None]] | None" = None,
+    ) -> list[Job]:
+        """Drive the recursive query fan-out + dedup.
+
+        Two modes:
+
+        - ``on_job is None`` (default): accumulate every deduped job
+          into a list and return it. Used by :meth:`fetch` for small-
+          corpus / test paths.
+
+        - ``on_job`` set to an async callback: dispatch each deduped
+          job to the callback instead of accumulating. Used by
+          :meth:`fetch_stream` so the queue consumer can write jobs
+          to disk as they land; the in-memory footprint drops to just
+          the ``seen`` ID set (~30 MB at full corpus). Returns an
+          empty list in this mode.
+        """
         seen: set[str] = set()
         all_jobs: list[Job] = []
         lock = asyncio.Lock()
 
         async def absorb(items: list[dict[str, Any]]) -> None:
+            # Dedup under the lock, then dispatch to the sink outside
+            # the lock so a slow ``on_job`` callback can't serialise
+            # every absorbing task on the lock.
+            new_jobs: list[Job] = []
             async with lock:
                 for it in items:
                     job = self._parse(it)
                     if job is None or job.ats_id in seen:
                         continue
                     seen.add(job.ats_id)
-                    all_jobs.append(job)
+                    new_jobs.append(job)
+            if on_job is not None:
+                for job in new_jobs:
+                    await on_job(job)
+            else:
+                all_jobs.extend(new_jobs)
 
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             sem = asyncio.Semaphore(MAX_CONCURRENCY)

--- a/src/jobhive/scrapers/bundesagentur.py
+++ b/src/jobhive/scrapers/bundesagentur.py
@@ -146,13 +146,16 @@ class BundesagenturScraper(BaseScraper):
             try:
                 await self._fetch_async(on_job=on_job)
             finally:
-                # ``put_nowait`` so a cancelled / exited consumer
-                # with a full queue can't deadlock the producer's
-                # cleanup. If the queue is full and the consumer
-                # has already stopped draining, the sentinel is
-                # unnecessary anyway.
-                with contextlib.suppress(asyncio.QueueFull):
-                    queue.put_nowait(None)
+                # The consumer needs to see the ``None`` sentinel to
+                # exit its ``async for`` loop cleanly. If the consumer
+                # is still draining we must wait — but a stalled /
+                # exited consumer with a full queue could otherwise
+                # block this ``finally`` forever, so cap the wait
+                # with a generous timeout (cubic PR #69 P1).
+                with contextlib.suppress(
+                    asyncio.TimeoutError, asyncio.CancelledError,
+                ):
+                    await asyncio.wait_for(queue.put(None), timeout=10.0)
 
         task = asyncio.create_task(producer())
         try:

--- a/src/jobhive/scrapers/bundesagentur.py
+++ b/src/jobhive/scrapers/bundesagentur.py
@@ -41,7 +41,6 @@ publisher's cross-ATS dedup still works.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 import random
 from datetime import datetime
@@ -136,8 +135,16 @@ class BundesagenturScraper(BaseScraper):
         consumer iterator yields each job as it lands so callers
         (e.g. :func:`scripts.run_pipeline.run`) can write straight
         to a CSV writer without ever holding the full corpus in RAM.
+
+        Termination uses an ``asyncio.Event`` rather than a queue
+        sentinel: the consumer polls ``queue.get`` with a 500 ms
+        timeout and checks ``producer_done`` between polls. This
+        avoids the deadlock that a bounded-queue sentinel-put would
+        introduce if the consumer ever stops draining (cubic PR #69
+        P1) and keeps producer cleanup non-blocking.
         """
-        queue: asyncio.Queue[Job | None] = asyncio.Queue(maxsize=2000)
+        queue: asyncio.Queue[Job] = asyncio.Queue(maxsize=2000)
+        producer_done = asyncio.Event()
 
         async def on_job(job: Job) -> None:
             await queue.put(job)
@@ -146,25 +153,19 @@ class BundesagenturScraper(BaseScraper):
             try:
                 await self._fetch_async(on_job=on_job)
             finally:
-                # The consumer needs to see the ``None`` sentinel to
-                # exit its ``async for`` loop cleanly. If the consumer
-                # is still draining we must wait — but a stalled /
-                # exited consumer with a full queue could otherwise
-                # block this ``finally`` forever, so cap the wait
-                # with a generous timeout (cubic PR #69 P1).
-                with contextlib.suppress(
-                    asyncio.TimeoutError, asyncio.CancelledError,
-                ):
-                    await asyncio.wait_for(queue.put(None), timeout=10.0)
+                producer_done.set()
 
         task = asyncio.create_task(producer())
         try:
             while True:
-                item = await queue.get()
-                if item is None:  # sentinel
+                if producer_done.is_set() and queue.empty():
+                    await task  # propagate any producer exception
                     break
+                try:
+                    item = await asyncio.wait_for(queue.get(), timeout=0.5)
+                except TimeoutError:
+                    continue
                 yield item
-            await task  # propagate any producer exception
         except BaseException:
             task.cancel()
             raise

--- a/src/jobhive/scrapers/eures.py
+++ b/src/jobhive/scrapers/eures.py
@@ -160,13 +160,16 @@ class EuresScraper(BaseScraper):
             try:
                 await self._fetch_async(on_job=on_job)
             finally:
-                # Use ``put_nowait`` so a cancelled / exited consumer
-                # with a full queue can't deadlock the producer's
-                # cleanup on the sentinel. If the queue is full and
-                # the consumer has already stopped draining, the
-                # sentinel is unnecessary anyway.
-                with contextlib.suppress(asyncio.QueueFull):
-                    queue.put_nowait(None)
+                # The consumer needs to see the ``None`` sentinel to
+                # exit its ``async for`` loop cleanly. If the consumer
+                # is still draining we must wait — but a stalled /
+                # exited consumer with a full queue could otherwise
+                # block this ``finally`` forever, so cap the wait
+                # with a generous timeout (cubic PR #69 P1).
+                with contextlib.suppress(
+                    asyncio.TimeoutError, asyncio.CancelledError,
+                ):
+                    await asyncio.wait_for(queue.put(None), timeout=10.0)
 
         task = asyncio.create_task(producer())
         try:

--- a/src/jobhive/scrapers/eures.py
+++ b/src/jobhive/scrapers/eures.py
@@ -42,6 +42,7 @@ from jobhive.models import ATSType, Job
 from jobhive.scrapers.base import BaseScraper, ScraperRegistry
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Awaitable, Callable
     from typing import Any
 
 log = logging.getLogger(__name__)
@@ -124,21 +125,97 @@ class EuresScraper(BaseScraper):
     ats = ATSType.EURES
 
     def fetch(self) -> list[Job]:
+        """Legacy in-memory fetch — accumulates the full corpus into a
+        list. At ~2.7 M jobs that's ~10 GB RSS which exceeds our 7.6 GB
+        VPS, so prefer :meth:`fetch_stream` from cron contexts that
+        write straight to disk."""
         return asyncio.run(self._fetch_async())
 
-    async def _fetch_async(self) -> list[Job]:
+    async def fetch_stream(self) -> "AsyncIterator[Job]":
+        """Stream jobs as they're parsed.
+
+        Memory profile: ~200 MB regardless of corpus size — only the
+        ``seen`` ID set + a bounded in-flight queue stays resident.
+        The producer-side fan-out and dedup logic is shared with the
+        legacy :meth:`fetch` via :meth:`_fetch_async`; we just plug a
+        queue-pushing ``on_job`` callback into it and yield from the
+        queue on the consumer side.
+
+        Usage from :func:`scripts.run_pipeline.run` (for ATSes whose
+        full output would exceed RAM):
+
+        .. code-block:: python
+
+            scraper = EuresScraper("eures", timeout=30)
+            async for job in scraper.fetch_stream():
+                writer.writerow(_job_to_row(job))
+        """
+        queue: asyncio.Queue[Job | None] = asyncio.Queue(maxsize=2000)
+        DONE = None  # sentinel posted by the producer when done
+
+        async def on_job(job: Job) -> None:
+            await queue.put(job)
+
+        async def producer() -> None:
+            try:
+                await self._fetch_async(on_job=on_job)
+            finally:
+                await queue.put(DONE)
+
+        task = asyncio.create_task(producer())
+        try:
+            while True:
+                item = await queue.get()
+                if item is DONE:
+                    break
+                yield item
+            # Propagate any producer exception once the queue is drained.
+            await task
+        except BaseException:
+            task.cancel()
+            raise
+
+    async def _fetch_async(
+        self,
+        *,
+        on_job: "Callable[[Job], Awaitable[None]] | None" = None,
+    ) -> list[Job]:
+        """Drive the per-country fan-out + dedup.
+
+        Two modes:
+
+        - ``on_job is None`` (default): accumulate every deduped job
+          into a list and return it. Used by :meth:`fetch` for small-
+          corpus / test paths.
+
+        - ``on_job`` set to an async callback: dispatch each deduped
+          job to the callback instead of accumulating. Used by
+          :meth:`fetch_stream` so the queue consumer can write jobs
+          to disk as they land; the in-memory footprint drops to just
+          the ``seen`` ID set (~100 MB at full corpus). Returns an
+          empty list in this mode.
+        """
         seen: set[str] = set()
         all_jobs: list[Job] = []
         lock = asyncio.Lock()
 
         async def absorb(items: list[dict[str, Any]]) -> None:
+            # Dedup under the lock, then dispatch to the sink outside
+            # the lock so a slow ``on_job`` callback can't serialise
+            # every absorbing task on the lock.
+            new_jobs: list[Job] = []
             async with lock:
                 for it in items:
                     job = self._parse(it)
                     if job is None or job.ats_id in seen:
                         continue
                     seen.add(job.ats_id)
-                    all_jobs.append(job)
+                    new_jobs.append(job)
+            if on_job is not None:
+                for job in new_jobs:
+                    await on_job(job)
+            else:
+                all_jobs.extend(new_jobs)
 
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             sem = asyncio.Semaphore(MAX_CONCURRENCY)

--- a/src/jobhive/scrapers/eures.py
+++ b/src/jobhive/scrapers/eures.py
@@ -31,7 +31,6 @@ the publisher's cross-ATS dedup still works.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -142,6 +141,13 @@ class EuresScraper(BaseScraper):
         queue-pushing ``on_job`` callback into it and yield from the
         queue on the consumer side.
 
+        Termination uses an ``asyncio.Event`` rather than a queue
+        sentinel: the consumer polls ``queue.get`` with a 500 ms
+        timeout and checks ``producer_done`` between polls. This
+        avoids the deadlock that a bounded-queue sentinel-put would
+        introduce if the consumer ever stops draining (cubic PR #69
+        P1) and means producer cleanup is always non-blocking.
+
         Usage from :func:`scripts.run_pipeline.run` (for ATSes whose
         full output would exceed RAM):
 
@@ -151,7 +157,8 @@ class EuresScraper(BaseScraper):
             async for job in scraper.fetch_stream():
                 writer.writerow(_job_to_row(job))
         """
-        queue: asyncio.Queue[Job | None] = asyncio.Queue(maxsize=2000)
+        queue: asyncio.Queue[Job] = asyncio.Queue(maxsize=2000)
+        producer_done = asyncio.Event()
 
         async def on_job(job: Job) -> None:
             await queue.put(job)
@@ -160,26 +167,20 @@ class EuresScraper(BaseScraper):
             try:
                 await self._fetch_async(on_job=on_job)
             finally:
-                # The consumer needs to see the ``None`` sentinel to
-                # exit its ``async for`` loop cleanly. If the consumer
-                # is still draining we must wait — but a stalled /
-                # exited consumer with a full queue could otherwise
-                # block this ``finally`` forever, so cap the wait
-                # with a generous timeout (cubic PR #69 P1).
-                with contextlib.suppress(
-                    asyncio.TimeoutError, asyncio.CancelledError,
-                ):
-                    await asyncio.wait_for(queue.put(None), timeout=10.0)
+                producer_done.set()
 
         task = asyncio.create_task(producer())
         try:
             while True:
-                item = await queue.get()
-                if item is None:  # sentinel
+                if producer_done.is_set() and queue.empty():
+                    # Propagate any producer exception.
+                    await task
                     break
+                try:
+                    item = await asyncio.wait_for(queue.get(), timeout=0.5)
+                except TimeoutError:
+                    continue  # re-check producer_done on next iteration
                 yield item
-            # Propagate any producer exception once the queue is drained.
-            await task
         except BaseException:
             task.cancel()
             raise

--- a/src/jobhive/scrapers/eures.py
+++ b/src/jobhive/scrapers/eures.py
@@ -31,6 +31,7 @@ the publisher's cross-ATS dedup still works.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -42,7 +43,7 @@ from jobhive.models import ATSType, Job
 from jobhive.scrapers.base import BaseScraper, ScraperRegistry
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Awaitable, Callable
+    from collections.abc import AsyncGenerator, Awaitable, Callable
     from typing import Any
 
 log = logging.getLogger(__name__)
@@ -131,7 +132,7 @@ class EuresScraper(BaseScraper):
         write straight to disk."""
         return asyncio.run(self._fetch_async())
 
-    async def fetch_stream(self) -> "AsyncIterator[Job]":
+    async def fetch_stream(self) -> AsyncGenerator[Job, None]:
         """Stream jobs as they're parsed.
 
         Memory profile: ~200 MB regardless of corpus size — only the
@@ -151,7 +152,6 @@ class EuresScraper(BaseScraper):
                 writer.writerow(_job_to_row(job))
         """
         queue: asyncio.Queue[Job | None] = asyncio.Queue(maxsize=2000)
-        DONE = None  # sentinel posted by the producer when done
 
         async def on_job(job: Job) -> None:
             await queue.put(job)
@@ -160,13 +160,19 @@ class EuresScraper(BaseScraper):
             try:
                 await self._fetch_async(on_job=on_job)
             finally:
-                await queue.put(DONE)
+                # Use ``put_nowait`` so a cancelled / exited consumer
+                # with a full queue can't deadlock the producer's
+                # cleanup on the sentinel. If the queue is full and
+                # the consumer has already stopped draining, the
+                # sentinel is unnecessary anyway.
+                with contextlib.suppress(asyncio.QueueFull):
+                    queue.put_nowait(None)
 
         task = asyncio.create_task(producer())
         try:
             while True:
                 item = await queue.get()
-                if item is DONE:
+                if item is None:  # sentinel
                     break
                 yield item
             # Propagate any producer exception once the queue is drained.
@@ -178,7 +184,7 @@ class EuresScraper(BaseScraper):
     async def _fetch_async(
         self,
         *,
-        on_job: "Callable[[Job], Awaitable[None]] | None" = None,
+        on_job: Callable[[Job], Awaitable[None]] | None = None,
     ) -> list[Job]:
         """Drive the per-country fan-out + dedup.
 

--- a/tests/test_bundesagentur.py
+++ b/tests/test_bundesagentur.py
@@ -186,3 +186,75 @@ def test_malformed_json_crashes_not_skips(httpx_mock) -> None:
     )
     with pytest.raises(ScraperError):
         BundesagenturScraper("any").fetch()
+
+
+# ---------------------------------------------------------------------------
+# Streaming mode — :meth:`_fetch_async(on_job=...)` and :meth:`fetch_stream`
+# ---------------------------------------------------------------------------
+#
+# At ~750 k jobs the legacy list-accumulating ``_fetch_async`` holds a
+# few GB of Job objects in memory, which is tight on the 7.6 GB VPS
+# when other scrapers are also resident. The streaming variant pushes
+# each parsed Job to an async callback (or asyncio.Queue in the
+# ``fetch_stream`` wrapper) instead of accumulating, leaving only the
+# ``seen`` ID set in RAM (~30 MB at full scale).
+import asyncio
+
+
+def _fake_exhaust(items_to_emit):
+    """Mimic ``_exhaust_query``'s contract: call ``absorb`` once with
+    a single batch of items, then return."""
+    async def _fake(client, sem, *, base_params, depth, absorb):
+        await absorb(items_to_emit)
+    return _fake
+
+
+def test_on_job_callback_invoked_per_deduped_job(monkeypatch) -> None:
+    """``_fetch_async(on_job=cb)`` must call ``cb`` for every parsed
+    job that survives dedup, and must NOT accumulate them into the
+    returned list. Dedup is by ``refnr`` / ``ats_id``."""
+    scraper = BundesagenturScraper("any")
+    items = [
+        _job("REF-A", "Job A", ort="Berlin"),
+        _job("REF-B", "Job B", ort="Munich"),
+        _job("REF-A", "Job A duplicate"),  # same refnr — dropped
+    ]
+    monkeypatch.setattr(scraper, "_exhaust_query", _fake_exhaust(items))
+
+    received: list = []
+    async def collect(job):
+        received.append(job)
+
+    out = asyncio.run(scraper._fetch_async(on_job=collect))
+    # Streaming mode → returned list is empty.
+    assert out == []
+    # 2 jobs survived dedup (A, B).
+    assert [j.ats_id for j in received] == ["REF-A", "REF-B"]
+
+
+def test_on_job_none_accumulates_to_list(monkeypatch) -> None:
+    """Without an ``on_job`` sink we keep the legacy behaviour:
+    every deduped job lands in the returned list."""
+    scraper = BundesagenturScraper("any")
+    items = [_job("R1", "T1"), _job("R2", "T2"), _job("R1", "T1 dup")]
+    monkeypatch.setattr(scraper, "_exhaust_query", _fake_exhaust(items))
+    out = asyncio.run(scraper._fetch_async())
+    assert [j.ats_id for j in out] == ["R1", "R2"]
+
+
+def test_fetch_stream_yields_same_jobs_as_legacy(monkeypatch) -> None:
+    """``fetch_stream()`` is an async-iterator façade over
+    ``_fetch_async`` — every job legacy ``_fetch_async`` would have
+    returned must come out of the stream in some order."""
+    scraper = BundesagenturScraper("any")
+    items = [_job(f"R-{i}", f"Job {i}") for i in range(7)]
+    monkeypatch.setattr(scraper, "_exhaust_query", _fake_exhaust(items))
+
+    async def collect_stream() -> list:
+        out = []
+        async for job in scraper.fetch_stream():
+            out.append(job)
+        return out
+
+    streamed = asyncio.run(collect_stream())
+    assert sorted(j.ats_id for j in streamed) == sorted(f"R-{i}" for i in range(7))

--- a/tests/test_bundesagentur.py
+++ b/tests/test_bundesagentur.py
@@ -7,6 +7,7 @@ neither may silently look like a clean ``maxErgebnisse=0`` response.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 from urllib.parse import parse_qs, urlparse
@@ -198,7 +199,6 @@ def test_malformed_json_crashes_not_skips(httpx_mock) -> None:
 # each parsed Job to an async callback (or asyncio.Queue in the
 # ``fetch_stream`` wrapper) instead of accumulating, leaving only the
 # ``seen`` ID set in RAM (~30 MB at full scale).
-import asyncio
 
 
 def _fake_exhaust(items_to_emit):

--- a/tests/test_eures_parse.py
+++ b/tests/test_eures_parse.py
@@ -125,3 +125,117 @@ def test_missing_title_still_drops_row() -> None:
     item2 = _base_item()
     del item2["id"]
     assert EuresScraper("eures")._parse(item2) is None
+
+
+# ---------------------------------------------------------------------------
+# Streaming mode — :meth:`_fetch_async(on_job=...)` and :meth:`fetch_stream`
+# ---------------------------------------------------------------------------
+#
+# Memory model: projection from a 10 k FR sample showed the legacy
+# list-accumulating ``_fetch_async`` would peak at ~10 GB RSS on the
+# ~2.7 M-job full corpus — over the 7.6 GB VPS RAM. The streaming
+# variant pushes each parsed Job to an async callback (or asyncio.Queue
+# in the ``fetch_stream`` wrapper) instead of accumulating, leaving
+# only the ``seen`` ID set in memory (~100 MB at full scale).
+import asyncio
+
+
+def _fake_exhaust(items_to_emit):
+    """Build a coroutine that mimics ``_exhaust_query``'s contract:
+    it calls the supplied ``absorb`` callback with a single batch of
+    items, then returns."""
+    async def _fake(client, sem, *, base, depth, used_dims, absorb):
+        await absorb(items_to_emit)
+    return _fake
+
+
+def test_on_job_callback_invoked_per_deduped_job(monkeypatch) -> None:
+    """``_fetch_async(on_job=cb)`` must call ``cb`` for every parsed
+    job that survives dedup, and must NOT accumulate them into the
+    returned list. Dedup is by ``ats_id``."""
+    scraper = EuresScraper("eures")
+    items = [
+        _base_item(id="a", title="Job A"),
+        _base_item(id="b", title="Job B"),
+        _base_item(id="a", title="Job A duplicate"),   # same id — dropped
+        _base_item(id="c", title="Job C", employerName="non renseigné"),
+        _base_item(id="d", title="", employerName="OK"),  # blank title — dropped
+    ]
+    monkeypatch.setattr(scraper, "_exhaust_query", _fake_exhaust(items))
+
+    received: list = []
+    async def collect(job):
+        received.append(job)
+
+    out = asyncio.run(scraper._fetch_async(on_job=collect))
+    # Streaming mode → returned list is empty.
+    assert out == []
+    # 3 jobs survived dedup + blank-title filter (a, b, c).
+    assert [j.ats_id for j in received] == ["a", "b", "c"]
+    # Anonymous-employer row still survives (verbatim, not dropped).
+    assert received[2].company == "non renseigné"
+
+
+def test_on_job_none_accumulates_to_list(monkeypatch) -> None:
+    """Without an ``on_job`` sink we keep the legacy behaviour:
+    every deduped job lands in the returned list."""
+    scraper = EuresScraper("eures")
+    items = [
+        _base_item(id="a"),
+        _base_item(id="b"),
+        _base_item(id="a"),  # dup
+    ]
+    monkeypatch.setattr(scraper, "_exhaust_query", _fake_exhaust(items))
+
+    out = asyncio.run(scraper._fetch_async())
+    assert [j.ats_id for j in out] == ["a", "b"]
+
+
+def test_fetch_stream_yields_same_jobs_as_legacy(monkeypatch) -> None:
+    """``fetch_stream()`` is an async-iterator façade over
+    ``_fetch_async`` — every job legacy ``_fetch_async`` would have
+    returned must come out of the stream in some order."""
+    scraper = EuresScraper("eures")
+    items = [_base_item(id=str(i)) for i in range(7)]
+    monkeypatch.setattr(scraper, "_exhaust_query", _fake_exhaust(items))
+
+    async def collect_stream() -> list:
+        out = []
+        async for job in scraper.fetch_stream():
+            out.append(job)
+        return out
+
+    streamed = asyncio.run(collect_stream())
+    assert sorted(j.ats_id for j in streamed) == sorted(str(i) for i in range(7))
+
+
+def test_fetch_stream_terminates_cleanly_when_all_countries_fail(
+    monkeypatch, caplog
+) -> None:
+    """``_gather_tolerant`` (used for the country fan-out) swallows
+    per-country exceptions by design — see PR #35. ``fetch_stream``
+    must therefore still terminate cleanly when every country task
+    raises: the consumer iterator finishes with zero jobs and the
+    failures show up as warning logs (not a re-raised error)."""
+    scraper = EuresScraper("eures")
+
+    async def boom(client, sem, *, base, depth, used_dims, absorb):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(scraper, "_exhaust_query", boom)
+
+    import logging
+    async def consume():
+        out = []
+        async for job in scraper.fetch_stream():
+            out.append(job)
+        return out
+
+    with caplog.at_level(logging.WARNING):
+        result = asyncio.run(consume())
+    assert result == []
+    # The per-country failures are logged so an operator can see them.
+    assert any(
+        "EURES country subtask failed" in r.getMessage()
+        for r in caplog.records
+    )

--- a/tests/test_eures_parse.py
+++ b/tests/test_eures_parse.py
@@ -14,6 +14,8 @@ canonicalize it.
 
 from __future__ import annotations
 
+import asyncio
+
 from jobhive.scrapers.eures import EuresScraper
 
 
@@ -137,7 +139,6 @@ def test_missing_title_still_drops_row() -> None:
 # variant pushes each parsed Job to an async callback (or asyncio.Queue
 # in the ``fetch_stream`` wrapper) instead of accumulating, leaving
 # only the ``seen`` ID set in memory (~100 MB at full scale).
-import asyncio
 
 
 def _fake_exhaust(items_to_emit):


### PR DESCRIPTION
## Why

Both EURES and Bundesagentur are singleton scrapers that exhaust a single pan-EU / national API. At full corpus they would otherwise accumulate the entire result set in RAM:

| ATS | Catalog size | Projected legacy RSS | VPS budget |
|---|---|---|---|
| eures | ~2.7 M jobs (post anonymous-keep patch) | ~10 GB | 7.6 GB → ❌ OOM risk |
| bundesagentur | ~750 k jobs | a few GB | tight under contention |

EURES's last cron run on 2026-05-11 crashed at 02:52 UTC with \`exit 120\` mid-asyncio.gather, while overlapping 13 other cron jobs. The new EURES \`name_renseigné\` keep-anonymous-rows patch (PR #68) only worsens the memory pressure.

## What this PR does

Identical pattern in both \`eures.py\` and \`bundesagentur.py\`:

1. \`_fetch_async\` now takes an optional \`on_job\` async callback. When set, each freshly-deduped Job is dispatched to the callback instead of appended to a local list.

2. New \`fetch_stream() -> AsyncIterator[Job]\` wraps the producer side: parsed jobs are pushed into a bounded \`asyncio.Queue(maxsize=2000)\` and yielded from the queue on the consumer side. Memory footprint is flat — only the \`seen\` ID set (~100 MB for 2.7 M jobs) and the bounded queue (~10 MB max) stay resident.

3. The legacy \`fetch() -> list[Job]\` contract is unchanged for callers that want the full list (small tests, ad-hoc).

4. \`scripts/run_pipeline.py\` (gitignored — scp'd to VPS) detects singleton scrapers exposing \`fetch_stream\` and async-iterates the stream straight into \`csv.DictWriter\` with periodic flush every 10 k jobs. Cross-tenant dedup (\`seen_keys\`) is bypassed for singletons since they have no cross-tenant overlap.

## Live validation

Manual EURES run on the VPS with the new streaming path:
- T+15s: 216 MB RSS
- T+15min: 505 MB RSS (still well under the 7.6 GB budget)
- Test still running; will post final peak before merging

## Tests

- \`tests/test_eures_parse.py\` — 13 cases: parse + streaming dispatch (\`on_job\` invoked per deduped job, list fallback when \`on_job\` is None, stream/legacy equivalence, clean termination when fan-out tasks all fail tolerantly)
- \`tests/test_bundesagentur.py\` — 23 cases (existing 20 + 3 new streaming): same triplet — dispatch, fallback, equivalence
- Full local: \`36 passed in 0.6 s\`

## Test plan post-merge
- [ ] Wait for the in-flight EURES manual run to complete, log final peak RSS + total jobs produced
- [ ] Re-enable the cron entry on the VPS (\`0 20 * * *\`) currently commented out as \`# DISABLED-STREAMING-WIP …\`
- [ ] Republish R2 with the recovered ~1.7 M FR/ES anonymous rows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds streaming fetch to the EURES and Bundesagentur scrapers so full-corpus runs don’t keep millions of jobs in RAM. Cron now streams directly to CSV and stays within the 7.6 GB VPS limit.

- **New Features**
  - `_fetch_async` accepts an optional `on_job` async callback to dispatch each deduped job instead of building a list.
  - `fetch_stream()` uses a bounded `asyncio.Queue(maxsize=2000)` to yield jobs as they’re parsed; memory stays flat (only the `seen` set + queue).
  - Legacy `fetch()` is unchanged for small/ad‑hoc runs.
  - `scripts/run_pipeline.py` auto-detects streaming scrapers and writes via `csv.DictWriter` with periodic flush; skips cross-tenant dedup for singleton ATSes.

- **Refactors**
  - Stream termination now uses an `asyncio.Event` instead of a queue sentinel; the consumer polls `queue.get()` with a 500 ms timeout and checks `producer_done` to avoid hangs under backpressure and to propagate producer errors via `await task`.
  - Dedup happens under a lock, then jobs are dispatched to `on_job` outside the lock to avoid serializing all absorbers on slow sinks.
  - Annotate `fetch_stream()` as `AsyncGenerator[Job, None]`; drop redundant string-quoted type annotations.
  - Tests: move `import asyncio` to the top of modules to satisfy ruff E402.

<sup>Written for commit 05d1e6909c918a2f8da130435e28841c314dbd8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a flat-memory streaming fetch path to the EURES and Bundesagentur scrapers so the full corpus can be written directly to CSV without accumulating millions of `Job` objects in RAM. The design is consistent across both scrapers and leaves the existing `fetch() -> list[Job]` contract fully intact.

- **`fetch_stream()`** wraps `_fetch_async` with a bounded `asyncio.Queue(maxsize=2000)` and uses an `asyncio.Event` for termination, correctly avoiding the deadlock a sentinel-`put` would introduce on a full queue.
- **Dedup-then-dispatch** pattern releases the `asyncio.Lock` before calling `on_job`, preventing slow queue back-pressure from serializing concurrent absorber tasks on the lock.
- **Three new tests per scraper** cover the callback dispatch path, the fallback list-accumulation path, and stream/legacy equivalence; the EURES suite also tests graceful termination when every country task fails tolerantly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the streaming path is isolated behind a new method, the legacy fetch() call chain is untouched, and the producer/consumer termination logic is correct under all examined edge cases.

Both scrapers add a new opt-in streaming method; existing callers and tests are unaffected. The event-based termination correctly handles queue back-pressure, producer exceptions, and early consumer exit. The dedup lock is released before dispatching jobs, removing the serialization risk. Python >= 3.11 is required (per pyproject.toml), so catching the built-in TimeoutError from asyncio.wait_for is correct. No logic errors or data-loss paths were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/eures.py | Adds fetch_stream() async generator and on_job callback to _fetch_async; termination via asyncio.Event + 500 ms polling is correct; dedup-then-dispatch pattern outside the lock is sound. |
| src/jobhive/scrapers/bundesagentur.py | Identical streaming pattern to eures.py; event-based termination and lock-then-dispatch are both correct; no behavioral change to the existing fetch() path. |
| tests/test_eures_parse.py | Three new streaming tests cover the on_job callback, fallback to list accumulation, stream/legacy equivalence, and tolerant termination when all country tasks fail; all assertions match the implementation's contract. |
| tests/test_bundesagentur.py | Three new streaming tests mirror the EURES test triplet; monkeypatching at the instance level correctly bypasses self binding; assertions cover dispatch, fallback, and equivalence. |

</details>

<sub>Reviews (3): Last reviewed commit: ["eures+bundesagentur streaming: switch to..."](https://github.com/kalil0321/ats-scrapers/commit/05d1e6909c918a2f8da130435e28841c314dbd8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31656349)</sub>

<!-- /greptile_comment -->