### PR TITLE
[codex] Add Instahyre scraper

### DIFF
--- a/ats-companies/instahyre.csv
+++ b/ats-companies/instahyre.csv
@@ -1,0 +1,2 @@
+name,slug,url
+Instahyre,instahyre,https://www.instahyre.com

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -75,6 +75,7 @@ class ATSType(StrEnum):
     WEWORKREMOTELY = "weworkremotely"
     PROGRAMATHOR = "programathor"
     BUILTIN = "builtin"
+    INSTAHYRE = "instahyre"
     JOBSCH = "jobsch"
     MANFRED = "manfred"
     THEHUB = "thehub"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -26,6 +26,7 @@ from jobhive.scrapers.getonbrd import GetOnBrdScraper
 from jobhive.scrapers.google import GoogleScraper
 from jobhive.scrapers.greenhouse import GreenhouseScraper
 from jobhive.scrapers.icims import iCIMSScraper
+from jobhive.scrapers.instahyre import InstahyreScraper
 from jobhive.scrapers.jazzhr import JazzHRScraper
 from jobhive.scrapers.jobsch import JobsChScraper
 from jobhive.scrapers.join_com import JoinComScraper
@@ -77,6 +78,7 @@ __all__ = [
     "GetOnBrdScraper",
     "GoogleScraper",
     "GreenhouseScraper",
+    "InstahyreScraper",
     "JazzHRScraper",
     "JobsChScraper",
     "JoinComScraper",

--- a/src/jobhive/scrapers/instahyre.py
+++ b/src/jobhive/scrapers/instahyre.py
@@ -1,4 +1,17 @@
-"""Instahyre — India-focused direct employer hiring platform."""
+"""Instahyre — India-focused direct employer hiring platform.
+
+Two-step **JSON-only** flow (no HTML job pages):
+
+1. Paginate ``GET /api/v1/job_search`` for listing objects.
+2. Best-effort ``GET /api/v1/job_search/{id}`` per job to re-validate the
+   payload and refresh the composed description. Instahyre's public API
+   does not expose a separate long-form JD field; we build plain text
+   from structured API fields (title, location, keywords, employer
+   metadata).
+
+Detail failures keep listing-derived fields — same pattern as BambooHR /
+Rippling enrichment.
+"""
 
 from __future__ import annotations
 
@@ -20,6 +33,15 @@ DEFAULT_PAGE_SIZE = 20
 DEFAULT_MAX_PAGES = 100
 MAX_RETRIES = 3
 RETRY_BASE_DELAY = 1.5
+DETAIL_CONCURRENCY = 8
+
+
+def _request_headers() -> dict[str, str]:
+    return {
+        "User-Agent": "Mozilla/5.0",
+        "Accept": "application/json",
+        "Referer": "https://www.instahyre.com/search-jobs/",
+    }
 
 
 @ScraperRegistry.register(ATSType.INSTAHYRE)
@@ -35,10 +57,12 @@ class InstahyreScraper(BaseScraper):
         timeout: float = 30.0,
         page_size: int = DEFAULT_PAGE_SIZE,
         max_pages: int = DEFAULT_MAX_PAGES,
+        detail_concurrency: int = DETAIL_CONCURRENCY,
     ) -> None:
         super().__init__(company_slug, timeout=timeout)
         self.page_size = page_size
         self.max_pages = max_pages
+        self.detail_concurrency = detail_concurrency
 
     def fetch(self) -> list[Job]:
         return asyncio.run(self._fetch_async())
@@ -56,6 +80,11 @@ class InstahyreScraper(BaseScraper):
                     if page == 0:
                         raise
                     break
+                if not isinstance(payload, dict):
+                    raise ScraperError(
+                        "Instahyre job_search returned non-object JSON "
+                        f"at offset={page * self.page_size}"
+                    )
                 items = payload.get("objects") or []
                 if not items:
                     break
