### PR TITLE
Add Hosco hospitality scraper

### DIFF
--- a/ats-companies/hosco.csv
+++ b/ats-companies/hosco.csv
@@ -1,0 +1,2 @@
+name,slug,url
+Hosco,hosco,https://www.hosco.com

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -75,6 +75,7 @@ class ATSType(StrEnum):
     WEWORKREMOTELY = "weworkremotely"
     PROGRAMATHOR = "programathor"
     BUILTIN = "builtin"
+    HOSCO = "hosco"
     JOBSCH = "jobsch"
     MANFRED = "manfred"
     THEHUB = "thehub"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -25,6 +25,7 @@ from jobhive.scrapers.gem import GemScraper
 from jobhive.scrapers.getonbrd import GetOnBrdScraper
 from jobhive.scrapers.google import GoogleScraper
 from jobhive.scrapers.greenhouse import GreenhouseScraper
+from jobhive.scrapers.hosco import HoscoScraper
 from jobhive.scrapers.icims import iCIMSScraper
 from jobhive.scrapers.jazzhr import JazzHRScraper
 from jobhive.scrapers.jobsch import JobsChScraper
@@ -77,6 +78,7 @@ __all__ = [
     "GetOnBrdScraper",
     "GoogleScraper",
     "GreenhouseScraper",
+    "HoscoScraper",
     "JazzHRScraper",
     "JobsChScraper",
     "JoinComScraper",

--- a/src/jobhive/scrapers/hosco.py
+++ b/src/jobhive/scrapers/hosco.py
@@ -93,6 +93,30 @@ _EMPLOYMENT_TYPE_MAP: dict[str, str] = {
     "trainee": "INTERN",
 }
 
+# Hosco pay-range cadence labels → canonical ``SalaryPeriod`` enum.
+# Hospitality pay is frequently quoted monthly or hourly, so we never
+# assume annual — unknown/absent cadences leave the period ``None``.
+_SALARY_PERIOD_MAP: dict[str, str] = {
+    "hour": "HOUR",
+    "hourly": "HOUR",
+    "per-hour": "HOUR",
+    "day": "DAY",
+    "daily": "DAY",
+    "per-day": "DAY",
+    "week": "WEEK",
+    "weekly": "WEEK",
+    "per-week": "WEEK",
+    "month": "MONTH",
+    "monthly": "MONTH",
+    "per-month": "MONTH",
+    "year": "YEAR",
+    "yearly": "YEAR",
+    "annual": "YEAR",
+    "annually": "YEAR",
+    "per-year": "YEAR",
+    "per-annum": "YEAR",
+}
+
 
 @ScraperRegistry.register(ATSType.HOSCO)
 class HoscoScraper(BaseScraper):
@@ -124,9 +148,14 @@ class HoscoScraper(BaseScraper):
         ) as client:
             sem = asyncio.Semaphore(MAX_CONCURRENCY)
             build_id = await self._discover_build_id(client)
+            build_id_holder = [build_id]
             # Page 1 also tells us the total count — fetch sequentially
-            # so we can size the concurrent fan-out correctly.
-            first = await self._fetch_page(client, sem, build_id, page=1)
+            # so we can size the concurrent fan-out correctly. Route it
+            # through the refresh path too, so a stale buildId is
+            # re-discovered here rather than silently yielding 0 jobs.
+            first = await self._fetch_page_with_refresh(
+                client, sem, build_id_holder, page=1
+            )
             results = _extract_results(first)
             count = _extract_count(first)
 
@@ -149,7 +178,6 @@ class HoscoScraper(BaseScraper):
                 total_pages = self.max_pages
 
             if total_pages > 1:
