### PR TITLE
Add 104.com.tw (Taiwan) scraper

### DIFF
--- a/ats-companies/job104.csv
+++ b/ats-companies/job104.csv
@@ -1,0 +1,2 @@
+name,slug,url
+104.com.tw,job104,https://www.104.com.tw

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -71,6 +71,7 @@ class ATSType(StrEnum):
     WELCOMETOTHEJUNGLE = "welcometothejungle"
     GETONBRD = "getonbrd"
     WANTED = "wanted"
+    JOB104 = "104"
     REMOTEOK = "remoteok"
     WEWORKREMOTELY = "weworkremotely"
     PROGRAMATHOR = "programathor"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -27,6 +27,7 @@ from jobhive.scrapers.google import GoogleScraper
 from jobhive.scrapers.greenhouse import GreenhouseScraper
 from jobhive.scrapers.icims import iCIMSScraper
 from jobhive.scrapers.jazzhr import JazzHRScraper
+from jobhive.scrapers.job104 import Job104Scraper
 from jobhive.scrapers.jobsch import JobsChScraper
 from jobhive.scrapers.join_com import JoinComScraper
 from jobhive.scrapers.lever import LeverScraper
@@ -78,6 +79,7 @@ __all__ = [
     "GoogleScraper",
     "GreenhouseScraper",
     "JazzHRScraper",
+    "Job104Scraper",
     "JobsChScraper",
     "JoinComScraper",
     "LeverScraper",

--- a/src/jobhive/scrapers/job104.py
+++ b/src/jobhive/scrapers/job104.py
@@ -259,8 +259,10 @@ class Job104Scraper(BaseScraper):
                             f"104 fetch failed for area={area} "
                             f"jobcat={jobcat} page={page}: {exc}"
                         ) from exc
-                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
-                    continue
+                    response = None  # release sem before backing off
+            if response is None:
+                await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                continue
             if response.status_code == 200:
                 try:
                     return response.json()
@@ -344,6 +346,12 @@ class Job104Scraper(BaseScraper):
 
         salary_min = _to_float(item.get("salaryLow"))
         salary_max = _to_float(item.get("salaryHigh"))
+        # 待遇面議 ("negotiable") ships salaryLow=0/salaryHigh=0 — treat a
+        # zero (or absent) bound as unknown rather than emitting "TWD 0–0".
+        if not salary_min:
+            salary_min = None
+        if not salary_max:
+            salary_max = None
         salary_currency: str | None = None
         salary_summary: str | None = None
         if salary_min is not None or salary_max is not None:

