### PR TITLE
Add Wantedly Japan scraper

### DIFF
--- a/ats-companies/wantedly.csv
+++ b/ats-companies/wantedly.csv
@@ -1,0 +1,2 @@
+name,slug,url
+Wantedly,wantedly,https://www.wantedly.com

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -80,6 +80,7 @@ class ATSType(StrEnum):
     THEHUB = "thehub"
     YCOMBINATOR = "ycombinator"
     WELLFOUND = "wellfound"
+    WANTEDLY = "wantedly"
     # Additional multi-tenant ATSes (post-0.1)
     BAMBOOHR = "bamboohr"
     BREEZY = "breezy"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -52,6 +52,7 @@ from jobhive.scrapers.tiktok import TikTokScraper
 from jobhive.scrapers.uber import UberScraper
 from jobhive.scrapers.usajobs import USAJobsScraper
 from jobhive.scrapers.wanted import WantedScraper
+from jobhive.scrapers.wantedly import WantedlyScraper
 from jobhive.scrapers.welcometothejungle import WTTJScraper
 from jobhive.scrapers.wellfound import WellfoundScraper
 from jobhive.scrapers.weworkremotely import WeWorkRemotelyScraper
@@ -105,6 +106,7 @@ __all__ = [
     "UberScraper",
     "WTTJScraper",
     "WantedScraper",
+    "WantedlyScraper",
     "WeWorkRemotelyScraper",
     "WellfoundScraper",
     "WorkableScraper",

--- a/src/jobhive/scrapers/wantedly.py
+++ b/src/jobhive/scrapers/wantedly.py
@@ -1,0 +1,363 @@
+"""Wantedly (https://www.wantedly.com) — Japan-focused direct-employer scraper.
+
+Wantedly is the largest direct-posting startup / tech job platform in
+Japan with ~158k live ``projects`` (their term for job postings). Companies
+post directly through Wantedly's recruiting product — it is not an
+aggregator of LinkedIn / Indeed feeds.
+
+Public JSON API at ``https://www.wantedly.com/api/v1/projects`` — no auth,
+no key. The endpoint requires ``X-Requested-With: XMLHttpRequest`` to
+return JSON; without it Wantedly serves the HTML SSR page instead. The
+``_metadata`` block on the first page exposes ``total_objects`` and
+``total_pages`` for stable termination.
+
+Pagination is page-numbered (one-indexed) via ``page=N&per_page=10``. The
+API hard-caps ``per_page`` at 10 — any larger value is silently rejected
+and 10 items are returned. We cap the default crawl at 500 pages
+(~5k jobs) so ad-hoc runs stay bounded; pass ``max_pages`` to lift the
+cap and walk the whole dataset.
+
+Single-source scraper: ``company_slug`` is informational and ignored
+(matches the usajobs / mycareersfuture / wanted pattern). Output rows
+carry the publishing employer's name as ``company`` so the publisher's
+cross-ATS dedup still works.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+API_URL = "https://www.wantedly.com/api/v1/projects"
+PROJECT_URL_TEMPLATE = "https://www.wantedly.com/projects/{id}"
+PAGE_SIZE = 10  # API hard-caps at 10; larger values are silently clamped.
+DEFAULT_MAX_PAGES = 500  # ~5k jobs by default; bump via ``max_pages``.
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 4
+RETRY_BASE_DELAY = 1.5
+MAX_DESCRIPTION_LEN = 10_000
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_WHITESPACE_RE = re.compile(r"\s+")
+
+# CJK Unified Ideographs + Hiragana + Katakana + Halfwidth Katakana ranges.
+# Used as a quick "is this a Japanese listing?" heuristic on the title.
+_CJK_RE = re.compile(
+    r"[　-〿"   # CJK symbols & punctuation
+    r"぀-ゟ"    # Hiragana
+    r"゠-ヿ"    # Katakana
+    r"㐀-䶿"    # CJK Unified Ideographs Ext A
+    r"一-鿿"    # CJK Unified Ideographs
+    r"ｦ-ﾟ"    # Halfwidth Katakana
+    r"]"
+)
+
+# Standalone tokens in ``location`` that signal the role is clearly
+# outside Japan. The default ``country_iso`` is ``"JP"`` — when any of
+# these match (case-insensitive whole token), we drop back to ``None``
+# so downstream enrichment can resolve the actual country. Mixed bag of
+# ISO-3166 alpha-2 / alpha-3 codes and common English country / city
+# names that show up on Wantedly's growing global postings.
+_NON_JP_HINTS = frozenset({
+    # Country codes
+    "US", "USA", "UK", "GB", "FR", "DE", "ES", "IT", "PT", "NL", "BE",
+    "CH", "AT", "SE", "NO", "DK", "FI", "PL", "CZ", "GR", "IE",
+    "CA", "MX", "BR", "AR", "CL", "CO", "PE",
+    "CN", "HK", "TW", "KR", "SG", "MY", "TH", "VN", "PH", "ID", "IN",
+    "AU", "NZ", "ZA", "AE", "SA", "IL", "TR",
+    # Common country names (English).
+    "SINGAPORE", "TAIWAN", "KOREA", "CHINA", "HONG", "KONG", "VIETNAM",
+    "THAILAND", "MALAYSIA", "INDONESIA", "PHILIPPINES", "INDIA",
+    "AUSTRALIA", "CANADA", "MEXICO", "BRAZIL", "FRANCE", "GERMANY",
+    "SPAIN", "ITALY", "PORTUGAL", "NETHERLANDS", "BELGIUM", "SWITZERLAND",
+    "AUSTRIA", "SWEDEN", "NORWAY", "DENMARK", "FINLAND", "POLAND",
+    "IRELAND", "GREECE", "TURKEY", "ISRAEL",
+})
+
+
+@ScraperRegistry.register(ATSType.WANTEDLY)
+class WantedlyScraper(BaseScraper):
+    """Wantedly (wantedly.com) — Japan-focused direct-employer postings.
+
+    Single-source scraper: ``company_slug`` is ignored. Pass anything
+    (``"any"``, ``""``) — the scraper enumerates the full ``/projects``
+    feed across all employers.
+
+    Default crawl stops at ``max_pages`` pages (500 = 5,000 jobs). Pass
+    a larger value (or ``None``) to walk the entire dataset.
+    """
+
+    ats = ATSType.WANTEDLY
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        max_pages: int | None = DEFAULT_MAX_PAGES,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.max_pages = max_pages
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        lock = asyncio.Lock()
+
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+
+            # First page is fetched serially so we can read ``total_pages``
+            # from ``_metadata`` and plan the rest of the walk.
+            first = await self._fetch_page(client, sem, page=1)
+            await self._absorb(first.get("data") or [], seen, jobs, lock)
+
+            total_pages = self._total_pages(first)
+            if self.max_pages is not None:
+                total_pages = min(total_pages, self.max_pages)
+            if total_pages <= 1:
+                return jobs
+
+            async def worker(page: int) -> None:
+                payload = await self._fetch_page(client, sem, page=page)
+                await self._absorb(payload.get("data") or [], seen, jobs, lock)
+
+            await asyncio.gather(*(worker(p) for p in range(2, total_pages + 1)))
+
+        return jobs
+
+    @staticmethod
+    def _total_pages(payload: dict[str, Any]) -> int:
+        meta = payload.get("_metadata") or {}
+        if not isinstance(meta, dict):
+            return 1
+        total = meta.get("total_pages")
+        if isinstance(total, int) and total > 0:
+            return total
+        # Fallback: derive from total_objects when total_pages is absent.
+        total_objects = meta.get("total_objects")
+        if isinstance(total_objects, int) and total_objects > 0:
+            return (total_objects + PAGE_SIZE - 1) // PAGE_SIZE
+        return 1
+
+    async def _absorb(
+        self,
+        items: list[dict[str, Any]],
+        seen: set[str],
+        jobs: list[Job],
+        lock: asyncio.Lock,
+    ) -> None:
+        async with lock:
+            for item in items:
+                job = self._parse_job(item)
+                if job is None or job.ats_id in seen:
+                    continue
+                seen.add(job.ats_id)
+                jobs.append(job)
+
+    # --- HTTP layer ---------------------------------------------------------
+
+    async def _fetch_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        *,
+        page: int,
+    ) -> dict[str, Any]:
+        headers = {
+            "Accept": "application/json",
+            # Required — without this header Wantedly returns the HTML SSR
+            # page (200 OK) instead of the JSON document.
+            "X-Requested-With": "XMLHttpRequest",
+            "User-Agent": "Mozilla/5.0",
+        }
+        params = {
+            "per_page": PAGE_SIZE,
+            "page": page,
+            "hiring": "true",
+            "order": "published_at",
+        }
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(API_URL, params=params, headers=headers)
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"Wantedly fetch failed at page={page}: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                try:
+                    return response.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"Wantedly returned non-JSON at page={page}: {exc}"
+                    ) from exc
+            if response.status_code == 404:
+                # Past the end of the dataset — treat as empty slice.
+                return {"data": [], "_metadata": {}}
+            if response.status_code == 429 or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Wantedly returned {response.status_code} at "
+                        f"page={page} after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"Wantedly returned {response.status_code} at page={page}"
+            )
+        raise ScraperError(
+            f"Wantedly exhausted retries at page={page}: {last_exc}"
+        )
+
+    # --- parsing ------------------------------------------------------------
+
+    def _parse_job(self, project: dict[str, Any]) -> Job | None:
+        raw_id = project.get("id")
+        if raw_id is None:
+            return None
+        ats_id = str(raw_id).strip()
+        title = (project.get("title") or "").strip()
+        if not ats_id or not title:
+            return None
+
+        company_obj = project.get("company") or {}
+        if not isinstance(company_obj, dict):
+            company_obj = {}
+        company_name = (company_obj.get("name") or "").strip() or "Unknown"
+        # Wantedly's company object historically exposed ``slug``; the
+        # current v1 listing serializer ships ``id`` instead. Try both
+        # so a future schema bump that re-adds ``slug`` lands gracefully.
+        company_slug = company_obj.get("slug")
+        if not isinstance(company_slug, str) or not company_slug:
+            company_slug = None
+
+        location = _format_location(
+            project.get("location"), project.get("location_suffix")
+        )
+        country_iso = _infer_country_iso(location)
+        language = "ja" if _CJK_RE.search(title) else "en"
+
+        # Wantedly splits the body across ``description`` (overview) and
+        # ``looking_for`` (the "who we want" pitch). Concatenate so downstream
+        # text-mining sees one document.
+        description = _build_description(
+            project.get("description"), project.get("looking_for")
+        )
+
+        tags = project.get("tags") or []
+        tag_names: list[str] = []
+        if isinstance(tags, list):
+            for tag in tags:
+                if isinstance(tag, dict):
+                    name = tag.get("name")
+                    if isinstance(name, str) and name.strip():
+                        tag_names.append(name.strip())
+        department = tag_names[0] if tag_names else None
+
+        raw: dict[str, Any] = {
+            "company_slug": company_slug,
+            "tags": tag_names[:10],
+            "support_count": project.get("support_count"),
+            "page_view": project.get("page_view"),
+            "candidate_count": project.get("candidate_count"),
+        }
+
+        return Job(
+            url=PROJECT_URL_TEMPLATE.format(id=ats_id),
+            title=title,
+            company=company_name,
+            ats_type=ATSType.WANTEDLY,
+            ats_id=ats_id,
+            location=location,
+            country_iso=country_iso,
+            description=description,
+            department=department,
+            language=language,
+            posted_at=_parse_iso(project.get("published_at")),
+            fetched_at=datetime.now(),
+            raw=raw,
+        )
+
+
+def _format_location(location: object, suffix: object) -> str | None:
+    primary = location.strip() if isinstance(location, str) else ""
+    secondary = suffix.strip() if isinstance(suffix, str) else ""
+    if primary and secondary:
+        return f"{primary}, {secondary}"
+    return primary or secondary or None
+
+
+def _infer_country_iso(location: str | None) -> str | None:
+    """Default to ``JP`` — Wantedly is overwhelmingly Japanese — unless
+    ``location`` carries an obvious non-Japanese country hint.
+
+    Cheap and intentionally conservative: any CJK character anywhere in
+    the string keeps the JP default; otherwise we look for a standalone
+    non-JP country/region token (``"US"``, ``"Singapore"``, …) and bail
+    to ``None`` so downstream enrichment can resolve the actual country.
+    """
+    if not location:
+        return "JP"
+    if _CJK_RE.search(location):
+        return "JP"
+    # Tokenize on non-alphanumerics and check each token.
+    tokens = {t.upper() for t in re.findall(r"[A-Za-z]+", location)}
+    if tokens & _NON_JP_HINTS:
+        return None
+    return "JP"
+
+
+def _build_description(description: object, looking_for: object) -> str | None:
+    parts: list[str] = []
+    for piece in (description, looking_for):
+        text = _html_to_text(piece)
+        if text:
+            parts.append(text)
+    if not parts:
+        return None
+    joined = "\n\n".join(parts)
+    return joined[:MAX_DESCRIPTION_LEN]
+
+
+def _html_to_text(value: object) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    text = _HTML_TAG_RE.sub(" ", value)
+    text = _WHITESPACE_RE.sub(" ", text).strip()
+    return text or None
+
+
+def _parse_iso(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None

--- a/src/jobhive/scrapers/wantedly.py
+++ b/src/jobhive/scrapers/wantedly.py
@@ -70,11 +70,14 @@ _CJK_RE = re.compile(
 # ISO-3166 alpha-2 / alpha-3 codes and common English country / city
 # names that show up on Wantedly's growing global postings.
 _NON_JP_HINTS = frozenset({
-    # Country codes
-    "US", "USA", "UK", "GB", "FR", "DE", "ES", "IT", "PT", "NL", "BE",
-    "CH", "AT", "SE", "NO", "DK", "FI", "PL", "CZ", "GR", "IE",
-    "CA", "MX", "BR", "AR", "CL", "CO", "PE",
-    "CN", "HK", "TW", "KR", "SG", "MY", "TH", "VN", "PH", "ID", "IN",
+    # Country codes. Ambiguous 2-letter ISO codes that collide with common
+    # English words (AT, IN, IT, NO, CO, ID, PE) are intentionally omitted —
+    # they would wrongly null the country on valid JP postings; their full
+    # country names below still cover the unambiguous cases.
+    "US", "USA", "UK", "GB", "FR", "DE", "ES", "PT", "NL", "BE",
+    "CH", "SE", "DK", "FI", "PL", "CZ", "GR", "IE",
+    "CA", "MX", "BR", "AR", "CL",
+    "CN", "HK", "TW", "KR", "SG", "MY", "TH", "VN", "PH",
     "AU", "NZ", "ZA", "AE", "SA", "IL", "TR",
     # Common country names (English).
     "SINGAPORE", "TAIWAN", "KOREA", "CHINA", "HONG", "KONG", "VIETNAM",
@@ -214,6 +217,14 @@ class WantedlyScraper(BaseScraper):
                         f"Wantedly returned non-JSON at page={page}: {exc}"
                     ) from exc
             if response.status_code == 404:
+                # A 404 on the very first page is not "past the end" — it
+                # signals a geo-block or a changed API path. Raise so the
+                # run fails loudly instead of returning a silent empty slice.
+                if page == 1:
+                    raise ScraperError(
+                        f"Wantedly returned 404 at page=1 "
+                        f"(geo-block or API path change?)"
+                    )
                 # Past the end of the dataset — treat as empty slice.
                 return {"data": [], "_metadata": {}}
             if response.status_code == 429 or 500 <= response.status_code < 600:

--- a/src/jobhive/scrapers/wantedly.py
+++ b/src/jobhive/scrapers/wantedly.py
@@ -222,8 +222,8 @@ class WantedlyScraper(BaseScraper):
                 # run fails loudly instead of returning a silent empty slice.
                 if page == 1:
                     raise ScraperError(
-                        f"Wantedly returned 404 at page=1 "
-                        f"(geo-block or API path change?)"
+                        "Wantedly returned 404 at page=1 "
+                        "(geo-block or API path change?)"
                     )
                 # Past the end of the dataset — treat as empty slice.
                 return {"data": [], "_metadata": {}}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,7 +29,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
-        "manfred", "thehub", "ycombinator", "wellfound",
+        "manfred", "thehub", "ycombinator", "wellfound", "wantedly",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",
         "recruitee", "taleo", "teamtailor",

--- a/tests/test_wantedly.py
+++ b/tests/test_wantedly.py
@@ -1,0 +1,403 @@
+"""Tests for the Wantedly (Japan) scraper.
+
+Pin the parsing contract (each Wantedly project field → Job field) and
+the page-numbered pagination behaviour. ``_metadata.total_pages`` drives
+termination — the suite mirrors that.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import ScraperRegistry, WantedlyScraper
+
+_API_RE = re.compile(r"^https://www\.wantedly\.com/api/v1/projects")
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.wantedly as w
+    monkeypatch.setattr(w, "MAX_RETRIES", 1)
+    monkeypatch.setattr(w, "RETRY_BASE_DELAY", 0.0)
+
+
+def _project(
+    *,
+    project_id: int = 2261400,
+    title: str = "スタートアップでの開発に興味のあるフルスタックエンジニア募集！",
+    company_name: str = "Acme",
+    company_slug: str | None = "acme",
+    location: str | None = "東京都中央区日本橋茅場町１−８−１",
+    location_suffix: str | None = "茅場町一丁目平和ビル７階",
+    description: str = "▍募集背景 教育体制は完全内製化しており",
+    looking_for: str = "勤務地条件なし｜フルリモート",
+    published_at: str = "2026-05-08T17:16:29.611+09:00",
+    tags: list[dict[str, Any]] | None = None,
+    support_count: int = 42,
+    page_view: int = 1234,
+    candidate_count: int = 5,
+) -> dict[str, Any]:
+    company: dict[str, Any] = {"id": 999, "name": company_name}
+    if company_slug is not None:
+        company["slug"] = company_slug
+    return {
+        "id": project_id,
+        "title": title,
+        "published_at": published_at,
+        "support_count": support_count,
+        "page_view": page_view,
+        "candidate_count": candidate_count,
+        "location": location,
+        "location_suffix": location_suffix,
+        "description": description,
+        "looking_for": looking_for,
+        "company": company,
+        "tags": tags if tags is not None else [{"id": 1, "name": "Python"}],
+    }
+
+
+def _page(
+    items: list[dict[str, Any]],
+    *,
+    page: int = 1,
+    total_objects: int = 1,
+    total_pages: int = 1,
+) -> dict[str, Any]:
+    return {
+        "data": items,
+        "_metadata": {
+            "total_objects": total_objects,
+            "per_page": 10,
+            "current_page": page,
+            "total_pages": total_pages,
+        },
+    }
+
+
+# --- registry / wiring ------------------------------------------------------
+
+
+def test_registry_resolves_wantedly() -> None:
+    assert ScraperRegistry.get(ATSType.WANTEDLY) is WantedlyScraper
+
+
+# --- happy path -------------------------------------------------------------
+
+
+def test_parses_full_project_payload(httpx_mock) -> None:
+    """Single-page scrape with a Japanese-language project; verify every
+    populated Job field maps to the right Wantedly field."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page([_project()]),
+    )
+
+    jobs = WantedlyScraper("any").fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.WANTEDLY
+    assert j.ats_id == "2261400"
+    assert j.title.startswith("スタートアップ")
+    assert j.company == "Acme"
+    assert str(j.url) == "https://www.wantedly.com/projects/2261400"
+    # Location combines location + location_suffix with a comma.
+    assert j.location is not None
+    assert "東京都中央区" in j.location
+    assert "茅場町一丁目平和ビル" in j.location
+    assert ", " in j.location
+    # Japanese title → country_iso=JP, language=ja.
+    assert j.country_iso == "JP"
+    assert j.language == "ja"
+    # Description concatenates description + looking_for.
+    assert j.description is not None
+    assert "募集背景" in j.description
+    assert "勤務地条件なし" in j.description
+    # First tag becomes department; full tag list lives in raw.
+    assert j.department == "Python"
+    assert j.raw is not None
+    assert j.raw["tags"] == ["Python"]
+    assert j.raw["company_slug"] == "acme"
+    assert j.raw["support_count"] == 42
+    assert j.raw["page_view"] == 1234
+    assert j.raw["candidate_count"] == 5
+    # ISO datetime with +09:00 offset parses.
+    assert j.posted_at is not None
+    assert j.posted_at.year == 2026
+    assert j.posted_at.month == 5
+    assert j.fetched_at is not None
+
+
+# --- language / country heuristics ------------------------------------------
+
+
+def test_english_title_yields_language_en(httpx_mock) -> None:
+    """Some JP-based listings use an English title — language=en, but
+    location still JP-shaped so country_iso stays JP."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page([
+            _project(
+                project_id=1,
+                title="Software Engineer @ AcmeCorp",
+                location="東京",
+                location_suffix=None,
+            )
+        ]),
+    )
+    jobs = WantedlyScraper("any").fetch()
+    assert jobs[0].language == "en"
+    assert jobs[0].country_iso == "JP"
+
+
+def test_non_jp_location_strips_country_iso(httpx_mock) -> None:
+    """A Wantedly listing pointing at Singapore should leave country_iso
+    as None so downstream enrichment can resolve the actual country."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page([
+            _project(
+                project_id=2,
+                title="Engineering Manager",
+                location="Singapore",
+                location_suffix=None,
+            )
+        ]),
+    )
+    jobs = WantedlyScraper("any").fetch()
+    assert jobs[0].country_iso is None
+    assert jobs[0].language == "en"
+
+
+def test_us_country_code_strips_country_iso(httpx_mock) -> None:
+    """ISO alpha-2 ``US`` as a standalone token strips country_iso back
+    to None."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page([
+            _project(
+                project_id=3,
+                title="Backend Engineer",
+                location="San Francisco, US",
+                location_suffix=None,
+            )
+        ]),
+    )
+    jobs = WantedlyScraper("any").fetch()
+    assert jobs[0].country_iso is None
+
+
+def test_no_location_defaults_to_jp(httpx_mock) -> None:
+    """Empty location is the common case for fully-remote JP postings.
+    Default country_iso=JP — Wantedly is overwhelmingly Japanese."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page([
+            _project(
+                project_id=4,
+                title="Remote Job",
+                location=None,
+                location_suffix=None,
+            )
+        ]),
+    )
+    jobs = WantedlyScraper("any").fetch()
+    assert jobs[0].country_iso == "JP"
+    assert jobs[0].location is None
+
+
+# --- description ------------------------------------------------------------
+
+
+def test_strips_html_from_description(httpx_mock) -> None:
+    """``description`` may contain HTML — must be stripped to plain text."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page([
+            _project(
+                project_id=5,
+                description="<p>Hello <b>world</b></p>",
+                looking_for="<br>looking for <i>engineers</i>",
+            )
+        ]),
+    )
+    jobs = WantedlyScraper("any").fetch()
+    desc = jobs[0].description
+    assert desc is not None
+    assert "<" not in desc and ">" not in desc
+    assert "Hello world" in desc
+    assert "looking for engineers" in desc
+
+
+def test_description_truncated_to_10k(httpx_mock) -> None:
+    long_body = "x" * 20_000
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page([
+            _project(project_id=6, description=long_body, looking_for="")
+        ]),
+    )
+    jobs = WantedlyScraper("any").fetch()
+    assert jobs[0].description is not None
+    assert len(jobs[0].description) <= 10_000
+
+
+# --- pagination -------------------------------------------------------------
+
+
+def test_paginates_via_total_pages(httpx_mock) -> None:
+    """First page exposes ``_metadata.total_pages``; the worker walks
+    pages 2..N concurrently and merges."""
+    httpx_mock.add_response(
+        url=re.compile(r".*page=1(&|$).*"),
+        json=_page(
+            [_project(project_id=1, title="Job 1")],
+            page=1,
+            total_objects=3,
+            total_pages=3,
+        ),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r".*page=2(&|$).*"),
+        json=_page(
+            [_project(project_id=2, title="Job 2")],
+            page=2,
+            total_objects=3,
+            total_pages=3,
+        ),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r".*page=3(&|$).*"),
+        json=_page(
+            [_project(project_id=3, title="Job 3")],
+            page=3,
+            total_objects=3,
+            total_pages=3,
+        ),
+    )
+
+    jobs = WantedlyScraper("any").fetch()
+    assert {j.ats_id for j in jobs} == {"1", "2", "3"}
+
+
+def test_max_pages_caps_walk(httpx_mock) -> None:
+    """When ``_metadata.total_pages`` exceeds ``max_pages``, the walk
+    stops at the cap."""
+    httpx_mock.add_response(
+        url=re.compile(r".*page=1(&|$).*"),
+        json=_page(
+            [_project(project_id=1, title="Job 1")],
+            page=1,
+            total_objects=1000,
+            total_pages=100,
+        ),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r".*page=2(&|$).*"),
+        json=_page(
+            [_project(project_id=2, title="Job 2")],
+            page=2,
+            total_objects=1000,
+            total_pages=100,
+        ),
+    )
+
+    jobs = WantedlyScraper("any", max_pages=2).fetch()
+    assert {j.ats_id for j in jobs} == {"1", "2"}
+
+
+def test_dedupes_repeated_ids_across_pages(httpx_mock) -> None:
+    """If two pages echo the same project id, dedupe on ats_id."""
+    httpx_mock.add_response(
+        url=re.compile(r".*page=1(&|$).*"),
+        json=_page(
+            [_project(project_id=1), _project(project_id=2)],
+            page=1,
+            total_objects=3,
+            total_pages=2,
+        ),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r".*page=2(&|$).*"),
+        json=_page(
+            [_project(project_id=2), _project(project_id=3)],
+            page=2,
+            total_objects=3,
+            total_pages=2,
+        ),
+    )
+    jobs = WantedlyScraper("any").fetch()
+    assert {j.ats_id for j in jobs} == {"1", "2", "3"}
+
+
+# --- field handling ---------------------------------------------------------
+
+
+def test_skips_projects_missing_id_or_title(httpx_mock) -> None:
+    """Defensive: drop malformed entries rather than emitting broken rows."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page([
+            _project(project_id=1, title="Good"),
+            {"id": 2, "company": {"name": "Acme"}},  # no title
+            {"title": "No id", "company": {"name": "Acme"}},
+        ]),
+    )
+    jobs = WantedlyScraper("any").fetch()
+    assert [j.ats_id for j in jobs] == ["1"]
+
+
+def test_handles_missing_company_slug(httpx_mock) -> None:
+    """The current API serializer ships ``company.id`` but not ``slug``.
+    Scraper must not crash — raw.company_slug just goes to None."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page([_project(project_id=7, company_slug=None)]),
+    )
+    jobs = WantedlyScraper("any").fetch()
+    assert jobs[0].raw is not None
+    assert jobs[0].raw["company_slug"] is None
+
+
+def test_empty_tags_yields_no_department(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page([_project(project_id=8, tags=[])]),
+    )
+    jobs = WantedlyScraper("any").fetch()
+    assert jobs[0].department is None
+    assert jobs[0].raw is not None
+    assert jobs[0].raw["tags"] == []
+
+
+# --- error handling ---------------------------------------------------------
+
+
+def test_persistent_500_raises(httpx_mock) -> None:
+    """Real server failures should surface, not silently emit []."""
+    httpx_mock.add_response(url=_API_RE, status_code=500, is_reusable=True)
+    with pytest.raises(ScraperError):
+        WantedlyScraper("any").fetch()
+
+
+def test_404_on_overflow_page_returns_empty_slice(httpx_mock) -> None:
+    """Wantedly may 404 past the end of the dataset — treat as empty."""
+    httpx_mock.add_response(
+        url=re.compile(r".*page=1(&|$).*"),
+        json=_page(
+            [_project(project_id=1, title="Job 1")],
+            page=1,
+            total_objects=2,
+            total_pages=2,
+        ),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r".*page=2(&|$).*"),
+        status_code=404,
+    )
+    jobs = WantedlyScraper("any").fetch()
+    assert [j.ats_id for j in jobs] == ["1"]


