### PR TITLE
Add SEEK / JobsDB / JobStreet APAC scraper

### DIFF
--- a/ats-companies/seek.csv
+++ b/ats-companies/seek.csv
@@ -1,0 +1,9 @@
+name,slug,url
+SEEK Australia,au,https://www.seek.com.au
+SEEK New Zealand,nz,https://www.seek.co.nz
+JobsDB Hong Kong,hk,https://hk.jobsdb.com
+JobsDB Thailand,th,https://th.jobsdb.com
+JobStreet Malaysia,my,https://my.jobstreet.com
+JobStreet Indonesia,id,https://id.jobstreet.com
+JobStreet Philippines,ph,https://ph.jobstreet.com
+JobStreet Singapore,sg,https://sg.jobstreet.com

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -80,6 +80,8 @@ class ATSType(StrEnum):
     THEHUB = "thehub"
     YCOMBINATOR = "ycombinator"
     WELLFOUND = "wellfound"
+    # Regional multi-source aggregators (one brand-family per scraper)
+    SEEK = "seek"
     # Additional multi-tenant ATSes (post-0.1)
     BAMBOOHR = "bamboohr"
     BREEZY = "breezy"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -42,6 +42,7 @@ from jobhive.scrapers.recruitee import RecruiteeScraper
 from jobhive.scrapers.recruiterbox import RecruiterboxScraper
 from jobhive.scrapers.remoteok import RemoteOKScraper
 from jobhive.scrapers.rippling import RipplingScraper
+from jobhive.scrapers.seek import SeekScraper
 from jobhive.scrapers.smartrecruiters import SmartRecruitersScraper
 from jobhive.scrapers.successfactors import SuccessFactorsScraper
 from jobhive.scrapers.taleo import TaleoScraper
@@ -94,6 +95,7 @@ __all__ = [
     "RemoteOKScraper",
     "RipplingScraper",
     "ScraperRegistry",
+    "SeekScraper",
     "SmartRecruitersScraper",
     "SuccessFactorsScraper",
     "TaleoScraper",

--- a/src/jobhive/scrapers/seek.py
+++ b/src/jobhive/scrapers/seek.py
@@ -92,7 +92,10 @@ _REGION_CURRENCY: dict[str, str] = {
 }
 
 PAGE_SIZE = 100  # API caps pageSize at 100 (>100 returns HTML).
-PAGE_SAFETY_CAP = 1000  # Stop after this many pages regardless of total.
+PAGE_SAFETY_CAP = 5000  # Stop after this many pages regardless of total.
+# AU alone is ~159k postings (~1590 pages); a 1000-page cap would silently
+# drop ~59k rows. 5000 pages (~500k postings) covers the largest region
+# with headroom while still bounding a runaway/looping response.
 MAX_CONCURRENCY = 4
 MAX_RETRIES = 5
 RETRY_BASE_DELAY = 1.5
@@ -333,6 +336,7 @@ class SeekScraper(BaseScraper):
 
         salary_label = (item.get("salaryLabel") or "").strip() or None
         salary_currency = _REGION_CURRENCY.get(country) if salary_label else None
+        salary_period = _infer_salary_period(salary_label) if salary_currency else None
 
         posted_at = _parse_iso8601(item.get("listingDate"))
 
@@ -377,7 +381,7 @@ class SeekScraper(BaseScraper):
             country_iso=country,
             region="Oceania" if country in ("AU", "NZ") else "Asia",
             salary_currency=salary_currency,
-            salary_period="YEAR" if salary_currency else None,
+            salary_period=salary_period,
             salary_summary=salary_label,
             department=department,
             description=description,
@@ -386,6 +390,28 @@ class SeekScraper(BaseScraper):
             language="en",
             raw=raw or None,
         )
+
+
+def _infer_salary_period(label: str | None) -> str | None:
+    """Map a SEEK ``salaryLabel`` to a ``SalaryPeriod``.
+
+    SEEK labels embed the cadence in free text, e.g.
+    ``"$120,000 – $140,000 per year"``, ``"$45 per hour"``,
+    ``"$8,000 per month"``. We scan for the period keyword and default to
+    ``"YEAR"`` when none is present (the dominant case for annual ranges).
+    """
+    if not label:
+        return None
+    low = label.lower()
+    if "per hour" in low or "/hour" in low or "hourly" in low:
+        return "HOUR"
+    if "per day" in low or "/day" in low or "daily" in low:
+        return "DAY"
+    if "per week" in low or "/week" in low or "weekly" in low:
+        return "WEEK"
+    if "per month" in low or "/month" in low or "monthly" in low:
+        return "MONTH"
+    return "YEAR"
 
 
 def _parse_iso8601(value: object) -> datetime | None:

