### PR TITLE
[codex] Add Akhtaboot scraper

### DIFF
--- a/ats-companies/akhtaboot.csv
+++ b/ats-companies/akhtaboot.csv
@@ -1,0 +1,2 @@
+name,slug,url
+Akhtaboot,akhtaboot,https://www.akhtaboot.com

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -75,6 +75,7 @@ class ATSType(StrEnum):
     WEWORKREMOTELY = "weworkremotely"
     PROGRAMATHOR = "programathor"
     BUILTIN = "builtin"
+    AKHTABOOT = "akhtaboot"
     JOBSCH = "jobsch"
     MANFRED = "manfred"
     THEHUB = "thehub"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -8,6 +8,7 @@ in `jobhive.pipeline` so a scraper stays usable on its own.
 >>> jobs = GreenhouseScraper("openai").fetch()
 """
 
+from jobhive.scrapers.akhtaboot import AkhtabootScraper
 from jobhive.scrapers.amazon import AmazonScraper
 from jobhive.scrapers.apple import AppleScraper
 from jobhive.scrapers.arbetsformedlingen import ArbetsformedlingenScraper
@@ -60,6 +61,7 @@ from jobhive.scrapers.workday import WorkdayScraper
 from jobhive.scrapers.ycombinator import YCombinatorScraper
 
 __all__ = [
+    "AkhtabootScraper",
     "AmazonScraper",
     "AppleScraper",
     "ArbetsformedlingenScraper",

--- a/src/jobhive/scrapers/akhtaboot.py
+++ b/src/jobhive/scrapers/akhtaboot.py
@@ -1,0 +1,177 @@
+"""Akhtaboot — Middle East direct employer job board."""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+BASE_URL = "https://www.akhtaboot.com"
+LISTING_URL = f"{BASE_URL}/en/the-middle-east/jobs"
+DEFAULT_MAX_PAGES = 20
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1.5
+
+_JOB_BLOCK_RE = re.compile(
+    r"<div class='job clearfix'>(?P<body>.*?)"
+    r"(?=<div class='job clearfix'>|<div class='col-xs-12 text-center|$)",
+    re.DOTALL,
+)
+_REF_RE = re.compile(r"Ref\.\s*Number:\s*(?P<id>\d+)", re.IGNORECASE)
+_DATE_RE = re.compile(r"Date Posted:\s*(?P<date>\d{2}-\d{2}-\d{4})", re.IGNORECASE)
+_LINK_RE = re.compile(
+    r"<a class='job-link' href='(?P<href>[^']+)'[^>]*>\s*<h4>(?P<title>.*?)</h4>",
+    re.DOTALL,
+)
+_COMPANY_LOC_RE = re.compile(
+    r"<p class='no-margin'>\s*<strong>\s*(?P<company>.*?)\s*-\s*"
+    r"<span>\s*(?P<location>.*?)\s*</span>",
+    re.DOTALL,
+)
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+@ScraperRegistry.register(ATSType.AKHTABOOT)
+class AkhtabootScraper(BaseScraper):
+    """Akhtaboot MENA jobs scraper."""
+
+    ats = ATSType.AKHTABOOT
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        max_pages: int = DEFAULT_MAX_PAGES,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.max_pages = max_pages
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True
+        ) as client:
+            for page in range(1, self.max_pages + 1):
+                text = await self._fetch_page(client, page=page)
+                page_jobs = self._parse_page(text)
+                if not page_jobs:
+                    break
+                new_count = 0
+                for job in page_jobs:
+                    if job.ats_id in seen:
+                        continue
+                    seen.add(job.ats_id)
+                    jobs.append(job)
+                    new_count += 1
+                if new_count == 0:
+                    break
+        return jobs
+
+    async def _fetch_page(self, client: httpx.AsyncClient, *, page: int) -> str:
+        params: dict[str, Any] = {"page": page, "per_page": 25}
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                response = await client.get(
+                    LISTING_URL,
+                    params=params,
+                    headers={
+                        "User-Agent": "Mozilla/5.0",
+                        "Accept": "text/html,*/*",
+                    },
+                )
+            except httpx.HTTPError as exc:
+                last_exc = exc
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Akhtaboot fetch failed at page={page}: {exc}"
+                    ) from exc
+                await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                continue
+            if response.status_code == 200:
+                return response.text
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Akhtaboot returned {response.status_code} at "
+                        f"page={page} after {MAX_RETRIES} retries"
+                    )
+                await asyncio.sleep(RETRY_BASE_DELAY * (2**attempt))
+                continue
+            raise ScraperError(
+                f"Akhtaboot returned {response.status_code} at page={page}"
+            )
+        raise ScraperError(f"Akhtaboot exhausted retries at page={page}: {last_exc}")
+
+    def _parse_page(self, text: str) -> list[Job]:
+        jobs: list[Job] = []
+        for match in _JOB_BLOCK_RE.finditer(text):
+            job = self._parse_block(match.group("body"))
+            if job is not None:
+                jobs.append(job)
+        return jobs
+
+    def _parse_block(self, block: str) -> Job | None:
+        ref = _REF_RE.search(block)
+        link = _LINK_RE.search(block)
+        company_loc = _COMPANY_LOC_RE.search(block)
+        if not ref or not link:
+            return None
+
+        ats_id = ref.group("id")
+        title = _clean_html(link.group("title"))
+        href = html.unescape(link.group("href"))
+        if not title:
+            return None
+
+        company = "Unknown"
+        location = None
+        if company_loc:
+            company = _clean_html(company_loc.group("company")) or "Unknown"
+            location = _clean_html(company_loc.group("location")) or None
+
+        posted_at = None
+        date_match = _DATE_RE.search(block)
+        if date_match:
+            posted_at = _parse_date(date_match.group("date"))
+
+        return Job(
+            url=href if href.startswith("http") else f"{BASE_URL}{href}",
+            title=title,
+            company=company,
+            ats_type=ATSType.AKHTABOOT,
+            ats_id=ats_id,
+            location=location,
+            posted_at=posted_at,
+            fetched_at=datetime.now(),
+            raw={"source_region": "Middle East"},
+        )
+
+
+def _clean_html(value: str) -> str:
+    text = _TAG_RE.sub(" ", value)
+    text = html.unescape(text)
+    return " ".join(text.split())
+
+
+def _parse_date(value: str) -> datetime | None:
+    try:
+        return datetime.strptime(value, "%d-%m-%Y")
+    except ValueError:
+        return None

--- a/tests/test_akhtaboot.py
+++ b/tests/test_akhtaboot.py
@@ -1,0 +1,77 @@
+"""Tests for Akhtaboot."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import AkhtabootScraper, ScraperRegistry
+
+_API_RE = re.compile(r"^https://www\.akhtaboot\.com/en/the-middle-east/jobs")
+
+HTML_PAGE = """
+<div class='job clearfix'>
+  <div class='col-xs-12 col-sm-12 col-md-10 job-content'>
+    <small class='col-md-3 pull-right'>
+      Ref. Number: 166901
+      <br>
+      Date Posted: 11-05-2026
+    </small>
+    <a class='job-link' href='/en/jordan/jobs/amman/166901-Role-at-Acme' target=''>
+      <h4>COMMUNICATIONS PROFESSIONAL</h4>
+    </a>
+    <p class='no-margin'>
+      <strong>
+        Norwegian Refugee Council (NRC)
+        -
+        <span>Amman, Jordan</span>
+      </strong>
+    </p>
+  </div>
+</div>
+"""
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.akhtaboot as a
+
+    monkeypatch.setattr(a, "MAX_RETRIES", 1)
+    monkeypatch.setattr(a, "RETRY_BASE_DELAY", 0.0)
+
+
+def test_registry_resolves_akhtaboot() -> None:
+    assert ScraperRegistry.get(ATSType.AKHTABOOT) is AkhtabootScraper
+
+
+def test_parses_akhtaboot_job_html(httpx_mock) -> None:
+    httpx_mock.add_response(url=_API_RE, text=HTML_PAGE)
+    httpx_mock.add_response(url=_API_RE, text="")
+
+    jobs = AkhtabootScraper("any").fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.AKHTABOOT
+    assert j.ats_id == "166901"
+    assert j.title == "COMMUNICATIONS PROFESSIONAL"
+    assert j.company == "Norwegian Refugee Council (NRC)"
+    assert j.location == "Amman, Jordan"
+    assert str(j.url) == "https://www.akhtaboot.com/en/jordan/jobs/amman/166901-Role-at-Acme"
+    assert j.posted_at is not None
+
+
+def test_dedupes_repeated_pages(httpx_mock) -> None:
+    httpx_mock.add_response(url=_API_RE, text=HTML_PAGE)
+    httpx_mock.add_response(url=_API_RE, text=HTML_PAGE)
+
+    jobs = AkhtabootScraper("any", max_pages=2).fetch()
+    assert len(jobs) == 1
+
+
+def test_500_raises(httpx_mock) -> None:
+    httpx_mock.add_response(url=_API_RE, status_code=500, is_reusable=True)
+    with pytest.raises(ScraperError):
+        AkhtabootScraper("any").fetch()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -28,7 +28,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "bundesagentur", "arbetsformedlingen", "eures",
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
-        "weworkremotely", "programathor", "builtin", "jobsch",
+        "weworkremotely", "programathor", "builtin", "akhtaboot", "jobsch",
         "manfred", "thehub", "ycombinator", "wellfound",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",