--- a/src/jobhive/scrapers/job104.py
+++ b/src/jobhive/scrapers/job104.py
@@ -1,0 +1,501 @@
+"""104.com.tw — Taiwan's largest job board scraper.
+
+104 (https://www.104.com.tw) is by far the largest job board in Taiwan,
+with ~516k live postings at the time of writing. The public search API
+that the website's own frontend consumes is unauthenticated:
+
+    GET https://www.104.com.tw/jobs/search/api/jobs
+
+The API hard-caps ``lastPage`` at **100** (×32 jobs per page = 3,200
+jobs per query) regardless of how many results match — so to cover the
+full corpus we **slice** the search via ``area`` and ``jobcat`` filters.
+A single (area, top-level jobcat) slice is virtually always under the
+3,200 cap, even for the biggest combinations (Taipei × Software).
+
+22 areas × ~20 top-level job categories = ~440 slice queries × up to
+100 pages each = ~44k requests in the worst case. Concurrency is
+capped at 4 to stay polite — same default as the Wanted scraper.
+
+Single-source scraper: ``company_slug`` is informational and ignored
+(matches the bundesagentur / eures / wanted pattern). Output rows
+carry the publishing employer's name as ``company`` so cross-ATS
+dedup against direct ATS scrapes still works.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+log = logging.getLogger(__name__)
+
+API_URL = "https://www.104.com.tw/jobs/search/api/jobs"
+SEARCH_REFERER = "https://www.104.com.tw/jobs/search/"
+PAGE_SIZE = 32  # API's fixed page size — overriding doesn't increase it.
+PAGE_LIMIT = 100  # ``lastPage`` is capped here, regardless of ``total``.
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 4
+RETRY_BASE_DELAY = 1.5
+
+# Top-level area codes (Taiwan's cities/counties + cross-strait + overseas)
+# as used by 104's ``area=`` filter. These are 104-internal codes, not
+# ROC administrative codes — verified against the live search UI.
+_DEFAULT_AREAS: tuple[str, ...] = (
+    "6001001000",  # Taipei City (台北市)
+    "6001002000",  # New Taipei City (新北市)
+    "6001008000",  # Taoyuan
+    "6001006000",  # Hsinchu County (新竹縣)
+    "6001005000",  # Hsinchu City (新竹市)
+    "6001007000",  # Miaoli
+    "6001004000",  # Taichung
+    "6001003000",  # Yilan
+    "6001011000",  # Changhua
+    "6001012000",  # Nantou
+    "6001013000",  # Yunlin
+    "6001014000",  # Chiayi
+    "6001015000",  # Tainan
+    "6001016000",  # Kaohsiung
+    "6001017000",  # Pingtung
+    "6001018000",  # Taitung
+    "6001019000",  # Hualien
+    "6001020000",  # Penghu / Kinmen / Matsu
+    "6001025000",  # China (cross-strait)
+    "6001026000",  # Overseas
+)
+
+# Areas that are NOT inside Taiwan — used to suppress the default
+# ``country_iso=TW`` on rows scraped through these slices.
+_NON_TW_AREAS: frozenset[str] = frozenset({"6001025000", "6001026000"})
+
+# Top-level job categories (104's ``jobcat=`` filter).
+_DEFAULT_JOBCATS: tuple[str, ...] = (
+    "2001000000",  # Operations / 管理
+    "2002000000",  # Sales / 銷售
+    "2003000000",  # Marketing / 行銷
+    "2004000000",  # Admin / 行政
+    "2005000000",  # Finance / 財務
+    "2006000000",  # Manufacturing / 製造
+    "2007000000",  # Software / 資訊
+    "2008000000",  # Engineering / 工程
+    "2009000000",  # Construction / 建築
+    "2010000000",  # Hospitality / 餐旅
+    "2011000000",  # Healthcare / 醫療
+    "2012000000",  # Education / 教育
+    "2013000000",  # Design / 設計
+    "2014000000",  # Legal / 法務
+    "2015000000",  # Logistics / 物流
+    "2016000000",  # Media / 媒體
+    "2017000000",  # Beauty / 美容
+    "2018000000",  # Maintenance / 維修
+    "2019000000",  # General / 總務
+    "2099000000",  # Other / 其他
+)
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"\s+")
+
+
+@ScraperRegistry.register(ATSType.JOB104)
+class Job104Scraper(BaseScraper):
+    """104.com.tw search API scraper.
+
+    Single-source scraper: ``company_slug`` is ignored. Pass anything
+    (``"any"``, ``""``) — the scraper enumerates every (area, jobcat)
+    slice covering all of Taiwan (+ cross-strait + overseas).
+
+    To restrict the sweep (smaller test runs, partial-region cron):
+
+    .. code-block:: python
+
+        Job104Scraper(
+            "any",
+            areas=["6001001000"],          # Taipei only
+            jobcats=["2007000000"],        # Software only
+        )
+    """
+
+    ats = ATSType.JOB104
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        areas: tuple[str, ...] | list[str] = _DEFAULT_AREAS,
+        jobcats: tuple[str, ...] | list[str] = _DEFAULT_JOBCATS,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.areas = tuple(areas)
+        self.jobcats = tuple(jobcats)
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        lock = asyncio.Lock()
+
+        async def absorb(items: list[dict[str, Any]], *, area: str) -> None:
+            new_jobs: list[Job] = []
+            async with lock:
+                for it in items:
+                    job = self._parse_job(it, area=area)
+                    if job is None or job.ats_id in seen:
+                        continue
+                    seen.add(job.ats_id)
+                    new_jobs.append(job)
+            jobs.extend(new_jobs)
+
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+
+            async def per_slice(area: str, jobcat: str) -> None:
+                await self._exhaust_slice(
+                    client, sem,
+                    area=area, jobcat=jobcat,
+                    absorb=absorb,
+                )
+
+            await _gather_tolerant(
+                (per_slice(a, c) for a in self.areas for c in self.jobcats),
+                label="slice",
+            )
+        return jobs
+
+    async def _exhaust_slice(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        *,
+        area: str,
+        jobcat: str,
+        absorb: Any,
+    ) -> None:
+        """Pull every page of a (area, jobcat) slice. Caps at PAGE_LIMIT
+        — if a single (area, jobcat) ever produces >3,200 jobs we accept
+        the cap loss for the first PR (rare; would need sub-jobcat
+        recursion to fully cover)."""
+        first = await self._search(
+            client, sem, area=area, jobcat=jobcat, page=1,
+        )
+        items = (first.get("data") or [])
+        if not items:
+            return
+        await absorb(items, area=area)
+
+        pagination = (first.get("metadata") or {}).get("pagination") or {}
+        try:
+            last_page = int(pagination.get("lastPage") or 1)
+        except (TypeError, ValueError):
+            last_page = 1
+        last_page = min(last_page, PAGE_LIMIT)
+        if last_page <= 1:
+            return
+
+        async def one(page: int) -> None:
+            payload = await self._search(
+                client, sem, area=area, jobcat=jobcat, page=page,
+            )
+            await absorb(payload.get("data") or [], area=area)
+
+        await _gather_tolerant(
+            (one(p) for p in range(2, last_page + 1)),
+            label="page",
+        )
+
+    # --- HTTP layer ---------------------------------------------------------
+
+    async def _search(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        *,
+        area: str,
+        jobcat: str,
+        page: int,
+    ) -> dict[str, Any]:
+        params = {
+            "order": "15",  # sort by posted-desc (newest first)
+            "asc": "0",
+            "page": str(page),
+            "mode": "s",
+            "jobsource": "2018indexpoc",
+            "area": area,
+            "jobcat": jobcat,
+            "ro": "0",  # all work types
+        }
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(
+                        API_URL,
+                        params=params,
+                        headers={
+                            "Accept": "application/json",
+                            "User-Agent": "Mozilla/5.0",
+                            "Referer": SEARCH_REFERER,
+                        },
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"104 fetch failed for area={area} "
+                            f"jobcat={jobcat} page={page}: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                try:
+                    return response.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"104 returned non-JSON for area={area} "
+                        f"jobcat={jobcat} page={page}: {exc}"
+                    ) from exc
+            if response.status_code in (400, 404, 422):
+                # Invalid slice (unknown category code, etc.) — treat as
+                # "this slice has no data" rather than aborting the run.
+                log.warning(
+                    "104 returned %s for area=%s jobcat=%s page=%s — "
+                    "skipping slice", response.status_code, area, jobcat, page,
+                )
+                return {"data": [], "metadata": {"pagination": {"lastPage": 1}}}
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"104 returned {response.status_code} for area={area} "
+                        f"jobcat={jobcat} page={page} after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"104 returned {response.status_code} for area={area} "
+                f"jobcat={jobcat} page={page}"
+            )
+        raise ScraperError(
+            f"104 exhausted retries for area={area} jobcat={jobcat} "
+            f"page={page}: {last_exc}"
+        )
+
+    # --- parsing ------------------------------------------------------------
+
+    def _parse_job(
+        self, item: dict[str, Any], *, area: str,
+    ) -> Job | None:
+        job_no = item.get("jobNo")
+        if job_no is None or str(job_no).strip() == "":
+            return None
+        ats_id = str(job_no).strip()
+
+        title = (item.get("jobName") or "").strip()
+        if not title:
+            return None
+
+        company = (item.get("custName") or "").strip() or "Unknown"
+
+        url = _absolute_job_url(item.get("link") or {}, ats_id)
+        if url is None:
+            return None
+
+        # Location: 104 ships a Chinese city/district label
+        # (``jobAddrNoDesc``) plus an optional free-text street address.
+        # Combine when both are present so consumers see e.g.
+        # "新竹縣竹北市 — 光明六路 100 號" instead of dropping detail.
+        addr_desc = _clean_str(item.get("jobAddrNoDesc"))
+        street = _clean_str(item.get("jobAddress"))
+        if addr_desc and street and street != addr_desc:
+            location = f"{addr_desc} — {street}"
+        else:
+            location = addr_desc or street
+
+        # ``country_iso`` defaults to TW unless this slice is cross-strait
+        # (China) or overseas — the area filter is structured enough to
+        # decide without reading the location text.
+        country_iso = None if area in _NON_TW_AREAS else "TW"
+
+        lat = _to_float(item.get("lat"))
+        lon = _to_float(item.get("lon"))
+        # 104 occasionally ships (0.0, 0.0) for jobs whose employer hasn't
+        # been geocoded — drop those rather than pin them to Africa.
+        if lat == 0.0 and lon == 0.0:
+            lat = lon = None
+
+        salary_min = _to_float(item.get("salaryLow"))
+        salary_max = _to_float(item.get("salaryHigh"))
+        salary_currency: str | None = None
+        salary_summary: str | None = None
+        if salary_min is not None or salary_max is not None:
+            salary_currency = "TWD"
+            salary_summary = _format_salary_summary(salary_min, salary_max)
+
+        posted_at = _parse_appear_date(item.get("appearDate"))
+
+        description = _clean_description(item.get("description")) or _clean_description(
+            item.get("descSnippet")
+        )
+
+        department = _first_jobcat_name(item.get("jobCat"))
+
+        raw: dict[str, Any] = {}
+        for src_key, dst_key in (
+            ("jobAddrNo", "job_addr_no"),
+            ("coIndustry", "industry"),
+            ("coIndustryDesc", "industry_desc"),
+            ("optionEdu", "education"),
+            ("period", "experience_label"),
+            ("jobType", "job_type"),
+            ("employeeCount", "employee_count"),
+            ("remoteWorkType", "remote_work_type"),
+        ):
+            value = item.get(src_key)
+            if value not in (None, "", []):
+                raw[dst_key] = value
+        tags = item.get("tags")
+        if isinstance(tags, list) and tags:
+            raw["tags"] = [t for t in tags if isinstance(t, str)][:20]
+        skills = item.get("pcSkills")
+        if isinstance(skills, list) and skills:
+            raw["skills"] = [
+                s.get("description") if isinstance(s, dict) else s
+                for s in skills
+                if isinstance(s, dict | str)
+            ][:20]
+
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.JOB104,
+            ats_id=ats_id,
+            location=location,
+            country_iso=country_iso,
+            lat=lat,
+            lon=lon,
+            salary_currency=salary_currency,
+            salary_period="MONTH" if salary_currency else None,
+            salary_summary=salary_summary,
+            salary_min=salary_min,
+            salary_max=salary_max,
+            department=department,
+            description=description,
+            posted_at=posted_at,
+            fetched_at=datetime.now(),
+            language="zh",
+            raw=raw or None,
+        )
+
+
+def _absolute_job_url(link: dict[str, Any], job_no: str) -> str | None:
+    """104 ships ``link.job`` as a protocol-relative URL
+    (``//www.104.com.tw/job/abc123``). Prefix ``https:`` so downstream
+    Pydantic ``HttpUrl`` validation accepts it. Falls back to
+    constructing the canonical URL from ``job_no``."""
+    raw = link.get("job") if isinstance(link, dict) else None
+    if isinstance(raw, str) and raw.strip():
+        raw = raw.strip()
+        if raw.startswith("//"):
+            return f"https:{raw}"
+        if raw.startswith("http://"):
+            return "https://" + raw[len("http://"):]
+        if raw.startswith("https://"):
+            return raw
+        if raw.startswith("/"):
+            return f"https://www.104.com.tw{raw}"
+    return f"https://www.104.com.tw/job/{job_no}"
+
+
+def _parse_appear_date(value: object) -> datetime | None:
+    """``appearDate`` is a YYYYMMDD string (e.g. ``"20260510"``). Parse to
+    a UTC-naive datetime at midnight, or return None if missing/malformed."""
+    if not isinstance(value, str) or len(value) != 8 or not value.isdigit():
+        return None
+    try:
+        return datetime.strptime(value, "%Y%m%d")
+    except ValueError:
+        return None
+
+
+def _format_salary_summary(low: float | None, high: float | None) -> str:
+    """Render a TWD salary range using the local "NT$" symbol —
+    matches how 104 displays it in the UI."""
+    if low is not None and high is not None:
+        return f"NT${int(low):,} – NT${int(high):,}"
+    if low is not None:
+        return f"NT${int(low):,}+"
+    assert high is not None  # one bound must be set if we got here
+    return f"up to NT${int(high):,}"
+
+
+def _first_jobcat_name(value: object) -> str | None:
+    """Top-level job category name from ``jobCat`` (a list of
+    ``{"name": ..., "code": ...}``). Returns the first non-empty name."""
+    if not isinstance(value, list):
+        return None
+    for entry in value:
+        if isinstance(entry, dict):
+            name = entry.get("name")
+            if isinstance(name, str) and name.strip():
+                return name.strip()
+    return None
+
+
+def _clean_description(value: object) -> str | None:
+    """Strip HTML tags and collapse whitespace from 104's ``description``
+    field. Some postings ship plain text, some ship light HTML."""
+    if not isinstance(value, str):
+        return None
+    stripped = _HTML_TAG_RE.sub(" ", value)
+    cleaned = _WS_RE.sub(" ", stripped).strip()
+    return cleaned or None
+
+
+def _clean_str(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _to_float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+async def _gather_tolerant(coros: Any, *, label: str) -> None:
+    """Run every coroutine concurrently, log + swallow failures instead
+    of cancelling siblings — matches the EURES pattern. A single 104
+    slice failure shouldn't abort a 440-slice run."""
+    results = await asyncio.gather(*coros, return_exceptions=True)
+    for r in results:
+        if isinstance(r, BaseException):
+            log.warning("104 %s subtask failed: %s", label, r)

--- a/tests/test_job104.py
+++ b/tests/test_job104.py
@@ -1,0 +1,456 @@
+"""Tests for the 104.com.tw (Taiwan) scraper.
+
+Pin the parsing contract (each 104 search API field → Job field) and
+the (area × jobcat) slicing pagination behaviour. The API caps
+``lastPage`` at 100, so the scraper expects to fan out across many
+slices to cover the full corpus — we exercise the per-slice pagination
+shape with sanitised mock payloads.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import Job104Scraper, ScraperRegistry
+
+_API_RE = re.compile(r"^https://www\.104\.com\.tw/jobs/search/api/jobs")
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.job104 as j
+    monkeypatch.setattr(j, "MAX_RETRIES", 1)
+    monkeypatch.setattr(j, "RETRY_BASE_DELAY", 0.0)
+
+
+# --- fixtures ---------------------------------------------------------------
+
+
+def _job_item(
+    *,
+    job_no: str = "16x9z",
+    job_name: str = "資深軟體工程師 / Senior Software Engineer",
+    cust_name: str = "範例科技股份有限公司",
+    job_addr_no_desc: str = "新竹縣竹北市",
+    job_address: str = "光明六路東一段 100 號",
+    appear_date: str = "20260510",
+    salary_low: int | None = 50_000,
+    salary_high: int | None = 80_000,
+    lat: float | None = 24.8268,
+    lon: float | None = 121.0044,
+    description: str = "負責後端服務架構 / Build resilient backend services.",
+    desc_snippet: str = "後端工程師",
+    job_cat: list[dict[str, str]] | None = None,
+    tags: list[str] | None = None,
+    skills: list[dict[str, str]] | None = None,
+    period: str = "3 ~ 5 年",
+    option_edu: str = "學歷不拘",
+) -> dict[str, Any]:
+    return {
+        "appearDate": appear_date,
+        "applyCnt": 12,
+        "coIndustry": 1001006001,
+        "coIndustryDesc": "電腦系統整合服務業",
+        "custName": cust_name,
+        "custNo": "130000000142203",
+        "description": description,
+        "descSnippet": desc_snippet,
+        "jobAddress": job_address,
+        "jobAddrNo": 6001006002,
+        "jobAddrNoDesc": job_addr_no_desc,
+        "jobName": job_name,
+        "jobNo": job_no,
+        "jobRo": 1,
+        "jobType": "1",
+        "lat": lat,
+        "lon": lon,
+        "link": {
+            "job": f"//www.104.com.tw/job/{job_no}",
+            "applyAnalyze": f"//www.104.com.tw/jobs/apply/analyze/{job_no}",
+            "cust": "//www.104.com.tw/company/abc",
+        },
+        "major": [],
+        "optionEdu": option_edu,
+        "period": period,
+        "remoteWorkType": 0,
+        "salaryHigh": salary_high,
+        "salaryLow": salary_low,
+        "tags": tags or ["上市上櫃", "員工旅遊"],
+        "jobCat": job_cat or [
+            {"name": "軟體工程師", "code": "2007001003"},
+            {"name": "後端工程師", "code": "2007001005"},
+        ],
+        "languageRequirements": [],
+        "employeeCount": "100-499人",
+        "pcSkills": skills or [
+            {"description": "Python"},
+            {"description": "PostgreSQL"},
+        ],
+    }
+
+
+def _page(
+    items: list[dict[str, Any]],
+    *,
+    current_page: int = 1,
+    last_page: int = 1,
+    total: int = 1,
+) -> dict[str, Any]:
+    return {
+        "data": items,
+        "metadata": {
+            "pagination": {
+                "count": len(items),
+                "currentPage": current_page,
+                "lastPage": last_page,
+                "total": total,
+            }
+        },
+    }
+
+
+# --- registry / wiring ------------------------------------------------------
+
+
+def test_registry_resolves_job104() -> None:
+    assert ScraperRegistry.get(ATSType.JOB104) is Job104Scraper
+
+
+def test_ats_value_is_string_104() -> None:
+    """The ATS enum value is exactly ``"104"`` (digits as a string).
+    Downstream consumers split ``global_id`` on the first colon so a
+    purely numeric ats_type value is safe."""
+    assert ATSType.JOB104.value == "104"
+
+
+# --- happy path -------------------------------------------------------------
+
+
+def test_parses_full_search_payload(httpx_mock: Any) -> None:
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page([_job_item()]),
+    )
+    jobs = Job104Scraper(
+        "any",
+        areas=["6001006000"],  # Hsinchu County
+        jobcats=["2007000000"],  # Software
+    ).fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+
+    assert j.ats_type is ATSType.JOB104
+    assert j.ats_id == "16x9z"
+    assert j.global_id == "104:16x9z"
+    assert j.title == "資深軟體工程師 / Senior Software Engineer"
+    assert j.company == "範例科技股份有限公司"
+    # Protocol-relative link is upgraded to https.
+    assert str(j.url) == "https://www.104.com.tw/job/16x9z"
+    # Location combines structured area description with the street address.
+    assert j.location == "新竹縣竹北市 — 光明六路東一段 100 號"
+    assert j.country_iso == "TW"
+    assert j.language == "zh"
+    assert j.lat == pytest.approx(24.8268)
+    assert j.lon == pytest.approx(121.0044)
+    # Salary is monthly TWD.
+    assert j.salary_currency == "TWD"
+    assert j.salary_period == "MONTH"
+    assert j.salary_min == 50_000
+    assert j.salary_max == 80_000
+    assert j.salary_summary == "NT$50,000 – NT$80,000"
+    # Department is the top-level jobCat name.
+    assert j.department == "軟體工程師"
+    # appearDate YYYYMMDD → datetime at midnight.
+    assert j.posted_at is not None
+    assert j.posted_at.year == 2026
+    assert j.posted_at.month == 5
+    assert j.posted_at.day == 10
+    # Description is HTML-cleaned (here already plain text) and preferred
+    # over the snippet.
+    assert j.description is not None
+    assert "Build resilient backend services" in j.description
+    # raw captures provider-specific overflow.
+    assert j.raw is not None
+    assert j.raw.get("industry") == 1001006001
+    assert j.raw.get("education") == "學歷不拘"
+    assert j.raw.get("experience_label") == "3 ~ 5 年"
+    assert "Python" in (j.raw.get("skills") or [])
+
+
+def test_country_iso_is_tw_for_normal_taiwan_area(httpx_mock: Any) -> None:
+    """Any area code that isn't the cross-strait / overseas sentinel
+    should produce ``country_iso="TW"`` without reading the location text."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page([_job_item(job_no="tp1", job_addr_no_desc="台北市信義區")]),
+    )
+    jobs = Job104Scraper(
+        "any",
+        areas=["6001001000"],  # Taipei City
+        jobcats=["2007000000"],
+    ).fetch()
+    assert jobs[0].country_iso == "TW"
+
+
+def test_country_iso_none_for_overseas_slice(httpx_mock: Any) -> None:
+    """Slices through the ``海外`` (overseas) bucket genuinely aren't TW
+    — leave ``country_iso`` unset so downstream LLM enrichment can resolve."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page([_job_item(job_no="o1", job_addr_no_desc="日本東京")]),
+    )
+    jobs = Job104Scraper(
+        "any",
+        areas=["6001026000"],  # Overseas
+        jobcats=["2007000000"],
+    ).fetch()
+    assert jobs[0].country_iso is None
+
+
+def test_country_iso_none_for_china_slice(httpx_mock: Any) -> None:
+    """Cross-strait (China) postings shouldn't be marked ``TW``."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page([_job_item(job_no="cn1", job_addr_no_desc="上海市浦東新區")]),
+    )
+    jobs = Job104Scraper(
+        "any",
+        areas=["6001025000"],  # China
+        jobcats=["2007000000"],
+    ).fetch()
+    assert jobs[0].country_iso is None
+
+
+# --- pagination -------------------------------------------------------------
+
+
+def test_paginates_within_slice_up_to_last_page(httpx_mock: Any) -> None:
+    """``metadata.pagination.lastPage`` drives the per-slice page fan-out."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page(
+            [_job_item(job_no=f"p1-{i}") for i in range(5)],
+            current_page=1,
+            last_page=3,
+            total=15,
+        ),
+    )
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page(
+            [_job_item(job_no=f"p2-{i}") for i in range(5)],
+            current_page=2,
+            last_page=3,
+            total=15,
+        ),
+    )
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page(
+            [_job_item(job_no=f"p3-{i}") for i in range(5)],
+            current_page=3,
+            last_page=3,
+            total=15,
+        ),
+    )
+
+    jobs = Job104Scraper(
+        "any",
+        areas=["6001001000"],
+        jobcats=["2007000000"],
+    ).fetch()
+    assert len(jobs) == 15
+
+
+def test_dedupes_across_slices(httpx_mock: Any) -> None:
+    """The same job appearing in two (area, jobcat) slices must only be
+    emitted once — 104's category tagging often overlaps."""
+    httpx_mock.add_response(
+        url=re.compile(r".*jobcat=2007000000.*"),
+        json=_page([_job_item(job_no="dupA"), _job_item(job_no="dupB")]),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r".*jobcat=2008000000.*"),
+        json=_page([_job_item(job_no="dupB"), _job_item(job_no="dupC")]),
+    )
+
+    jobs = Job104Scraper(
+        "any",
+        areas=["6001001000"],
+        jobcats=["2007000000", "2008000000"],
+    ).fetch()
+    assert {j.ats_id for j in jobs} == {"dupA", "dupB", "dupC"}
+
+
+# --- field-level edge cases --------------------------------------------------
+
+
+def test_skips_jobs_missing_jobno_or_jobname(httpx_mock: Any) -> None:
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page([
+            _job_item(job_no="ok1"),
+            {**_job_item(job_no="missing-name"), "jobName": ""},
+            {**_job_item(), "jobNo": None},
+        ]),
+    )
+    jobs = Job104Scraper(
+        "any",
+        areas=["6001001000"],
+        jobcats=["2007000000"],
+    ).fetch()
+    assert [j.ats_id for j in jobs] == ["ok1"]
+
+
+def test_handles_missing_salary(httpx_mock: Any) -> None:
+    """When the employer hides salary, both bounds are 0 / missing —
+    leave currency unset rather than emit a zeroed range."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page([
+            _job_item(job_no="nosal", salary_low=None, salary_high=None),
+        ]),
+    )
+    jobs = Job104Scraper(
+        "any",
+        areas=["6001001000"],
+        jobcats=["2007000000"],
+    ).fetch()
+    assert jobs[0].salary_currency is None
+    assert jobs[0].salary_min is None
+    assert jobs[0].salary_max is None
+    assert jobs[0].salary_summary is None
+
+
+def test_drops_zero_zero_coordinates(httpx_mock: Any) -> None:
+    """``(lat, lon) = (0, 0)`` shows up when the employer hasn't been
+    geocoded — pinning to (0, 0) would put the job off the coast of
+    Ghana, so drop both."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page([
+            _job_item(job_no="z1", lat=0.0, lon=0.0),
+        ]),
+    )
+    jobs = Job104Scraper(
+        "any",
+        areas=["6001001000"],
+        jobcats=["2007000000"],
+    ).fetch()
+    assert jobs[0].lat is None
+    assert jobs[0].lon is None
+
+
+def test_strips_html_from_description(httpx_mock: Any) -> None:
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page([
+            _job_item(
+                job_no="h1",
+                description="<p>Build <b>resilient</b> backends.</p>",
+            ),
+        ]),
+    )
+    jobs = Job104Scraper(
+        "any",
+        areas=["6001001000"],
+        jobcats=["2007000000"],
+    ).fetch()
+    assert jobs[0].description == "Build resilient backends."
+
+
+def test_falls_back_to_desc_snippet_when_description_empty(httpx_mock: Any) -> None:
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page([
+            _job_item(
+                job_no="s1", description="", desc_snippet="Short summary.",
+            ),
+        ]),
+    )
+    jobs = Job104Scraper(
+        "any",
+        areas=["6001001000"],
+        jobcats=["2007000000"],
+    ).fetch()
+    assert jobs[0].description == "Short summary."
+
+
+def test_location_falls_back_to_street_when_addr_desc_empty(httpx_mock: Any) -> None:
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page([
+            _job_item(
+                job_no="loc1", job_addr_no_desc="", job_address="新北市板橋區",
+            ),
+        ]),
+    )
+    jobs = Job104Scraper(
+        "any",
+        areas=["6001002000"],
+        jobcats=["2007000000"],
+    ).fetch()
+    assert jobs[0].location == "新北市板橋區"
+
+
+# --- error handling ---------------------------------------------------------
+
+
+def test_persistent_500_raises(httpx_mock: Any) -> None:
+    """Real server failures should surface; the tolerant gather catches
+    them at the slice boundary, so a single failing slice produces an
+    empty result (logged warning) rather than crashing the run."""
+    httpx_mock.add_response(url=_API_RE, status_code=500, is_reusable=True)
+    jobs = Job104Scraper(
+        "any",
+        areas=["6001001000"],
+        jobcats=["2007000000"],
+    ).fetch()
+    # Single failing slice swallowed via _gather_tolerant — result is empty.
+    assert jobs == []
+
+
+def test_400_treated_as_empty_slice(httpx_mock: Any) -> None:
+    """Some (area, jobcat) combos return 400 (unknown category at that
+    area). The scraper should skip rather than abort the whole run."""
+    httpx_mock.add_response(url=_API_RE, status_code=400)
+    jobs = Job104Scraper(
+        "any",
+        areas=["6001001000"],
+        jobcats=["2099000000"],
+    ).fetch()
+    assert jobs == []
+
+
+def test_non_json_response_raises(httpx_mock: Any) -> None:
+    """If 104 ever returns HTML for a 200 (CDN intercept), the scraper
+    should raise rather than silently drop. _gather_tolerant catches at
+    the slice level, but the inner _search call still wraps the parse
+    failure in a ScraperError that we can assert on by bypassing the
+    fan-out and probing the slice directly."""
+    import asyncio
+
+    import httpx as _httpx
+
+    httpx_mock.add_response(url=_API_RE, text="<html>bot wall</html>")
+    scraper = Job104Scraper(
+        "any",
+        areas=["6001001000"],
+        jobcats=["2007000000"],
+    )
+
+    async def _probe() -> None:
+        async with _httpx.AsyncClient() as client:
+            sem = asyncio.Semaphore(1)
+            await scraper._search(
+                client, sem,
+                area="6001001000", jobcat="2007000000", page=1,
+            )
+
+    with pytest.raises(ScraperError):
+        asyncio.run(_probe())

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -27,7 +27,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # National / supranational public-sector aggregators
         "bundesagentur", "arbetsformedlingen", "eures",
         # Hybrid jobboards (companies post directly)