--- a/src/jobhive/scrapers/seek.py
+++ b/src/jobhive/scrapers/seek.py
@@ -1,0 +1,407 @@
+"""SEEK / JobsDB / JobStreet — APAC job board family scraper.
+
+SEEK Ltd. owns a family of regional job boards across the Asia-Pacific
+that all share the same backend search service (``chalice-search v5``).
+A single scraper covers every brand because the API shape is identical
+— only the host and ``siteKey`` parameter change:
+
+    GET https://{host}/api/jobsearch/v5/search
+        ?siteKey={siteKey}&page=N&pageSize=100&sortmode=ListedDate
+
+No authentication, no API key, JSON response. The eight covered sites
+host roughly **474k live postings** in aggregate (as of May 2026):
+
+==========  =================  ===========  =======  ============
+Region      Host               siteKey      ISO      Approx. jobs
+==========  =================  ===========  =======  ============
+au          au.seek.com        AU-Main      AU        159k
+nz          www.seek.co.nz     NZ-Main      NZ         19k
+hk          hk.jobsdb.com      HK-Main      HK         34k
+th          th.jobsdb.com      TH-Main      TH         18k
+my          my.jobstreet.com   MY-Main      MY         50k
+id          id.jobstreet.com   ID-Main      ID         56k
+ph          ph.jobstreet.com   PH-Main      PH         73k
+sg          sg.jobstreet.com   SG-Main      SG         66k
+==========  =================  ===========  =======  ============
+
+Usage. The ``company_slug`` constructor argument picks the region:
+
+    SeekScraper("au")   # SEEK AU only
+    SeekScraper("sg")   # JobStreet Singapore only
+    SeekScraper("all")  # all eight regions, sequentially
+
+Pagination. The API caps ``pageSize`` at 100 (200 returns HTML).
+``page * pageSize`` does **not** appear to have a hard cap the way
+Bundesagentur / EURES do, so we iterate ``page=1..N`` until either
+``len(data) < pageSize``, ``page * pageSize >= totalCount``, or a
+safety limit of 1000 pages — whichever comes first.
+
+Description handling. The search response only carries a ``teaser``
+plus a few ``bulletPoints`` — the full job description requires a
+per-posting fetch. With 159k AU postings alone, opting into a second
+round-trip per row would be 159k extra requests; we deliberately keep
+the search payload as the description source (summary only) and let
+downstream enrichment fetch full bodies on demand if a consumer needs
+them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+# Region code → (host, siteKey, country_iso). The "all" sentinel is
+# handled separately in ``_fetch_async`` — it isn't a real region.
+SEEK_SITES: dict[str, tuple[str, str, str]] = {
+    "au": ("au.seek.com", "AU-Main", "AU"),
+    "nz": ("www.seek.co.nz", "NZ-Main", "NZ"),
+    "hk": ("hk.jobsdb.com", "HK-Main", "HK"),
+    "th": ("th.jobsdb.com", "TH-Main", "TH"),
+    "my": ("my.jobstreet.com", "MY-Main", "MY"),
+    "id": ("id.jobstreet.com", "ID-Main", "ID"),
+    "ph": ("ph.jobstreet.com", "PH-Main", "PH"),
+    "sg": ("sg.jobstreet.com", "SG-Main", "SG"),
+}
+
+# ISO 3166-1 alpha-2 → ISO 4217 currency. Only used when a row already
+# has a populated ``salaryLabel`` — we never invent a currency for
+# salary-less rows.
+_REGION_CURRENCY: dict[str, str] = {
+    "AU": "AUD",
+    "NZ": "NZD",
+    "HK": "HKD",
+    "TH": "THB",
+    "MY": "MYR",
+    "ID": "IDR",
+    "PH": "PHP",
+    "SG": "SGD",
+}
+
+PAGE_SIZE = 100  # API caps pageSize at 100 (>100 returns HTML).
+PAGE_SAFETY_CAP = 1000  # Stop after this many pages regardless of total.
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 5
+RETRY_BASE_DELAY = 1.5
+
+# Raw overflow is capped to ~5kB serialized per the Job schema. We keep
+# a small whitelist of stable identifier fields that downstream consumers
+# (cross-ATS dedup, ad-tracking) may want. Heavy fields like
+# ``solMetadata`` and ``tracking`` are dropped.
+_RAW_KEYS = ("advertiserId", "employerId", "roleId", "displayType",
+             "isFeatured", "workTypes", "workArrangements",
+             "companyProfileStructuredDataId")
+
+
+@ScraperRegistry.register(ATSType.SEEK)
+class SeekScraper(BaseScraper):
+    """SEEK / JobsDB / JobStreet — single scraper for the whole family.
+
+    ``company_slug`` is interpreted as a region code (``au``, ``nz``,
+    ``hk``, ``th``, ``my``, ``id``, ``ph``, ``sg``) or the special
+    ``all`` value that iterates every region.
+    """
+
+    ats = ATSType.SEEK
+
+    def __init__(self, company_slug: str, *, timeout: float = 30.0) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        region = company_slug.strip().lower()
+        if region == "all":
+            self.regions: tuple[str, ...] = tuple(SEEK_SITES)
+        elif region in SEEK_SITES:
+            self.regions = (region,)
+        else:
+            raise ScraperError(
+                f"Unknown SEEK region {company_slug!r}. "
+                f"Valid: {sorted(SEEK_SITES)} or 'all'."
+            )
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        jobs: list[Job] = []
+        seen: set[str] = set()
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+            for region in self.regions:
+                region_jobs = await self._fetch_region(client, sem, region)
+                # Cross-region dedup — same posting can theoretically
+                # appear under two siteKeys (rare but observed for
+                # multi-country remote roles).
+                for job in region_jobs:
+                    if job.global_id in seen:
+                        continue
+                    seen.add(job.global_id)
+                    jobs.append(job)
+        return jobs
+
+    async def _fetch_region(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        region: str,
+    ) -> list[Job]:
+        host, site_key, country_iso = SEEK_SITES[region]
+        first = await self._search(client, sem, host=host,
+                                   site_key=site_key, page=1)
+        total = int(first.get("totalCount") or 0)
+        data = first.get("data") or []
+        jobs: list[Job] = [
+            self._parse_job(item, host=host, country_iso=country_iso)
+            for item in data
+        ]
+        if total <= PAGE_SIZE or not data:
+            return [j for j in jobs if j is not None]
+
+        # Pages beyond the first — fan out with bounded concurrency.
+        last_page = min(
+            (total + PAGE_SIZE - 1) // PAGE_SIZE,
+            PAGE_SAFETY_CAP,
+        )
+        if last_page <= 1:
+            return [j for j in jobs if j is not None]
+
+        results: list[list[Job]] = [jobs]
+
+        async def one_page(page: int) -> list[Job]:
+            payload = await self._search(client, sem, host=host,
+                                         site_key=site_key, page=page)
+            items = payload.get("data") or []
+            return [
+                self._parse_job(it, host=host, country_iso=country_iso)
+                for it in items
+            ]
+
+        gathered = await asyncio.gather(
+            *(one_page(p) for p in range(2, last_page + 1)),
+            return_exceptions=True,
+        )
+        for r in gathered:
+            if isinstance(r, BaseException):
+                log.warning("SEEK region=%s page fetch failed: %s", region, r)
+                continue
+            results.append(r)
+
+        flat: list[Job] = []
+        for batch in results:
+            for j in batch:
+                if j is not None:
+                    flat.append(j)
+        return flat
+
+    async def _search(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        *,
+        host: str,
+        site_key: str,
+        page: int,
+    ) -> dict[str, Any]:
+        url = (
+            f"https://{host}/api/jobsearch/v5/search"
+            f"?siteKey={site_key}&page={page}&pageSize={PAGE_SIZE}"
+            f"&sortmode=ListedDate"
+        )
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    r = await client.get(
+                        url,
+                        headers={
+                            "Accept": "application/json",
+                            "User-Agent": "Mozilla/5.0",
+                        },
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"SEEK fetch failed for {url}: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if r.status_code == 200:
+                try:
+                    return r.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"SEEK returned non-JSON for {url}: {exc}"
+                    ) from exc
+            if r.status_code in (429,) or 500 <= r.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"SEEK returned {r.status_code} for {url} after "
+                        f"{MAX_RETRIES} retries"
+                    )
+                retry_after = r.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            # 4xx other than 429 — treat as a terminal slice failure so
+            # we don't burn retries on a permanent error.
+            raise ScraperError(
+                f"SEEK returned {r.status_code} for {url}: {r.text[:120]}"
+            )
+        raise ScraperError(f"SEEK exhausted retries for {url}: {last_exc}")
+
+    def _parse_job(
+        self,
+        item: dict[str, Any],
+        *,
+        host: str,
+        country_iso: str,
+    ) -> Job | None:
+        ats_id = str(item.get("id") or "").strip()
+        title = (item.get("title") or "").strip()
+        if not ats_id or not title:
+            return None
+
+        advertiser = item.get("advertiser") or {}
+        company = (
+            advertiser.get("description")
+            or item.get("companyName")
+            or "Unknown"
+        )
+
+        # Location — the search response gives a list. ``label`` is the
+        # display string (e.g. ``"Tampines North, East Region"``);
+        # ``countryCode`` is the ISO-2. If multiple locations are listed
+        # we keep the first and append the country only when the label
+        # doesn't already include it (most APAC labels are city / region
+        # only, no country suffix).
+        locations = item.get("locations") or []
+        location: str | None = None
+        loc_country: str | None = None
+        if locations and isinstance(locations[0], dict):
+            primary = locations[0]
+            label = (primary.get("label") or "").strip() or None
+            loc_country = (primary.get("countryCode") or "").strip().upper() or None
+            location = label
+
+        country = loc_country or country_iso
+
+        # Description — search response is summary-only. We concatenate
+        # the teaser with the bullet points (when both are present) so
+        # downstream consumers have *something* searchable; the canonical
+        # 10kB cap from the model docs is preserved.
+        teaser = (item.get("teaser") or "").strip()
+        bullets = [
+            b.strip() for b in (item.get("bulletPoints") or [])
+            if isinstance(b, str) and b.strip()
+        ]
+        if teaser and bullets:
+            description = teaser + "\n\n- " + "\n- ".join(bullets)
+        elif bullets:
+            description = "- " + "\n- ".join(bullets)
+        else:
+            description = teaser or None
+        if description is not None and len(description) > 10_000:
+            description = description[:10_000]
+
+        # Classification — ``classifications[0].classification.description``
+        # is the high-level category (e.g. "Information & Communication
+        # Technology"). ``subclassification`` is finer-grained — we keep
+        # the parent in ``department``.
+        department: str | None = None
+        classifications = item.get("classifications") or []
+        if classifications and isinstance(classifications[0], dict):
+            cls = classifications[0].get("classification") or {}
+            label = (cls.get("description") or cls.get("label") or "").strip()
+            department = label or None
+
+        salary_label = (item.get("salaryLabel") or "").strip() or None
+        salary_currency = _REGION_CURRENCY.get(country) if salary_label else None
+
+        posted_at = _parse_iso8601(item.get("listingDate"))
+
+        raw: dict[str, Any] = {}
+        # Surface a compact subset of identifiers. ``advertiser.id`` is
+        # the most useful cross-posting key.
+        adv_id = advertiser.get("id")
+        if adv_id:
+            raw["advertiserId"] = str(adv_id)
+        employer = item.get("employer") or {}
+        emp_id = employer.get("id")
+        if emp_id:
+            raw["employerId"] = str(emp_id)
+        for k in ("roleId", "displayType", "isFeatured", "workTypes",
+                  "companyProfileStructuredDataId"):
+            v = item.get(k)
+            if v not in (None, "", []):
+                raw[k] = v
+        wa = item.get("workArrangements") or {}
+        if isinstance(wa, dict) and wa.get("data"):
+            # workArrangements.data is a small list of {id, label}; we
+            # keep the labels as a flat list of strings.
+            labels: list[str] = []
+            for entry in wa["data"]:
+                if not isinstance(entry, dict):
+                    continue
+                lbl = entry.get("label")
+                if isinstance(lbl, dict):
+                    text = lbl.get("text")
+                    if isinstance(text, str) and text:
+                        labels.append(text)
+            if labels:
+                raw["workArrangements"] = labels
+
+        return Job(
+            url=f"https://{host}/job/{ats_id}",
+            title=title,
+            company=company,
+            ats_type=ATSType.SEEK,
+            ats_id=ats_id,
+            location=location,
+            country_iso=country,
+            region="Oceania" if country in ("AU", "NZ") else "Asia",
+            salary_currency=salary_currency,
+            salary_period="YEAR" if salary_currency else None,
+            salary_summary=salary_label,
+            department=department,
+            description=description,
+            posted_at=posted_at,
+            fetched_at=datetime.now(),
+            language="en",
+            raw=raw or None,
+        )
+
+
+def _parse_iso8601(value: object) -> datetime | None:
+    """Parse SEEK's ``listingDate`` (``2026-04-29T00:23:37Z``).
+
+    Returns ``None`` for missing / malformed values rather than raising —
+    a single bad date in a 158k payload shouldn't abort the whole scrape.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return None
+    s = value.strip()
+    # ``datetime.fromisoformat`` accepts a trailing offset but not the
+    # literal ``Z`` shorthand until Python 3.11; we normalize defensively.
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(s)
+    except ValueError:
+        return None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -30,6 +30,8 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
         "manfred", "thehub", "ycombinator", "wellfound",
