### PR TITLE
Add VietnamWorks scraper

### DIFF
--- a/ats-companies/vietnamworks.csv
+++ b/ats-companies/vietnamworks.csv
@@ -1,0 +1,2 @@
+name,slug,url
+VietnamWorks,vietnamworks,https://www.vietnamworks.com

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -71,6 +71,7 @@ class ATSType(StrEnum):
     WELCOMETOTHEJUNGLE = "welcometothejungle"
     GETONBRD = "getonbrd"
     WANTED = "wanted"
+    VIETNAMWORKS = "vietnamworks"
     REMOTEOK = "remoteok"
     WEWORKREMOTELY = "weworkremotely"
     PROGRAMATHOR = "programathor"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -51,6 +51,7 @@ from jobhive.scrapers.thehub import TheHubScraper
 from jobhive.scrapers.tiktok import TikTokScraper
 from jobhive.scrapers.uber import UberScraper
 from jobhive.scrapers.usajobs import USAJobsScraper
+from jobhive.scrapers.vietnamworks import VietnamWorksScraper
 from jobhive.scrapers.wanted import WantedScraper
 from jobhive.scrapers.welcometothejungle import WTTJScraper
 from jobhive.scrapers.wellfound import WellfoundScraper
@@ -103,6 +104,7 @@ __all__ = [
     "TikTokScraper",
     "USAJobsScraper",
     "UberScraper",
+    "VietnamWorksScraper",
     "WTTJScraper",
     "WantedScraper",
     "WeWorkRemotelyScraper",

--- a/src/jobhive/scrapers/vietnamworks.py
+++ b/src/jobhive/scrapers/vietnamworks.py
@@ -27,7 +27,7 @@ import asyncio
 import html
 import re
 import unicodedata
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import httpx
@@ -422,7 +422,7 @@ def _parse_iso(value: object) -> datetime | None:
     if dt.tzinfo is not None:
         # Convert to UTC then drop tzinfo to keep parity with the other
         # scrapers' naive datetimes.
-        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+        dt = dt.astimezone(UTC).replace(tzinfo=None)
     return dt
 
 

--- a/src/jobhive/scrapers/vietnamworks.py
+++ b/src/jobhive/scrapers/vietnamworks.py
@@ -1,0 +1,459 @@
+"""VietnamWorks (https://www.vietnamworks.com) — Vietnamese jobs scraper.
+
+VietnamWorks (operated by Navigos Group / en-Japan) is the largest
+English-friendly direct-posting job platform in Vietnam (~13.7k active
+postings as of May 2026). Companies publish directly through
+VietnamWorks' recruiting product — postings come with structured
+company / location / salary / skills data, not a free-text aggregator
+feed.
+
+Public REST API at ``https://ms.vietnamworks.com/job-search/v1.0/search``
+— no auth, no key. POST with a JSON body of
+``{"keyword": "", "page": N, "size": S}``. The server clamps
+``size`` to 10 regardless of what's requested; pagination is driven by
+``meta.nbHits`` / ``meta.nbPages`` from the first page, with a defensive
+stop on the first short page in case the server returns less than
+requested.
+
+Single-source scraper: ``company_slug`` is informational and ignored
+(matches the bundesagentur / wanted / getonbrd pattern). Output rows
+carry the publishing employer's name as ``company`` so the publisher's
+cross-ATS dedup still works.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import re
+import unicodedata
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+API_URL = "https://ms.vietnamworks.com/job-search/v1.0/search"
+SITE_ROOT = "https://www.vietnamworks.com"
+PER_PAGE = 50  # Requested page size — server clamps to 10 but we honour
+# whatever it actually returns when terminating.
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 4
+RETRY_BASE_DELAY = 1.5
+DESCRIPTION_CAP = 10_000
+
+# ``typeWorkingId`` → canonical ``employment_type`` enum. Mapping derived
+# from the VietnamWorks help center taxonomy ("Hình thức làm việc"):
+# 1 = Full-time / Toàn thời gian (the overwhelming majority of postings),
+# 2 = Part-time / Bán thời gian, 3 = Contract / Hợp đồng,
+# 4 = Internship / Thực tập, 5 = Temporary / Thời vụ.
+_EMPLOYMENT_TYPE_MAP: dict[int, str] = {
+    1: "FULL_TIME",
+    2: "PART_TIME",
+    3: "CONTRACT",
+    4: "INTERN",
+    5: "TEMPORARY",
+}
+
+# ``salaryPeriodId`` → canonical ``salary_period``. 1 = month (the
+# default on VietnamWorks for monthly salaries), 2 = year. Everything
+# else is left to the LLM enrichment.
+_SALARY_PERIOD_MAP: dict[int, str] = {
+    1: "MONTH",
+    2: "YEAR",
+}
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_WHITESPACE_RE = re.compile(r"\s+")
+
+# ASCII range plus the Vietnamese-language extra-ASCII characters that
+# show up in titles that are otherwise English (đ / Đ). Anything outside
+# this set in a title — i.e. any diacritic-bearing Latin char or a
+# Vietnamese tone mark — is treated as evidence the listing is in
+# Vietnamese.
+_VIETNAMESE_DIACRITIC_RE = re.compile(
+    r"["
+    r"À-ɏ"          # Latin extended (covers most VN accents)
+    r"Ạ-ỹ"          # Vietnamese-specific block (ạ, ậ, ệ, …)
+    r"̀-ͯ"          # Combining diacritical marks
+    r"]"
+)
+
+
+@ScraperRegistry.register(ATSType.VIETNAMWORKS)
+class VietnamWorksScraper(BaseScraper):
+    """VietnamWorks (vietnamworks.com) — direct postings from VN employers.
+
+    Single-source scraper: ``company_slug`` is ignored. Pass anything
+    (``"any"``, ``""``, ``"vn"``) — the scraper enumerates the whole site.
+    """
+
+    ats = ATSType.VIETNAMWORKS
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        seen: set[str] = set()
+        jobs: list[Job] = []
+
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+
+            # First page seeds the pagination: nbHits / nbPages tells us
+            # how far to walk, and confirms the server-side clamped page
+            # size (which we then use to decide when we've reached the
+            # end if the meta numbers are missing on later pages).
+            first = await self._request_page(client, sem, page=1)
+            self._absorb_page(first, seen, jobs)
+
+            meta = first.get("meta") or {}
+            nb_hits = _to_int(meta.get("nbHits")) or 0
+            nb_pages = _to_int(meta.get("nbPages")) or 0
+            served = len(first.get("data") or [])
+            if served == 0:
+                return jobs
+            # The server has historically clamped to 10 even when 50 is
+            # requested; trust the actual first-page length over the
+            # documented ``size`` so the termination check below stays
+            # correct even if the limit changes.
+            effective_size = served
+
+            # When ``nb_pages`` is present, walk pages 2..nb_pages. When
+            # it's missing (rare; defensive), fall back to walking until
+            # a short page comes back.
+            if nb_pages > 1:
+                page_numbers = list(range(2, nb_pages + 1))
+            else:
+                page_numbers = []
+                if nb_hits and effective_size:
+                    expected = (nb_hits + effective_size - 1) // effective_size
+                    page_numbers = list(range(2, expected + 1))
+
+            stop = asyncio.Event()
+
+            async def fetch_one(page: int) -> None:
+                if stop.is_set():
+                    return
+                payload = await self._request_page(client, sem, page=page)
+                served_here = len(payload.get("data") or [])
+                self._absorb_page(payload, seen, jobs)
+                # Short page = we're past the end. Signal sibling
+                # coroutines that nothing remains to do.
+                if served_here < effective_size:
+                    stop.set()
+
+            await asyncio.gather(*(fetch_one(p) for p in page_numbers))
+
+        return jobs
+
+    def _absorb_page(
+        self,
+        payload: dict[str, Any],
+        seen: set[str],
+        jobs: list[Job],
+    ) -> None:
+        for item in payload.get("data") or []:
+            job = self._parse_job(item)
+            if job is None or job.ats_id in seen:
+                continue
+            seen.add(job.ats_id)
+            jobs.append(job)
+
+    # --- HTTP layer ---------------------------------------------------------
+
+    async def _request_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        *,
+        page: int,
+    ) -> dict[str, Any]:
+        body = {"keyword": "", "page": page, "size": PER_PAGE}
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.post(
+                        API_URL,
+                        json=body,
+                        headers={
+                            "User-Agent": "Mozilla/5.0",
+                            "Accept": "application/json",
+                            "Content-Type": "application/json",
+                        },
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"VietnamWorks fetch failed for page {page}: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                try:
+                    data = response.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"VietnamWorks returned non-JSON for page {page}: {exc}"
+                    ) from exc
+                # Out-of-range pages echo back ``{"meta": null, "data": null}``.
+                # Normalise so callers can iterate cleanly.
+                if not isinstance(data, dict):
+                    return {"data": [], "meta": {}}
+                if data.get("data") is None:
+                    data["data"] = []
+                if data.get("meta") is None:
+                    data["meta"] = {}
+                return data
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"VietnamWorks returned {response.status_code} for "
+                        f"page {page} after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after)
+                    if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"VietnamWorks returned {response.status_code} for page {page}"
+            )
+        raise ScraperError(
+            f"VietnamWorks exhausted retries for page {page}: {last_exc}"
+        )
+
+    # --- parsing ------------------------------------------------------------
+
+    def _parse_job(self, item: dict[str, Any]) -> Job | None:
+        raw_id = item.get("jobId")
+        if raw_id is None:
+            return None
+        ats_id = str(raw_id)
+        title = (item.get("jobTitle") or "").strip()
+        if not ats_id or not title:
+            return None
+
+        company = (item.get("companyName") or "").strip() or "Unknown"
+
+        url = _absolute_url(item.get("jobUrl"), ats_id=ats_id)
+
+        location = _format_location(item.get("workingLocations") or [])
+
+        # Description: combine jobDescription + jobRequirement (both HTML).
+        # Falls back to the title when neither is present so the canonical
+        # description field is never empty for a parsed job.
+        description = _strip_html(
+            _concat_text(item.get("jobDescription"), item.get("jobRequirement"))
+        )
+        if not description:
+            description = title
+
+        salary_currency, salary_min, salary_max = _parse_salary(item)
+        salary_summary = _coerce_str(item.get("prettySalary"))
+        salary_period = _SALARY_PERIOD_MAP.get(
+            _to_int(item.get("salaryPeriodId")) or 0
+        )
+
+        employment_type = _EMPLOYMENT_TYPE_MAP.get(
+            _to_int(item.get("typeWorkingId")) or 0
+        )
+
+        posted_at = _parse_iso(item.get("approvedOn")) or _parse_iso(
+            item.get("createdOn")
+        )
+
+        language = "vi" if _VIETNAMESE_DIACRITIC_RE.search(title) else "en"
+
+        experience = _to_int(item.get("yearsOfExperience"))
+
+        department = _coerce_str(
+            (item.get("jobFunction") or {}).get("parentName")
+        )
+        team_children = (item.get("jobFunction") or {}).get("children") or []
+        team: str | None = None
+        if team_children and isinstance(team_children, list):
+            first = team_children[0]
+            if isinstance(first, dict):
+                team = _coerce_str(first.get("name"))
+
+        raw: dict[str, Any] = {
+            "company_id": item.get("companyId"),
+            "alias": item.get("alias"),
+            "expired_on": item.get("expiredOn"),
+            "is_active": item.get("isActive"),
+        }
+        # Strip Nones so the raw payload stays compact across the CSV.
+        raw = {k: v for k, v in raw.items() if v is not None}
+
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.VIETNAMWORKS,
+            ats_id=ats_id,
+            location=location,
+            country_iso="VN",
+            salary_currency=salary_currency,
+            salary_period=salary_period,
+            salary_summary=salary_summary,
+            salary_min=salary_min,
+            salary_max=salary_max,
+            experience=experience,
+            employment_type=employment_type,
+            department=department,
+            team=team,
+            description=description,
+            posted_at=posted_at,
+            fetched_at=datetime.now(),
+            language=language,
+            raw=raw or None,
+        )
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+def _absolute_url(raw: object, *, ats_id: str) -> str:
+    """``jobUrl`` is normally absolute (``https://www.vietnamworks.com/...``)
+    but the contract allows for a path-only form. Synthesize a canonical
+    URL from the jobId as a last resort so the row stays well-formed."""
+    if isinstance(raw, str) and raw.strip():
+        s = raw.strip()
+        if s.startswith("http://") or s.startswith("https://"):
+            return s
+        if s.startswith("/"):
+            return f"{SITE_ROOT}{s}"
+        return f"{SITE_ROOT}/{s}"
+    return f"{SITE_ROOT}/job-{ats_id}-jv"
+
+
+def _format_location(working_locations: list[dict[str, Any]]) -> str | None:
+    """``workingLocations`` is a list of structured city entries. Prefer
+    the English ``cityName`` so cross-language consumers can group; fall
+    back to ``cityNameVI`` if the English one is missing. Multiple
+    cities are joined with ", " (rare — most postings have a single
+    location)."""
+    if not isinstance(working_locations, list) or not working_locations:
+        return None
+    names: list[str] = []
+    for loc in working_locations:
+        if not isinstance(loc, dict):
+            continue
+        city = loc.get("cityName") or loc.get("cityNameVI")
+        if isinstance(city, str) and city.strip() and city.strip() not in names:
+            names.append(city.strip())
+    if not names:
+        return None
+    return ", ".join(names[:3])  # cap to avoid pathological multi-city rows
+
+
+def _parse_salary(
+    item: dict[str, Any],
+) -> tuple[str | None, float | None, float | None]:
+    """VietnamWorks ships ``salaryMin`` / ``salaryMax`` as numeric fields
+    with ``salaryCurrency`` (3-letter ISO 4217 — observed values: USD,
+    VND). ``isSalaryVisible=false`` postings have both at zero — treat
+    that as 'no salary disclosed' and return (None, None, None)."""
+    if not item.get("isSalaryVisible", True):
+        return None, None, None
+    min_amount = _to_positive_float(item.get("salaryMin"))
+    max_amount = _to_positive_float(item.get("salaryMax"))
+    # Some listings populate only ``salary`` (a flat number) when min and
+    # max are equal — fall back to it so we don't drop the structured
+    # value entirely.
+    if min_amount is None and max_amount is None:
+        flat = _to_positive_float(item.get("salary"))
+        if flat is None:
+            return None, None, None
+        min_amount = max_amount = flat
+    currency = _coerce_str(item.get("salaryCurrency"))
+    if currency and len(currency) == 3:
+        return currency.upper(), min_amount, max_amount
+    return None, min_amount, max_amount
+
+
+def _concat_text(*parts: object) -> str:
+    """Join the populated string parts with a blank line."""
+    pieces: list[str] = []
+    for p in parts:
+        if isinstance(p, str) and p.strip():
+            pieces.append(p)
+    return "\n\n".join(pieces)
+
+
+def _strip_html(text: str) -> str:
+    """Strip tags + entities + collapse whitespace, then truncate to the
+    ~10kB description budget the canonical schema documents."""
+    if not text:
+        return ""
+    cleaned = _TAG_RE.sub(" ", text)
+    cleaned = html.unescape(cleaned)
+    cleaned = unicodedata.normalize("NFC", cleaned)
+    cleaned = _WHITESPACE_RE.sub(" ", cleaned).strip()
+    return cleaned[:DESCRIPTION_CAP]
+
+
+def _parse_iso(value: object) -> datetime | None:
+    """VietnamWorks emits ISO-8601 with a ``+07:00`` offset
+    (e.g. ``2026-04-21T17:25:42+07:00``). Python's ``fromisoformat``
+    handles that natively since 3.11; we drop the tzinfo so the
+    resulting datetime is comparable with the ``fetched_at`` field
+    (naive UTC-ish, matching the rest of the codebase)."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if dt.tzinfo is not None:
+        # Convert to UTC then drop tzinfo to keep parity with the other
+        # scrapers' naive datetimes.
+        dt = dt.astimezone(tz=None).replace(tzinfo=None)
+    return dt
+
+
+def _coerce_str(value: object) -> str | None:
+    if isinstance(value, str):
+        s = value.strip()
+        return s or None
+    return None
+
+
+def _to_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str) and value.strip().lstrip("-").isdigit():
+        return int(value)
+    return None
+
+
+def _to_positive_float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value) if value > 0 else None
+    if isinstance(value, str):
+        try:
+            f = float(value)
+        except ValueError:
+            return None
+        return f if f > 0 else None
+    return None