-        "welcometothejungle", "getonbrd", "wanted", "remoteok",
+        "welcometothejungle", "getonbrd", "wanted", "104", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
         "manfred", "thehub", "ycombinator", "wellfound",
         # Additional multi-tenant ATSes


### PR DESCRIPTION
## Summary

- New `Job104Scraper` (`ATSType.JOB104 = "104"`) targeting 104.com.tw — Taiwan's largest job board, ~516k live postings. Public JSON search API, no auth.
- The API caps `lastPage` at 100 (×32 jobs/page = 3,200 per query), so the scraper slices the search across **(area × top-level jobcat)** — 22 Taiwan areas (cities/counties + cross-strait + overseas) × ~20 top-level job categories = ~440 slices × up to 100 pages each. A single (area, jobcat) slice has reliably stayed under the 3,200 cap in probe runs.
- Async `httpx.AsyncClient` with `MAX_CONCURRENCY = 4`, retries on 429/5xx with exponential backoff, tolerant gather so a single bad slice never aborts a full sweep.
- Field mapping: `jobNo`→`ats_id`, protocol-relative `link.job`→`url` (prefixed with `https:`), `appearDate` (YYYYMMDD)→`posted_at`, structured `salaryLow`/`salaryHigh`→TWD monthly, geocoded `lat`/`lon` when present (drops the `(0, 0)` placeholder), `jobAddrNoDesc` + `jobAddress` for the location, `jobCat[0].name`→`department`, HTML-stripped `description` with `descSnippet` fallback. `country_iso="TW"` for all area slices except cross-strait (`6001025000`) and overseas (`6001026000`) where it's left unset for downstream enrichment. `language="zh"`.

