### PR TITLE
Add MyCareersFuture SG scraper

### DIFF
--- a/ats-companies/mycareersfuture.csv
+++ b/ats-companies/mycareersfuture.csv
@@ -1,0 +1,2 @@
+name,slug,url
+MyCareersFuture,mycareersfuture,https://www.mycareersfuture.gov.sg

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -67,6 +67,7 @@ class ATSType(StrEnum):
     BUNDESAGENTUR = "bundesagentur"
     ARBETSFORMEDLINGEN = "arbetsformedlingen"
     EURES = "eures"
+    MYCAREERSFUTURE = "mycareersfuture"
     # Hybrid jobboards (companies post directly, not aggregated)
     WELCOMETOTHEJUNGLE = "welcometothejungle"
     GETONBRD = "getonbrd"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -33,6 +33,7 @@ from jobhive.scrapers.lever import LeverScraper
 from jobhive.scrapers.manfred import ManfredScraper
 from jobhive.scrapers.mercor import MercorScraper
 from jobhive.scrapers.meta import MetaScraper
+from jobhive.scrapers.mycareersfuture import MyCareersFutureScraper
 from jobhive.scrapers.oracle import OracleScraper
 from jobhive.scrapers.personio import PersonioScraper
 from jobhive.scrapers.phenom import PhenomScraper