+        # Regional multi-source aggregators
+        "seek",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",
         "recruitee", "taleo", "teamtailor",

--- a/tests/test_seek.py
+++ b/tests/test_seek.py
@@ -1,0 +1,394 @@
+"""Tests for the SEEK / JobsDB / JobStreet APAC scraper.
+
+The scraper covers eight regional sites (au, nz, hk, th, my, id, ph,
+sg) that all share the same ``chalice-search v5`` JSON API. Tests
+verify:
+
+- region → (host, siteKey, country_iso) mapping
+- ``_parse_job`` populates the canonical Job fields correctly
+- country_iso / salary_currency / region are inferred from the region
+- pagination follows ``totalCount`` and stops cleanly
+
+All network access is mocked via ``httpx_mock``.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import ScraperRegistry, SeekScraper
+from jobhive.scrapers.seek import SEEK_SITES, _parse_iso8601
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.seek as seek_mod
+
+    monkeypatch.setattr(seek_mod, "MAX_RETRIES", 1)
+    monkeypatch.setattr(seek_mod, "RETRY_BASE_DELAY", 0.0)
+
+
+# --- fixtures ---------------------------------------------------------------
+
+
+def _au_job(**overrides) -> dict:
+    base = {
+        "id": "91798287",
+        "title": "Operations Manager",
+        "companyName": "Go 3 pl",
+        "advertiser": {"id": "63113577", "description": "Go 3 pl"},
+        "bulletPoints": [
+            "Large 30,000m² 3PL site",
+            "Fast-paced hands-on operations",
+        ],
+        "teaser": "Hands-on Warehouse Ops Manager for busy 3PL in Braeside.",
+        "classifications": [
+            {
+                "classification": {
+                    "id": "6092",
+                    "description": "Manufacturing, Transport & Logistics",
+                },
+                "subclassification": {
+                    "id": "6102",
+                    "description": "Management",
+                },
+            }
+        ],
+        "locations": [
+            {
+                "label": "Braeside, Melbourne VIC",
+                "countryCode": "AU",
+            }
+        ],
+        "salaryLabel": "$115,000 – $125,000 per year",
+        "listingDate": "2026-04-29T00:23:37Z",
+        "listingDateDisplay": "13d ago",
+        "workTypes": ["Full time"],
+        "workArrangements": {
+            "data": [{"id": "1", "label": {"text": "On-site"}}]
+        },
+        "roleId": "operations-manager",
+        "displayType": "standard",
+        "isFeatured": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def _sg_job(**overrides) -> dict:
+    base = {
+        "id": "78311013",
+        "title": "Backend Engineer",
+        "companyName": "Acme Pte Ltd",
+        "advertiser": {"id": "12345", "description": "Acme Pte Ltd"},
+        "bulletPoints": ["Modern stack", "Hybrid working"],
+        "teaser": "Join our growing backend team.",
+        "classifications": [
+            {
+                "classification": {
+                    "id": "6281",
+                    "description": "Information & Communication Technology",
+                },
+            }
+        ],
+        "locations": [
+            {"label": "Tampines North, East Region", "countryCode": "SG"}
+        ],
+        "salaryLabel": "S$8,000 - S$12,000 per month",
+        "listingDate": "2026-05-10T09:00:00Z",
+    }
+    base.update(overrides)
+    return base
+
+
+def _page(jobs: list[dict], total: int | None = None) -> dict:
+    return {
+        "data": jobs,
+        "totalCount": total if total is not None else len(jobs),
+        "info": {},
+        "facets": {},
+        "searchParams": {},
+        "sortModes": [],
+    }
+
+
+def _search_url(host: str, site_key: str, page: int) -> re.Pattern[str]:
+    """Match the search URL for a given host/siteKey/page regardless of
+    parameter order (httpx serializes querystring deterministically but
+    the test should not depend on it)."""
+    return re.compile(
+        rf"^https://{re.escape(host)}/api/jobsearch/v5/search\?"
+        rf"(?=.*siteKey={re.escape(site_key)})"
+        rf"(?=.*page={page}\b)"
+    )
+
+
+# --- registry / wiring ------------------------------------------------------
+
+
+def test_registry_resolves_seek() -> None:
+    assert ScraperRegistry.get(ATSType.SEEK) is SeekScraper
+
+
+def test_eight_regions_in_sites_map() -> None:
+    """If somebody drops a region, the dataset coverage shrinks
+    silently. Pin the eight regions explicitly."""
+    assert set(SEEK_SITES) == {
+        "au", "nz", "hk", "th", "my", "id", "ph", "sg",
+    }
+
+
+def test_unknown_region_rejected() -> None:
+    with pytest.raises(ScraperError, match="Unknown SEEK region"):
+        SeekScraper("zz")
+
+
+def test_all_region_expands_to_every_site() -> None:
+    s = SeekScraper("all")
+    assert set(s.regions) == set(SEEK_SITES)
+
+
+def test_single_region_is_singleton_tuple() -> None:
+    s = SeekScraper("au")
+    assert s.regions == ("au",)
+
+
+def test_region_is_case_insensitive() -> None:
+    assert SeekScraper("AU").regions == ("au",)
+    assert set(SeekScraper("ALL").regions) == set(SEEK_SITES)
+
+
+# --- _parse_iso8601 ---------------------------------------------------------
+
+
+def test_parse_iso8601_handles_z_suffix() -> None:
+    dt = _parse_iso8601("2026-04-29T00:23:37Z")
+    assert dt == datetime(2026, 4, 29, 0, 23, 37, tzinfo=UTC)
+
+
+def test_parse_iso8601_handles_offset() -> None:
+    dt = _parse_iso8601("2026-04-29T00:23:37+00:00")
+    assert dt is not None
+    assert dt.year == 2026
+
+
+def test_parse_iso8601_returns_none_for_garbage() -> None:
+    assert _parse_iso8601("not a date") is None
+    assert _parse_iso8601(None) is None
+    assert _parse_iso8601("") is None
+
+
+# --- _parse_job per region --------------------------------------------------
+
+
+def test_parse_au_job_populates_canonical_fields() -> None:
+    scraper = SeekScraper("au")
+    job = scraper._parse_job(
+        _au_job(), host="au.seek.com", country_iso="AU"
+    )
+    assert job is not None
+    assert job.ats_type is ATSType.SEEK
+    assert job.ats_id == "91798287"
+    assert job.global_id == "seek:91798287"
+    assert job.title == "Operations Manager"
+    assert job.company == "Go 3 pl"
+    assert str(job.url) == "https://au.seek.com/job/91798287"
+    assert job.location == "Braeside, Melbourne VIC"
+    assert job.country_iso == "AU"
+    assert job.region == "Oceania"
+    assert job.language == "en"
+    # Salary label + AU region → AUD currency, period YEAR.
+    assert job.salary_currency == "AUD"
+    assert job.salary_period == "YEAR"
+    assert job.salary_summary == "$115,000 – $125,000 per year"
+    assert job.department == "Manufacturing, Transport & Logistics"
+    # Description: teaser + bullets, no HTML.
+    assert job.description is not None
+    assert "Hands-on Warehouse Ops Manager" in job.description
+    assert "Large 30,000m" in job.description
+    assert job.posted_at == datetime(
+        2026, 4, 29, 0, 23, 37, tzinfo=UTC
+    )
+
+
+def test_parse_sg_job_uses_sgd_currency() -> None:
+    scraper = SeekScraper("sg")
+    job = scraper._parse_job(
+        _sg_job(), host="sg.jobstreet.com", country_iso="SG"
+    )
+    assert job is not None
+    assert job.country_iso == "SG"
+    assert job.region == "Asia"
+    assert job.salary_currency == "SGD"
+    assert str(job.url) == "https://sg.jobstreet.com/job/78311013"
+
+
+@pytest.mark.parametrize(
+    "region,host,country,currency,continent",
+    [
+        ("au", "au.seek.com", "AU", "AUD", "Oceania"),
+        ("nz", "www.seek.co.nz", "NZ", "NZD", "Oceania"),
+        ("hk", "hk.jobsdb.com", "HK", "HKD", "Asia"),
+        ("th", "th.jobsdb.com", "TH", "THB", "Asia"),
+        ("my", "my.jobstreet.com", "MY", "MYR", "Asia"),
+        ("id", "id.jobstreet.com", "ID", "IDR", "Asia"),
+        ("ph", "ph.jobstreet.com", "PH", "PHP", "Asia"),
+        ("sg", "sg.jobstreet.com", "SG", "SGD", "Asia"),
+    ],
+)
+def test_parse_job_per_region_iso_and_currency(
+    region: str, host: str, country: str, currency: str, continent: str,
+) -> None:
+    """Every region resolves to the right country code, ISO 4217 currency,
+    and Oceania/Asia continent."""
+    scraper = SeekScraper(region)
+    payload = _au_job(
+        id=f"id-{region}",
+        locations=[{"label": "Somewhere", "countryCode": country}],
+        salaryLabel="some salary",
+    )
+    job = scraper._parse_job(payload, host=host, country_iso=country)
+    assert job is not None
+    assert job.country_iso == country
+    assert job.salary_currency == currency
+    assert job.region == continent
+    assert str(job.url).startswith(f"https://{host}/job/")
+
+
+def test_parse_job_no_salary_means_no_currency() -> None:
+    """``salary_currency`` is only set when a salary label is present —
+    we don't invent a currency for empty rows."""
+    scraper = SeekScraper("au")
+    payload = _au_job(salaryLabel="")
+    job = scraper._parse_job(payload, host="au.seek.com", country_iso="AU")
+    assert job is not None
+    assert job.salary_summary is None
+    assert job.salary_currency is None
+    assert job.salary_period is None
+
+
+def test_parse_job_falls_back_to_company_name_when_advertiser_missing() -> None:
+    scraper = SeekScraper("au")
+    payload = _au_job(advertiser={})
+    job = scraper._parse_job(payload, host="au.seek.com", country_iso="AU")
+    assert job is not None
+    assert job.company == "Go 3 pl"  # from companyName
+
+
+def test_parse_job_unknown_company_when_both_advertiser_and_name_missing() -> None:
+    scraper = SeekScraper("au")
+    payload = _au_job(advertiser={}, companyName=None)
+    job = scraper._parse_job(payload, host="au.seek.com", country_iso="AU")
+    assert job is not None
+    assert job.company == "Unknown"
+
+
+def test_parse_job_uses_location_country_when_present() -> None:
+    """Some postings carry a location countryCode that differs from
+    the region — pass-through that value rather than the region's
+    default."""
+    scraper = SeekScraper("au")
+    payload = _au_job(
+        locations=[{"label": "Auckland", "countryCode": "NZ"}],
+    )
+    job = scraper._parse_job(payload, host="au.seek.com", country_iso="AU")
+    assert job is not None
+    assert job.country_iso == "NZ"
+    # NZ has its own currency mapping even though we're on the AU site.
+    assert job.salary_currency == "NZD"
+
+
+def test_parse_job_returns_none_for_empty_id() -> None:
+    scraper = SeekScraper("au")
+    assert scraper._parse_job(
+        _au_job(id=""), host="au.seek.com", country_iso="AU"
+    ) is None
+    assert scraper._parse_job(
+        _au_job(title=""), host="au.seek.com", country_iso="AU"
+    ) is None
+
+
+def test_parse_job_raw_payload_is_compact() -> None:
+    scraper = SeekScraper("au")
+    job = scraper._parse_job(
+        _au_job(), host="au.seek.com", country_iso="AU"
+    )
+    assert job is not None and job.raw is not None
+    # Heavy fields like solMetadata / tracking should NOT appear.
+    assert "solMetadata" not in job.raw
+    assert "tracking" not in job.raw
+    # Identifier fields we do keep.
+    assert job.raw.get("advertiserId") == "63113577"
+    assert job.raw.get("workArrangements") == ["On-site"]
+
+
+def test_parse_job_description_handles_missing_bullets() -> None:
+    scraper = SeekScraper("au")
+    payload = _au_job(bulletPoints=[])
+    job = scraper._parse_job(payload, host="au.seek.com", country_iso="AU")
+    assert job is not None
+    assert job.description == "Hands-on Warehouse Ops Manager for busy 3PL in Braeside."
+
+
+def test_parse_job_description_handles_missing_teaser() -> None:
+    scraper = SeekScraper("au")
+    payload = _au_job(teaser="")
+    job = scraper._parse_job(payload, host="au.seek.com", country_iso="AU")
+    assert job is not None
+    assert job.description is not None
+    assert job.description.startswith("- ")
+
+
+# --- end-to-end pagination via httpx_mock -----------------------------------
+
+
+def test_fetch_single_page(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_search_url("au.seek.com", "AU-Main", 1),
+        json=_page([_au_job(id="1"), _au_job(id="2")], total=2),
+    )
+    jobs = SeekScraper("au").fetch()
+    assert len(jobs) == 2
+    assert {j.ats_id for j in jobs} == {"1", "2"}
+
+
+def test_fetch_paginates_until_total_reached(httpx_mock) -> None:
+    # Total 150 → 2 pages of 100. With ``is_reusable=True`` we let
+    # httpx_mock match by page index in the URL.
+    httpx_mock.add_response(
+        url=_search_url("au.seek.com", "AU-Main", 1),
+        json=_page(
+            [_au_job(id=f"p1-{i}") for i in range(100)], total=150,
+        ),
+    )
+    httpx_mock.add_response(
+        url=_search_url("au.seek.com", "AU-Main", 2),
+        json=_page(
+            [_au_job(id=f"p2-{i}") for i in range(50)], total=150,
+        ),
+    )
+    jobs = SeekScraper("au").fetch()
+    assert len(jobs) == 150
+    ids = {j.ats_id for j in jobs}
+    assert "p1-0" in ids and "p2-49" in ids
+
+
+def test_fetch_dedupes_cross_region_for_all(httpx_mock) -> None:
+    """Two regions both return job id=999 — only one survives the
+    cross-region dedup in ``_fetch_async``."""
+    shared = _au_job(id="999")
+    for region, (host, site_key, _) in SEEK_SITES.items():
+        httpx_mock.add_response(
+            url=_search_url(host, site_key, 1),
+            json=_page([shared], total=1),
+        )
+        del region  # only the URL matters
+    jobs = SeekScraper("all").fetch()
+    # All 8 regions returned the same row → only one in the final list.
+    assert len(jobs) == 1
+    assert jobs[0].ats_id == "999"