### PR DESCRIPTION
## Summary

Adds an Akhtaboot scraper for Middle East direct employer postings.

## Source note

I ran `reverse-api-engineer agent` against Akhtaboot. The listing surface did not expose a clean JSON list API; the available listing endpoint returns server-rendered HTML / XHR HTML fragments. This PR keeps Akhtaboot isolated as an HTML fallback so it can be reviewed independently.

## Coverage impact

Live smoke fetch on 2026-05-11 returned 65 Middle East jobs.

## Validation

- `uv run --extra dev pytest tests/test_akhtaboot.py tests/test_models.py -q`
- `uv run --extra dev ruff check src/jobhive/scrapers/akhtaboot.py tests/test_akhtaboot.py src/jobhive/models.py src/jobhive/scrapers/__init__.py tests/test_models.py`
- Smoke: `AkhtabootScraper('any').fetch()` returned 65 jobs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Akhtaboot scraper to ingest Middle East direct employer postings via HTML parsing and register `ATSType.AKHTABOOT` to expand coverage.

- New Features
  - Added `AkhtabootScraper` with async fetch, pagination (`max_pages`), and dedupe by `ats_id`.
  - Retry with backoff for 429/5xx and robust error handling.
  - HTML parsing for title, company, location, posted date, and job link.
  - Registered `ATSType.AKHTABOOT` and export in `jobhive.scrapers`; added tests for parsing, dedupe, and failures.
  - Seeded `ats-companies/akhtaboot.csv` for company metadata.