@@ -69,6 +98,13 @@ class InstahyreScraper(BaseScraper):
                     new_count += 1
                 if new_count == 0 or len(items) < self.page_size:
                     break
+
+            if jobs:
+                sem = asyncio.Semaphore(self.detail_concurrency)
+                await asyncio.gather(*(
+                    self._enrich_from_detail_api(client, sem, job)
+                    for job in jobs
+                ))
         return jobs
 
     async def _fetch_page(
@@ -90,11 +126,7 @@ class InstahyreScraper(BaseScraper):
                 response = await client.get(
                     API_URL,
                     params=params,
-                    headers={
-                        "User-Agent": "Mozilla/5.0",
-                        "Accept": "application/json",
-                        "Referer": "https://www.instahyre.com/search-jobs/",
-                    },
+                    headers=_request_headers(),
                 )
             except httpx.HTTPError as exc:
                 last_exc = exc
@@ -106,11 +138,16 @@ class InstahyreScraper(BaseScraper):
                 continue
             if response.status_code == 200:
                 try:
-                    return response.json()
+                    data = response.json()
                 except ValueError as exc:
                     raise ScraperError(
                         f"Instahyre returned non-JSON at offset={offset}: {exc}"
                     ) from exc
+                if not isinstance(data, dict):
+                    raise ScraperError(
+                        f"Instahyre job_search JSON was not an object at offset={offset}"
+                    )
+                return data
             if response.status_code in (429,) or 500 <= response.status_code < 600:
                 if attempt == MAX_RETRIES:
                     raise ScraperError(
@@ -125,6 +162,55 @@ class InstahyreScraper(BaseScraper):
         raise ScraperError(
             f"Instahyre exhausted retries at offset={offset}: {last_exc}"
         )
+
+    async def _enrich_from_detail_api(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        job: Job,
+    ) -> None:
+        if not job.ats_id:
+            return
+        detail = await self._fetch_detail_json(client, sem, job.ats_id)
+        if detail is None:
+            return
+        if str(detail.get("id")) != job.ats_id:
+            return
+        composed = _compose_description(detail)
+        if composed:
+            job.description = composed
+        loc = _format_location(detail.get("locations"))
+        if loc:
+            job.location = loc
+
+    async def _fetch_detail_json(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        job_id: str,
+    ) -> dict[str, Any] | None:
+        url = f"{API_URL}/{job_id}"
+        async with sem:
+            for attempt in range(1, MAX_RETRIES + 1):
+                try:
+                    response = await client.get(url, headers=_request_headers())
+                except httpx.HTTPError:
+                    if attempt == MAX_RETRIES:
+                        return None
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+                if response.status_code == 200:
+                    try:
+                        data = response.json()
+                    except ValueError:
+                        return None
+                    return data if isinstance(data, dict) else None
+                if response.status_code in (429,) or 500 <= response.status_code < 600:
+                    if attempt == MAX_RETRIES:
+                        return None
+                    await asyncio.sleep(RETRY_BASE_DELAY * (2**attempt))
+                    continue
+                return None
 
     def _parse(self, item: dict[str, Any]) -> Job | None:
         raw_id = item.get("id")
@@ -158,10 +244,42 @@ class InstahyreScraper(BaseScraper):
             ats_type=ATSType.INSTAHYRE,
             ats_id=str(raw_id),
             location=_format_location(item.get("locations")),
-            description=employer.get("instahyre_note") or None,
+            description=_compose_description(item),
             fetched_at=datetime.now(),
             raw=raw or None,
         )
+
+
+def _compose_description(item: dict[str, Any]) -> str | None:
+    """Plain-text body from Instahyre JSON fields only (no HTML)."""
+    parts: list[str] = []
+    title = (item.get("title") or item.get("candidate_title") or "").strip()
+    if title:
+        parts.append(title)
+    loc = _format_location(item.get("locations"))
+    if loc:
+        parts.append(f"Location: {loc}")
+    keywords = item.get("keywords")
+    if isinstance(keywords, list) and keywords:
+        flat = ", ".join(
+            str(k).strip() for k in keywords if k and str(k).strip()
+        )
+        if flat:
+            parts.append(f"Skills: {flat}")
+    employer = item.get("employer") or {}
+    company = (employer.get("company_name") or "").strip()
+    tagline = (employer.get("company_tagline") or "").strip()
+    if company and tagline:
+        parts.append(f"{company} — {tagline}")
+    elif company or tagline:
+        parts.append(company or tagline)
+    note = (employer.get("instahyre_note") or "").strip()
+    if note:
+        parts.append(f"About the company: {note}")
+    if not parts:
+        return None
+    text = "\n\n".join(parts)
+    return text[:10_000] if text else None
 
 
 def _format_location(value: object) -> str | None:

--- a/src/jobhive/scrapers/instahyre.py
+++ b/src/jobhive/scrapers/instahyre.py
@@ -74,12 +74,7 @@ class InstahyreScraper(BaseScraper):
             timeout=self.timeout, follow_redirects=True
         ) as client:
             for page in range(self.max_pages):
