### PR TITLE
Add JD.com careers scraper

### DIFF
--- a/ats-companies/jd.csv
+++ b/ats-companies/jd.csv
@@ -1,0 +1,2 @@
+name,slug,url
+JD.com,jd,https://zhaopin.jd.com

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -60,6 +60,7 @@ class ATSType(StrEnum):
     META = "meta"
     TESLA = "tesla"
     TIKTOK = "tiktok"
+    JD = "jd"
     UBER = "uber"
     USAJOBS = "usajobs"
     # National public-sector job boards (single-source, single-tenant

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -27,6 +27,7 @@ from jobhive.scrapers.google import GoogleScraper
 from jobhive.scrapers.greenhouse import GreenhouseScraper
 from jobhive.scrapers.icims import iCIMSScraper
 from jobhive.scrapers.jazzhr import JazzHRScraper
+from jobhive.scrapers.jd import JDScraper
 from jobhive.scrapers.jobsch import JobsChScraper
 from jobhive.scrapers.join_com import JoinComScraper
 from jobhive.scrapers.lever import LeverScraper
@@ -77,6 +78,7 @@ __all__ = [
     "GetOnBrdScraper",
     "GoogleScraper",
     "GreenhouseScraper",
+    "JDScraper",
     "JazzHRScraper",
     "JobsChScraper",
     "JoinComScraper",

--- a/src/jobhive/scrapers/jd.py
+++ b/src/jobhive/scrapers/jd.py
@@ -1,0 +1,335 @@
+"""JD.com (京东) careers scraper.
+
+JD.com is one of China's top 3 e-commerce/retail giants, comprising
+JD Retail (京东零售), JD Industrials (京东工业), JD Logistics (京东物流),
+JD Health (京东健康), and other subsidiaries — all visible in the
+``positionDeptName`` field of each posting.
+
+The careers backend at https://zhaopin.jd.com/web/job/job_list is a
+public, no-auth POST endpoint that returns a **flat JSON array** of job
+objects (no wrapper, no metadata, no total in the body). The endpoint
+expects a **form-encoded** body — despite what one might guess from a
+JSON-style URL — with ``pageIndex``/``pageSize`` parameters. A sibling
+``job_count`` endpoint returns the overall total as a bare integer, used
+here for an early upper bound on pagination.
+
+The companion ``job_detail`` page redirects through JD's passport
+SSO for any logged-out visitor — we keep ``url`` pointing at the
+canonical job-detail URL anyway since downstream consumers can still
+follow it (the redirect lands back at zhaopin.jd.com after auth).
+
+The listing is Chinese-only (``zh``). All Chinese category/department
+labels are passed through verbatim — translation is downstream LLM
+enrichment's job.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+LIST_URL = "https://zhaopin.jd.com/web/job/job_list"
+COUNT_URL = "https://zhaopin.jd.com/web/job/job_count"
+DEFAULT_PAGE_SIZE = 100  # Server hard-caps at 100; higher silently truncates.
+DEFAULT_MAX_PAGES = 500
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1.5
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0",
+    "Accept": "application/json, text/plain, */*",
+    "Content-Type": "application/x-www-form-urlencoded",
+    "Origin": "https://zhaopin.jd.com",
+    "Referer": "https://zhaopin.jd.com/web/job/job_info_list/3",
+}
+
+# Empty-filter form body — matches what the public web UI sends when no
+# search params are selected.
+_EMPTY_FILTERS = {
+    "workCityJson": "[]",
+    "jobTypeJson": "[]",
+    "jobSearch": "",
+    "depTypeJson": "[]",
+}
+
+
+@ScraperRegistry.register(ATSType.JD)
+class JDScraper(BaseScraper):
+    """JD.com careers scraper.
+
+    ``company_slug`` is informational only — JD's single careers surface
+    exposes every subsidiary in one feed. ``positionDeptName`` records
+    which JD subsidiary (JD Retail / Industrials / Logistics / Health)
+    a given role belongs to.
+    """
+
+    ats = ATSType.JD
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        page_size: int = DEFAULT_PAGE_SIZE,
+        max_pages: int = DEFAULT_MAX_PAGES,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.page_size = min(max(page_size, 1), 100)
+        self.max_pages = max_pages
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+
+            # Page 1 always — sets the deduplication baseline and gives
+            # us an early-exit signal if the feed is smaller than one
+            # page.
+            first_posts = await self._fetch_page(client, sem, page=1)
+            jobs = self._parse_posts(first_posts)
+            if len(first_posts) < self.page_size:
+                return jobs
+
+            # The sibling ``job_count`` endpoint returns the total as a
+            # bare integer; if it succeeds we use it to bound pagination
+            # tightly. If it fails or returns nonsense, fall back to
+            # ``max_pages`` and rely on the short-page break inside
+            # ``one()``.
+            total = await self._fetch_count(client, sem)
+            if total > 0:
+                page_count = min(
+                    (total + self.page_size - 1) // self.page_size,
+                    self.max_pages,
+                )
+            else:
+                page_count = self.max_pages
+
+            seen: set[str | None] = {j.ats_id for j in jobs}
+            lock = asyncio.Lock()
+            stop = asyncio.Event()
+
+            async def one(page: int) -> None:
+                if stop.is_set():
+                    return
+                posts = await self._fetch_page(client, sem, page=page)
+                if not posts:
+                    # Empty page means we've walked off the end — signal
+                    # remaining workers to stop fetching.
+                    stop.set()
+                    return
+                page_jobs = self._parse_posts(posts)
+                async with lock:
+                    for job in page_jobs:
+                        if job.ats_id in seen:
+                            continue
+                        seen.add(job.ats_id)
+                        jobs.append(job)
+                if len(posts) < self.page_size:
+                    stop.set()
+
+            await asyncio.gather(*(one(p) for p in range(2, page_count + 1)))
+        return jobs
+
+    async def _fetch_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        *,
+        page: int,
+    ) -> list[dict[str, Any]]:
+        data = {
+            "pageIndex": str(page),
+            "pageSize": str(self.page_size),
+            **_EMPTY_FILTERS,
+        }
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.post(
+                        LIST_URL, data=data, headers=HEADERS
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"JD.com fetch failed at page={page}: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                try:
+                    payload = response.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"JD.com returned non-JSON at page={page}: {exc}"
+                    ) from exc
+                if not isinstance(payload, list):
+                    raise ScraperError(
+                        f"JD.com returned unexpected payload shape at "
+                        f"page={page}: {type(payload).__name__}"
+                    )
+                return payload
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"JD.com returned {response.status_code} at "
+                        f"page={page} after {MAX_RETRIES} retries"
+                    )
+                await asyncio.sleep(RETRY_BASE_DELAY * (2**attempt))
+                continue
+            raise ScraperError(
+                f"JD.com returned {response.status_code} at page={page}"
+            )
+        raise ScraperError(f"JD.com exhausted retries at page={page}: {last_exc}")
+
+    async def _fetch_count(
+        self, client: httpx.AsyncClient, sem: asyncio.Semaphore
+    ) -> int:
+        """Probe the sibling ``job_count`` endpoint for the total.
+
+        Returns 0 on any failure — callers fall back to a page-cap.
+        Failures are intentionally silent: a missing count is not fatal,
+        it just means we walk pages until they short-return.
+        """
+        async with sem:
+            try:
+                response = await client.post(
+                    COUNT_URL, data=_EMPTY_FILTERS, headers=HEADERS
+                )
+            except httpx.HTTPError:
+                return 0
+        if response.status_code != 200:
+            return 0
+        try:
+            return int(response.text.strip())
+        except (ValueError, AttributeError):
+            return 0
+
+    def _parse_posts(self, posts: list[dict[str, Any]]) -> list[Job]:
+        return [job for post in posts if (job := self._parse_post(post)) is not None]
+
+    def _parse_post(self, item: dict[str, Any]) -> Job | None:
+        ats_id = str(item.get("positionId") or item.get("id") or "")
+        # Prefer ``positionNameOpen`` when set (the publicly-facing
+        # marketing title) — it's frequently identical to ``positionName``
+        # but occasionally more specific (e.g. "服务器采销岗" vs "采销岗").
+        title = _first_nonempty(item.get("positionNameOpen"), item.get("positionName"))
+        if not ats_id or not title:
+            return None
+
+        description = _compose_description(
+            item.get("workContent"),
+            item.get("qualification"),
+        )
+
+        # ``publishTime`` is epoch milliseconds; ``formatPublishTime`` is
+        # the same value already rendered as ``YYYY-MM-DD`` in CST. We
+        # prefer the numeric form for precision.
+        posted_at = _parse_epoch_ms(item.get("publishTime")) or _parse_date(
+            item.get("formatPublishTime")
+        )
+
+        raw: dict[str, Any] = {}
+        for source, dest in (
+            ("positionCode", "position_code"),
+            ("workCityCode", "work_city_code"),
+            ("jobTypeCode", "job_type_code"),
+            ("requirementId", "requirement_id"),
+            ("isHot", "is_hot"),
+        ):
+            value = item.get(source)
+            if value not in (None, ""):
+                raw[dest] = value
+
+        req_number = item.get("reqNumber")
+        requisition_id = (
+            req_number.strip()
+            if isinstance(req_number, str) and req_number.strip()
+            else None
+        )
+
+        return Job(
+            url=f"https://zhaopin.jd.com/web/job/job_detail?jobId={ats_id}",
+            title=title,
+            company="JD.com",
+            ats_type=ATSType.JD,
+            ats_id=ats_id,
+            location=_first_nonempty(item.get("workCity")),
+            country_iso="CN",
+            department=_first_nonempty(item.get("jobType")),
+            team=_first_nonempty(item.get("positionDeptName")),
+            requisition_id=requisition_id,
+            description=description,
+            posted_at=posted_at,
+            fetched_at=datetime.now(),
+            language="zh",
+            raw=raw or None,
+        )
+
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _strip_html(text: str) -> str:
+    """Strip HTML tags from a description fragment.
+
+    JD.com listings are almost always plain text with newlines, but the
+    odd posting smuggles in ``<br/>`` or ``<p>`` tags from the WYSIWYG
+    editor. Cheap regex strip is enough — no nested-tag edge cases here.
+    """
+    return _HTML_TAG_RE.sub("", text)
+
+
+def _compose_description(*sources: object) -> str | None:
+    """Concatenate description-like fields, strip HTML, cap at 10kB."""
+    parts: list[str] = []
+    for source in sources:
+        if isinstance(source, str) and source.strip():
+            parts.append(_strip_html(source).strip())
+    if not parts:
+        return None
+    text = "\n\n".join(parts)
+    text = re.sub(r"\n{3,}", "\n\n", text).strip()
+    return text[:10_000] or None
+
+
+def _first_nonempty(*values: object) -> str | None:
+    for v in values:
+        if isinstance(v, str) and v.strip():
+            return v.strip()
+    return None
+
+
+def _parse_epoch_ms(value: object) -> datetime | None:
+    if not isinstance(value, (int, float)) or value <= 0:
+        return None
+    try:
+        return datetime.fromtimestamp(value / 1000)
+    except (ValueError, OSError, OverflowError):
+        return None
+
+
+def _parse_date(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return datetime.strptime(value.strip(), "%Y-%m-%d")
+    except ValueError:
+        return None

--- a/src/jobhive/scrapers/jd.py
+++ b/src/jobhive/scrapers/jd.py
@@ -167,12 +167,14 @@ class JDScraper(BaseScraper):
                     )
                 except httpx.HTTPError as exc:
                     last_exc = exc
-                    if attempt == MAX_RETRIES:
-                        raise ScraperError(
-                            f"JD.com fetch failed at page={page}: {exc}"
-                        ) from exc
-                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
-                    continue
+                    response = None
+            if response is None:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"JD.com fetch failed at page={page}: {last_exc}"
+                    ) from last_exc
+                await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                continue
             if response.status_code == 200:
                 try:
                     payload = response.json()

--- a/tests/test_jd.py
+++ b/tests/test_jd.py
@@ -1,0 +1,182 @@
+"""Tests for the JD.com (京东) careers scraper.
+
+JD's public ``/web/job/job_list`` endpoint returns a flat array of job
+objects with no wrapper. We don't hit the live API — fixtures below
+mirror the real response shape verbatim (subset of fields).
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import JDScraper, ScraperRegistry
+
+_LIST_RE = re.compile(r"^https://zhaopin\.jd\.com/web/job/job_list")
+_COUNT_RE = re.compile(r"^https://zhaopin\.jd\.com/web/job/job_count")
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.jd as jd
+
+    monkeypatch.setattr(jd, "MAX_RETRIES", 1)
+    monkeypatch.setattr(jd, "RETRY_BASE_DELAY", 0.0)
+
+
+_SAMPLE_POSTS = [
+    {
+        "id": 162678,
+        "positionId": 217330,
+        "positionCode": "00673821",
+        "positionName": "商业分析岗",
+        "positionNameOpen": "商业分析岗",
+        "positionDeptName": "京东零售",
+        "jobType": "运营类",
+        "jobTypeCode": "YUNGYUN",
+        "workCity": "北京市",
+        "workCityCode": "11",
+        "publishTime": 1778428800000,
+        "formatPublishTime": "2026-05-11",
+        "isHot": 1,
+        "reqNumber": "ZP2605110173",
+        "requirementId": 217404,
+        "qualification": "1. 教育背景：本科及以上学历。",
+        "workContent": "1. 负责运动户外品类的市场分析。",
+    },
+    {
+        "id": 162677,
+        "positionId": 217354,
+        "positionCode": "00792377",
+        "positionName": "解决方案岗",
+        # ``positionNameOpen`` deliberately blank — exercise the
+        # fallback to ``positionName``.
+        "positionNameOpen": "",
+        "positionDeptName": "京东工业",
+        "jobType": "运营类",
+        "jobTypeCode": "YUNGYUN",
+        "workCity": "北京市",
+        "workCityCode": "11",
+        "publishTime": 1778428800000,
+        "formatPublishTime": "2026-05-11",
+        "isHot": 1,
+        "reqNumber": "ZP2605114177",
+        "requirementId": 217428,
+        "qualification": "本科及以上学历。",
+        "workContent": "1. 负责面向重点客户提供行业解决方案。",
+    },
+]
+
+
+def test_registry_resolves_jd() -> None:
+    assert ScraperRegistry.get(ATSType.JD) is JDScraper
+
+
+def test_parses_jd_job_payload(httpx_mock) -> None:
+    httpx_mock.add_response(url=_LIST_RE, json=_SAMPLE_POSTS)
+    # ``job_count`` is consulted only when page 1 returns a full page;
+    # 2 < page_size=100 so we don't expect a hit. Optional in case
+    # implementation changes.
+    httpx_mock.add_response(url=_COUNT_RE, text="2", is_optional=True)
+
+    jobs = JDScraper("any").fetch()
+
+    assert len(jobs) == 2
+    first, second = jobs
+    assert first.ats_type is ATSType.JD
+    assert first.ats_id == "217330"
+    assert first.global_id == "jd:217330"
+    assert first.title == "商业分析岗"
+    assert first.company == "JD.com"
+    assert first.location == "北京市"
+    assert first.country_iso == "CN"
+    assert first.language == "zh"
+    assert first.department == "运营类"
+    assert first.team == "京东零售"
+    assert first.requisition_id == "ZP2605110173"
+    assert str(first.url) == "https://zhaopin.jd.com/web/job/job_detail?jobId=217330"
+    # Description merges workContent + qualification, in that order.
+    assert first.description is not None
+    assert first.description.startswith("1. 负责运动户外品类的市场分析。")
+    assert "1. 教育背景" in first.description
+    # publishTime 1778428800000 ms -> 2026-05-11 (local TZ — assert UTC date)
+    assert first.posted_at is not None
+    assert first.posted_at.year == 2026 and first.posted_at.month == 5
+    assert isinstance(first.fetched_at, datetime)
+    assert first.raw == {
+        "position_code": "00673821",
+        "work_city_code": "11",
+        "job_type_code": "YUNGYUN",
+        "requirement_id": 217404,
+        "is_hot": 1,
+    }
+
+    # Second row exercises ``positionNameOpen`` → ``positionName`` fallback
+    # and a different subsidiary in ``team``.
+    assert second.title == "解决方案岗"
+    assert second.team == "京东工业"
+
+
+def test_skips_post_with_missing_id_and_title(httpx_mock) -> None:
+    """Defensive: malformed posts shouldn't crash the whole scrape."""
+    httpx_mock.add_response(
+        url=_LIST_RE,
+        json=[
+            {"positionId": None, "positionName": "Ghost"},
+            {"positionId": 1, "positionName": ""},
+            {"positionId": 2, "positionName": "Real"},
+        ],
+    )
+    httpx_mock.add_response(url=_COUNT_RE, text="3", is_optional=True)
+
+    jobs = JDScraper("any").fetch()
+    assert [j.ats_id for j in jobs] == ["2"]
+
+
+def test_html_stripped_from_description(httpx_mock) -> None:
+    """Some JD postings embed ``<br/>`` from the WYSIWYG editor."""
+    httpx_mock.add_response(
+        url=_LIST_RE,
+        json=[
+            {
+                "positionId": 99,
+                "positionName": "Test",
+                "workContent": "Line 1<br/>Line 2",
+                "qualification": "<p>Req</p>",
+                "publishTime": 1778428800000,
+                "workCity": "上海",
+            }
+        ],
+    )
+    httpx_mock.add_response(url=_COUNT_RE, text="1", is_optional=True)
+
+    jobs = JDScraper("any").fetch()
+    assert len(jobs) == 1
+    desc = jobs[0].description
+    assert desc is not None
+    assert "<" not in desc and ">" not in desc
+    assert "Line 1Line 2" in desc
+    assert "Req" in desc
+
+
+def test_non_200_raises(httpx_mock) -> None:
+    httpx_mock.add_response(url=_LIST_RE, status_code=500, is_reusable=True)
+    with pytest.raises(ScraperError):
+        JDScraper("any").fetch()
+
+
+def test_short_first_page_skips_pagination(httpx_mock) -> None:
+    """When page 1 returns fewer than ``page_size``, no further pages
+    are fetched and ``job_count`` is never consulted."""
+    httpx_mock.add_response(
+        url=_LIST_RE,
+        json=[
+            {"positionId": 1, "positionName": "Only", "publishTime": 1778428800000}
+        ],
+    )
+    jobs = JDScraper("any", page_size=100).fetch()
+    assert len(jobs) == 1

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -23,7 +23,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "successfactors", "workable", "workday",
         # Big-tech custom careers systems
         "amazon", "apple", "google", "meta",
-        "tesla", "tiktok", "uber", "usajobs",
+        "tesla", "tiktok", "jd", "uber", "usajobs",
         # National / supranational public-sector aggregators
         "bundesagentur", "arbetsformedlingen", "eures",
         # Hybrid jobboards (companies post directly)


### PR DESCRIPTION
## Summary

Adds a scraper for **JD.com (京东)**, one of China's top 3 e-commerce/retail giants. The careers backend at `zhaopin.jd.com/web/job/job_list` is public and no-auth.

- New `ATSType.JD` enum entry (Big-tech custom careers block, next to TIKTOK)
- New `JDScraper` class registered via `ScraperRegistry`
- Single source / no per-tenant slug: `company_slug` is informational only
- Captures all four JD subsidiaries (JD Retail / Industrials / Logistics / Health) via `positionDeptName` in `team`

## Scale

The sibling `/web/job/job_count` endpoint reports **~3,351 active postings** (verified 2026-05-11), much smaller than the "tens of thousands" originally estimated. Still a meaningful catalog, fully Chinese-language.

## Endpoint

**Caveat re. the spec'd payload:** the JSON-style request body in the task description (`{"command":{"data":{"page":{"page":1,"pageSize":50}}}}`) is the **wrong shape** — the server ignores unknown keys and silently caps results at 10 per page, regardless of `pageSize`. The real public web UI uses a **form-encoded** body with `pageIndex` / `pageSize`. Switching to that shape unlocks proper pagination (page 2/3/… return distinct ids) and `pageSize` up to 100.

```
curl -X POST 'https://zhaopin.jd.com/web/job/job_list' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -H 'User-Agent: Mozilla/5.0' \
  --data 'pageIndex=1&pageSize=100&workCityJson=[]&jobTypeJson=[]&jobSearch=&depTypeJson=[]'
```

Response: flat JSON array of job objects (no wrapper). The scraper:
- Fetches page 1 sequentially to set the dedup baseline.
- Calls `/web/job/job_count` to bound total pages tightly.
- Fans out pages 2..N at concurrency=4 with 429/5xx retry+backoff.
- Stops early when a short / empty page is observed.

## Field mapping

| canonical | JD field |
| --- | --- |
| `ats_id` | `positionId` (fallback `id`) |
| `url` | `https://zhaopin.jd.com/web/job/job_detail?jobId={positionId}` (probed — redirects through JD passport SSO for non-authed visitors, still a valid absolute URL) |
| `title` | `positionNameOpen` else `positionName` |
| `company` | hard-coded `"JD.com"` |
| `team` | `positionDeptName` (京东零售 / 京东工业 / 京东物流 / 京东健康 / ...) |
| `department` | `jobType` (运营类 / 研发类 / ...) — Chinese label preserved verbatim |
| `requisition_id` | `reqNumber` (e.g. `ZP2605110173`) |
| `location` | `workCity` |
| `country_iso` | `"CN"` |
| `language` | `"zh"` |
| `description` | `workContent` + `\n\n` + `qualification`, HTML stripped, capped at 10kB |
| `posted_at` | `publishTime` (epoch ms / 1000) |
| `raw` | `position_code`, `work_city_code`, `job_type_code`, `requirement_id`, `is_hot` |

## Test plan

- [x] `ruff check src/jobhive/scrapers/jd.py tests/test_jd.py` — passes
- [x] `pytest tests/test_jd.py tests/test_models.py -x` — 68 passed
- [x] `pytest tests/test_scrapers.py tests/test_manifest.py -x` — 45 passed (registry + ATSType enum still consistent)
- [ ] Live smoke: `python -c "from jobhive.scrapers import JDScraper; jobs = JDScraper('jd').fetch(); print(len(jobs))"` should return ~3,351

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `JDScraper` to ingest JD.com jobs via the public `zhaopin.jd.com/web/job/job_list` API, and introduces `ATSType.JD`. Also fixes retry backoff so connection errors no longer block concurrent page fetches.

- **New Features**
  - Added `ATSType.JD` and registered/exported `JDScraper` via `ScraperRegistry`.
  - Uses form-encoded `pageIndex`/`pageSize` (up to 100) for `job_list`, plus `job_count` to bound pages.
  - Concurrency set to 4 with early stop on short/empty pages and cross-page dedup.
  - Maps fields; merges `workContent` + `qualification`, strips HTML, caps to 10KB; sets `country_iso="CN"` and `language="zh"`; captures subsidiaries in `team` via `positionDeptName`.
  - Adds tests for parsing, fallbacks, HTML stripping, pagination, and error handling.
  - Seeds `ats-companies/jd.csv` with JD.com.

- **Bug Fixes**
  - Moved `httpx.HTTPError` retry sleep outside the semaphore to prevent holding slots and stalling concurrency.

<sup>Written for commit 3d9fb76f1627d431743d9325c55411834e369473. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/84?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `JDScraper` for JD.com's public careers API (`zhaopin.jd.com/web/job/job_list`), registers it as `ATSType.JD`, and seeds the company CSV. The scraper uses form-encoded pagination with `pageIndex`/`pageSize`, a sibling `job_count` endpoint to bound pages, and concurrent fetching (semaphore=4) with retry/backoff.

- `JDScraper` fetches page 1 sequentially, then fans out pages 2..N at concurrency 4 with deduplication via a shared `seen` set guarded by an `asyncio.Lock`; stops early on short/empty pages.
- Field mapping covers all four JD subsidiaries via `positionDeptName`, merges `workContent`+`qualification` with HTML stripping capped at 10 kB, and hard-codes `country_iso=\"CN\"` / `language=\"zh\"`.
- Tests cover parsing, fallbacks, HTML stripping, short-page early-exit, and error propagation, but do not exercise the concurrent multi-page path.

<h3>Confidence Score: 3/5</h3>

Safe to merge after fixing the retry sleep inside the semaphore; the bug does not cause data loss but can stall all concurrent fetches during connection errors.

The semaphore is held while sleeping on connection-level retries, which can serialize all 4 concurrent page fetches whenever the network is flaky — directly undermining the concurrency model the scraper is built around. This is a real defect in the changed code's intended behavior.

src/jobhive/scrapers/jd.py — specifically the retry loop in _fetch_page around lines 162–175.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/jd.py | New JD.com scraper with async pagination; retry sleep incorrectly holds the semaphore slot on connection errors, stalling concurrent fetches during network hiccups. |
| tests/test_jd.py | Good unit-test coverage for parsing, HTML stripping, short-page early-exit, and error handling; no test exercises the concurrent multi-page path (pages 2..N with deduplication). |
| src/jobhive/models.py | Adds ATSType.JD enum value in the correct position; no other model changes. |
| src/jobhive/scrapers/__init__.py | Imports and exports JDScraper alphabetically; consistent with the rest of the file. |
| ats-companies/jd.csv | Adds a single JD.com seed entry with correct schema columns. |
| tests/test_models.py | Adds "jd" to the expected ATSType set; correctly reflects the new enum value. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/jobhive/scrapers/jd.py:162-175
**Retry sleep holds the semaphore slot**

`await asyncio.sleep(RETRY_BASE_DELAY * attempt)` on line 174 is executed inside the `async with sem:` block. The `async with` context isn't exited until after the sleep completes, so the semaphore slot is held for the entire backoff period (1.5 s on attempt 1, 3.0 s on attempt 2) on every connection-level error. With `MAX_CONCURRENCY=4`, if multiple pages simultaneously get an `httpx.HTTPError`, up to all 4 slots can be blocked sleeping, stalling the entire concurrent fetch. The 429/5xx backoff (line 195) is correctly placed outside the semaphore — the connection-error path should match that pattern: capture the exception, exit `async with sem:`, then sleep and retry.

### Issue 2 of 2
src/jobhive/scrapers/jd.py:123
**`None` admitted into `seen` set via `ats_id` type**

`seen` is typed `set[str | None]`, but a `None` can only enter if `j.ats_id` is `None`. In practice `_parse_post` always returns a `Job` with a non-empty `ats_id` (the `if not ats_id` guard on line 234 filters those out), so `None` can never be in `seen`. The broader concern is that an `ats_id` of `None` could slip in from page-1 jobs if the guard were ever relaxed, and then `None` would match every future unresolvable posting. Narrowing to `set[str]` makes the invariant explicit and removes the latent dedup hole.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: jd.csv"](https://github.com/kalil0321/ats-scrapers/commit/4e38382d78805663f845ab4facc01069dac514ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732405)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->