### PR TITLE
Add Workforce Australia scraper

### DIFF
--- a/ats-companies/workforceaustralia.csv
+++ b/ats-companies/workforceaustralia.csv
@@ -1,0 +1,2 @@
+name,slug,url
+Workforce Australia,workforceaustralia,https://www.workforceaustralia.gov.au

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -67,6 +67,7 @@ class ATSType(StrEnum):
     BUNDESAGENTUR = "bundesagentur"
     ARBETSFORMEDLINGEN = "arbetsformedlingen"
     EURES = "eures"
+    WORKFORCEAUSTRALIA = "workforceaustralia"
     # Hybrid jobboards (companies post directly, not aggregated)
     WELCOMETOTHEJUNGLE = "welcometothejungle"
     GETONBRD = "getonbrd"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -57,6 +57,7 @@ from jobhive.scrapers.wellfound import WellfoundScraper
 from jobhive.scrapers.weworkremotely import WeWorkRemotelyScraper
 from jobhive.scrapers.workable import WorkableScraper
 from jobhive.scrapers.workday import WorkdayScraper
+from jobhive.scrapers.workforceaustralia import WorkforceAustraliaScraper
 from jobhive.scrapers.ycombinator import YCombinatorScraper
 
 __all__ = [
@@ -109,6 +110,7 @@ __all__ = [
     "WellfoundScraper",
     "WorkableScraper",
     "WorkdayScraper",
+    "WorkforceAustraliaScraper",
     "YCombinatorScraper",
     "get_scraper",
     "iCIMSScraper",

--- a/src/jobhive/scrapers/workforceaustralia.py
+++ b/src/jobhive/scrapers/workforceaustralia.py
@@ -1,0 +1,407 @@
+"""Workforce Australia (jobsearch.gov.au) scraper.
+
+Workforce Australia is the Australian federal government's national job
+board, operated by the Department of Employment and Workplace Relations.
+It carries ~170k+ live postings spanning the full Australian labour
+market: private-sector employers, public-sector roles, indigenous
+employment, regional jobs, and apprenticeships.
+
+The site exposes a public REST API — no auth, no API key, plain JSON:
+
+    GET https://www.workforceaustralia.gov.au/api/v1/global/vacancies
+        ?size={1..100}&page={0..N}
+
+Each response carries ``totalCount``, ``pageNumber`` (0-indexed),
+``pageSize`` and a ``results`` array of ``{score, result}`` wrappers.
+The wrapped ``result`` is the actual vacancy with a stable integer
+``vacancyId`` we use as ``ats_id``.
+
+Like USAJOBS / EURES / Arbetsförmedlingen / Bundesagentur this is a
+single-source scraper: there is no per-tenant slug. We accept any
+``company_slug`` argument (used for logging only) and pull the full
+active dataset on every fetch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+API_URL = "https://www.workforceaustralia.gov.au/api/v1/global/vacancies"
+JOB_URL_TEMPLATE = (
+    "https://www.workforceaustralia.gov.au/individuals/jobs/details/{id}"
+)
+PAGE_SIZE = 100  # API accepts up to 100/page.
+DEFAULT_MAX_PAGES = 100  # 100 pages * 100 = 10,000 jobs by default.
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1.5
+
+HTML_TAG_RE = re.compile(r"<[^>]+>")
+WHITESPACE_RE = re.compile(r"\s+")
+MAX_DESCRIPTION_LEN = 10_000
+
+# ``workType.label`` → canonical EmploymentType. The Workforce Australia
+# taxonomy distinguishes work type ("Full time" / "Part time" / "Casual")
+# from tenure ("Permanent" / "Contract"); we map work type first because
+# it carries the FT/PT signal, then fall back to tenure for contracts.
+_WORK_TYPE_MAP = {
+    "full time position": "FULL_TIME",
+    "full time": "FULL_TIME",
+    "part time position": "PART_TIME",
+    "part time": "PART_TIME",
+    "casual position": "TEMPORARY",
+    "casual": "TEMPORARY",
+}
+
+_TENURE_MAP = {
+    "permanent position": "FULL_TIME",
+    "permanent": "FULL_TIME",
+    "contract position": "CONTRACT",
+    "contract": "CONTRACT",
+    "apprenticeship": "INTERN",
+    "traineeship": "INTERN",
+    "internship": "INTERN",
+}
+
+
+@ScraperRegistry.register(ATSType.WORKFORCEAUSTRALIA)
+class WorkforceAustraliaScraper(BaseScraper):
+    """Workforce Australia (jobsearch.gov.au) — single-source scraper.
+
+    ``company_slug`` is accepted for interface symmetry but ignored; the
+    scraper always pulls the full active dataset. ``max_pages`` caps the
+    pagination depth (default 100 → ~10,000 jobs).
+    """
+
+    ats = ATSType.WORKFORCEAUSTRALIA
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        max_pages: int = DEFAULT_MAX_PAGES,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.max_pages = max_pages
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        seen: set[str] = set()
+        jobs: list[Job] = []
+
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+
+            # First page tells us totalCount; we use it to size the
+            # remaining concurrent fetches.
+            first = await self._fetch_page(client, sem, page=0)
+            for item in first.get("results") or []:
+                job = self._parse(item)
+                if job is None or job.ats_id in seen:
+                    continue
+                seen.add(job.ats_id)
+                jobs.append(job)
+
+            total = int(first.get("totalCount") or 0)
+            if total <= PAGE_SIZE:
+                return jobs
+
+            # Cap total pages at both the API-implied count and the
+            # configured ceiling.
+            api_pages = (total + PAGE_SIZE - 1) // PAGE_SIZE
+            page_count = min(api_pages, self.max_pages)
+            remaining_pages = list(range(1, page_count))
+            if not remaining_pages:
+                return jobs
+
+            payloads = await asyncio.gather(*(
+                self._fetch_page(client, sem, page=p) for p in remaining_pages
+            ))
+            for payload in payloads:
+                items = payload.get("results") or []
+                if not items:
+                    continue
+                for item in items:
+                    job = self._parse(item)
+                    if job is None or job.ats_id in seen:
+                        continue
+                    seen.add(job.ats_id)
+                    jobs.append(job)
+        return jobs
+
+    async def _fetch_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        *,
+        page: int,
+    ) -> dict[str, Any]:
+        last_exc: Exception | None = None
+        params = {"size": PAGE_SIZE, "page": page}
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": "Mozilla/5.0",
+        }
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(
+                        API_URL, params=params, headers=headers
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                try:
+                    return response.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"Workforce Australia returned non-JSON at page={page}: {exc}"
+                    ) from exc
+            if response.status_code == 429 or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Workforce Australia returned {response.status_code} at "
+                        f"page={page} after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after)
+                    if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2**attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"Workforce Australia returned {response.status_code} at page={page}"
+            )
+        raise ScraperError(
+            f"Workforce Australia exhausted retries at page={page}: {last_exc}"
+        )
+
+    def _parse(self, wrapper: dict[str, Any]) -> Job | None:
+        """Parse a single ``{score, result}`` envelope into a ``Job``."""
+        if not isinstance(wrapper, dict):
+            return None
+        result = wrapper.get("result")
+        if not isinstance(result, dict):
+            return None
+
+        vacancy_id = result.get("vacancyId")
+        if vacancy_id is None:
+            return None
+        ats_id = str(vacancy_id).strip()
+        title = (result.get("title") or "").strip()
+        if not ats_id or not title:
+            return None
+
+        url = JOB_URL_TEMPLATE.format(id=ats_id)
+
+        company = (
+            (result.get("employerName") or "").strip()
+            or _label(result.get("organisation"))
+            or "Unknown"
+        )
+
+        location = _format_location(
+            result.get("suburb"), result.get("state"), result.get("postCode")
+        )
+
+        lat = _coerce_coord(result.get("latitude"))
+        lon = _coerce_coord(result.get("longitude"))
+
+        salary_summary = _label(result.get("salary")) or None
+        salary_currency = "AUD" if salary_summary else None
+
+        description = _html_to_text(result.get("description"))
+
+        industry_label = _label(result.get("industry"))
+        occupation_label = _label(result.get("occupation"))
+        department = industry_label or occupation_label
+        team = (
+            occupation_label
+            if occupation_label and occupation_label != department
+            else None
+        )
+
+        work_type_label = _label(result.get("workType"))
+        tenure_label = _label(result.get("tenure"))
+        contract_type_label = _label(result.get("contractType"))
+        job_type_label = _label(result.get("jobType"))
+        employment_type = _map_employment_type(
+            work_type_label, tenure_label, contract_type_label, job_type_label
+        )
+
+        commitment = (
+            contract_type_label
+            or tenure_label
+            or work_type_label
+            or None
+        )
+
+        requisition_id_raw = result.get("referenceCode")
+        requisition_id = (
+            str(requisition_id_raw).strip()
+            if isinstance(requisition_id_raw, str)
+            and requisition_id_raw.strip()
+            else None
+        )
+
+        raw: dict[str, object] = {}
+        site_label = _label(result.get("site"))
+        if site_label:
+            raw["site"] = site_label
+        if isinstance(result.get("isIndigenousJob"), bool):
+            raw["is_indigenous"] = result["isIndigenousJob"]
+        if isinstance(result.get("isExternalJob"), bool):
+            raw["is_external"] = result["isExternalJob"]
+        positions = result.get("positionsAvailable")
+        if isinstance(positions, int):
+            raw["positions_available"] = positions
+        how_to_apply = result.get("howToApplyCode")
+        if isinstance(how_to_apply, str) and how_to_apply.strip():
+            raw["how_to_apply"] = how_to_apply.strip()
+
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.WORKFORCEAUSTRALIA,
+            ats_id=ats_id,
+            location=location,
+            country_iso="AU",
+            lat=lat,
+            lon=lon,
+            description=description,
+            department=department,
+            team=team,
+            employment_type=employment_type,
+            commitment=commitment,
+            requisition_id=requisition_id,
+            salary_summary=salary_summary,
+            salary_currency=salary_currency,
+            language="en",
+            posted_at=_parse_iso(result.get("creationDate")),
+            fetched_at=datetime.now(),
+            raw=raw or None,
+        )
+
+
+def _label(value: object) -> str | None:
+    """Extract ``label`` from a Workforce Australia ``{code, label}`` dict."""
+    if isinstance(value, dict):
+        label = value.get("label")
+        if isinstance(label, str) and label.strip():
+            return label.strip()
+    elif isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _format_location(
+    suburb: object, state: object, postcode: object
+) -> str | None:
+    """Build a human-readable location like "Sydney, NSW 2000"."""
+    suburb_s = (
+        suburb.strip().title()
+        if isinstance(suburb, str) and suburb.strip()
+        else None
+    )
+    state_s = (
+        state.strip().upper()
+        if isinstance(state, str) and state.strip()
+        else None
+    )
+    postcode_s = (
+        postcode.strip()
+        if isinstance(postcode, str) and postcode.strip()
+        else None
+    )
+
+    if suburb_s and state_s and postcode_s:
+        return f"{suburb_s}, {state_s} {postcode_s}"
+    if suburb_s and state_s:
+        return f"{suburb_s}, {state_s}"
+    if state_s and postcode_s:
+        return f"{state_s} {postcode_s}"
+    return suburb_s or state_s or postcode_s
+
+
+def _coerce_coord(value: object) -> float | None:
+    """Coerce a latitude/longitude string or number to a non-zero float."""
+    if value in (None, "", 0, 0.0):
+        return None
+    try:
+        coord = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    if coord == 0.0:
+        return None
+    return coord
+
+
+def _map_employment_type(
+    work_type: str | None,
+    tenure: str | None,
+    contract_type: str | None,
+    job_type: str | None,
+) -> str | None:
+    """Coerce Workforce Australia labels to the shared enum.
+
+    ``workType`` carries the FT/PT/Casual signal; tenure carries
+    Permanent/Contract/Apprenticeship; contract_type and job_type
+    occasionally surface labels (e.g. internships) too. We check in
+    that order so a "Full time Permanent" role lands on FULL_TIME
+    rather than CONTRACT.
+    """
+    for label in (work_type, contract_type, job_type):
+        if isinstance(label, str):
+            key = label.strip().lower()
+            mapped = _WORK_TYPE_MAP.get(key)
+            if mapped:
+                return mapped
+    if isinstance(tenure, str):
+        key = tenure.strip().lower()
+        mapped = _TENURE_MAP.get(key)
+        if mapped:
+            return mapped
+    return None
+
+
+def _html_to_text(value: object) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    text = HTML_TAG_RE.sub(" ", value)
+    text = html.unescape(text)
+    text = WHITESPACE_RE.sub(" ", text).strip()
+    if not text:
+        return None
+    return text[:MAX_DESCRIPTION_LEN]
+
+
+def _parse_iso(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -25,7 +25,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "amazon", "apple", "google", "meta",
         "tesla", "tiktok", "uber", "usajobs",
         # National / supranational public-sector aggregators
-        "bundesagentur", "arbetsformedlingen", "eures",
+        "bundesagentur", "arbetsformedlingen", "eures", "workforceaustralia",
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",

--- a/tests/test_workforceaustralia.py
+++ b/tests/test_workforceaustralia.py
@@ -1,0 +1,299 @@
+"""Tests for the Workforce Australia (jobsearch.gov.au) scraper.
+
+Fixtures are real API responses captured from
+``https://www.workforceaustralia.gov.au/api/v1/global/vacancies``
+in 2026-05. No live HTTP — every test exercises ``_parse`` directly.
+"""
+
+from __future__ import annotations
+
+from jobhive.models import ATSType
+from jobhive.scrapers.workforceaustralia import (
+    WorkforceAustraliaScraper,
+    _format_location,
+    _map_employment_type,
+)
+
+# Real envelope captured from the live API. The wrapper is
+# ``{score, result}``; we exercise ``_parse`` against the full shape so
+# any future change to the envelope structure surfaces immediately.
+SAMPLE_FULL_TIME = {
+    "score": 2.0,
+    "result": {
+        "contractType": None,
+        "creationDate": "2026-04-13T11:54:27.357",
+        "description": (
+            "Title: Restaurant Manager\n\nLocation: Sandringham Victoria\n\n"
+            "<strong>Duties</strong> include shift management &amp; ordering."
+        ),
+        "displayFromDate": "2026-04-13T00:00:00",
+        "employerId": "CfDJ8NYRxeJdKHVJsNH820chayA",
+        "employerName": "George Migration",
+        "expiryDate": "2026-05-15T10:00:00",
+        "howToApplyCode": "APTR",
+        "industry": {"code": "124", "label": "Hospitality"},
+        "isApplyOnlineJob": True,
+        "isExternalJob": False,
+        "isFavourite": False,
+        "isIndigenousJob": False,
+        "isNewJob": False,
+        "jobType": {"code": "H", "label": "Normal position"},
+        "latitude": "-37.95361065000",
+        "location": {
+            "code": "71BASU",
+            "label": "VIC - Melbourne - Bayside & Peninsula Suburbs",
+        },
+        "logoUrl": "/api/v1/global/vacancies/logos/employer?employerId=x",
+        "longitude": "145.01463237999",
+        "modifiedDate": "2026-04-14T12:00:08.587",
+        "occupation": {
+            "code": "1411", "label": "Cafe and Restaurant Managers"
+        },
+        "organisation": {"code": "INET", "label": "Internet Business"},
+        "positionsAvailable": 1,
+        "postCode": "3191",
+        "salary": {"code": "SLAA", "label": "Above Award"},
+        "site": {"code": "NETV", "label": "Internet Vacancies"},
+        "state": "VIC",
+        "suburb": "SANDRINGHAM",
+        "tenure": {"code": "P", "label": "Permanent position"},
+        "title": "Restaurant Manager",
+        "vacancyId": 2348240495,
+        "workType": {"code": "F", "label": "Full time position"},
+    },
+}
+
+SAMPLE_CASUAL_CONTRACT = {
+    "score": 2.0,
+    "result": {
+        "contractType": None,
+        "creationDate": "2026-04-12T20:38:04.7",
+        "description": "Vending Machine Assistant needed urgently.",
+        "displayFromDate": "2026-04-12T00:00:00",
+        "employerId": "CfDJ8NYRxeJdKHVJsNH820chayAjAes5DSsN7b48nSVy",
+        "employerName": "Nabropure Water Vending",
+        "expiryDate": "2026-05-14T10:00:00",
+        "howToApplyCode": "APTR",
+        "industry": {"code": "137", "label": "Trades"},
+        "isApplyOnlineJob": True,
+        "isExternalJob": False,
+        "isIndigenousJob": False,
+        "jobType": {"code": "H", "label": "Normal position"},
+        "latitude": "-27.54009581",
+        "location": {
+            "code": "41BRIS",
+            "label": "QLD - Brisbane & Gold Coast - Brisbane & Surrounds",
+        },
+        "longitude": "152.95775258",
+        "modifiedDate": "2026-04-14T10:36:16.26",
+        "occupation": {"code": "8997", "label": "Vending Machine Attendants"},
+        "organisation": {"code": "INET", "label": "Internet Business"},
+        "positionsAvailable": 1,
+        "postCode": "4073",
+        "salary": {"code": "SLAW", "label": "Award"},
+        "site": {"code": "NETV", "label": "Internet Vacancies"},
+        "state": "QLD",
+        "suburb": "SEVENTEEN MILE ROCKS",
+        "tenure": {"code": "N", "label": "Contract position"},
+        "title": "Vending Machine Assistant",
+        "vacancyId": 2348184871,
+        "workType": {"code": "C", "label": "Casual position"},
+    },
+}
+
+
+def _scraper() -> WorkforceAustraliaScraper:
+    return WorkforceAustraliaScraper("workforceaustralia")
+
+
+# --- _parse: full-time permanent role ---------------------------------------
+
+
+def test_parse_full_time_role_populates_identity_fields() -> None:
+    job = _scraper()._parse(SAMPLE_FULL_TIME)
+    assert job is not None
+    assert job.ats_type is ATSType.WORKFORCEAUSTRALIA
+    assert job.ats_id == "2348240495"
+    assert job.title == "Restaurant Manager"
+    assert job.company == "George Migration"
+    assert str(job.url) == (
+        "https://www.workforceaustralia.gov.au/individuals/jobs/details/2348240495"
+    )
+
+
+def test_parse_populates_country_and_language_for_australia() -> None:
+    job = _scraper()._parse(SAMPLE_FULL_TIME)
+    assert job is not None
+    assert job.country_iso == "AU"
+    assert job.language == "en"
+
+
+def test_parse_builds_location_from_suburb_state_postcode() -> None:
+    job = _scraper()._parse(SAMPLE_FULL_TIME)
+    assert job is not None
+    assert job.location == "Sandringham, VIC 3191"
+
+
+def test_parse_extracts_geocoordinates_as_floats() -> None:
+    job = _scraper()._parse(SAMPLE_FULL_TIME)
+    assert job is not None
+    assert job.lat is not None and job.lon is not None
+    assert -38.0 < job.lat < -37.9
+    assert 144.9 < job.lon < 145.1
+
+
+def test_parse_strips_html_and_truncates_description() -> None:
+    job = _scraper()._parse(SAMPLE_FULL_TIME)
+    assert job is not None
+    assert job.description is not None
+    # HTML tags stripped, entities unescaped, whitespace collapsed.
+    assert "<strong>" not in job.description
+    assert "&amp;" not in job.description
+    assert "Duties include shift management & ordering." in job.description
+
+
+def test_parse_maps_full_time_work_type_to_full_time() -> None:
+    job = _scraper()._parse(SAMPLE_FULL_TIME)
+    assert job is not None
+    assert job.employment_type == "FULL_TIME"
+
+
+def test_parse_salary_summary_and_currency() -> None:
+    job = _scraper()._parse(SAMPLE_FULL_TIME)
+    assert job is not None
+    assert job.salary_summary == "Above Award"
+    assert job.salary_currency == "AUD"
+
+
+def test_parse_department_and_team_from_industry_and_occupation() -> None:
+    job = _scraper()._parse(SAMPLE_FULL_TIME)
+    assert job is not None
+    assert job.department == "Hospitality"
+    assert job.team == "Cafe and Restaurant Managers"
+
+
+def test_parse_raw_overflow_includes_flags() -> None:
+    job = _scraper()._parse(SAMPLE_FULL_TIME)
+    assert job is not None
+    assert job.raw is not None
+    assert job.raw.get("site") == "Internet Vacancies"
+    assert job.raw.get("is_indigenous") is False
+    assert job.raw.get("is_external") is False
+    assert job.raw.get("positions_available") == 1
+    assert job.raw.get("how_to_apply") == "APTR"
+
+
+def test_parse_posted_at_parses_iso_datetime() -> None:
+    job = _scraper()._parse(SAMPLE_FULL_TIME)
+    assert job is not None
+    assert job.posted_at is not None
+    assert job.posted_at.year == 2026
+    assert job.posted_at.month == 4
+    assert job.posted_at.day == 13
+
+
+# --- _parse: casual + contract tenure ---------------------------------------
+
+
+def test_parse_casual_work_type_maps_to_temporary() -> None:
+    job = _scraper()._parse(SAMPLE_CASUAL_CONTRACT)
+    assert job is not None
+    assert job.employment_type == "TEMPORARY"
+
+
+def test_parse_casual_role_keeps_tenure_in_commitment() -> None:
+    """Even though workType drives the canonical enum, the raw tenure
+    label should still surface in ``commitment`` so consumers see the
+    contract-vs-permanent distinction without parsing prose."""
+    job = _scraper()._parse(SAMPLE_CASUAL_CONTRACT)
+    assert job is not None
+    # workType wins for employment_type; commitment falls back to the
+    # most specific available raw label.
+    assert job.commitment in {
+        "Contract position",
+        "Casual position",
+    }
+
+
+# --- _parse: defensive edge cases -------------------------------------------
+
+
+def test_parse_missing_vacancy_id_returns_none() -> None:
+    bad = {"result": {"title": "X", "employerName": "Y"}}
+    assert _scraper()._parse(bad) is None
+
+
+def test_parse_missing_title_returns_none() -> None:
+    bad = {"result": {"vacancyId": 123, "employerName": "Y"}}
+    assert _scraper()._parse(bad) is None
+
+
+def test_parse_falls_back_to_organisation_when_employer_missing() -> None:
+    item = {
+        "result": {
+            "vacancyId": 999,
+            "title": "Engineer",
+            "employerName": "",
+            "organisation": {"code": "GOV", "label": "Federal Government"},
+            "state": "ACT",
+        }
+    }
+    job = _scraper()._parse(item)
+    assert job is not None
+    assert job.company == "Federal Government"
+
+
+def test_parse_drops_zero_coordinates() -> None:
+    item = dict(SAMPLE_FULL_TIME)
+    item["result"] = {**SAMPLE_FULL_TIME["result"], "latitude": "0", "longitude": "0"}
+    job = _scraper()._parse(item)
+    assert job is not None
+    assert job.lat is None
+    assert job.lon is None
+
+
+def test_parse_envelope_without_result_returns_none() -> None:
+    assert _scraper()._parse({"score": 1.0}) is None
+    assert _scraper()._parse({"score": 1.0, "result": None}) is None
+
+
+# --- Pure helpers -----------------------------------------------------------
+
+
+def test_format_location_combines_components() -> None:
+    assert _format_location("SYDNEY", "NSW", "2000") == "Sydney, NSW 2000"
+
+
+def test_format_location_handles_missing_postcode() -> None:
+    assert _format_location("Sydney", "NSW", None) == "Sydney, NSW"
+
+
+def test_format_location_handles_blank_values() -> None:
+    assert _format_location("", "NSW", "") == "NSW"
+    assert _format_location(None, None, None) is None
+
+
+def test_map_employment_type_permanent_full_time() -> None:
+    assert (
+        _map_employment_type(
+            "Full time position", "Permanent position", None, None
+        )
+        == "FULL_TIME"
+    )
+
+
+def test_map_employment_type_falls_back_to_tenure_for_contract() -> None:
+    assert (
+        _map_employment_type(None, "Contract position", None, None)
+        == "CONTRACT"
+    )
+
+
+def test_map_employment_type_unknown_returns_none() -> None:
+    assert _map_employment_type(None, None, None, None) is None
+    assert (
+        _map_employment_type(
+            "Unrecognized label", "Mystery tenure", None, None
+        )
+        is None
+    )


### PR DESCRIPTION
## Summary
- Adds `WorkforceAustraliaScraper` against the public Workforce Australia REST API (`jobsearch.gov.au`) — Australia's federal-government national job board with **~173k live postings** today (verified `totalCount=172977` on 2026-05-12).
- Single-source / single-tenant scraper (like USAJOBS, EURES, Bundesagentur, Arbetsförmedlingen). `company_slug` is accepted for interface symmetry but ignored.
- Maps the JSON envelope to canonical `Job` rows with `country_iso="AU"`, `language="en"`, AUD-tagged free-text `salary_summary`, `posted_at` from `creationDate`, lat/lon from numeric strings, and an HTML-stripped/whitespace-collapsed description capped at 10kB.

## Endpoint
```
GET https://www.workforceaustralia.gov.au/api/v1/global/vacancies?size=100&page=N
```
- No auth / no key, plain JSON.
- 0-indexed pagination (verified `page=0` and `page=1` both 200).
- Stable integer `vacancyId` per result → used as `ats_id`.
- Posting URL: `https://www.workforceaustralia.gov.au/individuals/jobs/details/{vacancyId}` (verified 200).

Sample probe:
```
curl 'https://www.workforceaustralia.gov.au/api/v1/global/vacancies?size=1&page=0' \
  -H 'Accept: application/json' -H 'User-Agent: Mozilla/5.0'
```

## Pagination
- `PAGE_SIZE=100`, `MAX_CONCURRENCY=4`, retry 429 / 5xx with exponential backoff.
- Default `max_pages=100` → ~10,000 jobs per run; overridable via constructor.
- First page reads `totalCount` and bounds the parallel fan-out.

## Mapping highlights
- `workType.label` ("Full time" / "Part time" / "Casual position") → `FULL_TIME` / `PART_TIME` / `TEMPORARY`.
- `tenure.label` ("Permanent" / "Contract" / "Apprenticeship") used as fallback for `employment_type`.
- `industry.label` → `department`; `occupation.label` → `team` when distinct.
- Raw overflow keeps `site`, `is_indigenous`, `is_external`, `positions_available`, `how_to_apply`.

## Registry / schema
- New `ATSType.WORKFORCEAUSTRALIA = "workforceaustralia"` in the National public-sector job-board block.
- `tests/test_models.py` expected-set updated.
- `src/jobhive/scrapers/__init__.py` export + `__all__` entry.

## Test plan
- [x] `uv run --extra dev ruff check src/jobhive/scrapers/workforceaustralia.py tests/test_workforceaustralia.py` — passes.
- [x] `uv run --extra dev pytest tests/test_workforceaustralia.py tests/test_models.py -x` — 85 passed.
- [x] `uv run --extra dev pytest tests/test_manifest.py tests/test_scrapers.py tests/test_scrapers_extra.py -x` — 70 passed (registry pickup confirmed).
- [x] `ScraperRegistry.get(ATSType.WORKFORCEAUSTRALIA)` resolves to `WorkforceAustraliaScraper`.
- [ ] Live smoke run (post-merge, off-CI): `WorkforceAustraliaScraper("workforceaustralia", max_pages=2).fetch()` returns ~200 jobs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `WorkforceAustraliaScraper` to ingest Australia’s national job board via its public REST API and map listings to canonical `Job` records with AU-specific metadata. Registers `ATSType.WORKFORCEAUSTRALIA` and includes tests.

- **New Features**
  - New `WorkforceAustraliaScraper` using `https://www.workforceaustralia.gov.au/api/v1/global/vacancies` (no auth, JSON); uses `vacancyId` as `ats_id`.
  - Concurrent pagination (`size=100`, `max_pages` default 100) with retry/backoff; links jobs to `/individuals/jobs/details/{vacancyId}`.
  - Field mapping: `country_iso="AU"`, `language="en"`, employment type from `workType`/`tenure`, location from suburb/state/postcode + lat/lon, `salary_summary` with `AUD`, HTML-stripped description capped at 10KB.
  - Single-source scraper; `company_slug` accepted but ignored.
  - Registry updates and exports for `ATSType.WORKFORCEAUSTRALIA`; added seed CSV `ats-companies/workforceaustralia.csv`; tests validate parsing and model enum.

- **Migration**
  - No credentials or config changes required.
  - Optional smoke run: `WorkforceAustraliaScraper("workforceaustralia", max_pages=2).fetch()` to validate ~200 jobs.

<sup>Written for commit 1ba913fae7bb53574ee156dff207ebcfad1440f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `WorkforceAustraliaScraper`, a new single-source scraper for Australia's national government job board (~173k live postings), using the public unauthenticated REST API at `workforceaustralia.gov.au`. The implementation follows the established pattern used by USAJOBS, EURES, and Arbetsförmedlingen.

- **New scraper** (`workforceaustralia.py`): concurrent pagination with `asyncio` + `httpx`, semaphore-controlled concurrency (`MAX_CONCURRENCY=4`), exponential backoff for 429/5xx, and thorough field mapping including employment type inference from `workType`/`tenure`, HTML-stripped descriptions, and AUD-tagged salary summaries.
- **Registry/model updates**: `ATSType.WORKFORCEAUSTRALIA` added to `models.py`, exported from `scrapers/__init__.py`, and the existing `test_models.py` expected-set updated.
- **Tests** (`test_workforceaustralia.py`): 299-line unit test file using real captured API fixtures with no live HTTP, covering parsing, helper functions, and edge cases.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the scraper is well-structured and follows the existing codebase patterns closely. One minor concurrency issue in the retry path is worth fixing but does not affect correctness.

The implementation is clean and consistent with the other single-source scrapers. The only notable issue is that the retry sleep for httpx.HTTPError cases happens inside the async with sem: block, holding a concurrency slot idle for 1.5–4.5 seconds during network error recovery. The 429/5xx retry path correctly places the sleep outside the semaphore, so the inconsistency is clear. This slows down large fetches when connection errors occur but does not produce wrong data or cause failures.

The retry logic in _fetch_page (lines 163–172 of workforceaustralia.py) deserves a second look to move the httpx.HTTPError sleep outside the semaphore block.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/workforceaustralia.py | New single-source scraper for Australia's national job board; well-structured with concurrent pagination, retry/backoff, and thorough field mapping. One concurrency issue: the retry sleep for httpx.HTTPError holds the semaphore, reducing effective concurrency during error recovery. |
| tests/test_workforceaustralia.py | Comprehensive unit tests covering parsing, field mapping, edge cases, and helper functions using real captured API fixtures; no live HTTP. |
| src/jobhive/models.py | Adds ATSType.WORKFORCEAUSTRALIA to the national public-sector job board block; minimal, correct change. |
| src/jobhive/scrapers/__init__.py | Adds import and __all__ entry for WorkforceAustraliaScraper; follows established pattern. |
| tests/test_models.py | Updates expected-set in test_ats_type_includes_every_supported_platform to include "workforceaustralia". |
| ats-companies/workforceaustralia.csv | New seed CSV with single row for the Workforce Australia source; correct format. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/jobhive/scrapers/workforceaustralia.py:163-172
**Retry sleep holds the semaphore slot**

The `await asyncio.sleep(RETRY_BASE_DELAY * attempt)` call is inside the `async with sem:` block — the semaphore isn't released until the sleep finishes and `continue` unwinds the context manager. During a network error retry (delay of 1.5–4.5 s), that slot is pinned, so only `MAX_CONCURRENCY - 1` other pages can be fetched concurrently. The 429/5xx path correctly sleeps *outside* the semaphore; the `httpx.HTTPError` path should do the same — capture the exception, exit the `sem` block, and sleep before looping.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: workforceaus..."](https://github.com/kalil0321/ats-scrapers/commit/1ba913fae7bb53574ee156dff207ebcfad1440f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732387)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->