### PR DESCRIPTION
## Summary

Single scraper for the SEEK family of APAC job boards. SEEK Ltd. owns SEEK (AU/NZ), JobsDB (HK/TH), and JobStreet (MY/ID/PH/SG) — eight regional sites that all share the same `chalice-search v5` JSON backend with only host + `siteKey` varying.

Total observed live postings (May 2026): **~474k**.

| Region | Host | siteKey | ISO | Jobs |
|--------|------|---------|-----|-----:|
| au | au.seek.com | AU-Main | AU | 159k |
| nz | www.seek.co.nz | NZ-Main | NZ | 19k |
| hk | hk.jobsdb.com | HK-Main | HK | 34k |
| th | th.jobsdb.com | TH-Main | TH | 18k |
| my | my.jobstreet.com | MY-Main | MY | 50k |
| id | id.jobstreet.com | ID-Main | ID | 56k |
| ph | ph.jobstreet.com | PH-Main | PH | 73k |
| sg | sg.jobstreet.com | SG-Main | SG | 66k |

`company_slug` selects the region — `SeekScraper("au")`, `SeekScraper("sg")`, or `SeekScraper("all")` to iterate every region.

Sample (verified, no auth, no API key):

```
curl 'https://au.seek.com/api/jobsearch/v5/search?siteKey=AU-Main&page=1&pageSize=100&sortmode=ListedDate' \
  -H 'Accept: application/json' \
  -H 'User-Agent: Mozilla/5.0'
```

