### PR TITLE
Add Torre.co scraper

### DIFF
--- a/ats-companies/torre.csv
+++ b/ats-companies/torre.csv
@@ -1,0 +1,2 @@
+name,slug,url
+Torre,torre,https://torre.ai

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -80,6 +80,7 @@ class ATSType(StrEnum):
     THEHUB = "thehub"
     YCOMBINATOR = "ycombinator"
     WELLFOUND = "wellfound"
+    TORRE = "torre"
     # Additional multi-tenant ATSes (post-0.1)
     BAMBOOHR = "bamboohr"
     BREEZY = "breezy"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -49,6 +49,7 @@ from jobhive.scrapers.teamtailor import TeamtailorScraper
 from jobhive.scrapers.tesla import TeslaScraper
 from jobhive.scrapers.thehub import TheHubScraper
 from jobhive.scrapers.tiktok import TikTokScraper
+from jobhive.scrapers.torre import TorreScraper
 from jobhive.scrapers.uber import UberScraper
 from jobhive.scrapers.usajobs import USAJobsScraper
 from jobhive.scrapers.wanted import WantedScraper
@@ -101,6 +102,7 @@ __all__ = [
     "TeslaScraper",
     "TheHubScraper",
     "TikTokScraper",
+    "TorreScraper",
     "USAJobsScraper",
     "UberScraper",
     "WTTJScraper",

--- a/src/jobhive/scrapers/torre.py
+++ b/src/jobhive/scrapers/torre.py
@@ -344,7 +344,7 @@ class TorreScraper(BaseScraper):
         deadline = opp.get("deadline")
         if isinstance(deadline, str) and deadline:
             raw["deadline"] = deadline
-        ac_details = opp.get("additionalCompensationDetails")
+        ac_details = (comp_root or {}).get("additionalCompensationDetails")
         if isinstance(ac_details, dict) and ac_details:
             raw["additional_compensation"] = ac_details
 

--- a/src/jobhive/scrapers/torre.py
+++ b/src/jobhive/scrapers/torre.py
@@ -1,0 +1,426 @@
+"""Torre.co (https://torre.ai) — LATAM-leaning direct-employer job platform.
+
+Torre is a Colombian-founded job/talent platform with global reach,
+especially strong across LATAM and remote roles. Companies post directly
+(not aggregated from other sources), so coverage is high-signal:
+~200k active opportunities worldwide at the time of writing — with
+the bulk concentrated in Spanish-speaking Latin America, plus a long
+remote/global tail in EN/PT.
+
+Public POST search API at ``https://search.torre.co/opportunities/_search/``
+— no auth, no key. The endpoint returns a fixed-shape envelope::
+
+    {
+        "total": 200534,
+        "size": 25,
+        "offset": 0,
+        "results": [ ...opportunity objects... ],
+        "pagination": {"previous": null, "next": "<base64-cursor>"}
+    }
+
+Pagination is **cursor-based** via ``?after=<token>`` even though the URL
+also accepts ``offset=N`` — the latter is silently ignored at the server
+side as of 2026-05, so the cursor is the only reliable forward-iterator.
+Page size is capped server-side at around 30 per call (the response is
+a 400 with ``meta.message: "Request size by <UA> too large: N"`` for
+anything larger). We hard-code ``PAGE_SIZE = 25`` to stay well under
+that bound across UA variants.
+
+Single-source scraper: ``company_slug`` is informational and ignored.
+Output rows carry the publishing employer's name as ``company`` so the
+publisher's cross-ATS dedup still works.
+
+Note: the search endpoint returns only a **summary** (``tagline``,
+skills list, structured compensation) — the full posting body is not
+included. ``Job.description`` is populated from the tagline plus a
+bulletised skills list; the LLM enrichment pass downstream is expected
+to fetch the full body from ``url`` if a richer description is needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+SEARCH_URL = "https://search.torre.co/opportunities/_search/"
+# Server caps page size around 30 for unauthenticated UAs (returns 400 with
+# ``meta.message: "Request size by <UA> too large: N"``). 25 leaves a small
+# safety margin for future tightening.
+PAGE_SIZE = 25
+MAX_RETRIES = 5
+RETRY_BASE_DELAY = 2.0
+# Cap concurrent requests to be polite. Cursor-based pagination is inherently
+# sequential, so concurrency only kicks in for retries; keep it low.
+MAX_CONCURRENCY = 4
+USER_AGENT = "Mozilla/5.0 (compatible; jobhive/1.0; +https://stapply.ai)"
+
+# Canonical web URL for a posting. Both ``torre.co/jobs/{id}/{slug}`` and
+# ``torre.ai/jobs/{id}/{slug}`` 301 → ``torre.ai/postings/{id}/{slug}``
+# (verified 2026-05-12).
+POSTING_URL = "https://torre.ai/postings/{id}/{slug}"
+
+# Torre exposes ``commitment`` as the human-readable label (``full-time``,
+# ``part-time``, ``contract``, ``internship``, ``temporary``, ``freelance``).
+# Map to the canonical employment_type enum.
+_COMMITMENT_MAP: dict[str, str] = {
+    "full-time": "FULL_TIME",
+    "part-time": "PART_TIME",
+    "contract": "CONTRACT",
+    "contractor": "CONTRACT",
+    "freelance": "CONTRACT",
+    "internship": "INTERN",
+    "intern": "INTERN",
+    "temporary": "TEMPORARY",
+}
+
+# ``compensation.data.periodicity`` → canonical ``salary_period``. Torre uses
+# lowercase singular nouns; the schema uses uppercase nouns.
+_PERIOD_MAP: dict[str, str] = {
+    "hourly": "HOUR",
+    "daily": "DAY",
+    "weekly": "WEEK",
+    "monthly": "MONTH",
+    "yearly": "YEAR",
+    "annually": "YEAR",
+}
+
+
+@ScraperRegistry.register(ATSType.TORRE)
+class TorreScraper(BaseScraper):
+    """Torre.co (torre.ai) — direct-employer job platform.
+
+    Single-source scraper: ``company_slug`` is ignored. Pass anything
+    (``"any"``, ``""``, ``"latam"``) — the scraper enumerates the entire
+    public opportunity feed via cursor-based pagination.
+    """
+
+    ats = ATSType.TORRE
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+            cursor: str | None = None
+            while True:
+                payload = await self._fetch_page(client, sem, cursor=cursor)
+                results = payload.get("results") or []
+                if not results:
+                    break
+                for opp in results:
+                    if not isinstance(opp, dict):
+                        continue
+                    ats_id = str(opp.get("id") or "").strip()
+                    if not ats_id or ats_id in seen:
+                        continue
+                    job = self._parse_job(opp)
+                    if job is None:
+                        continue
+                    seen.add(ats_id)
+                    jobs.append(job)
+                # Cursor-based pagination. ``pagination.next`` is None when
+                # we've reached the end. Some responses omit pagination
+                # entirely when the result count is below page size; treat
+                # that as "done" too.
+                next_cursor = (
+                    (payload.get("pagination") or {}).get("next")
+                    if isinstance(payload.get("pagination"), dict) else None
+                )
+                if not next_cursor:
+                    break
+                if next_cursor == cursor:
+                    # Defensive: if the server somehow returns the same
+                    # cursor twice, stop rather than spinning forever.
+                    break
+                cursor = next_cursor
+        return jobs
+
+    # --- HTTP layer ---------------------------------------------------------
+
+    async def _fetch_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        *,
+        cursor: str | None,
+    ) -> dict[str, Any]:
+        params: dict[str, str | int] = {
+            "size": PAGE_SIZE,
+            "aggregate": "false",
+        }
+        if cursor:
+            params["after"] = cursor
+        headers = {
+            "User-Agent": USER_AGENT,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.post(
+                        SEARCH_URL,
+                        params=params,
+                        headers=headers,
+                        json={},
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"Torre fetch failed (cursor={cursor!r}): {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                try:
+                    return response.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"Torre returned non-JSON (cursor={cursor!r}): {exc}"
+                    ) from exc
+            if response.status_code == 429 or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Torre returned {response.status_code} "
+                        f"(cursor={cursor!r}) after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after)
+                    if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"Torre returned {response.status_code} (cursor={cursor!r})"
+            )
+        raise ScraperError(
+            f"Torre exhausted retries (cursor={cursor!r}): {last_exc}"
+        )
+
+    # --- parsing ------------------------------------------------------------
+
+    def _parse_job(self, opp: dict[str, Any]) -> Job | None:
+        ats_id = str(opp.get("id") or "").strip()
+        title = (opp.get("objective") or "").strip()
+        slug = (opp.get("slug") or "").strip()
+        if not ats_id or not title:
+            return None
+
+        url = POSTING_URL.format(id=ats_id, slug=slug or ats_id)
+
+        orgs = opp.get("organizations") or []
+        first_org: dict[str, Any] = (
+            orgs[0] if isinstance(orgs, list) and orgs and isinstance(orgs[0], dict)
+            else {}
+        )
+        company = (first_org.get("name") or "").strip() or "Unknown"
+
+        # Location: prefer ``place.location[].id`` (always populated when the
+        # opportunity has any geographic grounding); fall back to the
+        # top-level ``locations`` array. Multi-location postings are
+        # comma-joined.
+        place = opp.get("place") if isinstance(opp.get("place"), dict) else {}
+        place_locs = (place or {}).get("location") or []
+        location_names: list[str] = []
+        country_iso: str | None = None
+        lat: float | None = None
+        lon: float | None = None
+        if isinstance(place_locs, list) and place_locs:
+            for entry in place_locs:
+                if not isinstance(entry, dict):
+                    continue
+                name = (entry.get("id") or "").strip()
+                if name:
+                    location_names.append(name)
+                cc = entry.get("countryCode")
+                if isinstance(cc, str) and len(cc) == 2 and country_iso is None:
+                    country_iso = cc.upper()
+                if lat is None and lon is None:
+                    e_lat, e_lon = entry.get("latitude"), entry.get("longitude")
+                    if isinstance(e_lat, (int, float)) and isinstance(e_lon, (int, float)):
+                        lat, lon = float(e_lat), float(e_lon)
+        if not location_names:
+            top_locs = opp.get("locations") or []
+            if isinstance(top_locs, list):
+                location_names = [
+                    s.strip() for s in top_locs
+                    if isinstance(s, str) and s.strip()
+                ]
+        location = ", ".join(location_names[:5]) if location_names else None
+
+        # Compensation. Three observed shapes:
+        #   - compensation: None  → no salary data
+        #   - compensation: {data: None, ...}  → employer hid salary
+        #   - compensation: {data: {code: "to-be-agreed", minAmount: 0, ...}}
+        #     → employer marked it negotiable; min/max are 0, treat as unknown
+        #   - compensation: {data: {code: "range", minAmount: 500, maxAmount: 1000, ...}}
+        #     → real range, populate fields.
+        comp_root = opp.get("compensation") if isinstance(opp.get("compensation"), dict) else {}
+        comp_data = (comp_root or {}).get("data") if isinstance((comp_root or {}).get("data"), dict) else None
+        salary_min: float | None = None
+        salary_max: float | None = None
+        salary_currency: str | None = None
+        salary_period: str | None = None
+        salary_summary: str | None = None
+        if isinstance(comp_data, dict):
+            min_amt = comp_data.get("minAmount")
+            max_amt = comp_data.get("maxAmount")
+            min_f = _to_positive_float(min_amt)
+            max_f = _to_positive_float(max_amt)
+            if min_f is not None or max_f is not None:
+                salary_min = min_f
+                salary_max = max_f
+                cur = comp_data.get("currency")
+                if isinstance(cur, str) and len(cur) == 3:
+                    salary_currency = cur.upper()
+                per = (comp_data.get("periodicity") or "").lower()
+                salary_period = _PERIOD_MAP.get(per)  # type: ignore[assignment]
+                # Build a human summary like "500 – 1000 USD / monthly"
+                if salary_currency:
+                    if min_f is not None and max_f is not None and min_f != max_f:
+                        amounts = f"{_fmt(min_f)} – {_fmt(max_f)}"
+                    elif max_f is not None:
+                        amounts = _fmt(max_f)
+                    elif min_f is not None:
+                        amounts = f"from {_fmt(min_f)}"
+                    else:
+                        amounts = ""
+                    if amounts:
+                        salary_summary = (
+                            f"{amounts} {salary_currency}"
+                            + (f" / {per}" if per else "")
+                        )
+
+        # Employment type: map ``commitment`` (or fall back to ``type``).
+        raw_commitment = (opp.get("commitment") or "").strip().lower()
+        employment_type = _COMMITMENT_MAP.get(raw_commitment)
+        commitment_label = opp.get("commitment") if isinstance(opp.get("commitment"), str) else None
+
+        # Skills: keep only the names, capped at 15 to bound size.
+        skill_names: list[str] = [
+            s.get("name")
+            for s in (opp.get("skills") or [])
+            if isinstance(s, dict) and isinstance(s.get("name"), str) and s.get("name").strip()
+        ]
+
+        description = _build_description(opp.get("tagline"), skill_names)
+
+        # ``raw`` overflow — keep verbatim the Torre-specific fields the
+        # canonical schema can't represent.
+        raw: dict[str, Any] = {}
+        org_size = first_org.get("size")
+        if isinstance(org_size, (int, float)):
+            raw["organization_size"] = org_size
+        org_pub = first_org.get("publicId")
+        if isinstance(org_pub, str) and org_pub:
+            raw["organization_public_id"] = org_pub
+        if skill_names:
+            raw["skills"] = skill_names[:15]
+        for key in ("type", "opportunity"):
+            v = opp.get(key)
+            if isinstance(v, str) and v:
+                raw[key] = v
+        if isinstance(opp.get("external"), bool):
+            raw["external"] = opp["external"]
+        deadline = opp.get("deadline")
+        if isinstance(deadline, str) and deadline:
+            raw["deadline"] = deadline
+        ac_details = opp.get("additionalCompensationDetails")
+        if isinstance(ac_details, dict) and ac_details:
+            raw["additional_compensation"] = ac_details
+
+        # ``is_remote``: only ever set True (matches project pattern; never
+        # claim on-site without a positive signal).
+        remote_flag = bool(opp.get("remote")) or bool((place or {}).get("remote"))
+        is_remote: bool | None = True if remote_flag else None
+
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.TORRE,
+            ats_id=ats_id,
+            location=location,
+            country_iso=country_iso,
+            lat=lat,
+            lon=lon,
+            is_remote=is_remote,
+            salary_currency=salary_currency,
+            salary_period=salary_period,  # type: ignore[arg-type]
+            salary_summary=salary_summary,
+            salary_min=salary_min,
+            salary_max=salary_max,
+            employment_type=employment_type,  # type: ignore[arg-type]
+            commitment=commitment_label,
+            description=description,
+            posted_at=_parse_iso(opp.get("created")),
+            fetched_at=datetime.now(),
+            raw=raw or None,
+        )
+
+
+def _to_positive_float(value: object) -> float | None:
+    """Coerce to ``float`` only when strictly positive.
+
+    Torre uses ``0.0`` as a sentinel for "no value" (paired with the
+    ``code: "to-be-agreed"`` marker on negotiable comp). Treating 0 as
+    a real bound would let nonsense ranges leak into the salary fields.
+    """
+    if isinstance(value, bool):  # bool is an int subclass — exclude.
+        return None
+    if isinstance(value, (int, float)) and value > 0:
+        return float(value)
+    return None
+
+
+def _fmt(value: float) -> str:
+    """Strip trailing ``.0`` from whole-number floats for the summary."""
+    if value == int(value):
+        return f"{int(value):,}"
+    return f"{value:,.2f}"
+
+
+def _parse_iso(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _build_description(tagline: object, skills: list[str]) -> str | None:
+    """The search endpoint exposes only a one-line ``tagline`` summary —
+    not the full posting body. Concatenate the tagline with a bulleted
+    skills list so the description field has *something* searchable;
+    LLM enrichment downstream is expected to fetch the full body from
+    ``url`` when richer text is needed.
+    """
+    parts: list[str] = []
+    if isinstance(tagline, str) and tagline.strip():
+        parts.append(tagline.strip())
+    if skills:
+        bullet = "\n".join(f"- {s}" for s in skills[:15])
+        parts.append(f"Skills:\n{bullet}")
+    if not parts:
+        return None
+    return "\n\n".join(parts)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,7 +29,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
-        "manfred", "thehub", "ycombinator", "wellfound",
+        "manfred", "thehub", "ycombinator", "wellfound", "torre",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",
         "recruitee", "taleo", "teamtailor",

--- a/tests/test_torre.py
+++ b/tests/test_torre.py
@@ -1,0 +1,374 @@
+"""Tests for the Torre.co (LATAM + global remote) scraper.
+
+Torre exposes a public POST search API with cursor-based pagination.
+These tests pin the parsing contract for the canonical ``Job`` row and
+exercise the cursor-following pagination loop. No live HTTP — fixtures
+below are trimmed from real probe responses (2026-05-12).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import ScraperRegistry, TorreScraper
+
+# pytest-httpx matches on URL path; matching with a regex keeps the test
+# tolerant of query-string ordering (httpx serializes ``params={}`` dicts
+# in insertion order, but the order isn't part of the contract).
+_SEARCH_RE = re.compile(r"^https://search\.torre\.co/opportunities/_search/")
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.torre as torre
+
+    monkeypatch.setattr(torre, "MAX_RETRIES", 1)
+    monkeypatch.setattr(torre, "RETRY_BASE_DELAY", 0.0)
+
+
+# --- fixture builders -------------------------------------------------------
+
+
+def _opp_to_be_agreed() -> dict[str, Any]:
+    """Real-world shape: ``compensation.data.code == "to-be-agreed"``,
+    min/max amounts both 0. Must NOT populate salary fields (treating 0
+    as a real bound would corrupt the dataset)."""
+    return {
+        "id": "Yd6mya1w",
+        "objective": "Asesor Profesional de Seguros e Inversiones",
+        "slug": "grupo-cuatro-vidas-asesor-profesional-de-seguros-e-inversiones",
+        "tagline": "Gestionarás capital y diseñarás estrategias.",
+        "type": "full-time-employment",
+        "opportunity": "employee",
+        "organizations": [
+            {
+                "id": 2923370,
+                "hashedId": "RZ3Lj7ro",
+                "name": "Grupo Cuatro Vidas",
+                "publicId": "GrupoCuatroVidas",
+                "size": 15,
+            }
+        ],
+        "locations": ["Querétaro, Qro., México"],
+        "remote": True,
+        "external": False,
+        "deadline": None,
+        "created": "2025-04-30T16:42:17.000Z",
+        "status": "open",
+        "commitment": "full-time",
+        "compensation": {
+            "data": {
+                "code": "to-be-agreed",
+                "currency": "MXN",
+                "minAmount": 0.0,
+                "minHourlyUSD": 0.0,
+                "maxAmount": 0.0,
+                "maxHourlyUSD": 0.0,
+                "periodicity": "monthly",
+                "negotiable": False,
+            },
+            "visible": True,
+            "additionalCompensationDetails": {"comissions": "65000"},
+        },
+        "skills": [
+            {"name": "Customer care", "proficiency": "novice"},
+            {"name": "Sales", "proficiency": "novice"},
+            {"name": "Insurance sales", "proficiency": "no-experience-interested"},
+        ],
+        "place": {
+            "remote": True,
+            "anywhere": False,
+            "locationType": "hybrid",
+            "location": [
+                {
+                    "id": "Querétaro, Qro., México",
+                    "countryCode": "MX",
+                    "latitude": 20.5887932,
+                    "longitude": -100.3898881,
+                }
+            ],
+        },
+    }
+
+
+def _opp_with_salary_range() -> dict[str, Any]:
+    """Real range: ``code == "range"``, min/max populated, currency USD."""
+    return {
+        "id": "arQneQnW",
+        "objective": "Mac User Research Participant",
+        "slug": "lusauto-mac-user-research-participant",
+        "tagline": "Contribuirás al éxito global en autopartes.",
+        "type": "full-time-employment",
+        "opportunity": "employee",
+        "organizations": [
+            {"id": 870801, "name": "Lusauto", "publicId": "Lusauto", "size": 100}
+        ],
+        "locations": ["Perú"],
+        "remote": True,
+        "external": False,
+        "deadline": "2026-06-08T14:01:21.000Z",
+        "created": "2026-05-09T14:01:21.000Z",
+        "status": "open",
+        "commitment": "part-time",
+        "compensation": {
+            "data": {
+                "code": "range",
+                "currency": "USD",
+                "minAmount": 500.0,
+                "maxAmount": 1000.0,
+                "periodicity": "monthly",
+                "negotiable": False,
+            },
+            "visible": True,
+            "additionalCompensationDetails": {},
+        },
+        "skills": [
+            {"name": "Office automation"},
+            {"name": "Software development"},
+        ],
+        "place": {
+            "remote": True,
+            "locationType": "remote_countries",
+            "location": [
+                {
+                    "id": "Perú",
+                    "countryCode": "PE",
+                    "latitude": -9.189967,
+                    "longitude": -75.015152,
+                }
+            ],
+        },
+    }
+
+
+def _opp_no_compensation() -> dict[str, Any]:
+    """``compensation.data`` is None when the employer hid the salary."""
+    return {
+        "id": "8wDqNZOd",
+        "objective": "Arquitecto de Soluciones Plataforma",
+        "slug": "acme-arquitecto",
+        "tagline": "Design platform architectures.",
+        "type": "full-time-employment",
+        "opportunity": "employee",
+        "organizations": [{"id": 1, "name": "Acme", "publicId": "Acme"}],
+        "locations": ["Colombia"],
+        "remote": True,
+        "created": "2025-12-01T00:00:00.000Z",
+        "status": "open",
+        "commitment": "full-time",
+        "compensation": {
+            "data": None,
+            "visible": False,
+            "additionalCompensationDetails": {},
+        },
+        "skills": [],
+        "place": {
+            "remote": True,
+            "location": [
+                {"id": "Bogotá, Colombia", "countryCode": "CO"}
+            ],
+        },
+    }
+
+
+def _envelope(results: list[dict[str, Any]], *, next_cursor: str | None) -> dict:
+    return {
+        "total": 200534,
+        "size": len(results),
+        "offset": 0,
+        "results": results,
+        "pagination": {
+            "previous": None,
+            "next": next_cursor,
+        },
+    }
+
+
+# --- registry / wiring ------------------------------------------------------
+
+
+def test_registry_resolves_torre() -> None:
+    assert ScraperRegistry.get(ATSType.TORRE) is TorreScraper
+
+
+def test_scraper_ats_attribute() -> None:
+    assert TorreScraper("any").ats is ATSType.TORRE
+
+
+# --- happy path: structured-range salary ------------------------------------
+
+
+def test_parses_full_opportunity_with_salary_range(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        json=_envelope([_opp_with_salary_range()], next_cursor=None),
+    )
+
+    jobs = TorreScraper("any").fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+
+    assert j.ats_type is ATSType.TORRE
+    assert j.ats_id == "arQneQnW"
+    assert j.title == "Mac User Research Participant"
+    assert j.company == "Lusauto"
+    assert str(j.url) == (
+        "https://torre.ai/postings/arQneQnW/lusauto-mac-user-research-participant"
+    )
+    # place.location → location + country + lat/lon
+    assert j.location == "Perú"
+    assert j.country_iso == "PE"
+    assert j.lat == pytest.approx(-9.189967)
+    assert j.lon == pytest.approx(-75.015152)
+    # remote flag: only ever set True per project convention
+    assert j.is_remote is True
+    # Structured salary
+    assert j.salary_currency == "USD"
+    assert j.salary_period == "MONTH"
+    assert j.salary_min == 500.0
+    assert j.salary_max == 1000.0
+    assert j.salary_summary is not None
+    assert "500" in j.salary_summary and "1,000" in j.salary_summary
+    assert "USD" in j.salary_summary
+    # Employment type: part-time → PART_TIME, raw commitment preserved
+    assert j.employment_type == "PART_TIME"
+    assert j.commitment == "part-time"
+    # Description: tagline + bulleted skills list
+    assert j.description is not None
+    assert "Contribuirás al éxito global" in j.description
+    assert "- Office automation" in j.description
+    assert "- Software development" in j.description
+    # Posted_at parsed from ISO 8601
+    assert j.posted_at is not None
+    assert j.posted_at.year == 2026
+    # raw overflow
+    assert j.raw is not None
+    assert j.raw.get("organization_public_id") == "Lusauto"
+    assert j.raw.get("organization_size") == 100
+    assert j.raw.get("type") == "full-time-employment"
+    assert j.raw.get("opportunity") == "employee"
+    assert j.raw.get("external") is False
+    assert "deadline" in j.raw
+    assert j.raw.get("skills") == ["Office automation", "Software development"]
+
+
+# --- to-be-agreed: salary must stay None ------------------------------------
+
+
+def test_to_be_agreed_yields_no_salary_fields(httpx_mock) -> None:
+    """``code == "to-be-agreed"`` ships with ``minAmount=0``, ``maxAmount=0``.
+    Treating these as real bounds would let nonsense ``0 MXN`` rows leak
+    into the dataset. The currency must NOT be set either when both
+    bounds are empty (per JOB_SCHEMA.md: ``salary_currency`` is set
+    iff the ATS exposes a real range)."""
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        json=_envelope([_opp_to_be_agreed()], next_cursor=None),
+    )
+
+    jobs = TorreScraper("any").fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.salary_min is None
+    assert j.salary_max is None
+    assert j.salary_currency is None
+    assert j.salary_period is None
+    assert j.salary_summary is None
+    # but the rest of the row still parses:
+    assert j.title == "Asesor Profesional de Seguros e Inversiones"
+    assert j.country_iso == "MX"
+    assert j.employment_type == "FULL_TIME"
+    assert j.commitment == "full-time"
+
+
+def test_null_compensation_data_yields_no_salary_fields(httpx_mock) -> None:
+    """``compensation.data: None`` is the "employer hid it" case. Treat
+    identically to "no salary at all"."""
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        json=_envelope([_opp_no_compensation()], next_cursor=None),
+    )
+
+    j = TorreScraper("any").fetch()[0]
+    assert j.salary_currency is None
+    assert j.salary_min is None
+    assert j.salary_max is None
+    # other fields still parse:
+    assert j.country_iso == "CO"
+    assert j.location == "Bogotá, Colombia"
+
+
+# --- pagination -------------------------------------------------------------
+
+
+def test_follows_cursor_pagination(httpx_mock) -> None:
+    """Two pages: first response has ``pagination.next`` set, second is
+    null → loop exits. Both opportunities should appear in the result."""
+    httpx_mock.add_response(
+        url=re.compile(rf"{_SEARCH_RE.pattern}(?!.*after=)"),
+        json=_envelope([_opp_with_salary_range()], next_cursor="CURSOR_PAGE_2"),
+    )
+    httpx_mock.add_response(
+        url=re.compile(rf"{_SEARCH_RE.pattern}.*after=CURSOR_PAGE_2"),
+        json=_envelope([_opp_to_be_agreed()], next_cursor=None),
+    )
+
+    jobs = TorreScraper("any").fetch()
+    assert len(jobs) == 2
+    assert {j.ats_id for j in jobs} == {"arQneQnW", "Yd6mya1w"}
+
+
+def test_dedups_repeated_ids_across_pages(httpx_mock) -> None:
+    """Defensive: if the server somehow yields the same opportunity on
+    two consecutive pages (cursor edge cases), we de-duplicate by
+    ``ats_id`` before adding to the output list."""
+    httpx_mock.add_response(
+        url=re.compile(rf"{_SEARCH_RE.pattern}(?!.*after=)"),
+        json=_envelope([_opp_with_salary_range()], next_cursor="C2"),
+    )
+    httpx_mock.add_response(
+        url=re.compile(rf"{_SEARCH_RE.pattern}.*after=C2"),
+        # Same id appears again.
+        json=_envelope([_opp_with_salary_range()], next_cursor=None),
+    )
+    jobs = TorreScraper("any").fetch()
+    assert len(jobs) == 1
+
+
+def test_stops_on_empty_results(httpx_mock) -> None:
+    """An empty ``results`` list terminates pagination even if a cursor
+    is set (defensive against the server returning an empty trailing
+    page)."""
+    httpx_mock.add_response(
+        url=_SEARCH_RE, json=_envelope([], next_cursor="SHOULD_NOT_FOLLOW")
+    )
+    jobs = TorreScraper("any").fetch()
+    assert jobs == []
+
+
+# --- error handling ---------------------------------------------------------
+
+
+def test_500_response_raises_scraper_error(httpx_mock) -> None:
+    httpx_mock.add_response(url=_SEARCH_RE, status_code=500, is_reusable=True)
+    with pytest.raises(ScraperError):
+        TorreScraper("any").fetch()
+
+
+def test_400_response_raises_scraper_error(httpx_mock) -> None:
+    """When the server rejects the page-size (``too large``) it returns
+    400 with a JSON body. The scraper currently fixes ``PAGE_SIZE`` to
+    something well under the cap, but a future bump should surface as
+    a hard error rather than silent zero-results."""
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        status_code=400,
+        json={"meta": {"message": "Request size too large"}},
+    )
+    with pytest.raises(ScraperError):
+        TorreScraper("any").fetch()


