### PR TITLE
[codex] Add Tencent careers scraper

### DIFF
--- a/ats-companies/tencent.csv
+++ b/ats-companies/tencent.csv
@@ -1,0 +1,2 @@
+name,slug,url
+Tencent,tencent,https://careers.tencent.com

--- a/provider-description-matrix.md
+++ b/provider-description-matrix.md
@@ -1,6 +1,6 @@
 # Provider Description Matrix
 
-This table covers the 47 providers configured in `scripts/run_pipeline.py`.
+This table covers the 48 providers configured in `scripts/run_pipeline.py`.
 `API/feed` means the data comes from a machine-readable endpoint such as JSON,
 XML, RSS, GraphQL, or a markdown endpoint. `HTML` means the scraper parses a
 page/rendered page rather than a structured job payload.
@@ -46,6 +46,7 @@ page/rendered page rather than a structured job payload.
 | `teamtailor` | Yes | No | API/feed (RSS/XML) | API/feed (RSS/XML) |
 | `tesla` | Yes | Yes | API/feed / browser | API/feed |
 | `thehub` | Yes | No | API/feed | API/feed |
+| `tencent` | Yes | No | API/feed | API/feed |
 | `tiktok` | Yes | No | API/feed | API/feed |
 | `uber` | Yes | No | API/feed | API/feed |
 | `wanted` | Yes | Yes | API/feed | API/feed |
@@ -54,3 +55,12 @@ page/rendered page rather than a structured job payload.
 | `workable` | Yes | Yes | API/feed | API/feed (Markdown) |
 | `workday` | Yes | Yes | API/feed | API/feed |
 | `ycombinator` | Yes | No | API/feed | API/feed |
+
+## Notes
+
+- `tencent` covers Tencent's managed `careers.tencent.com` source
+  (`SourceID=1`). Descriptions come directly from the listing API payload
+  (`Responsibility` + `Requirement`), so no second detail request is needed.
+- Tencent jobs whose `PostURL` points to Workday (`SourceID=4`) are handled
+  by the existing `workday` pipeline, where descriptions require the Workday
+  detail API path.

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -19,10 +19,10 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import fcntl
 import csv
-import os
+import fcntl
 import json
+import os
 import re
 import sqlite3
 import sys
