### PR TITLE
Add Zhaopin scraper for China coverage

### DIFF
--- a/ats-companies/zhaopin.csv
+++ b/ats-companies/zhaopin.csv
@@ -1,0 +1,2 @@
+name,slug,url
+Zhaopin,zhaopin,https://www.zhaopin.com

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -68,6 +68,7 @@ class ATSType(StrEnum):
     ARBETSFORMEDLINGEN = "arbetsformedlingen"
     EURES = "eures"
     # Hybrid jobboards (companies post directly, not aggregated)
+    ZHAOPIN = "zhaopin"
     WELCOMETOTHEJUNGLE = "welcometothejungle"
     GETONBRD = "getonbrd"
     WANTED = "wanted"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -58,6 +58,7 @@ from jobhive.scrapers.weworkremotely import WeWorkRemotelyScraper
 from jobhive.scrapers.workable import WorkableScraper
 from jobhive.scrapers.workday import WorkdayScraper
 from jobhive.scrapers.ycombinator import YCombinatorScraper
+from jobhive.scrapers.zhaopin import ZhaopinScraper
 
 __all__ = [
     "AmazonScraper",
@@ -110,6 +111,7 @@ __all__ = [
     "WorkableScraper",
     "WorkdayScraper",
     "YCombinatorScraper",
+    "ZhaopinScraper",
     "get_scraper",
     "iCIMSScraper",
 ]

--- a/src/jobhive/scrapers/zhaopin.py
+++ b/src/jobhive/scrapers/zhaopin.py
@@ -1,0 +1,290 @@
+"""Zhaopin / 智联招聘 — China direct job board API."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from typing import Any
+
+
+API_URL = "https://fe-api.zhaopin.com/c/i/search/positions"
+DEFAULT_PAGE_SIZE = 20
+DEFAULT_MAX_PAGES = 5
+MAX_RETRIES = 2
+
+DEFAULT_CITY_CODES = (
+    "489",  # Beijing
+    "538",  # Shanghai
+    "765",  # Shenzhen
+    "736",  # Guangzhou
+    "530",  # Hangzhou
+    "801",  # Chengdu
+    "854",  # Wuhan
+    "635",  # Nanjing
+    "702",  # Suzhou
+    "600",  # Tianjin
+)
+
+DEFAULT_KEYWORDS = (
+    "",
+    "工程师",
+    "销售",
+    "客服",
+    "会计",
+    "运营",
+    "产品",
+    "Java",
+    "Python",
+    "司机",
+)
+
+
+@ScraperRegistry.register(ATSType.ZHAOPIN)
+class ZhaopinScraper(BaseScraper):
+    """Zhaopin scraper using the official search JSON API.
+
+    `reverse-api-engineer` found the SPA's real endpoint on 2026-05-11:
+    `POST /c/i/search/positions` with a plain JSON body. The older `sou`
+    endpoint is CAPTCHA-gated, but this positions endpoint works without
+    cookies from a normal HTTP client.
+    """
+
+    ats = ATSType.ZHAOPIN
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        city_codes: Iterable[str] = DEFAULT_CITY_CODES,
+        keywords: Iterable[str] = DEFAULT_KEYWORDS,
+        page_size: int = DEFAULT_PAGE_SIZE,
+        max_pages: int = DEFAULT_MAX_PAGES,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.city_codes = tuple(city_codes)
+        self.keywords = tuple(keywords)
+        self.page_size = page_size
+        self.max_pages = max_pages
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        jobs: list[Job] = []
+        seen: set[str] = set()
+        async with httpx.AsyncClient(
+            timeout=self.timeout,
+            follow_redirects=True,
+            headers={
+                "Content-Type": "application/json;charset=UTF-8",
+                "Accept": "application/json, text/plain, */*",
+                "Referer": "https://www.zhaopin.com/",
+                "x-zp-business-system": "1",
+                "x-zp-page-code": "4019",
+                "x-zp-platform": "13",
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/124.0.0.0 Safari/537.36"
+                ),
+            },
+        ) as client:
+            for city_code in self.city_codes:
+                for keyword in self.keywords:
+                    for page in range(1, self.max_pages + 1):
+                        payload = await self._fetch_page(
+                            client,
+                            city_code=city_code,
+                            keyword=keyword,
+                            page=page,
+                        )
+                        data = payload.get("data") or {}
+                        items = data.get("list") or []
+                        if not items:
+                            break
+                        for job in self._parse_items(items):
+                            if job.ats_id in seen:
+                                continue
+                            seen.add(job.ats_id)
+                            jobs.append(job)
+                        if data.get("isEndPage"):
+                            break
+        return jobs
+
+    async def _fetch_page(
+        self,
+        client: httpx.AsyncClient,
+        *,
+        city_code: str,
+        keyword: str,
+        page: int,
+    ) -> dict[str, Any]:
+        action_id = str(uuid.uuid4())
+        body = {
+            "S_SOU_FULL_INDEX": keyword,
+            "S_SOU_WORK_CITY": city_code,
+            "order": 4,
+            "actionid": action_id,
+            "pageSize": self.page_size,
+            "pageIndex": page,
+            "eventScenario": "pcSearchedSouSearch",
+            "anonymous": 1,
+            "clickFilterBlackCompany": False,
+            "platform": 13,
+            "version": "0.0.0",
+        }
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                response = await client.post(
+                    API_URL,
+                    json=body,
+                    headers={"x-zp-action-id": action_id},
+                )
+            except httpx.HTTPError as exc:
+                last_exc = exc
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Zhaopin fetch failed city={city_code} "
+                        f"keyword={keyword!r} page={page}: {exc}"
+                    ) from exc
+                continue
+            if response.status_code == 200:
+                try:
+                    payload = response.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"Zhaopin returned invalid JSON city={city_code} "
+                        f"keyword={keyword!r} page={page}: {exc}"
+                    ) from exc
+                if payload.get("code") != 200:
+                    raise ScraperError(
+                        f"Zhaopin application code {payload.get('code')} "
+                        f"city={city_code} keyword={keyword!r} page={page}"
+                    )
+                return payload
+            if attempt == MAX_RETRIES:
+                raise ScraperError(
+                    f"Zhaopin returned HTTP {response.status_code} "
+                    f"city={city_code} keyword={keyword!r} page={page}"
+                )
+        raise ScraperError(
+            f"Zhaopin exhausted retries city={city_code} keyword={keyword!r} "
+            f"page={page}: {last_exc}"
+        )
+
+    def _parse_items(self, items: list[dict[str, Any]]) -> list[Job]:
+        return [job for item in items if (job := self._parse_item(item)) is not None]
+
+    def _parse_item(self, item: dict[str, Any]) -> Job | None:
+        detail = item.get("jobDetailData") or {}
+        position = (detail.get("position") or {}) if isinstance(detail, dict) else {}
+        base = (position.get("base") or {}) if isinstance(position, dict) else {}
+        desc = (position.get("desc") or {}) if isinstance(position, dict) else {}
+        location = (position.get("workLocation") or {}) if isinstance(position, dict) else {}
+
+        ats_id = str(
+            base.get("positionNumber") or item.get("positionNumber") or item.get("number") or ""
+        ).strip()
+        title = _clean(base.get("positionName")) or _clean(item.get("positionName"))
+        if not ats_id or not title:
+            return None
+
+        salary_summary = _clean(item.get("salary60")) or _clean(base.get("salary"))
+        salary_min, salary_max = _parse_salary(salary_summary)
+        company = _clean(item.get("companyName")) or "Zhaopin employer"
+        location_text = (
+            _clean(location.get("address"))
+            or _location_from_card(item.get("cardCustomJson"))
+            or _clean(item.get("cityDistrict"))
+        )
+        raw = {
+            key: value
+            for key, value in {
+                "city_id": item.get("cityId"),
+                "company_number": item.get("companyNumber"),
+                "company_size": item.get("companySize"),
+                "education": item.get("education") or base.get("education"),
+                "industry": item.get("industryName"),
+                "work_type": base.get("workType"),
+                "labels": desc.get("labels"),
+                "card_custom_json": item.get("cardCustomJson"),
+            }.items()
+            if value not in (None, "", [], {})
+        }
+
+        return Job(
+            url=_clean(item.get("positionURL"))
+            or _clean(item.get("positionUrl"))
+            or f"https://www.zhaopin.com/jobdetail/{ats_id}.htm",
+            title=title,
+            company=company,
+            ats_type=ATSType.ZHAOPIN,
+            ats_id=ats_id,
+            location=location_text,
+            country_iso="CN",
+            salary_currency="CNY" if salary_summary else None,
+            salary_period="MONTH" if salary_summary else None,
+            salary_summary=salary_summary,
+            salary_min=salary_min,
+            salary_max=salary_max,
+            experience=_parse_experience(
+                item.get("workingExp")
+                or item.get("workExperience")
+                or base.get("positionWorkingExp")
+            ),
+            department=_clean(item.get("industryName")),
+            description=_clean(desc.get("description")),
+            fetched_at=datetime.now(),
+            language="zh",
+            raw=raw or None,
+        )
+
+
+def _clean(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = re.sub(r"\s+", " ", value).strip()
+    return cleaned or None
+
+
+def _location_from_card(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    match = re.search(r'"address"\s*:\s*"([^"]+)"', value)
+    return match.group(1) if match else None
+
+
+def _parse_salary(summary: str | None) -> tuple[float | None, float | None]:
+    if not summary:
+        return None, None
+    match = re.search(r"(\d+(?:\.\d+)?)(?:-(\d+(?:\.\d+)?))?\s*(千|万)", summary)
+    if not match:
+        return None, None
+    unit = 1000 if match.group(3) == "千" else 10000
+    min_amount = float(match.group(1)) * unit
+    max_amount = float(match.group(2)) * unit if match.group(2) else None
+    return min_amount, max_amount
+
+
+def _parse_experience(value: object) -> int | None:
+    text = _clean(value)
+    if not text:
+        return None
+    if "不限" in text or "应届" in text or "在校" in text:
+        return 0
+    match = re.search(r"(\d+)", text)
+    return int(match.group(1)) if match else None

--- a/src/jobhive/scrapers/zhaopin.py
+++ b/src/jobhive/scrapers/zhaopin.py
@@ -236,8 +236,8 @@ class ZhaopinScraper(BaseScraper):
             ats_id=ats_id,
             location=location_text,
             country_iso="CN",
-            salary_currency="CNY" if salary_summary else None,
-            salary_period="MONTH" if salary_summary else None,
+            salary_currency="CNY" if salary_min is not None else None,
+            salary_period="MONTH" if salary_min is not None else None,
             salary_summary=salary_summary,
             salary_min=salary_min,
             salary_max=salary_max,
@@ -264,7 +264,7 @@ def _clean(value: object) -> str | None:
 def _location_from_card(value: object) -> str | None:
     if not isinstance(value, str):
         return None
-    match = re.search(r'"address"\s*:\s*"([^"]+)"', value)
+    match = re.search(r'"address"\s*:\s*"((?:[^"\\]|\\.)*)"', value)
     return match.group(1) if match else None
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -27,7 +27,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # National / supranational public-sector aggregators
         "bundesagentur", "arbetsformedlingen", "eures",
         # Hybrid jobboards (companies post directly)
-        "welcometothejungle", "getonbrd", "wanted", "remoteok",
+        "zhaopin", "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
         "manfred", "thehub", "ycombinator", "wellfound",
         # Additional multi-tenant ATSes

--- a/tests/test_zhaopin.py
+++ b/tests/test_zhaopin.py
@@ -1,0 +1,125 @@
+"""Tests for the Zhaopin China job board scraper."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import ScraperRegistry, ZhaopinScraper
+
+_API_RE = re.compile(r"^https://fe-api\.zhaopin\.com/c/i/search/positions")
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.zhaopin as z
+
+    monkeypatch.setattr(z, "MAX_RETRIES", 1)
+
+
+def _payload(items: list[dict], *, is_end: int = 1, count: int | None = None) -> dict:
+    return {
+        "code": 200,
+        "apiCode": 200,
+        "data": {
+            "count": len(items) if count is None else count,
+            "isEndPage": is_end,
+            "list": items,
+        },
+    }
+
+
+def _item(job_id: str = "CC000544460J40700710516") -> dict:
+    return {
+        "companyName": "软通动力信息技术(集团)股份有限公司",
+        "companyNumber": "CZ000544460",
+        "companySize": "10000人以上",
+        "salary60": "1.1-1.5万",
+        "cityId": "779",
+        "cityDistrict": "",
+        "education": "本科",
+        "workingExp": "经验不限",
+        "industryName": "软件/IT服务",
+        "cardCustomJson": (
+            '{"address":"东莞 南城街道","companyName":"软通动力信息技术(集团)",'
+            '"salary60":"1.1-1.5万"}'
+        ),
+        "jobDetailData": {
+            "position": {
+                "base": {
+                    "positionName": "python爬虫工程师",
+                    "positionNumber": job_id,
+                    "positionUrl": "",
+                    "positionWorkingExp": "经验不限",
+                    "salary": "1.1-1.5万",
+                    "workType": "全职",
+                },
+                "desc": {
+                    "description": "设计和实现高效稳定的爬虫程序。",
+                    "labels": ["Python", "爬虫开发"],
+                },
+                "workLocation": {
+                    "address": "工作地点：东莞 · 南城街道",
+                    "positionCityId": "779",
+                },
+            }
+        },
+    }
+
+
+def test_registry_resolves_zhaopin() -> None:
+    assert ScraperRegistry.get(ATSType.ZHAOPIN) is ZhaopinScraper
+
+
+def test_parses_zhaopin_payload(httpx_mock) -> None:
+    httpx_mock.add_response(url=_API_RE, json=_payload([_item()]))
+
+    jobs = ZhaopinScraper("zhaopin", city_codes=("489",), keywords=("python",)).fetch()
+
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.ZHAOPIN
+    assert j.ats_id == "CC000544460J40700710516"
+    assert j.title == "python爬虫工程师"
+    assert j.company == "软通动力信息技术(集团)股份有限公司"
+    assert j.location == "工作地点：东莞 · 南城街道"
+    assert j.country_iso == "CN"
+    assert j.salary_currency == "CNY"
+    assert j.salary_period == "MONTH"
+    assert j.salary_min == 11000
+    assert j.salary_max == 15000
+    assert j.experience == 0
+    assert j.department == "软件/IT服务"
+    assert j.description == "设计和实现高效稳定的爬虫程序。"
+    assert j.raw is not None
+    assert j.raw["company_number"] == "CZ000544460"
+
+
+def test_paginates_queries_and_dedupes(httpx_mock) -> None:
+    httpx_mock.add_response(url=_API_RE, json=_payload([_item("1")], is_end=0))
+    httpx_mock.add_response(url=_API_RE, json=_payload([_item("1"), _item("2")], is_end=1))
+    httpx_mock.add_response(url=_API_RE, json=_payload([_item("3")], is_end=1))
+
+    jobs = ZhaopinScraper(
+        "zhaopin",
+        city_codes=("489",),
+        keywords=("python", "java"),
+        max_pages=2,
+    ).fetch()
+
+    assert [j.ats_id for j in jobs] == ["1", "2", "3"]
+
+
+def test_empty_page_stops_query(httpx_mock) -> None:
+    httpx_mock.add_response(url=_API_RE, json=_payload([]))
+
+    assert ZhaopinScraper("zhaopin", city_codes=("489",), keywords=("nope",)).fetch() == []
+
+
+def test_application_error_raises(httpx_mock) -> None:
+    httpx_mock.add_response(url=_API_RE, json={"code": 500, "data": {}})
+    with pytest.raises(ScraperError):
+        ZhaopinScraper("zhaopin", city_codes=("489",), keywords=("python",)).fetch()


### PR DESCRIPTION
## Summary

Adds a dedicated Zhaopin / 智联招聘 scraper for China coverage using the direct JSON API discovered with `reverse-api-engineer`.

Provider: Zhaopin (`https://fe-api.zhaopin.com/c/i/search/positions`)
Method: `POST` JSON body, no HTML parsing, no cookies required in the verified path.

## Live impact

Verified live on 2026-05-11 with the default fan-out (`10` major city codes x `10` keyword families x up to `5` pages/query):

- `9,230` unique jobs collected
- Source is a direct China job board, not an aggregator scrape
- Rows include company, title, CN country code, location, salary summary/range where exposed, experience, industry, description, and raw source fields

This is still below the 300k+ target, but it is a reliable China source we can ship independently while continuing deeper work on larger surfaces such as Naukri, 51job, and China city/function subdivision.

## Validation

- `uv run --extra dev pytest tests/test_zhaopin.py tests/test_models.py -q` -> 67 passed
- `uv run --extra dev ruff check src/jobhive/scrapers/zhaopin.py src/jobhive/scrapers/__init__.py src/jobhive/models.py tests/test_zhaopin.py tests/test_models.py` -> clean
- Live scrape -> 9,230 unique jobs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Zhaopin/智联招聘 scraper using the direct JSON search API to expand China coverage. Initial runs collected 9,230 unique jobs.

- **New Features**
  - New `ZhaopinScraper` using `POST` to https://fe-api.zhaopin.com/c/i/search/positions (no HTML, no cookies).
  - Pagination and dedupe; configurable city codes, keywords, and page limits.
  - Parses CN salary ranges (千/万) to CNY monthly min/max; extracts experience, location, and description.
  - Adds `ZHAOPIN` to `ATSType` and registers in `ScraperRegistry`; seeds `ats-companies/zhaopin.csv`.
  - Tests cover parsing, pagination/deduplication, empty pages, and error handling.

- **Bug Fixes**
  - Gate `salary_currency` and `salary_period` so they are set only when a salary is parsed.
  - Improve `cardCustomJson` address parsing with a backslash/quote-safe regex.

<sup>Written for commit 7de6f966704ed7bcd8e7a5e8c79bfcdce3a052b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new `ZhaopinScraper` that scrapes China's 智联招聘 job board via its direct JSON API (`POST /c/i/search/positions`), fanning out over 10 city codes × 10 keyword families × up to 5 pages each with deduplication and a simple retry loop.

- **New scraper** (`src/jobhive/scrapers/zhaopin.py`): async pagination with `httpx.AsyncClient`, CN salary parsing (千/万 → CNY monthly), `ZHAOPIN` registered in `ScraperRegistry`.
- **Model/registry wiring**: `ATSType.ZHAOPIN` added to `models.py`; scraper imported and exported from `scrapers/__init__.py`.
- **Tests** (`tests/test_zhaopin.py`): covers payload parsing, deduplication across pages, empty-page early exit, and application-level error handling.

<h3>Confidence Score: 3/5</h3>

The scraper ships working China coverage but injects incorrect data into the `department` field on every row, which will silently corrupt department-level analytics downstream.

The `department` field is populated with `industryName` (e.g., `软件/IT服务`), a broad sector label rather than a hiring department, silently producing incorrect data for downstream consumers. Additionally, `_location_from_card` parses a JSON string via regex rather than `json.loads`, meaning addresses with any JSON escape sequence will be silently dropped.

src/jobhive/scrapers/zhaopin.py — the `_parse_item` field mapping (`department`) and `_location_from_card` helper both need attention before the data output is trustworthy in production.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/zhaopin.py | New scraper with solid async pagination/dedupe logic; has a fragile regex-on-JSON location fallback, a dead-code fallback raise after the retry loop, and the `department` field is incorrectly populated with the industry sector rather than an org department. |
| tests/test_zhaopin.py | Good test coverage of parsing, pagination/deduplication, empty-page early exit, and error handling; `_fast_retries` fixture keeps tests snappy. |
| src/jobhive/models.py | Minimal change: `ZHAOPIN` added to `ATSType` in the correct section with correct casing. |
| src/jobhive/scrapers/__init__.py | Imports `ZhaopinScraper` and adds it to `__all__`, consistent with existing scraper registration pattern. |
| ats-companies/zhaopin.csv | Single-row seed CSV with name, slug, and URL for the Zhaopin provider. |
| tests/test_models.py | Adds `"zhaopin"` to the expected ATSType set in the completeness test; consistent with the model change. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/jobhive/scrapers/zhaopin.py:264-268
Using regex to parse `cardCustomJson` is fragile. If the address string contains any JSON escape sequences (`
`, `\"`, or Unicode escapes like `\u4e2d\u6587`), the `[^"]+` character class will stop early or fail to match, silently dropping the location. Using `json.loads` is straightforward here since the field is already a JSON string.

```suggestion
def _location_from_card(value: object) -> str | None:
    if not isinstance(value, str):
        return None
    try:
        parsed = json.loads(value)
        if isinstance(parsed, dict):
            return _clean(parsed.get("address"))
    except (ValueError, KeyError):
        pass
    return None
```

### Issue 2 of 3
src/jobhive/scrapers/zhaopin.py:179-187
The final `raise ScraperError` after the retry loop is unreachable. With `MAX_RETRIES=2` and `range(1, MAX_RETRIES + 1)`, the loop always terminates either via `return` (200), `raise` on the last attempt with a bad status, or `raise` on the last attempt with an `httpx.HTTPError` — every exit path inside the loop raises or returns before the loop can finish normally. This dead code can mislead readers into thinking a fallback is needed.

```suggestion
            if attempt == MAX_RETRIES:
                raise ScraperError(
                    f"Zhaopin returned HTTP {response.status_code} "
                    f"city={city_code} keyword={keyword!r} page={page}"
                )
```

### Issue 3 of 3
src/jobhive/scrapers/zhaopin.py:235
**`department` field populated with industry sector, not organizational department.** `industryName` from Zhaopin is a broad sector classification (e.g., `软件/IT服务`), not a hiring department (e.g., Engineering, Sales). The `Job.department` field's purpose, per the schema docs, is classification within a company — passing an industry label here will mislead consumers doing department-level filtering or analytics. If Zhaopin doesn't expose a true department, leaving this field `None` (its default) is more accurate than filling it with the industry name.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: zhaopin.csv"](https://github.com/kalil0321/ats-scrapers/commit/4767cd4781b27e94524f2952eebcdd65c1dfe965) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732376)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->