<sup>Written for commit d6ce313a282b7d41ba15a1dde70c62ba48c944f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `AkhtabootScraper`, an HTML-parsing scraper for the Akhtaboot MENA job board, along with the `ATSType.AKHTABOOT` enum value, registry wiring, a seed CSV, and accompanying tests. The implementation is consistent with sibling single-source scrapers (`BuiltInScraper`, `JobschScraper`) in structure and retry strategy.

- The core scraper uses regex-based HTML parsing with pagination, retry/backoff on 429 and 5xx, and deduplication by `ats_id`; all paths are exercised by the new test suite.
- The final `raise ScraperError(...)` after the retry `for`-loop (line 120) is unreachable dead code.
- The `_COMPANY_LOC_RE` anchors on exact attribute strings, so minor future HTML changes would silently degrade company/location fields.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the scraper is well-isolated and the identified issues are non-blocking quality items.

The scraper is functional, correctly wired into the registry, and covered by focused tests. The dead-code trailing raise and the exact-match regex anchors are both worth cleaning up before the scraper runs at scale, but neither will cause incorrect behaviour under the current Akhtaboot HTML.

src/jobhive/scrapers/akhtaboot.py — the retry-loop dead code and the _COMPANY_LOC_RE exact-attribute anchors are the two spots worth a second look before this scraper runs in production.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/akhtaboot.py | New HTML-parsing scraper for Akhtaboot MENA board; retry logic, deduplication, and regex parsing are functional but include a dead-code unreachable raise after the retry loop, and the company/location regex is brittle to minor HTML attribute changes. |
| tests/test_akhtaboot.py | Covers registry lookup, HTML parsing, deduplication, and 500-error path; missing coverage for 429 retry behaviour, network errors (httpx.HTTPError), and malformed blocks missing only the link or only the ref. |
| src/jobhive/models.py | Adds ATSType.AKHTABOOT in the correct alphabetical position within the hybrid-jobboards block. |
| src/jobhive/scrapers/__init__.py | Exports AkhtabootScraper in alphabetical order; straightforward addition. |
| ats-companies/akhtaboot.csv | Seed CSV with a single Akhtaboot entry; correct header and format. |
| tests/test_models.py | Inserts akhtaboot into the exhaustive ATSType allowlist test; no issues. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/jobhive/scrapers/akhtaboot.py:120
**Unreachable dead code after retry loop**

The `raise ScraperError(...)` on this line is never reached. Every iteration of the `for` loop either returns (`200` path), raises inside the `except httpx.HTTPError` block (last attempt), raises inside the `429/5xx` block (last attempt), or raises immediately for a non-retryable status. On the last iteration (`attempt == MAX_RETRIES`) there is no `continue`, so all paths exit before the loop ends. `last_exc` would always be `None` here since it is only assigned in the `httpx.HTTPError` branch.

### Issue 2 of 3
src/jobhive/scrapers/akhtaboot.py:1
**`company_slug` is silently unused — document it like sibling scrapers do**

`AkhtabootScraper` is a single-source board scraper, so `company_slug` is accepted by the constructor (required by `BaseScraper`) but never consulted during fetching. Other identical-pattern scrapers in this codebase (e.g. `BuiltInScraper`) call this out explicitly in the module docstring. Without the note, callers passing a specific slug will silently get the entire board instead of a filtered view, with no warning.

```suggestion
"""Akhtaboot — Middle East direct employer job board.

Single-source scraper: ``company_slug`` is informational and ignored.
All jobs from the MENA listing page are always fetched regardless of
the slug passed to the constructor.
"""
```

### Issue 3 of 3
src/jobhive/scrapers/akhtaboot.py:37-41
**`_COMPANY_LOC_RE` is brittle to minor HTML attribute changes**

The regex anchors on `<p class='no-margin'>` and `<strong>` with exact string matches. Any future addition of a second CSS class (e.g. `<p class='no-margin active'>`) or an attribute on `<strong>` (e.g. `<strong data-v="1">`) will silently cause `company_loc` to be `None` for every job, falling back to `company="Unknown"` and `location=None` without any logged warning.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: akhtaboot.cs..."](https://github.com/kalil0321/ats-scrapers/commit/d6ce313a282b7d41ba15a1dde70c62ba48c944f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732374)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->