Per-region details captured:
- `country_iso` from `locations[0].countryCode`, falling back to the region's ISO
- `salary_currency` mapped from region (AUD/NZD/HKD/THB/MYR/IDR/PHP/SGD) — only when `salaryLabel` is non-empty, no invented currency
- `department` from `classifications[0].classification.description`
- `region` set to `Oceania` (AU/NZ) or `Asia` (rest)
- `language="en"` (SEEK is English even in non-English-majority markets)

### Description handling note

The chalice-search v5 response is **summary-only** — it ships `teaser` plus a few `bulletPoints` instead of the full job body. The scraper concatenates those into `description` rather than firing a second per-posting fetch: at AU's 159k postings alone, fetching full descriptions would mean 159k additional round-trips. Full bodies should be pulled by downstream enrichment if needed.

### Pagination

`pageSize` caps at 100 (200 returns HTML). The scraper iterates `page=1..N` until `len(data) < pageSize`, `page*pageSize >= totalCount`, or a 1000-page safety cap, with concurrency=4 across pages and exponential backoff on 429/5xx.

## Test plan

- [x] `ruff check src/jobhive/scrapers/seek.py tests/test_seek.py` passes
- [x] `pytest tests/test_seek.py tests/test_models.py -x` passes (92 tests)
- [x] Verified API responses against all 8 regions live before coding
- [ ] Run against `au` in staging, confirm ~158k rows materialize
- [ ] Run against `all` and verify cross-region dedup keeps the total at ~474k

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a single scraper for the SEEK family across APAC (SEEK, JobsDB, JobStreet) using the shared `chalice-search v5` JSON API. Ingests ~474k live postings with region selection, concurrent pagination, and correct salary period detection.