@@ -84,6 +85,7 @@ __all__ = [
     "ManfredScraper",
     "MercorScraper",
     "MetaScraper",
+    "MyCareersFutureScraper",
     "OracleScraper",
     "PersonioScraper",
     "PhenomScraper",

--- a/src/jobhive/scrapers/mycareersfuture.py
+++ b/src/jobhive/scrapers/mycareersfuture.py
@@ -1,0 +1,501 @@
+"""MyCareersFuture (Singapore government job board) scraper.
+
+MyCareersFuture is Singapore's federal job board, operated by Workforce
+Singapore (WSG). It exposes a clean, fully-open JSON API at:
+
+    GET https://api.mycareersfuture.gov.sg/v2/jobs?limit=N&offset=N
+
+No authentication, no API key, no captcha. ``total`` is reported on
+every page (currently ~87k active listings spanning private and public
+sector). Pagination is server-side via ``limit`` / ``offset``; the API
+accepts ``limit`` up to 100 in practice. We page through with an async
+semaphore for throughput, retrying 429/5xx with exponential backoff.
+
+Like USAJOBS / EURES / Bundesagentur, this is a *single source* — there
+is no per-tenant slug. We accept any ``company_slug`` argument (used for
+logging only) and pull the full active dataset on every fetch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import os
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+API_URL = "https://api.mycareersfuture.gov.sg/v2/jobs"
+PAGE_SIZE = 100  # API accepts up to 100 per page.
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1.5
+ENV_USER_AGENT = "MYCAREERSFUTURE_USER_AGENT"
+DEFAULT_USER_AGENT = "stapply-ai (open-source jobs dataset)"
+ENV_MAX_PAGES = "MYCAREERSFUTURE_MAX_PAGES"
+HTML_TAG_RE = re.compile(r"<[^>]+>")
+WHITESPACE_RE = re.compile(r"\s+")
+MAX_DESCRIPTION_LEN = 10_000
+MAX_RAW_SERIALIZED = 5_000
+
+# Singapore-specific posting URL template — used only as a fallback when
+# the API's ``metadata.jobDetailsUrl`` is missing. Both forms (with and
+# without the slug prefix) resolve on the live site.
+JOB_URL_TEMPLATE = "https://www.mycareersfuture.gov.sg/job/{uuid}"
+
+# Map MyCareersFuture's ``employmentType`` strings to the canonical enum.
+_EMP_TYPE_MAP = {
+    "permanent": "FULL_TIME",
+    "full time": "FULL_TIME",
+    "full-time": "FULL_TIME",
+    "part time": "PART_TIME",
+    "part-time": "PART_TIME",
+    "contract": "CONTRACT",
+    "freelance": "CONTRACT",
+    "temporary": "TEMPORARY",
+    "flexi-work": "TEMPORARY",
+    "flexi work": "TEMPORARY",
+    "internship": "INTERN",
+    "internship/attachment": "INTERN",
+}
+
+# Map salaryType labels to the canonical period enum.
+_SALARY_PERIOD_MAP = {
+    "hourly": "HOUR",
+    "daily": "DAY",
+    "weekly": "WEEK",
+    "monthly": "MONTH",
+    "yearly": "YEAR",
+    "annual": "YEAR",
+    "annually": "YEAR",
+}
+
+
+@ScraperRegistry.register(ATSType.MYCAREERSFUTURE)
+class MyCareersFutureScraper(BaseScraper):
+    """Singapore MyCareersFuture scraper. Single-source — ``company_slug``
+    is unused (kept for logging consistency with other scrapers).
+
+    Optional env vars:
+      - ``MYCAREERSFUTURE_USER_AGENT`` overrides the User-Agent header.
+      - ``MYCAREERSFUTURE_MAX_PAGES`` caps the number of pages fetched
+        (handy in dev / smoke tests; defaults to "as many as needed").
+    """
+
+    ats = ATSType.MYCAREERSFUTURE
+
+    def fetch(self) -> list[Job]:
+        user_agent = os.environ.get(ENV_USER_AGENT, DEFAULT_USER_AGENT)
+        max_pages_env = os.environ.get(ENV_MAX_PAGES, "").strip()
+        max_pages: int | None = None
+        if max_pages_env:
+            try:
+                max_pages = max(1, int(max_pages_env))
+            except ValueError:
+                max_pages = None
+        return asyncio.run(self._fetch_async(user_agent, max_pages))
+
+    async def _fetch_async(
+        self, user_agent: str, max_pages: int | None
+    ) -> list[Job]:
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True
+        ) as client:
+            # First page: discover ``total`` so we can plan pagination.
+            first = await self._fetch_page(client, user_agent, offset=0)
+            self._absorb(first.get("results") or [], seen, jobs)
+            total = int(first.get("total") or 0)
+            if total <= PAGE_SIZE:
+                return jobs
+
+            offsets = list(range(PAGE_SIZE, total, PAGE_SIZE))
+            if max_pages is not None:
+                # First page already consumed; cap the remainder.
+                offsets = offsets[: max(0, max_pages - 1)]
+
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+
+            async def fetch_one(offset: int) -> list[dict[str, Any]]:
+                async with sem:
+                    payload = await self._fetch_page(
+                        client, user_agent, offset=offset
+                    )
+                return payload.get("results") or []
+
+            results = await asyncio.gather(
+                *(fetch_one(o) for o in offsets), return_exceptions=False
+            )
+            for batch in results:
+                self._absorb(batch, seen, jobs)
+        return jobs
+
+    def _absorb(
+        self,
+        items: list[dict[str, Any]],
+        seen: set[str],
+        out: list[Job],
+    ) -> None:
+        for item in items:
+            job = self._parse_job(item)
+            if job is None or job.ats_id in seen:
+                continue
+            seen.add(job.ats_id)
+            out.append(job)
+
+    async def _fetch_page(
+        self,
+        client: httpx.AsyncClient,
+        user_agent: str,
+        *,
+        offset: int,
+    ) -> dict[str, Any]:
+        headers = {
+            "User-Agent": user_agent,
+            "Accept": "application/json",
+        }
+        params = {"limit": PAGE_SIZE, "offset": offset}
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                response = await client.get(
+                    API_URL, params=params, headers=headers
+                )
+            except httpx.HTTPError as exc:
+                last_exc = exc
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"MyCareersFuture fetch failed at offset={offset}: {exc}"
+                    ) from exc
+                await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                continue
+            if response.status_code == 200:
+                try:
+                    return response.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"MyCareersFuture returned non-JSON at offset={offset}: {exc}"
+                    ) from exc
+            if response.status_code == 429 or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"MyCareersFuture returned {response.status_code} at "
+                        f"offset={offset} after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after)
+                    if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"MyCareersFuture returned {response.status_code} at "
+                f"offset={offset}"
+            )
+        raise ScraperError(
+            f"MyCareersFuture exhausted retries at offset={offset}: {last_exc}"
+        )
+
+    def _parse_job(self, item: dict[str, Any]) -> Job | None:
+        if not isinstance(item, dict):
+            return None
+        ats_id = str(item.get("uuid") or "").strip()
+        title = (item.get("title") or "").strip()
+        if not ats_id or not title:
+            return None
+
+        url = _job_url(item, ats_id)
+        if not url:
+            return None
+
+        company = _company_name(item)
+        if not company:
+            return None
+
+        description = _html_to_text(item.get("description"))
+
+        emp_types = item.get("employmentTypes") or []
+        emp_label: str | None = None
+        if isinstance(emp_types, list) and emp_types:
+            first_emp = emp_types[0]
+            if isinstance(first_emp, dict):
+                emp_label = first_emp.get("employmentType")
+        employment_type = _map_employment_type(emp_label)
+
+        salary = item.get("salary") or {}
+        salary_min = _to_float(salary.get("minimum")) if isinstance(
+            salary, dict
+        ) else None
+        salary_max = _to_float(salary.get("maximum")) if isinstance(
+            salary, dict
+        ) else None
+        salary_period: str | None = None
+        salary_summary: str | None = None
+        salary_currency: str | None = None
+        if salary_min is not None or salary_max is not None:
+            salary_currency = "SGD"
+            stype = salary.get("type") if isinstance(salary, dict) else None
+            if isinstance(stype, dict):
+                salary_period = _map_salary_period(stype.get("salaryType"))
+            salary_summary = _format_salary_summary(
+                salary_min, salary_max, salary_period
+            )
+
+        addr = item.get("address") or {}
+        location = _format_location(addr)
+        lat = _to_float(addr.get("lat")) if isinstance(addr, dict) else None
+        lon = _to_float(addr.get("lng")) if isinstance(addr, dict) else None
+        is_overseas = (
+            bool(addr.get("isOverseas")) if isinstance(addr, dict) else False
+        )
+        # Overseas postings still get country_iso=SG since the listing
+        # itself is published on the Singapore board; consumers can use
+        # ``location`` / ``raw.overseasCountry`` to refine.
+        country_iso = "SG"
+
+        metadata = item.get("metadata") or {}
+        posted_at = _parse_iso(
+            metadata.get("createdAt") if isinstance(metadata, dict) else None
+        )
+        if posted_at is None and isinstance(metadata, dict):
+            posted_at = _parse_iso(metadata.get("originalPostingDate"))
+        requisition_id = None
+        if isinstance(metadata, dict):
+            raw_req = metadata.get("jobPostId")
+            if isinstance(raw_req, str) and raw_req.strip():
+                requisition_id = raw_req.strip()
+
+        experience = item.get("minimumYearsExperience")
+        if not isinstance(experience, int):
+            experience = None
+
+        raw = _build_raw(item, is_overseas=is_overseas)
+
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.MYCAREERSFUTURE,
+            ats_id=ats_id,
+            location=location,
+            country_iso=country_iso,
+            region="Asia",
+            lat=lat,
+            lon=lon,
+            employment_type=employment_type,
+            commitment=emp_label if isinstance(emp_label, str) else None,
+            requisition_id=requisition_id,
+            description=description,
+            salary_currency=salary_currency,
+            salary_period=salary_period,  # type: ignore[arg-type]
+            salary_summary=salary_summary,
+            salary_min=salary_min,
+            salary_max=salary_max,
+            experience=experience,
+            posted_at=posted_at,
+            fetched_at=datetime.now(),
+            language="en",
+            raw=raw or None,
+        )
+
+
+def _job_url(item: dict[str, Any], uuid_: str) -> str | None:
+    """Pick the best public posting URL for a job.
+
+    Order of preference: the human-readable ``metadata.jobDetailsUrl``
+    (pretty slug + uuid), then the canonical bare-uuid URL. The API's
+    ``_links.self.href`` is an API endpoint, not a user-facing page —
+    we only fall back to the synthesized site URL.
+    """
+    metadata = item.get("metadata")
+    if isinstance(metadata, dict):
+        details = metadata.get("jobDetailsUrl")
+        if (
+            isinstance(details, str)
+            and details.startswith("https://www.mycareersfuture.gov.sg/")
+        ):
+            return details
+    return JOB_URL_TEMPLATE.format(uuid=uuid_)
+
+
+def _company_name(item: dict[str, Any]) -> str | None:
+    """Prefer the hiring employer; fall back to the posting employer.
+
+    Many MCF rows have ``hiringCompany=null`` because the posting
+    employer (often a recruitment agency) is itself the hirer. The
+    name is the human-readable display label.
+    """
+    for key in ("hiringCompany", "postedCompany"):
+        node = item.get(key)
+        if isinstance(node, dict):
+            name = node.get("name")
+            if isinstance(name, str) and name.strip():
+                return name.strip()
+    return None
+
+
+def _format_location(addr: object) -> str | None:
+    """Build a human-readable location string from the ``address`` dict.
+
+    For Singapore-local postings the API gives us a structured block
+    (``block``, ``street``, ``postalCode``) plus a ``districts`` array
+    with planning-region labels. We pick the district label when
+    available — it's the closest analog to "neighborhood, Singapore"
+    that consumers expect. Overseas postings expose ``overseasCountry``
+    instead and we use that verbatim.
+    """
+    if not isinstance(addr, dict):
+        return "Singapore"
+    if addr.get("isOverseas"):
+        country = addr.get("overseasCountry")
+        if isinstance(country, str) and country.strip():
+            return country.strip()
+        return "Overseas"
+    districts = addr.get("districts") or []
+    if isinstance(districts, list) and districts:
+        first = districts[0]
+        if isinstance(first, dict):
+            label = first.get("location")
+            if isinstance(label, str) and label.strip():
+                return f"{label.strip()}, Singapore"
+    return "Singapore"
+
+
+def _map_employment_type(label: object) -> str | None:
+    if not isinstance(label, str) or not label.strip():
+        return None
+    return _EMP_TYPE_MAP.get(label.strip().lower())
+
+
+def _map_salary_period(label: object) -> str | None:
+    if not isinstance(label, str) or not label.strip():
+        return None
+    return _SALARY_PERIOD_MAP.get(label.strip().lower())
+
+
+def _format_salary_summary(
+    salary_min: float | None,
+    salary_max: float | None,
+    period: str | None,
+) -> str | None:
+    period_label = {
+        "HOUR": "/hour",
+        "DAY": "/day",
+        "WEEK": "/week",
+        "MONTH": "/month",
+        "YEAR": "/year",
+    }.get(period or "", "")
+    if salary_min is not None and salary_max is not None:
+        return f"SGD {int(salary_min):,} – {int(salary_max):,}{period_label}".strip()
+    if salary_min is not None:
+        return f"SGD {int(salary_min):,}+{period_label}".strip()
+    if salary_max is not None:
+        return f"up to SGD {int(salary_max):,}{period_label}".strip()
+    return None
+
+
+def _build_raw(
+    item: dict[str, Any], *, is_overseas: bool
+) -> dict[str, Any]:
+    """Pluck the small set of MCF-specific fields worth preserving.
+
+    Constraints:
+      - skills → list of plain strings (drop uuid / confidence noise)
+      - keep ssoc / occupation taxonomy codes (useful for downstream joins)
+      - keep flexible-work + schemes (Singapore-specific signals)
+      - serialized size capped at ``MAX_RAW_SERIALIZED`` to stay within
+        the schema's ~5 kB raw budget
+    """
+    raw: dict[str, Any] = {}
+    skills = item.get("skills") or []
+    if isinstance(skills, list):
+        names = [
+            s.get("skill").strip()
+            for s in skills
+            if isinstance(s, dict)
+            and isinstance(s.get("skill"), str)
+            and s.get("skill", "").strip()
+        ]
+        if names:
+            raw["skills"] = names[:25]  # hard cap; nobody needs 100 skills
+    for key in ("ssocCode", "occupationId", "ssocVersion"):
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            raw[key] = value.strip()
+    schemes = item.get("schemes")
+    if isinstance(schemes, list) and schemes:
+        raw["schemes"] = schemes[:10]
+    fwa = item.get("flexibleWorkArrangements")
+    if isinstance(fwa, list) and fwa:
+        raw["flexibleWorkArrangements"] = fwa[:10]
+    categories = item.get("categories")
+    if isinstance(categories, list) and categories:
+        cat_names = [
+            c.get("category").strip()
+            for c in categories
+            if isinstance(c, dict)
+            and isinstance(c.get("category"), str)
+            and c.get("category", "").strip()
+        ]
+        if cat_names:
+            raw["categories"] = cat_names[:10]
+    position_levels = item.get("positionLevels")
+    if isinstance(position_levels, list) and position_levels:
+        level_names = [
+            p.get("position").strip()
+            for p in position_levels
+            if isinstance(p, dict)
+            and isinstance(p.get("position"), str)
+            and p.get("position", "").strip()
+        ]
+        if level_names:
+            raw["positionLevels"] = level_names[:5]
+    if is_overseas:
+        raw["isOverseas"] = True
+    # Defensive size cap — re-serialize and trim aggressively if needed.
+    if raw:
+        import json
+        serialized = json.dumps(raw, default=str)
+        if len(serialized) > MAX_RAW_SERIALIZED:
+            # Drop the chattiest field first.
+            raw.pop("skills", None)
+    return raw
+
+
+def _html_to_text(value: object) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    text = HTML_TAG_RE.sub(" ", value)
+    text = html.unescape(text)
+    text = WHITESPACE_RE.sub(" ", text).strip()
+    return text[:MAX_DESCRIPTION_LEN] if text else None
+
+
+def _to_float(value: object) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_iso(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -25,7 +25,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "amazon", "apple", "google", "meta",
         "tesla", "tiktok", "uber", "usajobs",
         # National / supranational public-sector aggregators
-        "bundesagentur", "arbetsformedlingen", "eures",
+        "bundesagentur", "arbetsformedlingen", "eures", "mycareersfuture",
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",

--- a/tests/test_mycareersfuture.py
+++ b/tests/test_mycareersfuture.py
@@ -1,0 +1,428 @@
+"""Tests for the MyCareersFuture (Singapore) scraper.
+
+MyCareersFuture is a single-source public-sector job board (~87k live
+listings, no auth, no captcha). These tests pin the parse contract
+against a sanitized inline fixture — *no live HTTP*. The fixture mirrors
+the shape returned by ``GET https://api.mycareersfuture.gov.sg/v2/jobs``
+on 2026-05; field names match the live payload verbatim so parser
+breakage is caught at PR time.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import httpx
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import MyCareersFutureScraper
+
+_API_RE = re.compile(r"^https://api\.mycareersfuture\.gov\.sg/v2/jobs")
+
+
+def _job_record(**overrides: Any) -> dict[str, Any]:
+    """Minimal valid MCF job payload, modeled on the live API response.
+
+    Sanitized: real uuids are replaced with shorter test ids; long
+    description HTML is trimmed; skill/category lists are abbreviated.
+    Everything that the parser actually reads is structurally identical
+    to production.
+    """
+    base: dict[str, Any] = {
+        "uuid": "test-uuid-0000000000000000",
+        "sourceCode": "Employer Portal",
+        "title": "Senior Software Engineer",
+        "description": (
+            "<ol><li>Build &amp; ship distributed services.</li>"
+            "<li>Work with a cross-functional team.</li></ol>"
+        ),
+        "minimumYearsExperience": 5,
+        "skills": [
+            {"skill": "Python", "uuid": "s1", "isKeySkill": True},
+            {"skill": "Kubernetes", "uuid": "s2", "isKeySkill": False},
+        ],
+        "schemes": [],
+        "flexibleWorkArrangements": [
+            {"id": 1, "flexibleWorkArrangement": "Hybrid"},
+        ],
+        "ssocCode": "25121",
+        "occupationId": "OCC000001",
+        "ssocVersion": "2020v3",
+        "categories": [
+            {"id": 11, "category": "Information Technology"},
+        ],
+        "employmentTypes": [
+            {"id": 7, "employmentType": "Permanent"},
+        ],
+        "positionLevels": [
+            {"id": 3, "position": "Senior Executive"},
+        ],
+        "status": {"id": 102, "jobStatus": "Open"},
+        "postedCompany": {
+            "uen": "199912345A",
+            "name": "ACME PTE. LTD.",
+            "_links": {},
+        },
+        "hiringCompany": None,
+        "address": {
+            "block": "1",
+            "street": "MARINA BOULEVARD",
+            "postalCode": "018989",
+            "isOverseas": False,
+            "districts": [
+                {
+                    "id": 1,
+                    "location": "D01 Boat Quay, Marina, Raffles Place",
+                    "region": "Central",
+                }
+            ],
+            "lat": 1.2833,
+            "lng": 103.8519,
+        },
+        "metadata": {
+            "jobPostId": "MCF-2026-0000001",
+            "createdAt": "2026-05-10T08:30:00.000Z",
+            "expiryDate": "2026-06-10",
+            "originalPostingDate": "2026-05-10",
+            "jobDetailsUrl": (
+                "https://www.mycareersfuture.gov.sg/job/information-technology/"
+                "senior-software-engineer-acme-test-uuid-0000000000000000"
+            ),
+        },
+        "salary": {
+            "maximum": 12000,
+            "minimum": 8000,
+            "type": {"id": 4, "salaryType": "Monthly"},
+        },
+        "_links": {
+            "self": {
+                "href": "https://api.mycareersfuture.gov.sg/v2/jobs/test-uuid-0000000000000000"
+            }
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+# --- _parse_job contract -----------------------------------------------------
+
+
+def test_parse_job_minimal_fields() -> None:
+    scraper = MyCareersFutureScraper("sg")
+    job = scraper._parse_job(_job_record())
+    assert job is not None
+    assert job.ats_type is ATSType.MYCAREERSFUTURE
+    assert job.ats_id == "test-uuid-0000000000000000"
+    assert job.title == "Senior Software Engineer"
+    assert job.company == "ACME PTE. LTD."
+    assert job.global_id == "mycareersfuture:test-uuid-0000000000000000"
+
+
+def test_parse_job_country_iso_is_singapore() -> None:
+    """All MCF postings are published on the Singapore board — pin SG."""
+    job = MyCareersFutureScraper("sg")._parse_job(_job_record())
+    assert job is not None
+    assert job.country_iso == "SG"
+    assert job.region == "Asia"
+    assert job.language == "en"
+
+
+def test_parse_job_url_prefers_metadata_pretty_url() -> None:
+    """``metadata.jobDetailsUrl`` is a human-readable pretty URL — prefer
+    it over the bare-uuid fallback when the API gives us one."""
+    job = MyCareersFutureScraper("sg")._parse_job(_job_record())
+    assert job is not None
+    assert str(job.url).startswith(
+        "https://www.mycareersfuture.gov.sg/job/information-technology/"
+    )
+
+
+def test_parse_job_url_falls_back_to_uuid() -> None:
+    """If ``metadata.jobDetailsUrl`` is missing, build the canonical bare
+    ``/job/{uuid}`` URL — verified to resolve on the live site."""
+    record = _job_record()
+    record["metadata"].pop("jobDetailsUrl")
+    job = MyCareersFutureScraper("sg")._parse_job(record)
+    assert job is not None
+    assert (
+        str(job.url)
+        == "https://www.mycareersfuture.gov.sg/job/test-uuid-0000000000000000"
+    )
+
+
+def test_parse_job_hiring_company_takes_precedence_over_posted() -> None:
+    """When ``hiringCompany`` is set it's the actual employer; fall back
+    to ``postedCompany`` (often a recruitment agency) otherwise."""
+    record = _job_record(
+        hiringCompany={"name": "Hiring Co Ltd", "uen": "X"},
+    )
+    job = MyCareersFutureScraper("sg")._parse_job(record)
+    assert job is not None
+    assert job.company == "Hiring Co Ltd"
+
+
+def test_parse_job_description_html_stripped_and_entities_decoded() -> None:
+    """HTML tags are stripped, entities (``&amp;``) are decoded, and
+    whitespace is collapsed before truncation."""
+    job = MyCareersFutureScraper("sg")._parse_job(_job_record())
+    assert job is not None
+    assert job.description is not None
+    assert "<ol>" not in job.description
+    assert "<li>" not in job.description
+    assert "&amp;" not in job.description
+    assert "Build & ship" in job.description
+
+
+def test_parse_job_salary_monthly_maps_to_month_period() -> None:
+    job = MyCareersFutureScraper("sg")._parse_job(_job_record())
+    assert job is not None
+    assert job.salary_currency == "SGD"
+    assert job.salary_period == "MONTH"
+    assert job.salary_min == 8000
+    assert job.salary_max == 12000
+    assert job.salary_summary is not None
+    assert "SGD" in job.salary_summary
+    assert "/month" in job.salary_summary
+
+
+def test_parse_job_salary_absent_leaves_currency_none() -> None:
+    """No salary on the record → no salary fields populated. Pydantic
+    must not require ``salary_currency`` when min/max are both null."""
+    record = _job_record(salary=None)
+    job = MyCareersFutureScraper("sg")._parse_job(record)
+    assert job is not None
+    assert job.salary_currency is None
+    assert job.salary_min is None
+    assert job.salary_max is None
+
+
+def test_parse_job_employment_type_maps_permanent_to_full_time() -> None:
+    job = MyCareersFutureScraper("sg")._parse_job(_job_record())
+    assert job is not None
+    assert job.employment_type == "FULL_TIME"
+    assert job.commitment == "Permanent"
+
+
+@pytest.mark.parametrize(
+    ("label", "expected"),
+    [
+        ("Permanent", "FULL_TIME"),
+        ("Full Time", "FULL_TIME"),
+        ("Part Time", "PART_TIME"),
+        ("Contract", "CONTRACT"),
+        ("Freelance", "CONTRACT"),
+        ("Internship", "INTERN"),
+        ("Temporary", "TEMPORARY"),
+        ("Flexi-work", "TEMPORARY"),
+    ],
+)
+def test_employment_type_mapping(label: str, expected: str) -> None:
+    record = _job_record(
+        employmentTypes=[{"id": 1, "employmentType": label}],
+    )
+    job = MyCareersFutureScraper("sg")._parse_job(record)
+    assert job is not None
+    assert job.employment_type == expected
+
+
+def test_parse_job_location_uses_district_label() -> None:
+    """Singapore district labels are the closest analog to neighbourhood,
+    so we surface them as ``location`` rather than a free-form street."""
+    job = MyCareersFutureScraper("sg")._parse_job(_job_record())
+    assert job is not None
+    assert job.location is not None
+    assert "Singapore" in job.location
+    assert "Boat Quay" in job.location
+
+
+def test_parse_job_lat_lng_passed_through() -> None:
+    job = MyCareersFutureScraper("sg")._parse_job(_job_record())
+    assert job is not None
+    assert job.lat == pytest.approx(1.2833)
+    assert job.lon == pytest.approx(103.8519)
+
+
+def test_parse_job_overseas_uses_overseas_country() -> None:
+    """Overseas-tagged postings still publish on the SG board; the
+    ``location`` field should surface the foreign country name."""
+    record = _job_record(
+        address={
+            "isOverseas": True,
+            "overseasCountry": "Malaysia",
+            "districts": [],
+        },
+    )
+    job = MyCareersFutureScraper("sg")._parse_job(record)
+    assert job is not None
+    assert job.location == "Malaysia"
+    assert job.country_iso == "SG"  # board-level, not posting location
+
+
+def test_parse_job_requisition_id_from_job_post_id() -> None:
+    job = MyCareersFutureScraper("sg")._parse_job(_job_record())
+    assert job is not None
+    assert job.requisition_id == "MCF-2026-0000001"
+
+
+def test_parse_job_posted_at_parsed_from_created_at() -> None:
+    job = MyCareersFutureScraper("sg")._parse_job(_job_record())
+    assert job is not None
+    assert job.posted_at is not None
+    assert job.posted_at.year == 2026
+    assert job.posted_at.month == 5
+
+
+def test_parse_job_experience_passes_through_when_int() -> None:
+    job = MyCareersFutureScraper("sg")._parse_job(_job_record())
+    assert job is not None
+    assert job.experience == 5
+
+
+def test_parse_job_experience_none_when_null() -> None:
+    record = _job_record(minimumYearsExperience=None)
+    job = MyCareersFutureScraper("sg")._parse_job(record)
+    assert job is not None
+    assert job.experience is None
+
+
+def test_parse_job_raw_contains_skills_and_taxonomy() -> None:
+    job = MyCareersFutureScraper("sg")._parse_job(_job_record())
+    assert job is not None
+    assert isinstance(job.raw, dict)
+    assert "skills" in job.raw
+    assert "Python" in job.raw["skills"]
+    assert job.raw.get("ssocCode") == "25121"
+    assert job.raw.get("occupationId") == "OCC000001"
+
+
+def test_parse_job_returns_none_on_missing_uuid() -> None:
+    """No uuid → no global_id → skip the row defensively."""
+    record = _job_record(uuid="")
+    assert MyCareersFutureScraper("sg")._parse_job(record) is None
+
+
+def test_parse_job_returns_none_on_missing_title() -> None:
+    record = _job_record(title="")
+    assert MyCareersFutureScraper("sg")._parse_job(record) is None
+
+
+def test_parse_job_returns_none_on_missing_company() -> None:
+    """Both ``hiringCompany`` and ``postedCompany.name`` empty → drop."""
+    record = _job_record(
+        hiringCompany=None,
+        postedCompany={"uen": "X"},
+    )
+    assert MyCareersFutureScraper("sg")._parse_job(record) is None
+
+
+# --- registry + ATSType ------------------------------------------------------
+
+
+def test_scraper_registered_in_registry() -> None:
+    """The ``@ScraperRegistry.register`` decorator must wire the class
+    to ``ATSType.MYCAREERSFUTURE`` so ``get_scraper`` finds it."""
+    from jobhive.scrapers.base import ScraperRegistry
+    assert ScraperRegistry.get(ATSType.MYCAREERSFUTURE) is MyCareersFutureScraper
+
+
+def test_scraper_registered_by_string_lookup() -> None:
+    """``ScraperRegistry.get("mycareersfuture")`` is the manifest path —
+    must resolve to the scraper class even when called with a raw string."""
+    from jobhive.scrapers.base import ScraperRegistry
+    assert ScraperRegistry.get("mycareersfuture") is MyCareersFutureScraper
+
+
+# --- pagination & retries (fixture-driven, no live HTTP) ---------------------
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Collapse retry delays so failure-path tests run in milliseconds."""
+    import jobhive.scrapers.mycareersfuture as mcf
+    monkeypatch.setattr(mcf, "MAX_RETRIES", 2)
+    monkeypatch.setattr(mcf, "RETRY_BASE_DELAY", 0.0)
+
+
+def test_fetch_paginates_until_total_reached(httpx_mock, monkeypatch) -> None:
+    """``fetch`` walks ``offset`` in ``PAGE_SIZE`` strides until it has
+    covered ``total``. Use a small PAGE_SIZE so the test stays compact."""
+    import jobhive.scrapers.mycareersfuture as mcf
+    monkeypatch.setattr(mcf, "PAGE_SIZE", 2)
+
+    def serve(request: httpx.Request) -> httpx.Response:
+        from urllib.parse import parse_qs, urlparse
+        qs = parse_qs(urlparse(str(request.url)).query)
+        offset = int(qs.get("offset", ["0"])[0])
+        # 5 jobs total → offsets 0, 2, 4 → 3 pages (last page has 1 row).
+        all_records = [
+            _job_record(uuid=f"uuid-{i}", title=f"Job {i}") for i in range(5)
+        ]
+        page = all_records[offset : offset + 2]
+        return httpx.Response(200, json={"results": page, "total": 5})
+
+    httpx_mock.add_callback(serve, url=_API_RE, is_reusable=True)
+    jobs = MyCareersFutureScraper("sg").fetch()
+    ats_ids = {j.ats_id for j in jobs}
+    assert ats_ids == {f"uuid-{i}" for i in range(5)}
+
+
+def test_fetch_dedups_overlapping_pages(httpx_mock, monkeypatch) -> None:
+    """If two pages return the same uuid (rare but possible during a live
+    insertion), the second occurrence is dropped — the scraper's
+    ``seen`` set is the dedup guard."""
+    import jobhive.scrapers.mycareersfuture as mcf
+    monkeypatch.setattr(mcf, "PAGE_SIZE", 2)
+
+    def serve(request: httpx.Request) -> httpx.Response:
+        from urllib.parse import parse_qs, urlparse
+        qs = parse_qs(urlparse(str(request.url)).query)
+        offset = int(qs.get("offset", ["0"])[0])
+        # 3 total, but page 2 (offset=2) repeats uuid-1 — must be deduped.
+        if offset == 0:
+            page = [_job_record(uuid="uuid-0"), _job_record(uuid="uuid-1")]
+        else:
+            page = [_job_record(uuid="uuid-1"), _job_record(uuid="uuid-2")]
+        return httpx.Response(200, json={"results": page, "total": 3})
+
+    httpx_mock.add_callback(serve, url=_API_RE, is_reusable=True)
+    jobs = MyCareersFutureScraper("sg").fetch()
+    assert sorted(j.ats_id for j in jobs) == ["uuid-0", "uuid-1", "uuid-2"]
+
+
+def test_fetch_retries_on_5xx_then_succeeds(httpx_mock) -> None:
+    """A transient 503 must be retried (up to ``MAX_RETRIES``) before the
+    scraper gives up. The first attempt fails, the second succeeds."""
+    httpx_mock.add_response(url=_API_RE, status_code=503)
+    httpx_mock.add_response(
+        url=_API_RE,
+        status_code=200,
+        json={"results": [_job_record()], "total": 1},
+    )
+    jobs = MyCareersFutureScraper("sg").fetch()
+    assert len(jobs) == 1
+    assert jobs[0].ats_id == "test-uuid-0000000000000000"
+
+
+def test_fetch_raises_after_persistent_5xx(httpx_mock) -> None:
+    """A persistent 5xx (longer than the retry budget) must surface as a
+    ``ScraperError`` — silent ``[]`` would publish an undercount as a
+    successful run."""
+    httpx_mock.add_response(url=_API_RE, status_code=500, is_reusable=True)
+    with pytest.raises(ScraperError):
+        MyCareersFutureScraper("sg").fetch()
+
+
+def test_fetch_raises_on_non_json_response(httpx_mock) -> None:
+    """A 200 OK with a malformed body is a contract break — crash rather
+    than soft-fail to ``[]``."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        status_code=200,
+        content=b"<html>Maintenance</html>",
+        is_reusable=True,
+    )
+    with pytest.raises(ScraperError):
+        MyCareersFutureScraper("sg").fetch()


### PR DESCRIPTION
## Summary

- New scraper for **MyCareersFuture**, Singapore's government-run job board (run by Workforce Singapore / WSG).
- **~87.4k live postings** across private and public sector, exposed through a fully open REST API — no auth, no API key, no captcha.
- Follows the single-source pattern (no per-tenant slug) used by `USAJobsScraper`, `BundesagenturScraper`, `EuresScraper`, and `ArbetsformedlingenScraper`. The `company_slug` arg is accepted for logging only and the scraper always pulls the full active dataset.
- Async pagination with `limit=100&offset=N`, concurrency-capped at 4, 429 / 5xx retry with exponential backoff + `Retry-After` honouring. Optional `MYCAREERSFUTURE_MAX_PAGES` env var caps page count for dev / smoke runs.
- New `ATSType.MYCAREERSFUTURE = "mycareersfuture"` enum value, slotted into the "National public-sector job boards" block alongside EURES / Bundesagentur / USAJOBS / Arbetsförmedlingen. `tests/test_models.py` expected-set is updated to match.
- Strips HTML from `description` (regex + `html.unescape`, collapsed whitespace, 10 kB cap), maps Singapore-specific `employmentType` labels (Permanent → FULL_TIME, etc.) and `salary.type.salaryType` (Monthly → MONTH), pulls lat/lng from the structured address, and surfaces the district label as `location`. Country is pinned to `SG`, region to `Asia`, language to `en`. Skills, SSOC codes, schemes, and flexible-work arrangements are preserved verbatim in `raw` under the 5 kB budget.

Example curl (verified live):

```
curl 'https://api.mycareersfuture.gov.sg/v2/jobs?limit=100&offset=0'
# → {"results": [...], "total": 87440, ...}
```

## Test plan

- [x] `uv run ruff check src/jobhive/scrapers/mycareersfuture.py tests/test_mycareersfuture.py` passes
- [x] `uv run pytest tests/test_mycareersfuture.py tests/test_models.py -x` — 97 passed
- [x] Full scraper test sweep (`tests/test_scrapers*`, `tests/test_models.py`, `tests/test_mycareersfuture.py`) — 151 passed
- [x] URL forms verified live: `https://www.mycareersfuture.gov.sg/job/{uuid}` and the pretty `metadata.jobDetailsUrl` both return 200
- [ ] Smoke a real fetch with `MYCAREERSFUTURE_MAX_PAGES=2` before promoting from draft
- [ ] Confirm full ~87k crawl completes inside the scrape window once promoted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new scraper for Singapore’s MyCareersFuture to ingest the full public dataset via its open REST API, expanding national job board coverage. Adds a new ATS type, a company seed CSV, and robust pagination/retry logic.

- New Features
  - Implemented `MyCareersFutureScraper` (single-source). Async pagination with `limit=100&offset`, concurrency=4, and 429/5xx retries with backoff and `Retry-After`; `MYCAREERSFUTURE_MAX_PAGES` caps pages for dev; `MYCAREERSFUTURE_USER_AGENT` overrides UA.
  - Added `ATSType.MYCAREERSFUTURE`, registered the scraper in `scrapers/__init__.py`, and seeded `ats-companies/mycareersfuture.csv`.
  - Parsing: strip HTML from descriptions; map employment types and salary period; set `country_iso=SG`, `region=Asia`, `language=en`; location from district label or overseas country; include lat/lng; keep selected skills/SSOC/schemes/FWA in `raw` under ~5 kB.
  - Posting URL: prefer `metadata.jobDetailsUrl`, fallback to `https://www.mycareersfuture.gov.sg/job/{uuid}`.
  - Tests: added `tests/test_mycareersfuture.py` and updated `tests/test_models.py`.

<sup>Written for commit a945841c6c589af0d90268dbdbaaa605a3f5e845. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces a new `MyCareersFutureScraper` for Singapore's government job board (~87k live listings), following the existing single-source pattern used by EURES, Bundesagentur, and USAJOBS. The implementation adds async pagination with a concurrency semaphore, 429/5xx retry with backoff, HTML stripping, employment-type mapping, and structured lat/lng extraction.

- **New scraper** (`src/jobhive/scrapers/mycareersfuture.py`): 501 lines covering async fetch, pagination, retry logic, and field parsing; registers under `ATSType.MYCAREERSFUTURE` via `@ScraperRegistry.register`.
- **Model + registry updates**: `ATSType.MYCAREERSFUTURE` added to `models.py` in the correct block; scraper wired into `scrapers/__init__.py`; expected-set updated in `test_models.py`.
- **Tests** (`tests/test_mycareersfuture.py`): 97 fixture-driven tests covering parse contract, pagination, deduplication, retry behaviour, and error paths — no live HTTP.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all three findings are non-blocking quality improvements to the scraper's retry and raw-payload logic.

The core pagination, deduplication, and field-mapping logic is correct and well-tested. The three issues found are: the Retry-After parser silently ignores server-provided float delays; the raw-payload size cap only drops skills and never re-checks, so a job with many verbose schemes or FWA entries can still exceed the 5 kB budget; and there is unreachable dead code at the tail of _fetch_page. None of these affect correctness of the produced Job objects or the published dataset in typical cases.

src/jobhive/scrapers/mycareersfuture.py — specifically the _fetch_page retry-delay logic and the _build_raw size-trimming loop.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/mycareersfuture.py | New single-source scraper for Singapore's MyCareersFuture API; async pagination with concurrency cap and retry logic is sound, but Retry-After header parsing silently ignores float values, the raw size cap only drops skills (may still exceed budget), and there is dead unreachable code at the end of _fetch_page. |
| tests/test_mycareersfuture.py | Comprehensive fixture-driven tests covering parse contract, pagination, deduplication, retry behaviour, and error paths; no live HTTP calls; well structured. |
| src/jobhive/models.py | Adds ATSType.MYCAREERSFUTURE in the correct 'National public-sector job boards' block; no other model changes. |
| src/jobhive/scrapers/__init__.py | Imports and exports MyCareersFutureScraper in alphabetical order; straightforward wiring. |
| tests/test_models.py | Adds 'mycareersfuture' to the expected ATSType set; minimal, correct change. |
| ats-companies/mycareersfuture.csv | Minimal seed CSV with the single MyCareersFuture entry; correct format. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/jobhive/scrapers/mycareersfuture.py:195-200
`Retry-After` header parsing uses `str.isdigit()`, which returns `False` for any float string like `"1.5"` or negative-integer strings like `"-1"`, silently discarding the server-provided delay and falling back to exponential backoff instead. A `float()` conversion with a `try/except` is more robust.

```suggestion
                retry_after = response.headers.get("Retry-After")
                delay = RETRY_BASE_DELAY * (2 ** attempt)
                if retry_after:
                    try:
                        delay = float(retry_after)
                    except ValueError:
                        pass
```

### Issue 2 of 3
src/jobhive/scrapers/mycareersfuture.py:468-474
**Incomplete raw size-cap enforcement**

After dropping `skills`, the function returns without re-checking whether `raw` still exceeds `MAX_RAW_SERIALIZED`. A job with 10 verbose `schemes` and 10 `flexibleWorkArrangements` entries can push the serialized size past 5 kB even with skills removed. Consider iterating through other droppable fields (e.g. `flexibleWorkArrangements`, then `schemes`) or re-checking after the first trim.

### Issue 3 of 3
src/jobhive/scrapers/mycareersfuture.py:207-209
The `raise ScraperError` at the bottom of `_fetch_page` is unreachable: every exit path of the `for` loop either `return`s on a 200, `raise`s on a non-retryable status, or `raise`s when `attempt == MAX_RETRIES` for both the `httpx.HTTPError` and 429/5xx branches. The final raise can never execute — it is harmless but misleading dead code.

```suggestion
        # Unreachable: every loop iteration either returns, raises, or continues
        # until MAX_RETRIES, at which point it raises explicitly above.
        raise AssertionError("unreachable")
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: mycareersfut..."](https://github.com/kalil0321/ats-scrapers/commit/a945841c6c589af0d90268dbdbaaa605a3f5e845) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732379)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->