### PR DESCRIPTION
## Summary

- New scraper for **Wantedly** (https://www.wantedly.com), the largest direct-employer startup / tech job platform in Japan. Verified ~**157,613 live ``projects``** today via the public no-auth JSON API.
- Endpoint: ``GET https://www.wantedly.com/api/v1/projects?per_page=10&page=N&hiring=true&order=published_at``. Header ``X-Requested-With: XMLHttpRequest`` is **required** — without it Wantedly serves the HTML SSR page instead of JSON.
- Page-numbered (one-indexed) pagination driven by ``_metadata.total_pages``. ``per_page`` is hard-capped at 10 server-side regardless of the requested value, so the scraper uses 10 with ``concurrency=4`` + retry/backoff to keep throughput sane. Default crawl is capped at 500 pages (~5k jobs); pass ``max_pages=None`` to walk the full ~158k-row dataset.
- Hybrid jobboard slot in ``ATSType`` (direct employer postings, not aggregated). Single-source/multi-tenant pattern — ``company_slug`` is informational, matches ``usajobs`` / ``wanted``.

## Verified curl

```
curl 'https://www.wantedly.com/api/v1/projects?per_page=10&page=1&hiring=true&order=published_at' \
  -H 'Accept: application/json' \
  -H 'X-Requested-With: XMLHttpRequest' \
  -H 'User-Agent: Mozilla/5.0'
```

## Field mapping highlights

- ``url`` → ``https://www.wantedly.com/projects/{id}`` (verified 200 for live IDs).
- ``location`` → ``location`` + ``location_suffix`` joined with ``", "``.
- ``country_iso`` → default ``"JP"``; stripped to ``None`` when the location carries an obvious non-JP token (ISO alpha-2 country code or common English country name).
- ``language`` → ``"ja"`` when the title contains any CJK / Hiragana / Katakana character, otherwise ``"en"``. Many JP listings use English titles, so we infer per-row rather than hard-coding ``ja``.
- ``description`` → ``description`` + ``looking_for`` concatenated, HTML stripped, truncated 10 kB.
- ``department`` → first tag's name when ``tags`` is non-empty.
- ``raw`` → ``company_slug`` + top-10 tag names + ``support_count`` / ``page_view`` / ``candidate_count``.

## Test plan

- [x] ``ruff check src/jobhive/scrapers/wantedly.py tests/test_wantedly.py`` passes
- [x] ``pytest tests/test_wantedly.py tests/test_models.py -x`` — 78 tests pass (16 new + existing models suite)
- [x] Manual API probe — ``_metadata.total_objects = 157,613`` confirmed; ``per_page`` capped at 10 server-side
- [x] Manual URL probe — ``https://www.wantedly.com/projects/{id}`` returns 200 for a live ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Wantedly Japan scraper that pulls direct-employer postings from Wantedly’s public JSON API, registers it as `ATSType.WANTEDLY`, and seeds `ats-companies/wantedly.csv`.

- **New Features**
  - New `WantedlyScraper` using `GET https://www.wantedly.com/api/v1/projects` with `X-Requested-With: XMLHttpRequest`; page-indexed (`per_page=10`), `concurrency=4`, retries/backoff; default `max_pages=500` (use `None` for full crawl).
  - Field mapping: URL from `id`; location join; `country_iso` defaults to JP with non‑JP hints fallback; language from title (CJK→`ja`, else `en`); description = `description` + `looking_for` (HTML stripped, 10k cap); department from first tag; extra stats in `raw`.
  - Wiring and data: registered `ATSType.WANTEDLY`, exported in `scrapers`, and added `ats-companies/wantedly.csv`; tests cover parsing, pagination, heuristics, and errors.

- **Bug Fixes**
  - `404` on `page=1` now raises a clear error; overflow pages return empty.
  - Removed ambiguous two‑letter non‑JP hints (e.g., `AT`, `IN`, `IT`, `NO`, `CO`, `ID`, `PE`) to avoid false `country_iso=None` on JP listings.
  - Ruff lint warnings fixed.

<sup>Written for commit d26fd92b5fa5c4e223469c237b6dc02129e29769. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new `WantedlyScraper` for [Wantedly](https://www.wantedly.com), Japan's largest direct-employer startup job platform, using its public no-auth paginated JSON API. It follows the established single-source scraper pattern and includes thorough tests.

- **New scraper** (`src/jobhive/scrapers/wantedly.py`): async page-numbered pagination via `_metadata.total_pages`, `concurrency=4` with retry/backoff, field mapping for location, country/language inference, and HTML-stripped description concatenation.
- **Wiring**: `ATSType.WANTEDLY` added to the enum, scraper exported from `scrapers/__init__.py`, and a seed CSV added.
- **Tests** (`tests/test_wantedly.py`): 16 new tests covering happy path, pagination, dedup, heuristics, and error handling.

<h3>Confidence Score: 3/5</h3>

Safe to merge after fixing the semaphore-during-sleep issue; leaving it means connection-error retries stall all concurrent workers.

The retry sleep inside the semaphore block means that on connection errors, the affected worker holds its concurrency slot dormant for the full backoff window. With MAX_CONCURRENCY=4, four simultaneous errors park all slots and make the crawl effectively single-threaded. The country-inference false-positive risk is lower impact but can produce incorrect country_iso=None on JP listings.

src/jobhive/scrapers/wantedly.py — specifically the _fetch_page retry loop and the _NON_JP_HINTS token set.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/wantedly.py | New Wantedly scraper; retry sleep inside semaphore block reduces effective concurrency on connection errors; _NON_JP_HINTS short tokens can cause false-positive country_iso=None for JP listings with all-ASCII locations. |
| tests/test_wantedly.py | New test file; covers happy path, pagination, dedup, field edge cases, language/country heuristics, HTML stripping, and error handling; well-structured with good fixture isolation. |
| src/jobhive/models.py | Adds ATSType.WANTEDLY = 'wantedly' in the correct alphabetical/category position. |
| src/jobhive/scrapers/__init__.py | Wires WantedlyScraper import and __all__ entry; follows the established alphabetical ordering. |
| ats-companies/wantedly.csv | Seed CSV with a single platform entry; format matches the rest of the ats-companies directory. |
| tests/test_models.py | Adds 'wantedly' to the completeness assertion list; no issues. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/jobhive/scrapers/wantedly.py:197-208
**Semaphore held during retry sleep on network error**

The `await asyncio.sleep(...)` on line 207 executes *inside* `async with sem:`, so the semaphore slot stays occupied for the full backoff duration. With `MAX_CONCURRENCY = 4`, a burst of connection errors on 4 concurrent workers will park all 4 slots and starve every other pending `worker()` coroutine until the sleeps drain. The 429 / 5xx path (lines 226-230) correctly sleeps *outside* the semaphore — the same fix applies here: release the sem before sleeping.

### Issue 2 of 2
src/jobhive/scrapers/wantedly.py:72-86
**Short tokens in `_NON_JP_HINTS` can false-positive on common English words**

`_NON_JP_HINTS` contains single tokens that double as ordinary English words: `"AT"` (Austria), `"IN"` (India), `"IT"` (Italy), `"NO"` (Norway), `"CO"` (Colombia), `"ID"` (Indonesia), `"PE"` (Peru). Because `_infer_country_iso` tokenises with `re.findall(r"[A-Za-z]+", location)`, a location string like `"Innovation at Tokyo"` or `"No fixed office"` (no CJK present) would match `"AT"` or `"NO"` and silently return `None` instead of `"JP"`. Two-letter country codes with this ambiguity risk should either be removed from the set or require a paired context check.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: wantedly.csv"](https://github.com/kalil0321/ats-scrapers/commit/d4e3c1f414ac7f3c204319465dbf6c6e4b8a7aa5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732390)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->