- **New Features**
  - Supports `au`, `nz`, `hk`, `th`, `my`, `id`, `ph`, `sg`, or `all` via `SeekScraper(company_slug)`.
  - Paginates with `pageSize=100`, stops on `totalCount` or a 5000-page cap; concurrency=4 with retries/backoff for 429/5xx.
  - Builds descriptions from `teaser` + `bulletPoints` only; avoids per-post fetches.
  - Sets `country_iso`, `salary_currency` (AUD/NZD/HKD/THB/MYR/IDR/PHP/SGD when salary present), infers `salary_period` from the label (hour/day/week/month/year), `region` (“Oceania”/“Asia”), `language="en"`.
  - Deduplicates cross-region results by `global_id`.
  - Adds `ATSType.SEEK`, exports `SeekScraper`, and includes tests for parsing, pagination, and region mapping; adds `ats-companies/seek.csv` seed for all eight sites.

<sup>Written for commit ebb9a8d7fda7709821a7959d2a507e1fe4a0ae5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a unified scraper for the SEEK family of APAC job boards (SEEK AU/NZ, JobsDB HK/TH, JobStreet MY/ID/PH/SG), all sharing the same `chalice-search v5` JSON API, covering ~474k live postings across eight regions with concurrent pagination and cross-region deduplication.