### PR DESCRIPTION
## Summary

- Adds a single-source scraper for **Torre.co** (https://torre.ai) — a Colombian-founded direct-employer job platform with strong LATAM coverage plus a long global / remote tail. Verified **200,534** live opportunities on 2026-05-12.
- New `ATSType.TORRE` registered in the Hybrid-jobboards block (alongside Wellfound / YC), with corresponding entry in `tests/test_models.py`.
- Pulls the full active opportunity feed via Torre's public **POST** search endpoint — no auth, no API key.

## Endpoint

```
POST https://search.torre.co/opportunities/_search/?size=25&aggregate=false
Content-Type: application/json
Body: {}
```

Sample probe (returns total + 2 opportunities):

```
curl -X POST 'https://search.torre.co/opportunities/_search/?size=2&aggregate=false' \
  -H 'content-type: application/json' \
  -H 'accept: application/json' \
  -H 'User-Agent: Mozilla/5.0' \
  --data-raw '{}'
```

## Pagination

The URL accepts `?offset=N` but it's silently ignored server-side as of 2026-05. Pagination is **cursor-based** via `?after=<base64-token>` returned in `pagination.next`. The scraper follows the cursor until `next` is null.

## Page size

Server caps `size` at ~30 for unauthenticated UAs (400 with `meta.message: "Request size by <UA> too large: N"` above that). Scraper uses `PAGE_SIZE = 25` for safety margin.

## URL handling

Both `torre.co/jobs/{id}/{slug}` and `torre.ai/jobs/{id}/{slug}` 301 → the canonical `https://torre.ai/postings/{id}/{slug}` (verified). Scraper uses the canonical form.

## Salary handling

Three observed compensation shapes — handled distinctly:

1. `compensation: null` → no salary fields populated
2. `compensation.data: null` (employer hid it) → no salary fields populated
3. `compensation.data.code == "to-be-agreed"` with `minAmount=0`, `maxAmount=0` → **no salary fields populated** (treating 0 as a real bound would corrupt the dataset; currency stays None too)
4. `compensation.data.code == "range"` with real amounts → `salary_min`, `salary_max`, `salary_currency` (ISO 4217, already correct from Torre), `salary_period` (mapped from `periodicity`), `salary_summary` populated

`_to_positive_float` is the single chokepoint enforcing the "0 is a sentinel" rule.

## Other field mappings

- `country_iso`, `lat`, `lon` derived from `place.location[0].countryCode` / `latitude` / `longitude` (real ISO 3166-1 alpha-2; Torre exposes these structured)
- `is_remote`: only ever `True` (never `False`) per project pattern
- `employment_type`: mapped from `commitment` (`full-time` → `FULL_TIME`, etc.); raw value preserved in `commitment`
- `description`: tagline + bulleted skills list (search endpoint is summary-only; LLM enrichment downstream is expected to fetch the full body when needed)

## Test plan

- [x] `ruff check src/jobhive/scrapers/torre.py tests/test_torre.py` passes
- [x] `pytest tests/test_torre.py tests/test_models.py -x` passes (72 tests, 10 new)
- [x] Test coverage: structured-range salary, `to-be-agreed` zero-bounds case, `compensation.data: null` case, cursor pagination across pages, dedup on repeated IDs, empty-results termination, 500/400 error handling
- [ ] Live smoke test: `TorreScraper("any").fetch()` should return ~200k jobs in a single run; currently un-run on the dataset publisher

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Torre.co scraper to ingest direct-employer jobs via Torre’s public search API. Registers `ATSType.TORRE`, handles cursor pagination, structured salary parsing, and fixes additional compensation mapping.

- New Features
  - Adds `TorreScraper` using `POST https://search.torre.co/opportunities/_search/` with cursor-based `pagination.next`, `PAGE_SIZE=25`, and retry/backoff; builds canonical `https://torre.ai/postings/{id}/{slug}` URLs and de-duplicates by `ats_id`.
  - Maps fields: skips null/“to-be-agreed” salaries; maps real ranges to `salary_min/max`, `salary_currency`, `salary_period`, `salary_summary`; extracts `country_iso`, `lat`, `lon`; infers `employment_type` from `commitment`; composes description from tagline + skills; sets `is_remote` only when true.
  - Registers `ATSType.TORRE`, exports `TorreScraper`, seeds `ats-companies/torre.csv`, and adds tests for salary shapes, cursor pagination, de-dup, empty results, and error handling.

- Bug Fixes
  - Reads `additionalCompensationDetails` from the nested `compensation` block into `raw.additional_compensation`.

<sup>Written for commit 9af3593bb76ce2939efffab2f1f5550a1674d2e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `TorreScraper` for Torre.co — a LATAM-focused direct-employer job platform exposing ~200k live opportunities via a public, unauthenticated POST search API. The scraper uses cursor-based pagination, exponential backoff for 429/5xx, and maps Torre's structured compensation, location, and commitment fields to the canonical `Job` model.

- **`TorreScraper`** (`torre.py`, 426 lines): full cursor-pagination loop, `_to_positive_float` sentinel-0 guard for \"to-be-agreed\" salary, `_build_description` composing tagline + bulleted skills, and overflow fields stored in `raw`.
- **`ATSType.TORRE`** added to `models.py` in the Hybrid-jobboards block alongside Wellfound/YC; export wired in `scrapers/__init__.py`.
- **Tests** (`test_torre.py`): 10 new tests covering all three compensation shapes, multi-page cursor following, dedup, empty-results exit, and 400/500 error surfacing — no live HTTP.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the scraper logic and parsing are correct, and the three issues found are non-blocking code quality concerns.

The core parsing path is well-tested and handles all documented salary shapes correctly. Two of the three issues are in the retry mechanism: the backoff sleep for network errors is held inside the semaphore, and there is a trailing unreachable raise after the for loop. Neither causes a present failure because pagination is sequential and only one coroutine ever runs concurrently. The third issue is a misleading comment about MAX_CONCURRENCY. None of these affect correctness of the current implementation.

src/jobhive/scrapers/torre.py — specifically the _fetch_page retry loop around lines 175–217.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/torre.py | New Torre.co scraper with cursor-based pagination, retry/backoff, and structured salary/location parsing. Minor issues: backoff sleep held inside the semaphore on network errors, unreachable dead-code raise after the retry loop, and the MAX_CONCURRENCY semaphore doesn't limit real concurrency given the sequential pagination model. |
| tests/test_torre.py | Comprehensive test coverage for all salary shapes, cursor pagination, deduplication, empty-results termination, and error handling (400/500). Uses pytest-httpx with regex URL matching and monkeypatches retry constants for fast runs. |
| src/jobhive/models.py | Adds ATSType.TORRE to the Hybrid-jobboards block, consistent with the placement of Wellfound and YCombinator. |
| src/jobhive/scrapers/__init__.py | Exports TorreScraper in alphabetical order in both the import block and __all__. |
| tests/test_models.py | Adds "torre" to the expected ATSType set in the platform enumeration test. |
| ats-companies/torre.csv | Single-row CSV seeding Torre's company metadata (name, slug, canonical URL). |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/jobhive/scrapers/torre.py:175-190
**Retry sleep holds the semaphore slot**

`asyncio.sleep(RETRY_BASE_DELAY * attempt)` at line 189 is inside the `async with sem:` block, so the semaphore slot remains acquired for the full backoff duration. The matching sleep for 429/5xx (line 210) is correctly placed outside `sem`. Right now pagination is sequential and only one page is in-flight at a time, so this doesn't cause a deadlock — but if the scheduling model changes (e.g. parallel page-fetch tasks added later), the sleeping coroutine would starve up to `MAX_CONCURRENCY` other waiters for the entire delay.

### Issue 2 of 3
src/jobhive/scrapers/torre.py:212-217
**Unreachable fallback raise after the retry loop**

Every iteration of the `for` loop body ends with `return`, `raise`, or `continue` — the loop body never falls through normally. When `response.status_code` is 200 the method returns; for 429/5xx on the last attempt it raises inside the loop; for non-retryable statuses (400, 404, …) it raises immediately; for network errors on the last attempt it raises inside the `except` block. The final `raise ScraperError(…last_exc…)` is therefore unreachable dead code.

```suggestion
            raise ScraperError(
                f"Torre returned {response.status_code} (cursor={cursor!r})"
            )
```

### Issue 3 of 3
src/jobhive/scrapers/torre.py:109-110
**`MAX_CONCURRENCY` semaphore is effectively unused**

The comment says "concurrency only kicks in for retries", but the retry loop inside `_fetch_page` is also sequential — no `asyncio.Task` or `asyncio.gather` is ever created, so `sem` is acquired by at most one coroutine at a time regardless of the `MAX_CONCURRENCY` value. The constant and the semaphore can stay as forward-compatible scaffolding, but the comment is misleading as written and may give a false impression that the scraper is already throttling parallel workers.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: torre.csv"](https://github.com/kalil0321/ats-scrapers/commit/ed6ab3eaaefdaebdd518ed5c31fb89faa9e4e0b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732401)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->