-                build_id_holder = [build_id]
                 tasks = [
                     self._fetch_page_with_refresh(
                         client, sem, build_id_holder, page=p
@@ -338,12 +366,16 @@ class HoscoScraper(BaseScraper):
         salary_min = _to_float(_first_present(pay_range, ("min", "minimum")))
         salary_max = _to_float(_first_present(pay_range, ("max", "maximum")))
         salary_currency = _normalize_currency(pay_range.get("currency"))
+        salary_period = _map_salary_period(
+            _first_present(pay_range, ("period", "frequency", "interval", "unit"))
+        )
         if salary_currency is None and (salary_min is not None or salary_max is not None):
             # We have a numeric range but no currency — drop the range
             # rather than guessing; the canonical schema treats currency
             # as required context for salary numbers.
             salary_min = None
             salary_max = None
+            salary_period = None
 
         employment_type = _map_employment_type(item.get("types"))
 
@@ -369,7 +401,7 @@ class HoscoScraper(BaseScraper):
             ats_id=ats_id,
             location=location,
             salary_currency=salary_currency,
-            salary_period="YEAR" if salary_currency else None,
+            salary_period=salary_period,
             salary_min=salary_min,
             salary_max=salary_max,
             employment_type=employment_type,  # type: ignore[arg-type]
@@ -445,6 +477,13 @@ def _map_employment_type(value: Any) -> str | None:
         return None
     key = candidate.strip().lower().replace(" ", "-")
     return _EMPLOYMENT_TYPE_MAP.get(key)
+
+
+def _map_salary_period(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    key = value.strip().lower().replace("_", "-").replace(" ", "-")
+    return _SALARY_PERIOD_MAP.get(key)
 
 
 def _parse_date(value: Any) -> datetime | None:

--- a/src/jobhive/scrapers/hosco.py
+++ b/src/jobhive/scrapers/hosco.py
@@ -1,0 +1,477 @@
+"""Hosco (https://www.hosco.com) — global hospitality jobs board.
+
+Hosco is the leading hospitality-industry job platform, with strong
+coverage of the MENA region (UAE, Saudi Arabia, Qatar, …), Europe, and
+South-East Asia. Roughly 5.5k live postings at any given time —
+front-of-house, back-of-house, F&B, hotel management, cruise lines.
+
+Single-source scraper: ``company_slug`` is informational and ignored.
+The site is a Next.js app that exposes a public, no-auth JSON data
+endpoint at ``/_next/data/{buildId}/en/jobs.json``. The ``buildId``
+changes on every Hosco deploy, so the scraper:
+
+  1. Fetches the public ``/en/jobs`` HTML page once at the start.
+  2. Extracts the current ``buildId`` via the embedded
+     ``"buildId":"..."`` JSON literal Next.js writes into the markup.
+  3. Calls ``/_next/data/{buildId}/en/jobs.json?page=N`` for pagination,
+     reusing the discovered buildId.
+
+If a mid-crawl page returns 404, the buildId has very likely rotated
+because Hosco redeployed mid-scrape — the scraper re-discovers it once
+and retries that page. Otherwise pagination stops when the response
+list is shorter than ``PAGE_SIZE`` or we've covered the reported
+``count``.
+
+The search response is summary-only; the description body is the
+``excerpt`` field. Deeper detail (full description, perks, …) would
+require N per-job requests we don't make here — that's a future
+enrichment pass.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import re
+from datetime import date, datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+BASE_URL = "https://www.hosco.com"
+JOBS_HTML_URL = f"{BASE_URL}/en/jobs"
+PAGE_SIZE = 10  # Hosco's fixed search page size — keep in sync with the API.
+DEFAULT_MAX_PAGES = 1_000  # 5.5k / 10 ≈ 550, give plenty of headroom.
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 5
+RETRY_BASE_DELAY = 1.5
+
+BROWSER_UA: dict[str, str] = {
+    "User-Agent": (
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like "
+        "Gecko) Chrome/124.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+JSON_HEADERS: dict[str, str] = {
+    "User-Agent": BROWSER_UA["User-Agent"],
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
+_BUILD_ID_RE = re.compile(r'"buildId":"([^"]+)"')
+_TAG_RE = re.compile(r"<[^>]+>")
+
+# Hosco's ``types`` field values → canonical ``EmploymentType`` enum.
+# Values are lowercased/slug-ified before lookup so spacing/casing
+# variants ("Full-Time", "full time", "FULL_TIME") all match.
+_EMPLOYMENT_TYPE_MAP: dict[str, str] = {
+    "full-time": "FULL_TIME",
+    "full_time": "FULL_TIME",
+    "fulltime": "FULL_TIME",
+    "permanent": "FULL_TIME",
+    "part-time": "PART_TIME",
+    "part_time": "PART_TIME",
+    "parttime": "PART_TIME",
+    "contract": "CONTRACT",
+    "freelance": "CONTRACT",
+    "seasonal": "TEMPORARY",
+    "temporary": "TEMPORARY",
+    "graduate-program": "INTERN",
+    "graduate_program": "INTERN",
+    "internship": "INTERN",
+    "intern": "INTERN",
+    "apprenticeship": "INTERN",
+    "trainee": "INTERN",
+}
+
+
+@ScraperRegistry.register(ATSType.HOSCO)
+class HoscoScraper(BaseScraper):
+    """Hosco (hosco.com) — global hospitality job board.
+
+    Single-source scraper: ``company_slug`` is ignored. Pass anything
+    (``"any"``, ``""``, ``"global"``) — the scraper enumerates the
+    entire ``/en/jobs`` directory.
+    """
+
+    ats = ATSType.HOSCO
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        max_pages: int = DEFAULT_MAX_PAGES,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.max_pages = max_pages
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+            build_id = await self._discover_build_id(client)
+            # Page 1 also tells us the total count — fetch sequentially
+            # so we can size the concurrent fan-out correctly.
+            first = await self._fetch_page(client, sem, build_id, page=1)
+            results = _extract_results(first)
+            count = _extract_count(first)
+
+            seen: set[str] = set()
+            jobs: list[Job] = []
+            for item in results:
+                job = self._parse_job(item)
+                if job is None or job.ats_id in seen:
+                    continue
+                seen.add(job.ats_id)
+                jobs.append(job)
+
+            if count is not None:
+                total_pages = min(
+                    self.max_pages, max(1, (count + PAGE_SIZE - 1) // PAGE_SIZE)
+                )
+            elif len(results) < PAGE_SIZE:
+                total_pages = 1
+            else:
+                total_pages = self.max_pages
+
+            if total_pages > 1:
+                build_id_holder = [build_id]
+                tasks = [
+                    self._fetch_page_with_refresh(
+                        client, sem, build_id_holder, page=p
+                    )
+                    for p in range(2, total_pages + 1)
+                ]
+                for coro in asyncio.as_completed(tasks):
+                    payload = await coro
+                    if not payload:
+                        continue
+                    for item in _extract_results(payload):
+                        job = self._parse_job(item)
+                        if job is None or job.ats_id in seen:
+                            continue
+                        seen.add(job.ats_id)
+                        jobs.append(job)
+        return jobs
+
+    # --- HTTP layer ---------------------------------------------------------
+
+    async def _discover_build_id(self, client: httpx.AsyncClient) -> str:
+        """Fetch the public listing page and pull the current Next.js
+        ``buildId`` out of the embedded ``__NEXT_DATA__`` script.
+
+        Raises :class:`ScraperError` if the page returns non-200 or the
+        regex doesn't match — both indicate a layout change worth alerting
+        on rather than silently producing an empty result.
+        """
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                response = await client.get(JOBS_HTML_URL, headers=BROWSER_UA)
+            except httpx.HTTPError as exc:
+                last_exc = exc
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Hosco buildId discovery failed: {exc}"
+                    ) from exc
+                await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                continue
+            if response.status_code == 200:
+                match = _BUILD_ID_RE.search(response.text)
+                if not match:
+                    raise ScraperError(
+                        "Hosco buildId not found — site layout changed"
+                    )
+                return match.group(1)
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Hosco buildId discovery got {response.status_code} "
+                        f"after {MAX_RETRIES} retries"
+                    )
+                await asyncio.sleep(RETRY_BASE_DELAY * (2**attempt))
+                continue
+            raise ScraperError(
+                f"Hosco buildId discovery got {response.status_code}"
+            )
+        raise ScraperError(
+            f"Hosco buildId discovery exhausted retries: {last_exc}"
+        )
+
+    async def _fetch_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        build_id: str,
+        *,
+        page: int,
+    ) -> dict[str, Any]:
+        url = f"{BASE_URL}/_next/data/{build_id}/en/jobs.json"
+        params = {"page": page}
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(
+                        url, params=params, headers=JSON_HEADERS,
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"Hosco fetch failed at page={page}: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                try:
+                    return response.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"Hosco returned non-JSON at page={page}: {exc}"
+                    ) from exc
+            if response.status_code == 404:
+                # Signal to the caller that the buildId is stale; let it
+                # decide whether to re-discover and retry.
+                return {"__hosco_stale_build_id__": True}
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Hosco returned {response.status_code} at "
+                        f"page={page} after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2**attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"Hosco returned {response.status_code} at page={page}"
+            )
+        raise ScraperError(
+            f"Hosco exhausted retries at page={page}: {last_exc}"
+        )
+
+    async def _fetch_page_with_refresh(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        build_id_holder: list[str],
+        *,
+        page: int,
+    ) -> dict[str, Any]:
+        """Fetch a page, re-discovering the buildId once on 404.
+
+        Hosco occasionally redeploys mid-scrape, which invalidates the
+        ``/_next/data/{buildId}/...`` URLs we hold. A single recovery
+        attempt covers that case without retry-storming the homepage on
+        every page failure.
+        """
+        payload = await self._fetch_page(client, sem, build_id_holder[0], page=page)
+        if payload.get("__hosco_stale_build_id__"):
+            new_id = await self._discover_build_id(client)
+            build_id_holder[0] = new_id
+            payload = await self._fetch_page(client, sem, new_id, page=page)
+            if payload.get("__hosco_stale_build_id__"):
+                # Two consecutive 404s — give up on this page rather than
+                # spinning. The next full run will pick it up.
+                return {}
+        return payload
+
+    # --- parsing ------------------------------------------------------------
+
+    def _parse_job(self, item: dict[str, Any]) -> Job | None:
+        raw_id = item.get("id")
+        if raw_id in (None, ""):
+            return None
+        ats_id = str(raw_id)
+
+        title = (item.get("title") or "").strip()
+        if not title:
+            return None
+
+        href = item.get("url") or ""
+        if isinstance(href, str) and href.startswith("/"):
+            url = f"{BASE_URL}{href}"
+        elif isinstance(href, str) and href.startswith("http"):
+            url = href
+        else:
+            url = f"{BASE_URL}/en/jobs/{ats_id}"
+
+        company_obj = item.get("company") or {}
+        company = (
+            company_obj.get("name").strip()
+            if isinstance(company_obj, dict)
+            and isinstance(company_obj.get("name"), str)
+            and company_obj.get("name").strip()
+            else "Unknown"
+        )
+
+        raw_location = item.get("displayed_location")
+        location = (
+            raw_location.strip() or None
+            if isinstance(raw_location, str)
+            else None
+        )
+
+        description = _strip_html(item.get("excerpt") or "")
+        if not description:
+            description = None
+
+        pay_range = item.get("pay_range") or {}
+        salary_min = _to_float(_first_present(pay_range, ("min", "minimum")))
+        salary_max = _to_float(_first_present(pay_range, ("max", "maximum")))
+        salary_currency = _normalize_currency(pay_range.get("currency"))
+        if salary_currency is None and (salary_min is not None or salary_max is not None):
+            # We have a numeric range but no currency — drop the range
+            # rather than guessing; the canonical schema treats currency
+            # as required context for salary numbers.
+            salary_min = None
+            salary_max = None
+
+        employment_type = _map_employment_type(item.get("types"))
+
+        raw: dict[str, Any] = {}
+        slug = item.get("slug")
+        if isinstance(slug, str) and slug:
+            raw["slug"] = slug
+        start_date = item.get("start_date")
+        if start_date:
+            raw["start_date"] = start_date
+        owner = item.get("owner")
+        if isinstance(owner, dict) and owner.get("type"):
+            raw["owner_kind"] = owner.get("type")
+        types = item.get("types")
+        if isinstance(types, list) and types:
+            raw["types"] = types
+
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.HOSCO,
+            ats_id=ats_id,
+            location=location,
+            salary_currency=salary_currency,
+            salary_period="YEAR" if salary_currency else None,
+            salary_min=salary_min,
+            salary_max=salary_max,
+            employment_type=employment_type,  # type: ignore[arg-type]
+            description=description,
+            posted_at=_parse_date(item.get("posted_date")),
+            fetched_at=datetime.now(),
+            language="en",
+            raw=raw or None,
+        )
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+def _extract_results(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    search = (
+        ((payload.get("pageProps") or {}).get("initialState") or {})
+        .get("jobDirectory")
+        or {}
+    ).get("search") or {}
+    results = search.get("results")
+    if isinstance(results, list):
+        return [item for item in results if isinstance(item, dict)]
+    return []
+
+
+def _extract_count(payload: dict[str, Any]) -> int | None:
+    search = (
+        ((payload.get("pageProps") or {}).get("initialState") or {})
+        .get("jobDirectory")
+        or {}
+    ).get("search") or {}
+    count = search.get("count")
+    if isinstance(count, int) and count >= 0:
+        return count
+    return None
+
+
+def _first_present(d: dict[str, Any], keys: tuple[str, ...]) -> Any:
+    for key in keys:
+        if key in d and d[key] not in (None, ""):
+            return d[key]
+    return None
+
+
+def _to_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)) and value > 0:
+        return float(value)
+    if isinstance(value, str):
+        cleaned = value.replace(",", "").strip()
+        try:
+            num = float(cleaned)
+        except ValueError:
+            return None
+        return num if num > 0 else None
+    return None
+
+
+def _normalize_currency(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    code = value.strip().upper()
+    if len(code) == 3 and code.isalpha():
+        return code
+    return None
+
+
+def _map_employment_type(value: Any) -> str | None:
+    candidate = value[0] if isinstance(value, list) and value else value
+    if not isinstance(candidate, str):
+        return None
+    key = candidate.strip().lower().replace(" ", "-")
+    return _EMPLOYMENT_TYPE_MAP.get(key)
+
+
+def _parse_date(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day)
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    # Hosco gives plain ``YYYY-MM-DD`` in the search payload; tolerate a
+    # full ISO timestamp too in case detail pages start to surface one.
+    for fmt in ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M:%SZ"):
+        try:
+            return datetime.strptime(text, fmt)
+        except ValueError:
+            continue
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _strip_html(text: str) -> str:
+    cleaned = _TAG_RE.sub(" ", text)
+    cleaned = html.unescape(cleaned)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned[:10_000]

--- a/tests/test_hosco.py
+++ b/tests/test_hosco.py
@@ -49,7 +49,12 @@ JOB_ITEM_FULL = {
     "company": {"id": 14021, "name": "Acme Hotel Group"},
     "owner": {"id": 9001, "type": "company"},
     "types": ["full-time"],
-    "pay_range": {"currency": "AED", "min": 18000, "max": 22000},
+    "pay_range": {
+        "currency": "AED",
+        "min": 18000,
+        "max": 22000,
+        "period": "monthly",
+    },
     "posted_date": "2026-05-10",
     "start_date": None,
     "cover_public_path": "/img/cover.png",
@@ -129,7 +134,9 @@ def test_parse_job_full_fields() -> None:
     assert job.salary_currency == "AED"
     assert job.salary_min == 18000
     assert job.salary_max == 22000
-    assert job.salary_period == "YEAR"
+    # Period is inferred from the pay_range cadence key (no longer hardcoded
+    # to YEAR); "monthly" maps to the canonical MONTH.
+    assert job.salary_period == "MONTH"
     assert job.employment_type == "FULL_TIME"
     assert job.language == "en"
     assert job.posted_at is not None
@@ -152,6 +159,8 @@ def test_parse_job_minimal_no_salary_no_owner() -> None:
     assert job.salary_currency is None
     assert job.salary_min is None
     assert job.salary_max is None
+    # No pay_range cadence to infer from — period stays None, not YEAR.
+    assert job.salary_period is None
     assert job.employment_type == "INTERN"
     assert job.location == "London, United Kingdom"
 

--- a/tests/test_hosco.py
+++ b/tests/test_hosco.py
@@ -1,0 +1,228 @@
+"""Tests for the Hosco scraper."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import HoscoScraper, ScraperRegistry
+from jobhive.scrapers.hosco import _BUILD_ID_RE, BASE_URL
+
+_JOBS_HTML_RE = re.compile(r"^https://www\.hosco\.com/en/jobs(?:\?|$)")
+_NEXT_DATA_RE = re.compile(r"^https://www\.hosco\.com/_next/data/[^/]+/en/jobs\.json")
+
+HOMEPAGE_HTML = """<!doctype html>
+<html><head><title>Jobs</title></head>
+<body>
+<script id="__NEXT_DATA__" type="application/json">
+{"props":{},"page":"/jobs","query":{},"buildId":"TTaH8yf--XYgZKUfroyVa","isFallback":false}
+</script>
+</body></html>
+"""
+
+
+def _api_payload(results: list[dict], *, count: int) -> dict:
+    return {
+        "pageProps": {
+            "initialState": {
+                "jobDirectory": {
+                    "search": {
+                        "count": count,
+                        "results": results,
+                    }
+                }
+            }
+        }
+    }
+
+
+JOB_ITEM_FULL = {
+    "id": 5018462,
+    "title": "Front Office Manager",
+    "slug": "front-office-manager-acme-hotel-dubai",
+    "url": "/en/jobs/front-office-manager-acme-hotel-dubai",
+    "excerpt": "<p>Lead the <strong>front desk</strong> team in a 300-key property.</p>",
+    "displayed_location": "Dubai, UAE",
+    "company": {"id": 14021, "name": "Acme Hotel Group"},
+    "owner": {"id": 9001, "type": "company"},
+    "types": ["full-time"],
+    "pay_range": {"currency": "AED", "min": 18000, "max": 22000},
+    "posted_date": "2026-05-10",
+    "start_date": None,
+    "cover_public_path": "/img/cover.png",
+    "avatar": "/img/avatar.png",
+}
+
+JOB_ITEM_MIN = {
+    "id": "abc-9912",
+    "title": "Sommelier",
+    "url": "/en/jobs/sommelier-london",
+    "displayed_location": "London, United Kingdom",
+    "company": {"name": "Maison Smith"},
+    "excerpt": "Pair wine for a 2-Michelin-star tasting menu.",
+    "types": ["Internship"],
+    "posted_date": "2026-04-22",
+}
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.hosco as h
+
+    monkeypatch.setattr(h, "MAX_RETRIES", 1)
+    monkeypatch.setattr(h, "RETRY_BASE_DELAY", 0.0)
+
+
+# --- registry --------------------------------------------------------------
+
+
+def test_registry_resolves_hosco() -> None:
+    assert ScraperRegistry.get(ATSType.HOSCO) is HoscoScraper
+
+
+def test_ats_type_value() -> None:
+    assert ATSType.HOSCO.value == "hosco"
+
+
+# --- buildId discovery -----------------------------------------------------
+
+
+def test_build_id_regex_extracts_id_from_next_data() -> None:
+    match = _BUILD_ID_RE.search(HOMEPAGE_HTML)
+    assert match is not None
+    assert match.group(1) == "TTaH8yf--XYgZKUfroyVa"
+
+
+def test_build_id_regex_handles_minified_html() -> None:
+    minified = (
+        '<script>{"props":{"x":1},"buildId":"abc123-def","page":"/"}</script>'
+    )
+    match = _BUILD_ID_RE.search(minified)
+    assert match is not None
+    assert match.group(1) == "abc123-def"
+
+
+def test_build_id_regex_missing_returns_none() -> None:
+    assert _BUILD_ID_RE.search("<html><body>no next data here</body></html>") is None
+
+
+# --- parsing ---------------------------------------------------------------
+
+
+def test_parse_job_full_fields() -> None:
+    scraper = HoscoScraper("any")
+    job = scraper._parse_job(JOB_ITEM_FULL)
+    assert job is not None
+    assert job.ats_type is ATSType.HOSCO
+    assert job.ats_id == "5018462"
+    assert job.global_id == "hosco:5018462"
+    assert job.title == "Front Office Manager"
+    assert job.company == "Acme Hotel Group"
+    assert (
+        str(job.url)
+        == f"{BASE_URL}/en/jobs/front-office-manager-acme-hotel-dubai"
+    )
+    assert job.location == "Dubai, UAE"
+    assert job.salary_currency == "AED"
+    assert job.salary_min == 18000
+    assert job.salary_max == 22000
+    assert job.salary_period == "YEAR"
+    assert job.employment_type == "FULL_TIME"
+    assert job.language == "en"
+    assert job.posted_at is not None
+    assert job.posted_at.year == 2026 and job.posted_at.month == 5
+    # HTML should have been stripped out of the excerpt.
+    assert job.description is not None
+    assert "<p>" not in job.description
+    assert "front desk" in job.description
+    assert job.raw is not None
+    assert job.raw["slug"] == "front-office-manager-acme-hotel-dubai"
+    assert job.raw["owner_kind"] == "company"
+
+
+def test_parse_job_minimal_no_salary_no_owner() -> None:
+    scraper = HoscoScraper("any")
+    job = scraper._parse_job(JOB_ITEM_MIN)
+    assert job is not None
+    assert job.ats_id == "abc-9912"
+    assert job.company == "Maison Smith"
+    assert job.salary_currency is None
+    assert job.salary_min is None
+    assert job.salary_max is None
+    assert job.employment_type == "INTERN"
+    assert job.location == "London, United Kingdom"
+
+
+def test_parse_job_missing_id_returns_none() -> None:
+    scraper = HoscoScraper("any")
+    assert scraper._parse_job({"title": "x", "url": "/foo"}) is None
+
+
+def test_parse_job_missing_title_returns_none() -> None:
+    scraper = HoscoScraper("any")
+    assert scraper._parse_job({"id": 1, "url": "/foo"}) is None
+
+
+def test_parse_job_drops_salary_when_currency_missing() -> None:
+    """Min/max without a currency is meaningless — drop it rather than
+    fabricating a currency."""
+    scraper = HoscoScraper("any")
+    item = dict(JOB_ITEM_FULL)
+    item["pay_range"] = {"min": 18000, "max": 22000}
+    job = scraper._parse_job(item)
+    assert job is not None
+    assert job.salary_currency is None
+    assert job.salary_min is None
+    assert job.salary_max is None
+
+
+def test_parse_job_falls_back_to_unknown_company() -> None:
+    scraper = HoscoScraper("any")
+    item = dict(JOB_ITEM_FULL)
+    item["company"] = {}
+    job = scraper._parse_job(item)
+    assert job is not None
+    assert job.company == "Unknown"
+
+
+# --- end-to-end fetch (httpx_mock) -----------------------------------------
+
+
+def test_fetch_async_discovers_build_id_then_paginates(httpx_mock) -> None:
+    httpx_mock.add_response(url=_JOBS_HTML_RE, text=HOMEPAGE_HTML)
+    httpx_mock.add_response(
+        url=_NEXT_DATA_RE,
+        json=_api_payload([JOB_ITEM_FULL, JOB_ITEM_MIN], count=2),
+    )
+
+    jobs = HoscoScraper("any").fetch()
+    assert len(jobs) == 2
+    ids = {j.ats_id for j in jobs}
+    assert ids == {"5018462", "abc-9912"}
+
+
+def test_fetch_dedupes_repeated_ids(httpx_mock) -> None:
+    httpx_mock.add_response(url=_JOBS_HTML_RE, text=HOMEPAGE_HTML)
+    httpx_mock.add_response(
+        url=_NEXT_DATA_RE,
+        json=_api_payload([JOB_ITEM_FULL, JOB_ITEM_FULL], count=2),
+    )
+    jobs = HoscoScraper("any").fetch()
+    assert len(jobs) == 1
+
+
+def test_fetch_raises_when_build_id_missing(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_JOBS_HTML_RE, text="<html><body>no next data</body></html>"
+    )
+    with pytest.raises(ScraperError, match="buildId"):
+        HoscoScraper("any").fetch()
+
+
+def test_fetch_raises_on_homepage_500(httpx_mock) -> None:
+    httpx_mock.add_response(url=_JOBS_HTML_RE, status_code=500, is_reusable=True)
+    with pytest.raises(ScraperError):
+        HoscoScraper("any").fetch()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -28,7 +28,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "bundesagentur", "arbetsformedlingen", "eures",
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
-        "weworkremotely", "programathor", "builtin", "jobsch",
+        "weworkremotely", "programathor", "builtin", "hosco", "jobsch",
         "manfred", "thehub", "ycombinator", "wellfound",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",


### PR DESCRIPTION
## Summary

- New scraper for [Hosco](https://www.hosco.com), the leading hospitality-industry job platform — ~5,575 live postings worldwide, with very strong MENA / UAE / Europe coverage (front-of-house, F&B, hotel management, cruise lines).
- Single-source scraper (`company_slug` ignored). Adds `ATSType.HOSCO = "hosco"` under the "Hybrid jobboards" block; canonical schema otherwise untouched.

## Endpoint

Hosco is a Next.js app with a public no-auth JSON data endpoint:

```
GET https://www.hosco.com/_next/data/{buildId}/en/jobs.json?page=N
```

Response is `pageProps.initialState.jobDirectory.search.{count, results[]}`; each result carries `id`, `title`, `slug`, `url`, `displayed_location`, `company.{id,name}`, `excerpt`, `types[]`, `pay_range.{currency,min,max}`, `posted_date`, `owner.{type}`. Mapped to canonical `Job` fields, with `language="en"` (the JSON endpoint is the `/en` locale) and `description` derived from the HTML-stripped `excerpt` (search payload is summary-only).

## buildId discovery

The Next.js `buildId` changes on every Hosco deploy, so the scraper:

1. Fetches `https://www.hosco.com/en/jobs` (HTML) with a browser UA.
2. Extracts the current `buildId` from the embedded `"buildId":"..."` JSON literal Next.js writes into `__NEXT_DATA__`.
3. Reuses that `buildId` across all paginated `_next/data/.../jobs.json` calls.

If a mid-crawl page returns 404, that almost certainly means Hosco redeployed during the run (stale `buildId`), so the scraper re-discovers it once and retries that page.

## Pagination + concurrency

- Page size is fixed at 10. Page 1 is fetched sequentially to read `count`; remaining pages fan out at concurrency=4 via `asyncio.Semaphore`.
- Stops at `ceil(count / 10)` pages (or `max_pages`, default 1000 — well above the ~550 needed for the current corpus).
- Retries 429/5xx with exponential backoff (respects `Retry-After`).

## Test plan

- [x] `uv run ruff check src/jobhive/scrapers/hosco.py tests/test_hosco.py` — clean
- [x] `uv run pytest tests/test_hosco.py tests/test_models.py -x` — 77 passed
- [x] No live HTTP in tests; uses `pytest-httpx` mocks
- [x] `tests/test_hosco.py` covers: registry resolution, `buildId` regex (happy + missing + minified), `_parse_job` (full row, minimal row, missing id/title, salary dropped when currency missing, unknown company), end-to-end fetch with mocked HTML + JSON, dedup, error on missing `buildId`, error on 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Hosco hospitality jobs scraper as a new hybrid job board source. It auto-discovers the Next.js `buildId`, handles mid-deploy rotations on page 1 and later pages, paginates reliably, maps results to our canonical schema, and seeds `ats-companies/hosco.csv`.

- **New Features**
  - Added `ATSType.HOSCO = "hosco"` and registered `HoscoScraper` (single-source; ignores `company_slug`).
  - Seeded `ats-companies/hosco.csv` with `Hosco,hosco,https://www.hosco.com`.
  - BuildId discovery: fetch `/en/jobs`, extract `"buildId"` from `__NEXT_DATA__`; on 404 refresh once; then call `/_next/data/{buildId}/en/jobs.json?page=N`.
  - Pagination: page size 10; page 1 sequential to read `count`; remaining pages at concurrency=4; retries with exponential backoff and `Retry-After`.
  - Parsing: id/title/url/company (fallback "Unknown")/location; `excerpt`→plain-text `description`; salary only if currency present; employment type normalization; posted date; `language="en"`.
  - Dedup by `ats_id`; tests use mocked HTTP for discovery, parsing edge cases, pagination, and errors.

- **Bug Fixes**
  - Applied stale `buildId` refresh to the page-1 fetch to avoid empty scrapes during mid-deploy rotations.
  - Salary period now maps from Hosco’s provided cadence; if cadence is missing, `salary_period` remains `None` (no default).

<sup>Written for commit a987792f70ffd8d358adcafcecfcd557e1800e24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new `HoscoScraper` for the Hosco hospitality job board, which dynamically discovers the Next.js `buildId` from the HTML page, paginates the `/_next/data/{buildId}/en/jobs.json` endpoint with concurrency-4 fan-out, and maps results to the canonical `Job` schema.

- The stale-buildId recovery (`_fetch_page_with_refresh`) is only wired up for pages 2+; if Hosco redeploys between `_discover_build_id` and the page-1 fetch, the scraper silently returns zero jobs instead of recovering or raising.
- `fetched_at` is populated with `datetime.now()` (naive, local timezone) rather than `datetime.now(timezone.utc)`, which will record incorrect timestamps on any host not running in UTC.
- The `asyncio.sleep` backoff on `httpx.HTTPError` inside `async with sem:` holds the semaphore slot for the full sleep duration, unnecessarily blocking all other concurrent page fetches during retry.

<h3>Confidence Score: 3/5</h3>

The scraper silently returns an empty job list when the Next.js build ID rotates between the discovery call and the first page fetch, producing undetected data loss with no error surfaced to the caller.

The page-1 stale-buildId gap means a Hosco redeploy at exactly the wrong moment causes a completely empty scrape with no error, which could silently hollow out the dataset for that run. The UTC timestamp issue affects every row written by this scraper on non-UTC hosts. Both are straightforward to fix before merging.

src/jobhive/scrapers/hosco.py — the page-1 recovery path and the fetched_at timestamp both need attention before this ships.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/hosco.py | Core scraper implementation — stale-buildId recovery on page 1 is missing (silent empty result), `fetched_at` uses naive local time instead of UTC, and the semaphore is held during HTTPError retry sleep. |
| tests/test_hosco.py | Comprehensive mocked tests covering parsing edge cases, dedup, error cases; no test for the page-1-stale-buildId silent-empty-result scenario. |
| src/jobhive/models.py | Adds ATSType.HOSCO = 'hosco' in the hybrid-jobboards block; correct placement and no schema changes. |
| src/jobhive/scrapers/__init__.py | Adds HoscoScraper import and __all__ entry in alphabetical order; no issues. |
| tests/test_models.py | Adds 'hosco' to the expected ATSType set; straightforward update. |
| ats-companies/hosco.csv | Single-row seed CSV with correct header and Hosco entry. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
src/jobhive/scrapers/hosco.py:129-149
**Page-1 stale-buildId silently returns zero jobs**

`_fetch_page` signals a stale build ID by returning `{"__hosco_stale_build_id__": True}`, but this sentinel is only checked in `_fetch_page_with_refresh` — which is only called for pages 2+. If Hosco redeploys between `_discover_build_id` and the page-1 fetch, `_extract_results` returns `[]`, `_extract_count` returns `None`, `len(results) < PAGE_SIZE` is `True`, `total_pages` is set to `1`, and the entire scrape silently returns an empty list. The same recovery logic used in `_fetch_page_with_refresh` (re-discover once, then retry) should be applied to the page-1 fetch path as well.

### Issue 2 of 4
src/jobhive/scrapers/hosco.py:36
`datetime.now()` returns a naive datetime in the local system timezone. The `fetched_at` field docs say "UTC", so this will be incorrect on any host not running in UTC. Use `datetime.now(timezone.utc)` (and add `timezone` to the import) to produce a timezone-aware UTC timestamp.

```suggestion
from datetime import date, datetime, timezone
```

### Issue 3 of 4
src/jobhive/scrapers/hosco.py:378
Companion fix for the `timezone` import above: `datetime.now()` should be `datetime.now(timezone.utc)` so `fetched_at` is always a UTC-aware timestamp as the field documentation specifies.

```suggestion
            fetched_at=datetime.now(timezone.utc),
```

### Issue 4 of 4
src/jobhive/scrapers/hosco.py:226-239
**Semaphore held during retry backoff on network errors**

The `asyncio.sleep(RETRY_BASE_DELAY * attempt)` inside the `async with sem:` block keeps the semaphore slot reserved for the full backoff duration on `httpx.HTTPError`. With `MAX_CONCURRENCY=4`, if all four in-flight fetches hit network errors simultaneously, all four slots are held during sleep and no other page fetches can start. The sleep should occur after the `async with sem:` block exits, the same way the 429/5xx backoff is correctly placed outside the semaphore context.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: hosco.csv"](https://github.com/kalil0321/ats-scrapers/commit/cac24f8bd82dfa4bd1a11b373a8ddf1055c0b5a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732393)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->