- `salary_period` is unconditionally set to `\"YEAR\"` for every row that has a salary label, but SEEK labels routinely describe monthly or hourly rates (e.g. `\"S$8,000 - S$12,000 per month\"` for SG); a helper that inspects the label text is needed to infer the actual period.
- In `_search`, the retry sleep for `httpx.HTTPError` is called inside the `async with sem:` block, holding a concurrency slot for the full backoff duration and blocking other in-flight page fetches.
- `_RAW_KEYS` is defined at module level but never referenced in the parsing loop, and `fetched_at` uses a timezone-naive `datetime.now()` while `posted_at` is timezone-aware.

<h3>Confidence Score: 3/5</h3>

Hold until the salary_period bug and the semaphore-during-sleep issue are resolved; the rest of the scraper logic is solid.

The salary_period field is hardcoded to YEAR for every row that has any salary label, producing wrong data for every monthly or hourly posting across all eight regions. The semaphore held during HTTPError retry sleeps can stall up to 3 of the 4 concurrency slots for seconds at a time under poor network conditions.

src/jobhive/scrapers/seek.py needs attention for the salary_period assignment and the retry sleep placement inside the semaphore block.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/seek.py | New SEEK/JobsDB/JobStreet scraper — has two correctness bugs: salary_period hardcoded to YEAR regardless of actual label period, and semaphore held during HTTPError retry sleep blocking concurrency; also has a dead _RAW_KEYS constant and timezone-naive fetched_at. |
| tests/test_seek.py | Comprehensive test suite covering parsing, pagination, and deduplication; notably absent is a test for salary_period on monthly/non-annual salary labels, which allowed the YEAR hardcoding bug to slip through. |
| src/jobhive/models.py | Adds ATSType.SEEK enum value in the correct position; no issues. |
| src/jobhive/scrapers/__init__.py | Adds SeekScraper import and __all__ export in alphabetical order; no issues. |
| ats-companies/seek.csv | Seed CSV for all eight SEEK-family regional sites; straightforward and correct. |
| tests/test_models.py | Adds "seek" to the ATSType platform list assertion; no issues. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
src/jobhive/scrapers/seek.py:380
`salary_period` is unconditionally set to `"YEAR"` whenever a currency is present, but SEEK salary labels routinely describe monthly, daily, or hourly rates — the test fixture for SG even shows `"S$8,000 - S$12,000 per month"`. Every monthly or hourly role ingested will carry an incorrect `YEAR` period, making downstream salary comparison or filtering wrong without any warning.