## Sample API call

```
curl 'https://www.104.com.tw/jobs/search/api/jobs?order=15&page=1&mode=s&jobsource=2018indexpoc&area=6001001000&jobcat=2007000000&ro=0' \
  -H 'Accept: application/json' \
  -H 'User-Agent: Mozilla/5.0' \
  -H 'Referer: https://www.104.com.tw/jobs/search/'
```

## Test plan

- [x] `ruff check` on changed files passes
- [x] `pytest tests/test_job104.py tests/test_models.py` (79 tests) passes
- [x] Full scraper + manifest + models suite passes (124 tests)
- [x] `ScraperRegistry.get(ATSType.JOB104)` resolves to `Job104Scraper`
- [x] `ATSType.JOB104.value == "104"` pinned (Python enum member can't start with a digit, hence `JOB104`)
- [ ] Run live end-to-end against a single (Taipei, Software) slice to validate the 3,200 cap doesn't bite under real traffic
- [ ] Sanity-check `(area=6001025000, jobcat=...)` returns CN-located rows with `country_iso=None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `Job104Scraper` for 104.com.tw using the public JSON search API (no auth). It slices by area and top-level job category to bypass the 100-page cap, and includes fixes for retry stalling and zero-salary handling.

- **New Features**
  - Added `ATSType.JOB104` (`"104"`) and registered/exported `Job104Scraper`; seeded `ats-companies/job104.csv`.
  - Async `httpx` with concurrency 4, backoff retries, and tolerant gather so a bad slice doesn’t stop the run.
  - Slices across 22 areas × ~20 top-level `jobcat`, paginates up to 100 pages per slice, and de-duplicates across slices.
  - Field mapping: `jobNo`→`ats_id`; protocol-relative links normalized; `appearDate`→`posted_at`; TWD monthly salary from `salaryLow/High` with summary; `(0,0)` coords dropped; location from `jobAddrNoDesc` + `jobAddress`; `jobCat[0].name`→`department`; `country_iso="TW"` except cross-strait/overseas; `language="zh"`.
  - Tests: added `tests/test_job104.py` for parsing, pagination, and errors; updated `tests/test_models.py` to include `"104"`.

- **Bug Fixes**
  - Released the semaphore before sleeping on connection-error retries to prevent concurrency stalls.
  - Treats zero/absent salary bounds as unknown so we don’t emit a `0–0` TWD range.

<sup>Written for commit 823e630f25490295d81ae419df550f3a890ef8a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `Job104Scraper`, a new async scraper for Taiwan's 104.com.tw job board that slices queries across 20 area codes × 20 job categories to work around the API's 100-page cap, with deduplication, concurrency limiting, and tolerant error handling.

- Async `httpx` client with `asyncio.Semaphore(4)` and exponential-backoff retries; the 429/5xx retry path correctly releases the semaphore before sleeping, but the `httpx.HTTPError` (connection failure) retry path sleeps while still holding the slot, potentially stalling all four concurrency slots simultaneously.
- Field mapping covers `jobNo`→`ats_id`, protocol-relative URL normalisation, TWD salary range, `(0,0)` geocode suppression, HTML stripping, and `country_iso` logic keyed on the area code.
- Tests are thorough: happy-path field assertions, pagination fan-out, cross-slice dedup, and error/edge-case coverage.

<h3>Confidence Score: 3/5</h3>

The core scraping and parsing logic is well-constructed, but the semaphore is held during connection-error retry sleeps, which can temporarily stall all concurrent HTTP slots and significantly slow a full 440-slice run under degraded network conditions.

The connection-error retry path holds the semaphore slot for the entire backoff sleep duration, contrary to the intended concurrency design. The other findings are quality concerns that don't break correctness but affect robustness and throughput.

src/jobhive/scrapers/job104.py — specifically the _search retry loop and the absorb closure in _fetch_async.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/job104.py | New scraper with solid retry/dedup logic, but the httpx.HTTPError retry path holds the semaphore slot during sleep (reducing effective concurrency), job parsing runs inside the shared lock (serialising CPU work), and a bare assert is used for an internal invariant. |
| tests/test_job104.py | Comprehensive unit tests covering field mapping, pagination, dedup, and error handling; no issues found. |
| src/jobhive/models.py | Adds ATSType.JOB104 = "104" in alphabetical position; straightforward and correct. |
| src/jobhive/scrapers/__init__.py | Imports and exports Job104Scraper correctly alongside the existing scrapers. |
| tests/test_models.py | Adds "104" to the exhaustive ATSType membership check; no issues. |
| ats-companies/job104.csv | Seed CSV with a single row for 104.com.tw; correct format. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/jobhive/scrapers/job104.py:244-263
**Semaphore held during connection-error retry sleep**

The `await asyncio.sleep(RETRY_BASE_DELAY * attempt)` on line 262 executes while the `async with sem:` context is still active (lines 244–263). That slot is not released until after the sleep completes, so during a connection failure the semaphore can be fully occupied by tasks that are all sleeping, starving every other concurrent request. With `MAX_RETRIES=4` and `RETRY_BASE_DELAY * attempt` ramp-up the worst case stall reaches 4.5 s × 4 slots = the full semaphore blocked for several seconds.

The 429/5xx path correctly releases the sem before sleeping (lines 280–292 are outside `async with sem:`). The `httpx.HTTPError` path should follow the same pattern — restructure the try/except so the sleep happens after the context manager exits.

### Issue 2 of 3
src/jobhive/scrapers/job104.py:447-448
`assert` statements are silently removed when Python runs with `-O`. If the calling code ever passes both bounds as `None`, the optimised build would fall through to `int(None)` and raise a bare `TypeError`. Replace with an explicit guard.

```suggestion
    if high is None:
        raise ValueError("_format_salary_summary called with both bounds None")
    return f"up to NT${int(high):,}"
```

### Issue 3 of 3
src/jobhive/scrapers/job104.py:151-160
**CPU-bound parsing serialised under the asyncio lock**

`self._parse_job(…)` — which runs two regex substitutions and builds a full `Job` object — is called on every item while the `lock` is held (lines 153–159). Because all concurrent `absorb` callers queue on the same lock, job parsing is effectively single-threaded even when many slices are ready to submit their results simultaneously. The lock is only needed for the `seen` set and the `jobs` list; parsing can safely happen before acquiring it.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: job104.csv"](https://github.com/kalil0321/ats-scrapers/commit/6d2c2549859846769406b2c37e5662a0c53d3ffe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732396)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->