### PR TITLE
[codex] Add Mustakbil scraper

### DIFF
--- a/ats-companies/mustakbil.csv
+++ b/ats-companies/mustakbil.csv
@@ -1,0 +1,2 @@
+name,slug,url
+Mustakbil,mustakbil,https://www.mustakbil.com

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -75,6 +75,7 @@ class ATSType(StrEnum):
     WEWORKREMOTELY = "weworkremotely"
     PROGRAMATHOR = "programathor"
     BUILTIN = "builtin"
+    MUSTAKBIL = "mustakbil"
     JOBSCH = "jobsch"
     MANFRED = "manfred"
     THEHUB = "thehub"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -33,6 +33,7 @@ from jobhive.scrapers.lever import LeverScraper
 from jobhive.scrapers.manfred import ManfredScraper
 from jobhive.scrapers.mercor import MercorScraper
 from jobhive.scrapers.meta import MetaScraper
+from jobhive.scrapers.mustakbil import MustakbilScraper
 from jobhive.scrapers.oracle import OracleScraper
 from jobhive.scrapers.personio import PersonioScraper
 from jobhive.scrapers.phenom import PhenomScraper
@@ -84,6 +85,7 @@ __all__ = [
     "ManfredScraper",
     "MercorScraper",
     "MetaScraper",
+    "MustakbilScraper",
     "OracleScraper",
     "PersonioScraper",
     "PhenomScraper",

--- a/src/jobhive/scrapers/mustakbil.py
+++ b/src/jobhive/scrapers/mustakbil.py
@@ -1,0 +1,219 @@
+"""Mustakbil — Pakistan direct employer job board public API."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+API_URL = "https://api-public.mustakbil.com/ws/jobs/search/"
+DEFAULT_MAX_PAGES = 500
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1.5
+PAKISTAN_COUNTRY_ID = 162
+
+
+@ScraperRegistry.register(ATSType.MUSTAKBIL)
+class MustakbilScraper(BaseScraper):
+    """Mustakbil Pakistan jobs scraper."""
+
+    ats = ATSType.MUSTAKBIL
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        max_pages: int = DEFAULT_MAX_PAGES,
+        country_id: int = PAKISTAN_COUNTRY_ID,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.max_pages = max_pages
+        self.country_id = country_id
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        jobs: list[Job] = []
+        seen: set[str] = set()
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True
+        ) as client:
+            for page in range(1, self.max_pages + 1):
+                try:
+                    payload = await self._fetch_page(client, page=page)
+                except ScraperError:
+                    if page == 1:
+                        raise
+                    break
+                items = payload.get("list") or []
+                if not items:
+                    break
+                new_count = 0
+                for item in items:
+                    job = self._parse(item)
+                    if job is None or job.ats_id in seen:
+                        continue
+                    seen.add(job.ats_id)
+                    jobs.append(job)
+                    new_count += 1
+                if new_count == 0:
+                    break
+        return jobs
+
+    async def _fetch_page(
+        self,
+        client: httpx.AsyncClient,
+        *,
+        page: int,
+    ) -> dict[str, Any]:
+        params = {"countryid": self.country_id, "page": page}
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                response = await client.get(
+                    API_URL,
+                    params=params,
+                    headers={
+                        "User-Agent": "Mozilla/5.0",
+                        "Accept": "application/json",
+                        "Origin": "https://www.mustakbil.com",
+                        "Referer": "https://www.mustakbil.com/jobs/pakistan",
+                    },
+                )
+            except httpx.HTTPError as exc:
+                last_exc = exc
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Mustakbil fetch failed at page={page}: {exc}"
+                    ) from exc
+                await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                continue
+            if response.status_code == 200:
+                try:
+                    return response.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"Mustakbil returned non-JSON at page={page}: {exc}"
+                    ) from exc
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Mustakbil returned {response.status_code} at "
+                        f"page={page} after {MAX_RETRIES} retries"
+                    )
+                await asyncio.sleep(RETRY_BASE_DELAY * (2**attempt))
+                continue
+            raise ScraperError(
+                f"Mustakbil returned {response.status_code} at page={page}"
+            )
+        raise ScraperError(f"Mustakbil exhausted retries at page={page}: {last_exc}")
+
+    def _parse(self, item: dict[str, Any]) -> Job | None:
+        raw_id = item.get("id")
+        title = (item.get("title") or "").strip()
+        if raw_id is None or not title:
+            return None
+
+        salary_min = _to_float(item.get("salaryMin"))
+        salary_max = _to_float(item.get("salaryMax"))
+        currency = item.get("currency")
+        salary_summary = None
+        if currency and (salary_min is not None or salary_max is not None):
+            salary_summary = f"{salary_min or ''}-{salary_max or ''} {currency}".strip()
+
+        raw: dict[str, Any] = {}
+        for key in (
+            "employerId",
+            "category",
+            "shift",
+            "experienceLevel",
+            "adType",
+            "vacancies",
+            "lastDate",
+        ):
+            value = item.get(key)
+            if value not in (None, ""):
+                raw[key] = value
+
+        return Job(
+            url=_job_url(item, str(raw_id)),
+            title=title,
+            company=(item.get("company") or "").strip() or "Unknown",
+            ats_type=ATSType.MUSTAKBIL,
+            ats_id=str(raw_id),
+            location=_join_nonempty(item.get("cities") or item.get("city"), item.get("country")),
+            country_iso="PK" if item.get("country") == "Pakistan" else None,
+            is_remote=True if item.get("telecommute") is True else None,
+            salary_min=salary_min,
+            salary_max=salary_max,
+            salary_currency=currency if isinstance(currency, str) and len(currency) == 3 else None,
+            salary_summary=salary_summary,
+            employment_type=_map_employment_type(item.get("type")),
+            commitment=item.get("type") or None,
+            department=item.get("category") or None,
+            description=item.get("description") or None,
+            posted_at=_parse_ts(item.get("postedOn")),
+            fetched_at=datetime.now(),
+            raw=raw or None,
+        )
+
+
+def _job_url(item: dict[str, Any], ats_id: str) -> str:
+    url_title = item.get("urlTitle")
+    country = item.get("urlCountry") or "pakistan"
+    city = item.get("urlCity") or ""
+    if isinstance(url_title, str) and url_title:
+        city_part = f"/{city}" if city else ""
+        return f"https://www.mustakbil.com/jobs/job/{ats_id}/{country}{city_part}/{url_title}"
+    return f"https://www.mustakbil.com/jobs/job/{ats_id}"
+
+
+def _join_nonempty(*values: object) -> str | None:
+    parts = [v.strip() for v in values if isinstance(v, str) and v.strip()]
+    return ", ".join(parts) if parts else None
+
+
+def _map_employment_type(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    norm = value.lower()
+    if "intern" in norm:
+        return "INTERN"
+    if "part" in norm:
+        return "PART_TIME"
+    if "contract" in norm or "freelance" in norm:
+        return "CONTRACT"
+    if "temporary" in norm:
+        return "TEMPORARY"
+    if "full" in norm:
+        return "FULL_TIME"
+    return None
+
+
+def _to_float(value: object) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_ts(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -28,7 +28,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "bundesagentur", "arbetsformedlingen", "eures",
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
-        "weworkremotely", "programathor", "builtin", "jobsch",
+        "weworkremotely", "programathor", "builtin", "mustakbil", "jobsch",
         "manfred", "thehub", "ycombinator", "wellfound",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",

--- a/tests/test_mustakbil.py
+++ b/tests/test_mustakbil.py
@@ -1,0 +1,89 @@
+"""Tests for Mustakbil Pakistan."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import MustakbilScraper, ScraperRegistry
+
+_API_RE = re.compile(r"^https://api-public\.mustakbil\.com/ws/jobs/search/")
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.mustakbil as m
+
+    monkeypatch.setattr(m, "MAX_RETRIES", 1)
+    monkeypatch.setattr(m, "RETRY_BASE_DELAY", 0.0)
+
+
+def _job(job_id: int, title: str = "Sales Executive") -> dict:
+    return {
+        "id": job_id,
+        "employerId": 128081,
+        "title": title,
+        "category": "Sales",
+        "type": "Full Time",
+        "shift": "Morning Shift",
+        "experienceLevel": "1 Year",
+        "salaryMin": 40000,
+        "salaryMax": 100000,
+        "currency": "PKR",
+        "description": "Drive B2B sales.",
+        "cities": "Rawalpindi",
+        "city": "Rawalpindi",
+        "country": "Pakistan",
+        "postedOn": "2026-04-28T09:21:00",
+        "lastDate": "2026-07-28T00:16:00",
+        "adType": "Premium",
+        "company": "Mend Skincare",
+        "vacancies": 1,
+        "telecommute": False,
+        "urlTitle": "sales-executive",
+        "urlCountry": "pakistan",
+        "urlCity": "rawalpindi",
+    }
+
+
+def test_registry_resolves_mustakbil() -> None:
+    assert ScraperRegistry.get(ATSType.MUSTAKBIL) is MustakbilScraper
+
+
+def test_parses_mustakbil_job_payload(httpx_mock) -> None:
+    httpx_mock.add_response(url=_API_RE, json={"list": [_job(1431768)]})
+    httpx_mock.add_response(url=_API_RE, json={"list": []})
+
+    jobs = MustakbilScraper("any").fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.MUSTAKBIL
+    assert j.ats_id == "1431768"
+    assert j.title == "Sales Executive"
+    assert j.company == "Mend Skincare"
+    assert j.location == "Rawalpindi, Pakistan"
+    assert j.country_iso == "PK"
+    assert j.employment_type == "FULL_TIME"
+    assert j.salary_currency == "PKR"
+    assert j.salary_min == 40000
+    assert j.salary_max == 100000
+    assert j.posted_at is not None
+    assert str(j.url) == "https://www.mustakbil.com/jobs/job/1431768/pakistan/rawalpindi/sales-executive"
+
+
+def test_paginates_until_empty(httpx_mock) -> None:
+    httpx_mock.add_response(url=_API_RE, json={"list": [_job(1), _job(2)]})
+    httpx_mock.add_response(url=_API_RE, json={"list": [_job(3)]})
+    httpx_mock.add_response(url=_API_RE, json={"list": []})
+
+    jobs = MustakbilScraper("any").fetch()
+    assert [j.ats_id for j in jobs] == ["1", "2", "3"]
+
+
+def test_500_raises(httpx_mock) -> None:
+    httpx_mock.add_response(url=_API_RE, status_code=500, is_reusable=True)
+    with pytest.raises(ScraperError):
+        MustakbilScraper("any").fetch()


### PR DESCRIPTION
## Summary

Adds a Mustakbil scraper for Pakistan using the public `api-public.mustakbil.com/ws/jobs/search/` JSON endpoint discovered via reverse-api-engineer.

## Coverage impact

Live smoke fetch on 2026-05-11 returned 593 Pakistan jobs before the API stopped deep pagination on this IP. The scraper keeps collected pages after page 1 when deeper pagination returns a transient block.

## Validation

- `uv run --extra dev pytest tests/test_mustakbil.py tests/test_models.py -q`
- `uv run --extra dev ruff check src/jobhive/scrapers/mustakbil.py tests/test_mustakbil.py src/jobhive/models.py src/jobhive/scrapers/__init__.py tests/test_models.py`
- Smoke: `MustakbilScraper('any').fetch()` returned 593 jobs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Mustakbil scraper for Pakistan using the public JSON search API. Handles pagination with retries and returns collected jobs even if deeper pages are blocked.

- **New Features**
  - Added `MustakbilScraper` that queries `https://api-public.mustakbil.com/ws/jobs/search/` with pagination, deduping by `ats_id`, and retry/backoff on 5xx/429.
  - Parses title, company, location, `country_iso=PK`, employment type, salary min/max/currency, posted date, and builds canonical job URLs.
  - Added `ATSType.MUSTAKBIL`, exported the scraper in `scrapers.__init__`, and seeded `ats-companies/mustakbil.csv`.
  - Tests cover registry resolution, pagination stop conditions, JSON parsing, and 500 error handling.

<sup>Written for commit b13492ce618d0b22e80a446fa4c560be594c6817. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/72?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new `MustakbilScraper` that queries the Mustakbil Pakistan public JSON API with pagination, deduplication, and retry/backoff logic, along with the corresponding model enum value, registry entry, CSV seed, and tests.

- **New scraper** (`mustakbil.py`): fetches paginated jobs from `api-public.mustakbil.com`, parses title/company/location/salary/employment type, and stops pagination on empty pages or transient 5xx blocks after page 1.
- **`salary_summary` formatting bug**: the f-string produces malformed output like `\"40000.0- PKR\"` or `\"-50000.0 PKR\"` when only one of min/max is set; raw salary fields are correct but the summary string is broken.
- **`cities` type assumption**: if the API returns `cities` as a list, `_join_nonempty` silently discards it and only the country name is retained in `location`.

<h3>Confidence Score: 3/5</h3>

The scraper is well-structured but the salary_summary field will store malformed strings whenever only one of min/max is populated, a data quality defect that propagates into the dataset.

The core fetch-and-parse logic is sound and tests cover the happy path well. The salary_summary formatting produces incorrect strings like 40000.0- PKR or -50000.0 PKR for jobs where only one salary bound is present. The city-as-list concern is speculative but warrants confirming against the live API response shape before merging.

src/jobhive/scrapers/mustakbil.py — specifically the salary_summary construction and the cities field handling

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/mustakbil.py | New scraper for Mustakbil Pakistan via public JSON API. Has a data-quality bug in salary_summary formatting when only one of min/max is present, a speculative issue with cities being a list silently dropping city names, and dead code after the retry loop. |
| tests/test_mustakbil.py | Tests cover registry resolution, full job payload parsing, pagination stop conditions, and 500 error handling. No test for the one-sided salary_summary formatting bug. |
| src/jobhive/models.py | Adds MUSTAKBIL to ATSType in the correct alphabetical position within the hybrid job boards section. |
| src/jobhive/scrapers/__init__.py | Correctly imports and exports MustakbilScraper in alphabetical order. |
| ats-companies/mustakbil.csv | Seeds the Mustakbil company entry with correct name, slug, and URL. |
| tests/test_models.py | Adds mustakbil to the expected ATSType set in the canonical-coverage test. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/jobhive/scrapers/mustakbil.py:132-133
When only one of `salary_min` or `salary_max` is present, the f-string produces a malformed `salary_summary`. If `salary_max` is `None`, the result is `"40000.0- PKR"` (trailing dash before currency). If `salary_min` is `None`, the result is `"-50000.0 PKR"` (leading dash). The raw `salary_min`/`salary_max` fields are correct, but the summary string stored in the dataset would be visually broken.

```suggestion
        if currency and (salary_min is not None or salary_max is not None):
            if salary_min is not None and salary_max is not None:
                salary_summary = f"{salary_min}-{salary_max} {currency}"
            elif salary_min is not None:
                salary_summary = f"{salary_min}+ {currency}"
            else:
                salary_summary = f"up to {salary_max} {currency}"
```

### Issue 2 of 3
src/jobhive/scrapers/mustakbil.py:155
**`cities` field type assumption may silently drop city data**

The expression `item.get("cities") or item.get("city")` passes the raw `cities` value (whatever type the API returns) directly to `_join_nonempty`. If `cities` is a list (e.g. `["Karachi", "Lahore"]`) it is truthy, so `city` is never consulted — but `_join_nonempty` filters with `isinstance(v, str)`, silently discarding the list. The resulting `location` would contain only the country name. If the Mustakbil API can return `cities` as a list for multi-city postings, you'd want to join the list elements before passing them in.

### Issue 3 of 3
src/jobhive/scrapers/mustakbil.py:115-118
**Unreachable fallback `raise` after retry loop**

The final `raise ScraperError(f"Mustakbil exhausted retries at page={page}: {last_exc}")` after the for-loop is dead code. On every last attempt (`attempt == MAX_RETRIES`), the function already raises inside the loop — for both `httpx.HTTPError` and 4xx/5xx responses. The loop can never exhaust its iterations without raising or returning, so this line is never reached. Additionally `last_exc` would be `None` there if only HTTP-status errors occurred (it's only set in the `httpx.HTTPError` branch), making the message misleading if the line ever ran.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: mustakbil.cs..."](https://github.com/kalil0321/ats-scrapers/commit/b13492ce618d0b22e80a446fa4c560be594c6817) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732372)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->