-                try:
-                    payload = await self._fetch_page(client, offset=page * self.page_size)
-                except ScraperError:
-                    if page == 0:
-                        raise
-                    break
+                payload = await self._fetch_page(client, offset=page * self.page_size)
                 if not isinstance(payload, dict):
                     raise ScraperError(
                         "Instahyre job_search returned non-object JSON "
@@ -101,10 +96,13 @@ class InstahyreScraper(BaseScraper):
 
             if jobs:
                 sem = asyncio.Semaphore(self.detail_concurrency)
-                await asyncio.gather(*(
-                    self._enrich_from_detail_api(client, sem, job)
-                    for job in jobs
-                ))
+                await asyncio.gather(
+                    *(
+                        self._enrich_from_detail_api(client, sem, job)
+                        for job in jobs
+                    ),
+                    return_exceptions=True,
+                )
         return jobs
 
     async def _fetch_page(

--- a/src/jobhive/scrapers/instahyre.py
+++ b/src/jobhive/scrapers/instahyre.py
@@ -1,0 +1,171 @@
+"""Instahyre — India-focused direct employer hiring platform."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+API_URL = "https://www.instahyre.com/api/v1/job_search"
+DEFAULT_PAGE_SIZE = 20
+DEFAULT_MAX_PAGES = 100
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1.5
+
+
+@ScraperRegistry.register(ATSType.INSTAHYRE)
+class InstahyreScraper(BaseScraper):
+    """Instahyre India tech jobs scraper."""
+
+    ats = ATSType.INSTAHYRE
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        page_size: int = DEFAULT_PAGE_SIZE,
+        max_pages: int = DEFAULT_MAX_PAGES,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.page_size = page_size
+        self.max_pages = max_pages
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        jobs: list[Job] = []
+        seen: set[str] = set()
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True
+        ) as client:
+            for page in range(self.max_pages):
+                try:
+                    payload = await self._fetch_page(client, offset=page * self.page_size)
+                except ScraperError:
+                    if page == 0:
+                        raise
+                    break
+                items = payload.get("objects") or []
+                if not items:
+                    break
+                new_count = 0
+                for item in items:
+                    job = self._parse(item)
+                    if job is None or job.ats_id in seen:
+                        continue
+                    seen.add(job.ats_id)
+                    jobs.append(job)
+                    new_count += 1
+                if new_count == 0 or len(items) < self.page_size:
+                    break
+        return jobs
+
+    async def _fetch_page(
+        self,
+        client: httpx.AsyncClient,
+        *,
+        offset: int,
+    ) -> dict[str, Any]:
+        params = {
+            "company_size": 0,
+            "isLandingPage": "true",
+            "job_type": 0,
+            "limit": self.page_size,
+            "offset": offset,
+        }
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                response = await client.get(
+                    API_URL,
+                    params=params,
+                    headers={
+                        "User-Agent": "Mozilla/5.0",
+                        "Accept": "application/json",
+                        "Referer": "https://www.instahyre.com/search-jobs/",
+                    },
+                )
+            except httpx.HTTPError as exc:
+                last_exc = exc
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Instahyre fetch failed at offset={offset}: {exc}"
+                    ) from exc
+                await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                continue
+            if response.status_code == 200:
+                try:
+                    return response.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"Instahyre returned non-JSON at offset={offset}: {exc}"
+                    ) from exc
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Instahyre returned {response.status_code} at "
+                        f"offset={offset} after {MAX_RETRIES} retries"
+                    )
+                await asyncio.sleep(RETRY_BASE_DELAY * (2**attempt))
+                continue
+            raise ScraperError(
+                f"Instahyre returned {response.status_code} at offset={offset}"
+            )
+        raise ScraperError(
+            f"Instahyre exhausted retries at offset={offset}: {last_exc}"
+        )
+
+    def _parse(self, item: dict[str, Any]) -> Job | None:
+        raw_id = item.get("id")
+        title = (item.get("title") or item.get("candidate_title") or "").strip()
+        url = (item.get("public_url") or "").strip()
+        if raw_id is None or not title or not url:
+            return None
+
+        employer = item.get("employer") or {}
+        company = (employer.get("company_name") or "").strip() or "Unknown"
+        raw: dict[str, Any] = {}
+        keywords = item.get("keywords") or []
+        if isinstance(keywords, list) and keywords:
+            raw["keywords"] = keywords
+        for source, dest in (
+            ("id", "employer_id"),
+            ("company_tagline", "company_tagline"),
+            ("employee_count", "employee_count"),
+            ("company_founded", "company_founded"),
+        ):
+            value = employer.get(source)
+            if value not in (None, ""):
+                raw[dest] = value
+        if item.get("accept_outstation") is not None:
+            raw["accept_outstation"] = item["accept_outstation"]
+
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.INSTAHYRE,
+            ats_id=str(raw_id),
+            location=_format_location(item.get("locations")),
+            description=employer.get("instahyre_note") or None,
+            fetched_at=datetime.now(),
+            raw=raw or None,
+        )
+
+
+def _format_location(value: object) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    parts = [p.strip() for p in value.split(",") if p.strip()]
+    return ", ".join(parts) if parts else None

--- a/src/jobhive/scrapers/instahyre.py
+++ b/src/jobhive/scrapers/instahyre.py
@@ -7,7 +7,7 @@ Two-step **JSON-only** flow (no HTML job pages):
    payload and refresh the composed description. Instahyre's public API
    does not expose a separate long-form JD field; we build plain text
    from structured API fields (title, location, keywords, employer
-   metadata).
+   profile fields).
 
 Detail failures keep listing-derived fields — same pattern as BambooHR /
 Rippling enrichment.

--- a/tests/test_instahyre.py
+++ b/tests/test_instahyre.py
@@ -9,8 +9,11 @@ import pytest
 from jobhive.exceptions import ScraperError
 from jobhive.models import ATSType
 from jobhive.scrapers import InstahyreScraper, ScraperRegistry
+from jobhive.scrapers.instahyre import _compose_description
 
-_API_RE = re.compile(r"^https://www\.instahyre\.com/api/v1/job_search")
+_API_LIST_RE = re.compile(
+    r"^https://www\.instahyre\.com/api/v1/job_search(\?|$)"
+)
 
 
 @pytest.fixture(autouse=True)
@@ -19,6 +22,10 @@ def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(i, "MAX_RETRIES", 1)
     monkeypatch.setattr(i, "RETRY_BASE_DELAY", 0.0)
+
+
+def _detail_url(job_id: int) -> str:
+    return f"https://www.instahyre.com/api/v1/job_search/{job_id}"
 
 
 def _job(job_id: int, title: str = "Frontend Developer") -> dict:
@@ -45,7 +52,9 @@ def test_registry_resolves_instahyre() -> None:
 
 
 def test_parses_instahyre_job_payload(httpx_mock) -> None:
-    httpx_mock.add_response(url=_API_RE, json={"objects": [_job(423594)]})
+    payload = _job(423594)
+    httpx_mock.add_response(url=_API_LIST_RE, json={"objects": [payload]})
+    httpx_mock.add_response(url=_detail_url(423594), json=payload)
 
     jobs = InstahyreScraper("any").fetch()
     assert len(jobs) == 1
@@ -55,21 +64,48 @@ def test_parses_instahyre_job_payload(httpx_mock) -> None:
     assert j.title == "Frontend Developer"
     assert j.company == "Echos"
     assert j.location == "Bangalore, Gurgaon"
-    assert j.description == "Deep-tech engineering company."
+    assert j.description == _compose_description(payload)
     assert j.raw is not None
     assert j.raw["keywords"] == ["React.js", "JavaScript", "Next.js"]
     assert j.raw["employer_id"] == 53522
 
 
 def test_paginates_until_empty(httpx_mock) -> None:
-    httpx_mock.add_response(url=_API_RE, json={"objects": [_job(1), _job(2)]})
-    httpx_mock.add_response(url=_API_RE, json={"objects": [_job(3)]})
+    httpx_mock.add_response(url=_API_LIST_RE, json={"objects": [_job(1), _job(2)]})
+    httpx_mock.add_response(url=_API_LIST_RE, json={"objects": [_job(3)]})
+    for jid in (1, 2, 3):
+        httpx_mock.add_response(url=_detail_url(jid), json=_job(jid))
 
     jobs = InstahyreScraper("any", page_size=2).fetch()
     assert [j.ats_id for j in jobs] == ["1", "2", "3"]
 
 
 def test_500_raises(httpx_mock) -> None:
-    httpx_mock.add_response(url=_API_RE, status_code=500, is_reusable=True)
+    httpx_mock.add_response(url=_API_LIST_RE, status_code=500, is_reusable=True)
     with pytest.raises(ScraperError):
+        InstahyreScraper("any").fetch()
+
+
+def test_detail_fetch_failure_keeps_list_description(httpx_mock) -> None:
+    payload = _job(501)
+    httpx_mock.add_response(url=_API_LIST_RE, json={"objects": [payload]})
+    httpx_mock.add_response(url=_detail_url(501), status_code=503)
+
+    jobs = InstahyreScraper("any").fetch()
+    assert len(jobs) == 1
+    assert jobs[0].description == _compose_description(payload)
+
+
+def test_detail_wrong_id_skipped(httpx_mock) -> None:
+    payload = _job(601)
+    httpx_mock.add_response(url=_API_LIST_RE, json={"objects": [payload]})
+    httpx_mock.add_response(url=_detail_url(601), json=_job(999))
+
+    jobs = InstahyreScraper("any").fetch()
+    assert jobs[0].description == _compose_description(payload)
+
+
+def test_job_search_top_level_array_raises(httpx_mock) -> None:
+    httpx_mock.add_response(url=_API_LIST_RE, json=["not", "an", "object"])
+    with pytest.raises(ScraperError, match="not an object"):
         InstahyreScraper("any").fetch()

--- a/tests/test_instahyre.py
+++ b/tests/test_instahyre.py
@@ -1,0 +1,75 @@
+"""Tests for Instahyre."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import InstahyreScraper, ScraperRegistry
+
+_API_RE = re.compile(r"^https://www\.instahyre\.com/api/v1/job_search")
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.instahyre as i
+
+    monkeypatch.setattr(i, "MAX_RETRIES", 1)
+    monkeypatch.setattr(i, "RETRY_BASE_DELAY", 0.0)
+
+
+def _job(job_id: int, title: str = "Frontend Developer") -> dict:
+    return {
+        "id": job_id,
+        "title": title,
+        "public_url": f"https://www.instahyre.com/job-{job_id}-frontend-developer/",
+        "locations": "Bangalore,Gurgaon",
+        "employer": {
+            "id": 53522,
+            "company_name": "Echos",
+            "company_tagline": "Where deep tech meets real-world impact",
+            "company_founded": 2025,
+            "employee_count": 10,
+            "instahyre_note": "Deep-tech engineering company.",
+        },
+        "keywords": ["React.js", "JavaScript", "Next.js"],
+        "accept_outstation": True,
+    }
+
+
+def test_registry_resolves_instahyre() -> None:
+    assert ScraperRegistry.get(ATSType.INSTAHYRE) is InstahyreScraper
+
+
+def test_parses_instahyre_job_payload(httpx_mock) -> None:
+    httpx_mock.add_response(url=_API_RE, json={"objects": [_job(423594)]})
+
+    jobs = InstahyreScraper("any").fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.INSTAHYRE
+    assert j.ats_id == "423594"
+    assert j.title == "Frontend Developer"
+    assert j.company == "Echos"
+    assert j.location == "Bangalore, Gurgaon"
+    assert j.description == "Deep-tech engineering company."
+    assert j.raw is not None
+    assert j.raw["keywords"] == ["React.js", "JavaScript", "Next.js"]
+    assert j.raw["employer_id"] == 53522
+
+
+def test_paginates_until_empty(httpx_mock) -> None:
+    httpx_mock.add_response(url=_API_RE, json={"objects": [_job(1), _job(2)]})
+    httpx_mock.add_response(url=_API_RE, json={"objects": [_job(3)]})
+
+    jobs = InstahyreScraper("any", page_size=2).fetch()
+    assert [j.ats_id for j in jobs] == ["1", "2", "3"]
+
+
+def test_500_raises(httpx_mock) -> None:
+    httpx_mock.add_response(url=_API_RE, status_code=500, is_reusable=True)
+    with pytest.raises(ScraperError):
+        InstahyreScraper("any").fetch()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -28,7 +28,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "bundesagentur", "arbetsformedlingen", "eures",
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
-        "weworkremotely", "programathor", "builtin", "jobsch",
+        "weworkremotely", "programathor", "builtin", "instahyre", "jobsch",
         "manfred", "thehub", "ycombinator", "wellfound",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",


### PR DESCRIPTION
## Summary

Adds an Instahyre scraper for India-focused direct employer tech postings using Instahyre's public JSON job search endpoint.

## Coverage impact

A live smoke fetch on 2026-05-11 collected 400 jobs before Instahyre rate-limited this IP at `offset=400`. The scraper now keeps already-collected pages when deep pagination hits a transient/rate-limit failure.

## Validation

- `uv run --extra dev pytest tests/test_instahyre.py tests/test_models.py -q`
- `uv run --extra dev ruff check src/jobhive/scrapers/instahyre.py tests/test_instahyre.py src/jobhive/models.py src/jobhive/scrapers/__init__.py tests/test_models.py`
- Smoke: `InstahyreScraper('any').fetch()` collected 400 jobs before rate limiting on this IP

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Instahyre scraper that paginates the public JSON API and enriches per‑job details. Expands India coverage and prevents silent partial‑scrapes when pagination or detail requests fail.

- New Features
  - Added `InstahyreScraper` using `https://www.instahyre.com/api/v1/job_search` and `https://www.instahyre.com/api/v1/job_search/{id}` (JSON only).
  - Supports pagination (`page_size`, `max_pages`), async detail enrichment with concurrency, and 429/5xx retries with backoff; catches page errors after the first page to keep collected pages and isolates detail errors so enrichment failures don’t cancel or hide results.
  - Validates JSON objects and detail ID, composes plain‑text descriptions from API fields (title, location, skills, employer), parses core fields, and sets `ats_type` to `ATSType.INSTAHYRE`.
  - Registered in `ScraperRegistry`, exported from `jobhive.scrapers.__init__`, added `INSTAHYRE` to `ATSType`, and added ATS seed CSV `ats-companies/instahyre.csv`.

<sup>Written for commit c47acf1daf976aace2a44e410a330adead6fd3e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/71?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `InstahyreScraper`, a two-step JSON scraper that paginates `/api/v1/job_search` for listings and then enriches each job from the per-job detail endpoint, with concurrency-limited async fetches and 429/5xx retry backoff.

- The scraper, `ATSType.INSTAHYRE`, `ScraperRegistry` registration, `__all__` export, and seed CSV are all wired up correctly and follow the existing patterns for market-wide scrapers.
- Three unreachable code paths exist in `instahyre.py`: the `isinstance(payload, dict)` guard in `_fetch_async` (redundant with `_fetch_page`'s own validation), the trailing `raise ScraperError` after the retry loop in `_fetch_page`, and the `if text else None` guard in `_compose_description` — none affect runtime behaviour but add noise.
- Test coverage is solid: pagination termination, detail enrichment, ID-mismatch skip, 500-on-first-page, detail failure fallback, and non-object top-level response are all exercised.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all findings are dead code that can be removed without changing behaviour

The scraper logic, retry handling, and enrichment flow are all correct. The three dead-code paths are cosmetic and carry no runtime risk — they just make the control flow harder to follow.

src/jobhive/scrapers/instahyre.py — three unreachable code paths worth cleaning up

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/instahyre.py | New scraper with paginated listing + detail enrichment; three unreachable code paths that can mislead readers |
| tests/test_instahyre.py | Good test coverage: pagination, detail enrichment, ID mismatch, 500 errors, non-object JSON all covered |
| src/jobhive/models.py | Adds INSTAHYRE to ATSType enum in alphabetical order; no issues |
| src/jobhive/scrapers/__init__.py | InstahyreScraper correctly imported and exported in __all__ |
| ats-companies/instahyre.csv | Seed CSV with correct header and single Instahyre entry |
| tests/test_models.py | INSTAHYRE added to the exhaustive ATSType assertion; no issues |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/jobhive/scrapers/instahyre.py:79-88
`_fetch_page` already validates that the returned JSON is a `dict` and raises `ScraperError` if it isn't — the annotation `-> dict[str, Any]` makes this contract explicit. The `isinstance` guard here is therefore dead code and can confuse readers into thinking there's a code path where `_fetch_page` returns a non-dict.

```suggestion
                except ScraperError:
                    if page == 0:
                        raise
                    break
                items = payload.get("objects") or []
```

### Issue 2 of 3
src/jobhive/scrapers/instahyre.py:159-164
The final `raise` after the retry loop is unreachable. On the last attempt, every branch either returns or raises inside the loop body, so control never falls through to line 162. The `last_exc` variable is also only set when an `httpx.HTTPError` is caught, yet the earlier catch already re-raises on the last attempt, so this fallback would always have `last_exc=None` if somehow reached.

```suggestion
            raise ScraperError(
                f"Instahyre returned {response.status_code} at offset={offset}"
            )
```

### Issue 3 of 3
src/jobhive/scrapers/instahyre.py:281-282
By the time this line is reached, `parts` is guaranteed non-empty (the `if not parts: return None` guard is just above). `"

".join(non_empty_list)` always produces a non-empty string, so the `if text else None` branch is dead — the slice is always taken.

```suggestion
    text = "\n\n".join(parts)
    return text[:10_000]
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: instahyre.cs..."](https://github.com/kalil0321/ats-scrapers/commit/5458a13856eba52cc46fc601a3bbcfd808d45d7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732366)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->