```suggestion
            salary_period=_infer_salary_period(salary_label),
```

### Issue 2 of 4
src/jobhive/scrapers/seek.py:234-241
**Semaphore held during HTTPError retry sleep**

When `httpx.HTTPError` is raised, `await asyncio.sleep(RETRY_BASE_DELAY * attempt)` is called inside the `async with sem:` block. This means the semaphore slot stays acquired for the full backoff duration (1.5 s on attempt 1, 3 s on attempt 2, etc.), blocking other concurrent coroutines from making any requests until it completes. The 429/5xx retry sleep is correctly placed outside the semaphore block (lines 260–261); the same pattern should apply here — release the semaphore before sleeping.

### Issue 3 of 4
src/jobhive/scrapers/seek.py:104-106
**`_RAW_KEYS` constant is dead code**

`_RAW_KEYS` is defined with all eight field names but is never referenced anywhere in the file. The actual loop in `_parse_job` (lines 349–353) hardcodes its own tuple of five keys, and `advertiserId`, `employerId`, and `workArrangements` are each handled separately. Any future maintainer editing `_RAW_KEYS` believing it governs the captured fields will be surprised to find the running code unchanged.

### Issue 4 of 4
src/jobhive/scrapers/seek.py:52
`datetime.now()` produces a timezone-naive datetime, while `posted_at` (from `_parse_iso8601`) is timezone-aware (UTC). Storing a naive `fetched_at` alongside an aware `posted_at` causes comparison errors and breaks any ORM/serializer that enforces tzinfo consistency.

```suggestion
from datetime import UTC, datetime
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: seek.csv"](https://github.com/kalil0321/ats-scrapers/commit/104b48b39d782b7d58f83c2ea11bda73d17b8496) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732384)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->