--- a/src/jobhive/scrapers/vietnamworks.py
+++ b/src/jobhive/scrapers/vietnamworks.py
@@ -27,7 +27,7 @@ import asyncio
 import html
 import re
 import unicodedata
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 import httpx
@@ -422,7 +422,7 @@ def _parse_iso(value: object) -> datetime | None:
     if dt.tzinfo is not None:
         # Convert to UTC then drop tzinfo to keep parity with the other
         # scrapers' naive datetimes.
-        dt = dt.astimezone(tz=None).replace(tzinfo=None)
+        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
     return dt
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -27,8 +27,8 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # National / supranational public-sector aggregators
         "bundesagentur", "arbetsformedlingen", "eures",
         # Hybrid jobboards (companies post directly)
-        "welcometothejungle", "getonbrd", "wanted", "remoteok",
-        "weworkremotely", "programathor", "builtin", "jobsch",
+        "welcometothejungle", "getonbrd", "wanted", "vietnamworks",
+        "remoteok", "weworkremotely", "programathor", "builtin", "jobsch",
         "manfred", "thehub", "ycombinator", "wellfound",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",

--- a/tests/test_vietnamworks.py
+++ b/tests/test_vietnamworks.py
@@ -1,0 +1,314 @@
+"""Tests for the VietnamWorks scraper.
+
+Pin the parsing contract (each VietnamWorks ``/job-search/v1.0/search``
+field → ``Job`` field) and the page-based pagination behaviour. The API
+clamps per-page size on the server, so the test suite mirrors that —
+asserting that we walk pages until the server returns a short batch.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import ScraperRegistry, VietnamWorksScraper
+from jobhive.scrapers.vietnamworks import VietnamWorksScraper as _Scraper
+
+_API_RE = re.compile(r"^https://ms\.vietnamworks\.com/job-search/v1\.0/search")
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.vietnamworks as v
+
+    monkeypatch.setattr(v, "MAX_RETRIES", 1)
+    monkeypatch.setattr(v, "RETRY_BASE_DELAY", 0.0)
+
+
+# A trimmed but realistic single job, captured live from
+# ``POST ms.vietnamworks.com/job-search/v1.0/search`` with
+# ``{"keyword":"","page":1,"size":2}``. Used as the structural fixture
+# the parsing tests pin against.
+_JOB_USD_VISIBLE: dict[str, Any] = {
+    "jobId": 2043697,
+    "jobTitle": "Recruitment Consultant (Industrial Manufacturing)",
+    "jobUrl": (
+        "https://www.vietnamworks.com/"
+        "recruitment-consultant-industrial-manufacturing--2043697-jv"
+    ),
+    "alias": "recruitment-consultant-industrial-manufacturing-",
+    "createdOn": "2026-04-21T17:25:42+07:00",
+    "approvedOn": "2026-04-22T10:44:38+07:00",
+    "expiredOn": "2026-05-31T23:59:59+07:00",
+    "companyName": "Navigos Group",
+    "companyId": 18364,
+    "isOnline": True,
+    "isActive": True,
+    "isApproved": True,
+    "isSalaryVisible": True,
+    "jobDescription": (
+        "<p>Navigos Search, a part of Navigos Group, is the No.1 provider"
+        " of executive search services in Vietnam.</p>"
+    ),
+    "jobRequirement": (
+        "<p>• Professionals with at least 2 years of experience in"
+        " Headhunting.</p>"
+    ),
+    "jobLevelId": 5,
+    "salary": 700,
+    "salaryMax": 0,
+    "salaryMin": 700,
+    "salaryCurrency": "USD",
+    "salaryPeriodId": 1,
+    "typeWorkingId": 1,
+    "workingLocations": [
+        {
+            "workingLocationId": 184409,
+            "addressId": 144172,
+            "cityId": 29,
+            "districtId": 0,
+            "address": "20th Floor - 11 Doan Van Bo",
+            "cityName": "Ho Chi Minh",
+            "cityNameVI": "Hồ Chí Minh",
+        }
+    ],
+    "jobFunction": {
+        "parentId": 12,
+        "parentName": "Human Resources/Recruitment",
+        "parentNameVI": "Nhân Sự/Tuyển Dụng",
+        "children": [
+            {"id": 76, "name": "Recruitment", "nameVI": "Tuyển Dụng"}
+        ],
+    },
+    "yearsOfExperience": 2,
+    "prettySalary": "Từ $ 700 /tháng",
+}
+
+
+# A job with the Vietnamese-titled "salary hidden" variant — both
+# ``salaryMin`` and ``salaryMax`` zero and ``isSalaryVisible`` false.
+_JOB_VI_HIDDEN: dict[str, Any] = {
+    "jobId": 2045604,
+    "jobTitle": "HO - Giám Đốc Bộ Phận Tài Chính Khối Kinh Doanh",
+    "jobUrl": (
+        "https://www.vietnamworks.com/"
+        "ho-giam-doc-bo-phan-tai-chinh-khoi-kinh-doanh-2045604-jv"
+    ),
+    "alias": "ho-giam-doc-bo-phan-tai-chinh-khoi-kinh-doanh",
+    "createdOn": "2026-04-24T14:01:07+07:00",
+    "approvedOn": "2026-04-24T15:23:27+07:00",
+    "expiredOn": "2026-06-02T23:59:59+07:00",
+    "companyName": "Ngân Hàng TMCP Á Châu (ACB)",
+    "companyId": 849,
+    "isOnline": True,
+    "isActive": True,
+    "isApproved": True,
+    "isSalaryVisible": False,
+    "jobDescription": "<p><strong>1. Hỗ trợ chiến lược kinh doanh.</strong></p>",
+    "jobRequirement": "<p>Kiến thức chuyên môn.</p>",
+    "jobLevelId": 3,
+    "salary": 0,
+    "salaryMax": 0,
+    "salaryMin": 0,
+    "salaryCurrency": "USD",
+    "salaryPeriodId": 1,
+    "typeWorkingId": 1,
+    "workingLocations": [
+        {
+            "cityName": "Ho Chi Minh",
+            "cityNameVI": "Hồ Chí Minh",
+        }
+    ],
+    "jobFunction": {
+        "parentName": "Banking & Financial Services",
+        "children": [{"name": "Financial Analysis & Research"}],
+    },
+    "yearsOfExperience": 5,
+    "prettySalary": "Thương lượng",
+}
+
+
+def _page(
+    items: list[dict[str, Any]],
+    *,
+    nb_hits: int | None = None,
+    nb_pages: int | None = None,
+) -> dict[str, Any]:
+    """Build a mock VietnamWorks page response. ``nb_hits`` / ``nb_pages``
+    drive the scraper's pagination when set; leave them out to simulate
+    a stripped response."""
+    meta: dict[str, Any] = {"code": 200, "message": "Success"}
+    if nb_hits is not None:
+        meta["nbHits"] = nb_hits
+    if nb_pages is not None:
+        meta["nbPages"] = nb_pages
+    return {"meta": meta, "data": items, "facets": {}}
+
+
+# --- registry / wiring -------------------------------------------------------
+
+
+def test_registry_resolves_vietnamworks() -> None:
+    assert ScraperRegistry.get(ATSType.VIETNAMWORKS) is VietnamWorksScraper
+
+
+def test_ats_attribute_matches_enum() -> None:
+    assert VietnamWorksScraper.ats is ATSType.VIETNAMWORKS
+
+
+# --- parsing -----------------------------------------------------------------
+
+
+def test_parses_full_payload_with_visible_salary() -> None:
+    scraper = _Scraper("any")
+    job = scraper._parse_job(_JOB_USD_VISIBLE)
+    assert job is not None
+    assert job.ats_type is ATSType.VIETNAMWORKS
+    assert job.ats_id == "2043697"
+    assert job.title.startswith("Recruitment Consultant")
+    assert job.company == "Navigos Group"
+    assert str(job.url).startswith("https://www.vietnamworks.com/")
+    assert job.country_iso == "VN"
+    assert job.location == "Ho Chi Minh"
+    # Salary: ``salaryMin=700, salaryMax=0`` — the parser should fall
+    # back to ``salary`` for the upper bound when max is unset, but
+    # currency and min must always survive.
+    assert job.salary_currency == "USD"
+    assert job.salary_min == 700.0
+    assert job.salary_period == "MONTH"
+    assert job.employment_type == "FULL_TIME"
+    assert job.experience == 2
+    assert job.language == "en"
+    assert job.department == "Human Resources/Recruitment"
+    assert job.team == "Recruitment"
+    # Description has HTML stripped + entities decoded.
+    assert job.description is not None
+    assert "<p>" not in job.description
+    assert "Navigos Search" in job.description
+    assert job.posted_at is not None
+    assert job.fetched_at is not None
+    assert job.global_id == "vietnamworks:2043697"
+    assert job.raw is not None
+    assert job.raw.get("company_id") == 18364
+    assert job.raw.get("alias") == "recruitment-consultant-industrial-manufacturing-"
+
+
+def test_parses_vietnamese_title_marks_language_vi() -> None:
+    job = _Scraper("any")._parse_job(_JOB_VI_HIDDEN)
+    assert job is not None
+    assert job.language == "vi"
+    # ``isSalaryVisible=False`` ⇒ scraper drops salary fields entirely.
+    assert job.salary_currency is None
+    assert job.salary_min is None
+    assert job.salary_max is None
+    # ``prettySalary`` is still preserved as a salary_summary so the
+    # downstream consumer doesn't lose the "Thương lượng" (Negotiable)
+    # signal.
+    assert job.salary_summary == "Thương lượng"
+
+
+def test_skips_jobs_missing_id_or_title() -> None:
+    """Defensive: drop malformed entries rather than emit half-built rows."""
+    scraper = _Scraper("any")
+    assert scraper._parse_job({"jobTitle": "No id"}) is None
+    assert scraper._parse_job({"jobId": 1, "jobTitle": ""}) is None
+    assert scraper._parse_job({"jobId": 1}) is None
+
+
+def test_synthesizes_url_when_joburl_missing() -> None:
+    """The contract calls for synthesizing the canonical URL from
+    ``jobId`` when the API omits ``jobUrl`` (defensive path)."""
+    job = _Scraper("any")._parse_job({
+        "jobId": 999,
+        "jobTitle": "Test Role",
+        "companyName": "Acme",
+    })
+    assert job is not None
+    assert "999" in str(job.url)
+    # When no description/requirement is present, fall back to the title.
+    assert job.description == "Test Role"
+
+
+def test_location_falls_back_to_vietnamese_city_name() -> None:
+    """When ``cityName`` (English) is empty, use ``cityNameVI``."""
+    job = _Scraper("any")._parse_job({
+        "jobId": 1,
+        "jobTitle": "Engineer",
+        "companyName": "Acme",
+        "workingLocations": [{"cityNameVI": "Hà Nội"}],
+    })
+    assert job is not None
+    assert job.location == "Hà Nội"
+
+
+# --- pagination --------------------------------------------------------------
+
+
+def test_walks_pages_until_meta_nb_pages(httpx_mock) -> None:
+    """``meta.nbPages`` drives the page sweep — walk 1..nbPages."""
+    # Server clamps page size to 10; mirror that here.
+    page1 = _page(
+        [{**_JOB_USD_VISIBLE, "jobId": i} for i in range(10)],
+        nb_hits=15, nb_pages=2,
+    )
+    page2 = _page(
+        [{**_JOB_USD_VISIBLE, "jobId": i} for i in range(10, 15)],
+        nb_hits=15, nb_pages=2,
+    )
+    httpx_mock.add_response(url=_API_RE, method="POST", json=page1)
+    httpx_mock.add_response(url=_API_RE, method="POST", json=page2)
+
+    jobs = VietnamWorksScraper("any").fetch()
+    assert len(jobs) == 15
+    assert {j.ats_id for j in jobs} == {str(i) for i in range(15)}
+
+
+def test_dedupes_overlapping_pages(httpx_mock) -> None:
+    """If a page repeats a tail item, collapse them on ``ats_id``."""
+    page1 = _page(
+        [{**_JOB_USD_VISIBLE, "jobId": i} for i in range(10)],
+        nb_hits=15, nb_pages=2,
+    )
+    page2 = _page(
+        # Re-includes jobIds 8, 9 plus new ones.
+        [{**_JOB_USD_VISIBLE, "jobId": i} for i in [8, 9, 10, 11, 12]],
+        nb_hits=15, nb_pages=2,
+    )
+    httpx_mock.add_response(url=_API_RE, method="POST", json=page1)
+    httpx_mock.add_response(url=_API_RE, method="POST", json=page2)
+
+    jobs = VietnamWorksScraper("any").fetch()
+    assert len({j.ats_id for j in jobs}) == 13
+
+
+def test_empty_first_page_returns_no_jobs(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_API_RE, method="POST", json=_page([], nb_hits=0, nb_pages=0),
+    )
+    assert VietnamWorksScraper("any").fetch() == []
+
+
+def test_out_of_range_page_with_null_payload(httpx_mock) -> None:
+    """Out-of-range pages echo back ``{"meta": null, "data": null}``.
+    The scraper should normalise that to an empty result without
+    crashing the run."""
+    httpx_mock.add_response(
+        url=_API_RE, method="POST", json={"meta": None, "data": None},
+    )
+    assert VietnamWorksScraper("any").fetch() == []
+
+
+# --- error handling ----------------------------------------------------------
+
+
+def test_persistent_500_raises(httpx_mock) -> None:
+    """Server-side failures must surface, not silently emit []."""
+    httpx_mock.add_response(
+        url=_API_RE, method="POST", status_code=500, is_reusable=True,
+    )
+    with pytest.raises(ScraperError):
+        VietnamWorksScraper("any").fetch()


### PR DESCRIPTION
## Summary

Adds `VietnamWorksScraper` — a single-source scraper for [VietnamWorks](https://www.vietnamworks.com), the largest English-friendly direct-posting job platform in Vietnam (~13.7k active postings as of May 2026, operated by Navigos Group / en-Japan).

- **Scale**: 13,723 live jobs verified today via the public API (`meta.nbHits`)
- **Endpoint** (no auth, no key): `POST https://ms.vietnamworks.com/job-search/v1.0/search`
- **Auth**: none — public no-auth POST API
- **Pattern**: single-source (`company_slug` is ignored, like `wanted` / `getonbrd` / `bundesagentur`)

## Sample curl

```bash
curl -X POST 'https://ms.vietnamworks.com/job-search/v1.0/search' \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json' \
  -H 'User-Agent: Mozilla/5.0' \
  --data-raw '{"keyword":"","page":1,"size":50}'
```

Returns `{meta: {nbHits, nbPages, ...}, data: [{jobId, jobTitle, companyName, workingLocations[], salaryMin, salaryMax, salaryCurrency, jobDescription, jobRequirement, jobFunction, createdOn, approvedOn, typeWorkingId, salaryPeriodId, ...}], facets: {...}}`.

Note: the server clamps page size to 10 regardless of the requested `size`, so the scraper trusts the first-page length when deciding pagination termination, walks `meta.nbPages` pages, and stops early on a short page. Concurrency=4 with retry on 429/5xx.

## Field mapping

| Source | `Job` field |
| --- | --- |
| `jobId` | `ats_id` (→ `global_id = vietnamworks:<jobId>`) |
| `jobUrl` | `url` (synthesised from `jobId` as fallback) |
| `jobTitle` | `title` |
| `companyName` | `company` |
| `workingLocations[].cityName` (fallback `cityNameVI`) | `location` |
| (hardcoded) | `country_iso = "VN"` |
| `salaryMin` / `salaryMax` / `salaryCurrency` (when `isSalaryVisible=true`) | `salary_min` / `salary_max` / `salary_currency` |
| `salaryPeriodId` (1→`MONTH`, 2→`YEAR`) | `salary_period` |
| `prettySalary` | `salary_summary` |
| `typeWorkingId` (1→`FULL_TIME`, …) | `employment_type` |
| `jobDescription` + `jobRequirement` (HTML stripped, 10kB cap, NFC normalised) | `description` |
| `approvedOn` → `createdOn` | `posted_at` |
| `yearsOfExperience` | `experience` |
| `jobFunction.parentName` / `children[0].name` | `department` / `team` |
| Vietnamese diacritic check on title | `language` (`vi` / `en`) |
| `companyId`, `alias`, `expiredOn`, `isActive` | `raw` |

## Test plan

- [x] `ruff check src/jobhive/scrapers/vietnamworks.py tests/test_vietnamworks.py` passes
- [x] `pytest tests/test_vietnamworks.py tests/test_models.py -x` passes (74 tests)
- [x] Registry resolution: `ScraperRegistry.get(ATSType.VIETNAMWORKS) is VietnamWorksScraper`
- [x] Parsing pinned against two real captured samples (USD-visible + Vietnamese-hidden)
- [x] Pagination walks `meta.nbPages`, dedupes overlapping pages, handles `{meta: null, data: null}` out-of-range responses
- [x] Persistent 500s raise `ScraperError`
- [ ] (Manual) full live sweep against ms.vietnamworks.com to validate end-to-end row counts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `VietnamWorksScraper` to ingest Vietnam job postings via VietnamWorks’ public no-auth API, expanding coverage in Vietnam. Also fixes `posted_at` timezone parsing to normalize timestamps to UTC.

- **New Features**
  - Added `ATSType.VIETNAMWORKS`, registered `VietnamWorksScraper`, and seed file `ats-companies/vietnamworks.csv`.
  - Fetches from `POST https://ms.vietnamworks.com/job-search/v1.0/search` (no auth) with pagination via `meta.nbPages`; handles the server’s 10-item clamp; concurrency=4; retries on 429/5xx; early-stop on short pages.
  - Field mapping to `Job`: `jobId`→`ats_id` (`global_id=vietnamworks:<id>`), URL synthesis fallback, location from `workingLocations`, salaries only when visible (`salary*`, `salaryPeriodId`→`MONTH|YEAR`), description from `jobDescription` + `jobRequirement` (HTML stripped), `typeWorkingId`→employment type, `yearsOfExperience`, `jobFunction`→department/team, language heuristic (`vi` when title has VN diacritics).
  - Resiliency: normalizes `{meta: null, data: null}` out-of-range pages; raises `ScraperError` on persistent 5xx.

- **Bug Fixes**
  - `_parse_iso` converts offsets to UTC before dropping tzinfo; cleaned up `ruff` lint.

<sup>Written for commit 2667d3588944638620073fe1eba99dc93cfd4c6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/82?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `VietnamWorksScraper`, a new single-source scraper that walks VietnamWorks' public no-auth POST API, maps structured job fields into the canonical `Job` model, and registers the new `ATSType.VIETNAMWORKS` enum value.

- Async pagination driven by `meta.nbPages` with a `MAX_CONCURRENCY=4` semaphore, exponential backoff on 429/5xx, and an `asyncio.Event` early-exit on short pages.
- Field mapping covers salary visibility, employment type, Vietnamese/English language heuristic, HTML-stripped descriptions, and timezone-aware `posted_at` parsing.
- Test suite pins parsing against two live-captured fixtures and exercises pagination, dedup, out-of-range pages, and persistent error paths.

<h3>Confidence Score: 3/5</h3>

Safe to merge on UTC-only infrastructure, but will silently produce wrong posted_at timestamps on any host running in a non-UTC local timezone.

The scraper is well-structured and the pagination/retry logic is solid, but the timezone conversion bug in _parse_iso would silently corrupt all posted_at timestamps on non-UTC hosts — a one-line fix is all that is needed.

src/jobhive/scrapers/vietnamworks.py — specifically the _parse_iso helper and the HTTPError retry sleep inside the semaphore block.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/vietnamworks.py | New single-source scraper for VietnamWorks with async pagination, retry logic, and field mapping — well-structured overall, but `_parse_iso` incorrectly uses `astimezone(tz=None)` (local time) instead of `astimezone(tz=timezone.utc)`, and the `asyncio.sleep` for `HTTPError` retries runs while the semaphore is held. |
| tests/test_vietnamworks.py | Good coverage of parsing, pagination, dedup, and error paths; a test comment mis-describes salary fallback behavior that the code does not actually implement, and `salary_max` is not asserted for the USD-visible fixture. |
| src/jobhive/models.py | Adds `VIETNAMWORKS` to `ATSType` enum in the correct location (hybrid jobboards group). |
| src/jobhive/scrapers/__init__.py | Registers `VietnamWorksScraper` in imports and `__all__`, alphabetically ordered correctly. |
| tests/test_models.py | Updates the exhaustive `ATSType` membership check to include `"vietnamworks"`. |
| ats-companies/vietnamworks.csv | Adds the single-row seed file for the VietnamWorks source entry. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/test_vietnamworks.py`, line 703-709 ([link](https://github.com/kalil0321/ats-scrapers/blob/e23c50efe7859ec41fb10c2e9acd544c3b91d7bd/tests/test_vietnamworks.py#L703-L709)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Test comment describes unimplemented fallback behavior**

   The comment says "the parser should fall back to `salary` for the upper bound when max is unset," implying `salary_max` should be `700.0` for this fixture. But `_parse_salary` only triggers the `salary` flat-field fallback when *both* `min_amount` and `max_amount` are `None`. Here `salaryMin=700` makes `min_amount=700.0`, so the condition is never entered and `salary_max` ends up `None`. The test doesn't assert `salary_max` at all, so the claimed behavior is neither implemented nor verified — the comment is misleading and should either be corrected or the fallback logic extended.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: tests/test_vietnamworks.py
   Line: 703-709

   Comment:
   **Test comment describes unimplemented fallback behavior**

   The comment says "the parser should fall back to `salary` for the upper bound when max is unset," implying `salary_max` should be `700.0` for this fixture. But `_parse_salary` only triggers the `salary` flat-field fallback when *both* `min_amount` and `max_amount` are `None`. Here `salaryMin=700` makes `min_amount=700.0`, so the condition is never entered and `salary_max` ends up `None`. The test doesn't assert `salary_max` at all, so the claimed behavior is neither implemented nor verified — the comment is misleading and should either be corrected or the fallback logic extended.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
src/jobhive/scrapers/vietnamworks.py:30
The `timezone` symbol needs to be imported alongside `datetime` to support the UTC conversion fix in `_parse_iso`.

```suggestion
from datetime import datetime, timezone
```

### Issue 2 of 4
src/jobhive/scrapers/vietnamworks.py:425
`astimezone(tz=None)` converts to the local system timezone, not UTC. The comment says "Convert to UTC" but on any non-UTC host the resulting naive datetime will carry local-time wall-clock values, making `posted_at` wrong by the host's UTC offset (e.g., up to ±14 h). The import on line 30 also needs `timezone` added alongside `datetime`.

```suggestion
        dt = dt.astimezone(tz=timezone.utc).replace(tzinfo=None)
```

### Issue 3 of 4
src/jobhive/scrapers/vietnamworks.py:194-201
**Semaphore held during network-error backoff sleep**

`await asyncio.sleep(RETRY_BASE_DELAY * attempt)` executes inside the `async with sem:` block, so the slot remains occupied for the entire sleep duration. With `MAX_CONCURRENCY=4` and `RETRY_BASE_DELAY=1.5`, a burst of `HTTPError`s across all four slots can stall the whole sweep for several seconds. The 429/5xx path already handles this correctly by sleeping *after* the semaphore is released (line 230). Consider using the same pattern here — capture a flag inside the `async with` block and sleep outside it.

### Issue 4 of 4
tests/test_vietnamworks.py:703-709
**Test comment describes unimplemented fallback behavior**

The comment says "the parser should fall back to `salary` for the upper bound when max is unset," implying `salary_max` should be `700.0` for this fixture. But `_parse_salary` only triggers the `salary` flat-field fallback when *both* `min_amount` and `max_amount` are `None`. Here `salaryMin=700` makes `min_amount=700.0`, so the condition is never entered and `salary_max` ends up `None`. The test doesn't assert `salary_max` at all, so the claimed behavior is neither implemented nor verified — the comment is misleading and should either be corrected or the fallback logic extended.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: vietnamworks..."](https://github.com/kalil0321/ats-scrapers/commit/e23c50efe7859ec41fb10c2e9acd544c3b91d7bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732398)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->