@@ -72,6 +72,7 @@ from jobhive.scrapers import (
     SuccessFactorsScraper,
     TaleoScraper,
     TeamtailorScraper,
+    TencentScraper,
     TeslaScraper,
     TheHubScraper,
     TikTokScraper,
@@ -531,6 +532,14 @@ CONFIGS: dict[str, dict[str, Any]] = {
         "scraper": TikTokScraper, "singleton": True,
         "output": "tiktok/jobs.csv",
     },
+    "tencent": {
+        # Tencent has two live sources: its managed careers API and a Workday
+        # board. Keep Workday wired separately and scrape the managed
+        # careers.tencent.com surface here so site-only jobs are not missed.
+        "scraper": TencentScraper, "singleton": True,
+        "kwargs": lambda r: {"language": "zh-cn", "area": "cn", "source_ids": (1,)},
+        "output": "tencent/jobs.csv",
+    },
     "uber": {
         "scraper": UberScraper, "singleton": True,
         "output": "uber/jobs.csv",
@@ -945,11 +954,12 @@ async def run(ats: str, concurrency: int, max_tenants: int | None, timeout: floa
     cfg = CONFIGS[ats]
 
     targets: list[tuple[str, dict[str, Any]]] = []
+    kwargs_factory = cfg.get("kwargs")
     if cfg.get("singleton"):
         # Single-tenant scraper (big-tech bespoke careers). No CSV — call
         # the scraper once with the ATS name as a placeholder slug; the
         # scraper itself ignores it (each company has its own private API).
-        targets = [(ats, {})]
+        targets = [(ats, kwargs_factory({}) if kwargs_factory else {})]
     else:
         csv_path = DATA_ROOT / cfg["csv"]
         if not csv_path.exists():
@@ -957,7 +967,6 @@ async def run(ats: str, concurrency: int, max_tenants: int | None, timeout: floa
             return 0
         with csv_path.open(newline="") as fh:
             rows = list(csv.DictReader(fh))
-        kwargs_factory = cfg.get("kwargs")
         for r in rows:
             slug = cfg["slug"](r)
             if slug:

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -60,6 +60,7 @@ class ATSType(StrEnum):
     META = "meta"
     TESLA = "tesla"
     TIKTOK = "tiktok"
+    TENCENT = "tencent"
     UBER = "uber"
     USAJOBS = "usajobs"
     # National public-sector job boards (single-source, single-tenant

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -46,6 +46,7 @@ from jobhive.scrapers.smartrecruiters import SmartRecruitersScraper
 from jobhive.scrapers.successfactors import SuccessFactorsScraper
 from jobhive.scrapers.taleo import TaleoScraper
 from jobhive.scrapers.teamtailor import TeamtailorScraper
+from jobhive.scrapers.tencent import TencentScraper
 from jobhive.scrapers.tesla import TeslaScraper
 from jobhive.scrapers.thehub import TheHubScraper
 from jobhive.scrapers.tiktok import TikTokScraper
@@ -98,6 +99,7 @@ __all__ = [
     "SuccessFactorsScraper",
     "TaleoScraper",
     "TeamtailorScraper",
+    "TencentScraper",
     "TeslaScraper",
     "TheHubScraper",
     "TikTokScraper",

--- a/src/jobhive/scrapers/tencent.py
+++ b/src/jobhive/scrapers/tencent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterable
 from datetime import datetime
 from typing import TYPE_CHECKING
 
@@ -43,12 +44,18 @@ class TencentScraper(BaseScraper):
         max_pages: int = DEFAULT_MAX_PAGES,
         language: str = "zh-cn",
         area: str = "cn",
+        source_ids: Iterable[int] | None = (1,),
     ) -> None:
         super().__init__(company_slug, timeout=timeout)
         self.page_size = page_size
         self.max_pages = max_pages
         self.language = language
         self.area = area
+        self.source_ids = (
+            {str(source_id) for source_id in source_ids}
+            if source_ids is not None
+            else None
+        )
 
     def fetch(self) -> list[Job]:
         return asyncio.run(self._fetch_async())
@@ -160,6 +167,14 @@ class TencentScraper(BaseScraper):
         return [job for post in posts if (job := self._parse_post(post)) is not None]
 
     def _parse_post(self, item: dict[str, Any]) -> Job | None:
+        source_id = item.get("SourceID")
+        if (
+            self.source_ids is not None
+            and source_id is not None
+            and str(source_id) not in self.source_ids
+        ):
+            return None
+
         ats_id = str(item.get("PostId") or item.get("RecruitPostId") or "")
         title = (item.get("RecruitPostName") or "").strip()
         if not ats_id or not title:
@@ -209,7 +224,7 @@ def _join_nonempty(*values: object, sep: str = ", ") -> str | None:
 def _parse_date(value: object) -> datetime | None:
     if not isinstance(value, str) or not value.strip():
         return None
-    for fmt in ("%Y年%m月%d日", "%Y-%m-%d"):
+    for fmt in ("%Y年%m月%d日", "%Y-%m-%d", "%b %d,%Y", "%B %d,%Y"):
         try:
             return datetime.strptime(value.strip(), fmt)
         except ValueError:

--- a/src/jobhive/scrapers/tencent.py
+++ b/src/jobhive/scrapers/tencent.py
@@ -1,0 +1,217 @@
+"""Tencent Careers — official China-first company careers API."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+API_URL = "https://careers.tencent.com/tencentcareer/api/post/Query"
+DEFAULT_PAGE_SIZE = 100
+DEFAULT_MAX_PAGES = 100
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1.5
+
+
+@ScraperRegistry.register(ATSType.TENCENT)
+class TencentScraper(BaseScraper):
+    """Tencent official careers scraper.
+
+    The default China/Chinese surface returned ~2.6k live postings when
+    verified on 2026-05-11. Pass ``language="en-us", area="us"`` for
+    Tencent's English/global view.
+    """
+
+    ats = ATSType.TENCENT
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        page_size: int = DEFAULT_PAGE_SIZE,
+        max_pages: int = DEFAULT_MAX_PAGES,
+        language: str = "zh-cn",
+        area: str = "cn",
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.page_size = page_size
+        self.max_pages = max_pages
+        self.language = language
+        self.area = area
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+            first = await self._fetch_page(client, sem, page=1)
+            data = first.get("Data") or {}
+            total = int(data.get("Count") or 0)
+            jobs = self._parse_posts(data.get("Posts") or [])
+            if total <= self.page_size:
+                return jobs
+
+            seen = {j.ats_id for j in jobs}
+            lock = asyncio.Lock()
+            page_count = min(
+                (total + self.page_size - 1) // self.page_size,
+                self.max_pages,
+            )
+
+            async def one(page: int) -> None:
+                payload = await self._fetch_page(client, sem, page=page)
+                page_jobs = self._parse_posts(
+                    (payload.get("Data") or {}).get("Posts") or []
+                )
+                async with lock:
+                    for job in page_jobs:
+                        if job.ats_id in seen:
+                            continue
+                        seen.add(job.ats_id)
+                        jobs.append(job)
+
+            await asyncio.gather(*(one(p) for p in range(2, page_count + 1)))
+        return jobs
+
+    async def _fetch_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        *,
+        page: int,
+    ) -> dict[str, Any]:
+        params = {
+            "timestamp": int(datetime.now().timestamp() * 1000),
+            "countryId": "",
+            "cityId": "",
+            "bgIds": "",
+            "productId": "",
+            "categoryId": "",
+            "parentCategoryId": "",
+            "attrId": "",
+            "keyword": "",
+            "pageIndex": page,
+            "pageSize": self.page_size,
+            "language": self.language,
+            "area": self.area,
+        }
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(
+                        API_URL,
+                        params=params,
+                        headers={
+                            "User-Agent": "Mozilla/5.0",
+                            "Accept": "application/json",
+                            "Referer": "https://careers.tencent.com/search.html",
+                        },
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"Tencent fetch failed at page={page}: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                try:
+                    payload = response.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"Tencent returned non-JSON at page={page}: {exc}"
+                    ) from exc
+                if payload.get("Code") != 200:
+                    raise ScraperError(
+                        f"Tencent returned application code "
+                        f"{payload.get('Code')} at page={page}"
+                    )
+                return payload
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Tencent returned {response.status_code} at "
+                        f"page={page} after {MAX_RETRIES} retries"
+                    )
+                await asyncio.sleep(RETRY_BASE_DELAY * (2**attempt))
+                continue
+            raise ScraperError(
+                f"Tencent returned {response.status_code} at page={page}"
+            )
+        raise ScraperError(f"Tencent exhausted retries at page={page}: {last_exc}")
+
+    def _parse_posts(self, posts: list[dict[str, Any]]) -> list[Job]:
+        return [job for post in posts if (job := self._parse_post(post)) is not None]
+
+    def _parse_post(self, item: dict[str, Any]) -> Job | None:
+        ats_id = str(item.get("PostId") or item.get("RecruitPostId") or "")
+        title = (item.get("RecruitPostName") or "").strip()
+        if not ats_id or not title:
+            return None
+
+        raw: dict[str, Any] = {}
+        for source, dest in (
+            ("RecruitPostId", "recruit_post_id"),
+            ("CountryName", "country"),
+            ("BGName", "business_group"),
+            ("ProductName", "product"),
+            ("CategoryName", "category"),
+            ("RequireWorkYearsName", "experience_label"),
+            ("LastUpdateTime", "last_update_time"),
+        ):
+            value = item.get(source)
+            if value not in (None, ""):
+                raw[dest] = value
+
+        return Job(
+            url=(
+                item.get("PostURL")
+                or f"https://careers.tencent.com/jobdesc.html?postId={ats_id}"
+            ),
+            title=title,
+            company="Tencent",
+            ats_type=ATSType.TENCENT,
+            ats_id=ats_id,
+            location=_join_nonempty(item.get("LocationName"), item.get("CountryName")),
+            department=(item.get("CategoryName") or None),
+            team=(item.get("ProductName") or item.get("BGName") or None),
+            description=_join_nonempty(
+                item.get("Responsibility"), item.get("Requirement"), sep="\n\n"
+            ),
+            posted_at=_parse_date(item.get("LastUpdateTime")),
+            fetched_at=datetime.now(),
+            language=self.language[:2],
+            raw=raw or None,
+        )
+
+
+def _join_nonempty(*values: object, sep: str = ", ") -> str | None:
+    parts = [v.strip() for v in values if isinstance(v, str) and v.strip()]
+    return sep.join(parts) if parts else None
+
+
+def _parse_date(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    for fmt in ("%Y年%m月%d日", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(value.strip(), fmt)
+        except ValueError:
+            continue
+    return None

--- a/src/jobhive/storage/publisher.py
+++ b/src/jobhive/storage/publisher.py
@@ -542,7 +542,7 @@ ATS_DEDUP_PRIORITY: dict[str, int] = {
     "workday": 1,
     # Big-tech bespoke careers — also priority 1 (single-tenant, canonical)
     "amazon": 1, "apple": 1, "google": 1, "meta": 1, "tesla": 1,
-    "tiktok": 1, "uber": 1,
+    "tiktok": 1, "tencent": 1, "uber": 1,
     # Hybrid jobboards
     "welcometothejungle": 3, "mercor": 3, "gem": 3,
     # Sourcing/matching layer that mirrors others

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -23,7 +23,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "successfactors", "workable", "workday",
         # Big-tech custom careers systems
         "amazon", "apple", "google", "meta",
-        "tesla", "tiktok", "uber", "usajobs",
+        "tesla", "tiktok", "tencent", "uber", "usajobs",
         # National / supranational public-sector aggregators
         "bundesagentur", "arbetsformedlingen", "eures",
         # Hybrid jobboards (companies post directly)

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -559,6 +559,60 @@ def test_cross_ats_dedup_keeps_higher_priority_ats(
     assert df["url"].str.contains("workday.com").all()
 
 
+def test_cross_ats_dedup_keeps_workday_over_tencent_duplicate(
+    tmp_path, fake_r2
+) -> None:
+    """Tencent's managed API can expose jobs whose canonical apply URL is
+    Workday. The global snapshot should keep the Workday row for that same
+    posting while preserving both raw per-ATS slices."""
+    workday_dir = tmp_path / "workday"
+    tencent_dir = tmp_path / "tencent"
+    workday_dir.mkdir()
+    tencent_dir.mkdir()
+
+    pd.DataFrame([
+        {
+            "url": (
+                "https://tencent.wd1.myworkdayjobs.com/Tencent_Careers/"
+                "job/US-California-Palo-Alto/Talent-Acquisition-Intern_R107505-1"
+            ),
+            "title": "Talent Acquisition Intern 107505",
+            "company": "Tencent",
+            "ats_type": "workday",
+            "ats_id": "R107505",
+            "location": "Palo Alto, USA",
+        }
+    ]).to_csv(workday_dir / "jobs.csv", index=False)
+    pd.DataFrame([
+        {
+            "url": (
+                "https://tencent.wd1.myworkdayjobs.com/Tencent_Careers/"
+                "job/US-California-Palo-Alto/Talent-Acquisition-Intern_R107505-1"
+            ),
+            "title": "Talent Acquisition Intern 107505",
+            "company": "Tencent",
+            "ats_type": "tencent",
+            "ats_id": "2057194706961612800",
+            "location": "Palo Alto, USA",
+        }
+    ]).to_csv(tencent_dir / "jobs.csv", index=False)
+
+    publisher = DatasetPublisher(fake_r2, write_parquet=True)
+    result = publisher.publish_from_directory(tmp_path)
+
+    assert result.total_jobs_raw == 2
+    assert result.total_jobs == 1
+    manifest = json.loads(fake_r2.uploads["jobhive/v1/manifest.json"]["data"])
+    assert manifest["by_ats"]["workday"]["rows"] == 1
+    assert manifest["by_ats"]["tencent"]["rows"] == 1
+
+    all_parquet = fake_r2.uploads["jobhive/v1/all.parquet"]["data"]
+    df = pd.read_parquet(pd.io.common.BytesIO(all_parquet))
+    assert len(df) == 1
+    assert df.iloc[0]["ats_type"] == "workday"
+    assert "myworkdayjobs.com" in df.iloc[0]["url"]
+
+
 # --- Phase 1 / Phase 2 cross-source fuzzy dedup -----------------------------
 
 

--- a/tests/test_run_pipeline_guards.py
+++ b/tests/test_run_pipeline_guards.py
@@ -76,6 +76,13 @@ def test_provider_slug_normalizers_match_current_company_csv_shape() -> None:
     }
     assert runner._avature_slug(avature_subdomain_row) == "bloomberg"
 
+    assert runner.CONFIGS["tencent"]["singleton"] is True
+    assert runner.CONFIGS["tencent"]["kwargs"]({}) == {
+        "language": "zh-cn",
+        "area": "cn",
+        "source_ids": (1,),
+    }
+
 
 def test_catastrophic_failure_preserves_previous_jobs_csv(
     tmp_path, monkeypatch: pytest.MonkeyPatch
@@ -150,6 +157,52 @@ def test_singleton_success_returns_zero_exit_code(
 
     assert rc == 0
     assert (tmp_path / "single" / "jobs.csv").exists()
+
+
+def test_singleton_kwargs_are_passed_to_scraper(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, object] = {}
+
+    class SingletonScraper:
+        def __init__(self, slug: str, **kwargs) -> None:
+            captured["slug"] = slug
+            captured.update(kwargs)
+
+        def fetch(self):
+            return [
+                Job(
+                    url="https://example.com/job/1",
+                    title="Engineer",
+                    company="Acme",
+                    ats_type=ATSType.CUSTOM,
+                    ats_id="1",
+                )
+            ]
+
+    monkeypatch.setattr(runner, "DATA_ROOT", tmp_path)
+    monkeypatch.setitem(
+        runner.CONFIGS,
+        "single",
+        {
+            "scraper": SingletonScraper,
+            "singleton": True,
+            "kwargs": lambda r: {
+                "language": "zh-cn",
+                "area": "cn",
+                "source_ids": (1,),
+            },
+            "output": "single/jobs.csv",
+        },
+    )
+
+    rc = asyncio.run(runner.run("single", concurrency=1, max_tenants=None, timeout=1))
+
+    assert rc == 0
+    assert captured["slug"] == "single"
+    assert captured["language"] == "zh-cn"
+    assert captured["area"] == "cn"
+    assert captured["source_ids"] == (1,)
 
 
 def test_pipeline_reuses_previous_description_without_refetching(

--- a/tests/test_tencent.py
+++ b/tests/test_tencent.py
@@ -66,6 +66,102 @@ def test_parses_tencent_job_payload(httpx_mock) -> None:
     assert j.raw["business_group"] == "TEG"
 
 
+def test_parses_real_managed_site_payload(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_payload([
+            {
+                "PostId": "2058113526362451968",
+                "RecruitPostId": 120196,
+                "RecruitPostName": " 腾讯云-医疗交付架构师(公有云迁移方向）",
+                "CountryName": "中国",
+                "LocationName": "深圳",
+                "BGName": "CSIG",
+                "ProductName": "腾讯云",
+                "CategoryName": "产品",
+                "Responsibility": "1.负责医疗行业客户公有云迁移项目的交付技术架构工作",
+                "LastUpdateTime": "2026年05月23日",
+                "PostURL": "http://careers.tencent.com/jobdesc.html?postId=2058113526362451968",
+                "SourceID": 1,
+                "RequireWorkYearsName": "五年以上工作经验",
+            }
+        ]),
+    )
+
+    jobs = TencentScraper("any", language="zh-cn", area="cn").fetch()
+    assert len(jobs) == 1
+    assert str(jobs[0].url) == (
+        "http://careers.tencent.com/jobdesc.html?postId=2058113526362451968"
+    )
+    assert jobs[0].title == "腾讯云-医疗交付架构师(公有云迁移方向）"
+    assert jobs[0].location == "深圳, 中国"
+    assert jobs[0].team == "腾讯云"
+    assert jobs[0].posted_at is not None
+    assert jobs[0].language == "zh"
+
+
+def test_skips_real_workday_backed_payload_by_default(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_payload([
+            {
+                "PostId": "2057194706961612800",
+                "RecruitPostId": 1254692268815900672,
+                "RecruitPostName": "Talent Acquisition Intern 107505",
+                "CountryName": "USA",
+                "LocationName": "Palo Alto",
+                "BGName": "S3",
+                "CategoryName": "Human Resources",
+                "LastUpdateTime": "May 20,2026",
+                "PostURL": (
+                    "https://tencent.wd1.myworkdayjobs.com/Tencent_Careers/"
+                    "job/US-California-Palo-Alto/Talent-Acquisition-Intern_R107505-1"
+                ),
+                "SourceID": 4,
+            }
+        ]),
+    )
+
+    jobs = TencentScraper("any", language="en-us", area="us").fetch()
+    assert jobs == []
+
+
+def test_can_parse_real_workday_backed_payload_when_all_sources_enabled(
+    httpx_mock,
+) -> None:
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_payload([
+            {
+                "PostId": "2057194706961612800",
+                "RecruitPostId": 1254692268815900672,
+                "RecruitPostName": "Talent Acquisition Intern 107505",
+                "CountryName": "USA",
+                "LocationName": "Palo Alto",
+                "BGName": "S3",
+                "CategoryName": "Human Resources",
+                "LastUpdateTime": "May 20,2026",
+                "PostURL": (
+                    "https://tencent.wd1.myworkdayjobs.com/Tencent_Careers/"
+                    "job/US-California-Palo-Alto/Talent-Acquisition-Intern_R107505-1"
+                ),
+                "SourceID": 4,
+            }
+        ]),
+    )
+
+    jobs = TencentScraper(
+        "any", language="en-us", area="us", source_ids=None
+    ).fetch()
+    assert len(jobs) == 1
+    assert str(jobs[0].url) == (
+        "https://tencent.wd1.myworkdayjobs.com/Tencent_Careers/"
+        "job/US-California-Palo-Alto/Talent-Acquisition-Intern_R107505-1"
+    )
+    assert jobs[0].posted_at is not None
+    assert jobs[0].language == "en"
+
+
 def test_paginates_and_dedupes(httpx_mock) -> None:
     httpx_mock.add_response(
         url=_API_RE,

--- a/tests/test_tencent.py
+++ b/tests/test_tencent.py
@@ -1,0 +1,92 @@
+"""Tests for Tencent Careers."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import ScraperRegistry, TencentScraper
+
+_API_RE = re.compile(r"^https://careers\.tencent\.com/tencentcareer/api/post/Query")
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.tencent as t
+
+    monkeypatch.setattr(t, "MAX_RETRIES", 1)
+    monkeypatch.setattr(t, "RETRY_BASE_DELAY", 0.0)
+
+
+def _payload(posts: list[dict], count: int | None = None) -> dict:
+    return {"Code": 200, "Data": {"Count": len(posts) if count is None else count, "Posts": posts}}
+
+
+def test_registry_resolves_tencent() -> None:
+    assert ScraperRegistry.get(ATSType.TENCENT) is TencentScraper
+
+
+def test_parses_tencent_job_payload(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_payload([
+            {
+                "PostId": "1965706679647625216",
+                "RecruitPostId": 114723,
+                "RecruitPostName": "云数据库内核研发工程师",
+                "CountryName": "中国",
+                "LocationName": "深圳",
+                "BGName": "TEG",
+                "ProductName": "TDSQL MySQL",
+                "CategoryName": "技术",
+                "Responsibility": "负责数据库内核模块的架构设计和特性开发",
+                "Requirement": "五年以上相关经验",
+                "LastUpdateTime": "2026年05月11日",
+                "PostURL": "http://careers.tencent.com/jobdesc.html?postId=1965706679647625216",
+                "RequireWorkYearsName": "五年以上工作经验",
+            }
+        ]),
+    )
+
+    jobs = TencentScraper("any").fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.TENCENT
+    assert j.ats_id == "1965706679647625216"
+    assert j.title == "云数据库内核研发工程师"
+    assert j.company == "Tencent"
+    assert j.location == "深圳, 中国"
+    assert j.department == "技术"
+    assert j.team == "TDSQL MySQL"
+    assert j.posted_at is not None
+    assert j.raw is not None
+    assert j.raw["business_group"] == "TEG"
+
+
+def test_paginates_and_dedupes(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_payload([
+            {"PostId": "1", "RecruitPostName": "One"},
+            {"PostId": "2", "RecruitPostName": "Two"},
+        ], count=3),
+    )
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_payload([
+            {"PostId": "2", "RecruitPostName": "Two repeated"},
+            {"PostId": "3", "RecruitPostName": "Three"},
+        ], count=3),
+    )
+
+    jobs = TencentScraper("any", page_size=2).fetch()
+    assert [j.ats_id for j in jobs] == ["1", "2", "3"]
+
+
+def test_non_200_raises(httpx_mock) -> None:
+    httpx_mock.add_response(url=_API_RE, status_code=500, is_reusable=True)
+    with pytest.raises(ScraperError):
+        TencentScraper("any").fetch()


### PR DESCRIPTION
## Summary

Adds a Tencent Careers scraper backed by Tencent's official public careers JSON API.

## Coverage impact

Live smoke fetch on 2026-05-11 returned 2,660 jobs from the China/Chinese careers surface.

## Validation

- `uv run --extra dev pytest tests/test_tencent.py tests/test_models.py -q`
- `uv run --extra dev ruff check src/jobhive/scrapers/tencent.py tests/test_tencent.py src/jobhive/models.py src/jobhive/scrapers/__init__.py tests/test_models.py`
- Smoke: `TencentScraper('any').fetch()` returned 2,660 jobs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Tencent Careers scraper using Tencent’s public JSON API and wires it into the pipeline. Workday-backed listings are skipped by default; a 2026‑05‑11 smoke run returned ~2,660 CN jobs.

- New Features
  - Added `TencentScraper` with async fetch, pagination, dedupe, retries; supports `language`, `area`, `page_size`, `max_pages`, and `source_ids` (default `(1,)` targets the managed site; set `None` to include all).
  - Registered in `ScraperRegistry` with `ATSType.TENCENT`, added a `tencent` singleton in `run_pipeline` (defaults: `zh-cn`/`cn`, `source_ids=(1,)`); singleton kwargs are now passed; output `tencent/jobs.csv`; added `ats-companies/tencent.csv` seed.
  - Parses id, title, location, team/department, description, and `posted_at`; descriptions are built from `Responsibility` + `Requirement` in the list payload (no detail request).
  - Cross-ATS dedup keeps Workday over Tencent when the same posting appears; publisher priority updated to include `tencent`; docs updated in the provider matrix.

<sup>Written for commit 2b797ee6882fedc86ae7eb68c127fc76708ad9dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `TencentScraper` backed by Tencent's public careers JSON API with async pagination, concurrency control, source-ID filtering, and retry logic, wired into the pipeline as a singleton. Workday-backed Tencent postings are filtered by default (`source_ids=(1,)`) and handled by the existing Workday scraper.

- New `src/jobhive/scrapers/tencent.py`: async paginator with semaphore-gated concurrency, exponential-backoff retries, and `SourceID`-based filtering; date parsing supports Chinese and Western formats.
- `scripts/run_pipeline.py`: fixes a pre-existing gap where singleton `kwargs` factories were never called; registers Tencent with `language="zh-cn"`, `area="cn"`, `source_ids=(1,)`.
- `src/jobhive/storage/publisher.py`: adds `tencent` to `ATS_DEDUP_PRIORITY` at level 1 (same as `workday`), meaning the Workday-over-Tencent dedup guarantee is maintained only by enum iteration order rather than explicit priority.

<h3>Confidence Score: 3/5</h3>

Two real defects need fixes before merging: a semaphore held during retry sleeps that can stall all concurrent page fetches, and a dedup priority that makes the stated Workday-wins behaviour fragile.

The scraper core is well-structured and the test coverage is thorough. However, the retry sleep inside `async with sem:` can block all four concurrency slots simultaneously during error conditions, turning a transient network glitch into a prolonged stall across every in-flight page request. Separately, giving `tencent` the same dedup priority as `workday` means the stated Workday-over-Tencent guarantee holds only by coincidence of enum ordering — a future enum reorder would silently flip which source wins.

`src/jobhive/scrapers/tencent.py` (retry semaphore logic) and `src/jobhive/storage/publisher.py` (dedup priority value for `tencent`).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/tencent.py | New Tencent scraper with async pagination and retries; retry sleep incorrectly holds the semaphore on HTTP-error paths, and the source-ID filter silently passes through posts with no SourceID field. |
| src/jobhive/storage/publisher.py | Adds `tencent` to ATS_DEDUP_PRIORITY at level 1 (same as workday), making the intended Workday-beats-Tencent dedup order-dependent on enum iteration rather than explicit priority. |
| scripts/run_pipeline.py | Registers the Tencent singleton with `kwargs` factory for language/area/source_ids; fixes a pre-existing bug where kwargs_factory was only invoked for non-singleton scrapers. |
| tests/test_tencent.py | Comprehensive test suite covering registry, parsing, pagination, dedup, source filtering, and error handling. |
| tests/test_publisher.py | Adds a Workday-over-Tencent dedup test; test passes currently but relies on enum iteration order rather than explicit priority. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/jobhive/scrapers/tencent.py:119-139
**Retry sleep holds the semaphore slot**

The `await asyncio.sleep()` on line 138 is executed inside the `async with sem:` block. Since `MAX_CONCURRENCY = 4`, all four semaphore slots can be occupied by failed requests sleeping simultaneously, starving every other in-flight page request for the full sleep duration. The 429/5xx branch (line 159) correctly places the sleep outside the semaphore — the HTTP-error branch should do the same. Move the `continue`/sleep outside the `async with sem:` block, or capture the exception and break out of the context manager before sleeping.

### Issue 2 of 3
src/jobhive/storage/publisher.py:545
**Tencent same priority as Workday makes dedup order-dependent**

Both `tencent` and `workday` have priority `1`, but the PR description says Workday should win when the same URL appears in both. The current guarantee only holds because `ATSType` enum iteration places `WORKDAY` before `TENCENT`, giving Workday lower `_orig_idx` values in the concatenated key frame. If the enum is ever reordered, the tiebreaker silently flips to Tencent. Assigning Tencent a higher number (lower priority) makes the intent explicit and order-independent.

```suggestion
    "tiktok": 1, "uber": 1,
    "tencent": 2,  # Workday-backed Tencent jobs are handled by the workday scraper; prefer workday on conflict
```

### Issue 3 of 3
src/jobhive/scrapers/tencent.py:169-176
**Source filter silently passes jobs with no `SourceID`**

The guard `source_id is not None` means that posts where `SourceID` is absent entirely bypass the filter even when `source_ids=(1,)`. The intent of the default is to include only the managed `careers.tencent.com` surface (source 1) and exclude Workday-backed posts (source 4). If the API begins omitting `SourceID` for some Workday-backed jobs, those will slip through and create duplicates with the Workday scraper. Treating a missing `SourceID` as "unknown / include" is a reasonable fallback, but should be documented explicitly in a comment so future readers understand the choice.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: tencent.csv"](https://github.com/kalil0321/ats-scrapers/commit/2b797ee6882fedc86ae7eb68c127fc76708ad9dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732362)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->