### PR TITLE
[codex] add 12 live non-EU ATS tenants

### DIFF
--- a/ats-companies/greenhouse.csv
+++ b/ats-companies/greenhouse.csv
@@ -332,6 +332,7 @@ BITKRAFT Ventures,bitkraft,https://job-boards.greenhouse.io/bitkraft
 Bitly Inc.,bitly,https://job-boards.greenhouse.io/bitly
 BitMEX,bitmex,https://job-boards.greenhouse.io/bitmex
 Bitpanda,bitpanda,https://job-boards.greenhouse.io/bitpanda
+Bitso,bitso,https://job-boards.greenhouse.io/bitso
 B Lab,blab,https://job-boards.greenhouse.io/blab
 Blackbird Health,blackbirdhealth,https://job-boards.greenhouse.io/blackbirdhealth
 Black Canyon Consulting,blackcanyonconsulting,https://job-boards.greenhouse.io/blackcanyonconsulting

--- a/ats-companies/oracle.csv
+++ b/ats-companies/oracle.csv
@@ -151,6 +151,7 @@ Fife Council Jobs and Careers,ekmu,https://ekmu.fa.em3.oraclecloud.com/hcmUI/Can
 Ford Global Career Site,efds,https://efds.fa.em5.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Fortive Careers,ejta,https://ejta.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Forward,eguq,https://eguq.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fujifilm Business Innovation APAC,hcjq,https://hcjq.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_17
 GCAA,elon,https://elon.fa.em8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 GCI Careers,edqv,https://edqv.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 GP Strategies Career Site,eetz,https://eetz.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
@@ -181,6 +182,7 @@ Hologic Careers,ebwb,https://ebwb.fa.us2.oraclecloud.com/hcmUI/CandidateExperien
 Home Page,hdhy,https://hdhy.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Honeywell,ibqbjb,https://ibqbjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 IB,ejst,https://ejst.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+IFM Investors,enlc,https://enlc.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
 INSEAD,iablgs,https://iablgs.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 INTEGRIS Health,ertr,https://ertr.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 IP Global Career Site,iazbqy,https://iazbqy.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
@@ -216,6 +218,7 @@ MAS Holdings,egmh,https://egmh.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/
 MBC Group,ehff,https://ehff.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 MHRA,eckx,https://eckx.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 MTN EXTERNAL CAREER SITE,ehle,https://ehle.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+MUFG Pension & Market Services,hcmn,https://hcmn.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
 MX Career Site,ehtc,https://ehtc.fa.ca2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Macy's,ebwh,https://ebwh.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Mashreq Careers,hcld,https://hcld.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
@@ -249,6 +252,7 @@ Online @ Air Selangor,egek,https://egek.fa.ap1.oraclecloud.com/hcmUI/CandidateEx
 Opus,iaaxiz,https://iaaxiz.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Oracle,eeho,https://eeho.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Oxford Nanopore Technologies,ejnh,https://ejnh.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+People First Bank,hcyt,https://hcyt.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
 Proskauer,dfa,https://dfa.fa.us1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Providence,evac,https://evac.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Pyxus,iahome,https://iahome.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1

--- a/ats-companies/workday.csv
+++ b/ats-companies/workday.csv
@@ -4,6 +4,7 @@ name,slug,url
 3i,3i/direct_hire,https://3i.wd103.myworkdayjobs.com/Direct_Hire
 7-Eleven,7eleven/7eleven,https://7eleven.wd3.myworkdayjobs.com/7eleven
 8x8,8x8inc/8x8_external_careers,https://8x8inc.wd5.myworkdayjobs.com/8x8_external_careers
+ABSA Group,absa/ABSAcareersite,https://absa.wd3.myworkdayjobs.com/ABSAcareersite
 CSAA Insurance Group,aaaie/csaacareers,https://aaaie.wd1.myworkdayjobs.com/csaacareers
 Advocate Health,aah/external,https://aah.wd5.myworkdayjobs.com/external
 Aalto University,aalto/aalto,https://aalto.wd3.myworkdayjobs.com/aalto
@@ -181,6 +182,7 @@ Axiscapital,axiscapital/axiscareers,https://axiscapital.wd1.myworkdayjobs.com/ax
 Axos,axos/axos,https://axos.wd5.myworkdayjobs.com/axos
 Ayvens,ayvens/ayvenscareers,https://ayvens.wd3.myworkdayjobs.com/ayvenscareers
 Azenta,azenta/azentajobs,https://azenta.wd1.myworkdayjobs.com/azentajobs
+BSI Group,bsigroup/BSI_Careers,https://bsigroup.wd3.myworkdayjobs.com/BSI_Careers
 Bacardi,bacardi/jobs_bacardi,https://bacardi.wd3.myworkdayjobs.com/jobs_bacardi
 Bacr,bacr/bacr,https://bacr.wd501.myworkdayjobs.com/bacr
 Badger Meter,badgermeter/us_careersite,https://badgermeter.wd5.myworkdayjobs.com/us_careersite
@@ -215,6 +217,7 @@ Bdoau,bdoau/bdocareers,https://bdoau.wd105.myworkdayjobs.com/bdocareers
 Bdx,bdx/external_career_site_malaysia,https://bdx.wd1.myworkdayjobs.com/external_career_site_malaysia
 Bdx,bdx/external_career_site_singapore,https://bdx.wd1.myworkdayjobs.com/external_career_site_singapore
 Bdx,bdx/external_career_site_usa,https://bdx.wd1.myworkdayjobs.com/external_career_site_usa
+Becton Dickinson Mexico,bdx/EXTERNAL_CAREER_SITE_MEXICO,https://bdx.wd1.myworkdayjobs.com/EXTERNAL_CAREER_SITE_MEXICO
 Becu,becu/external,https://becu.wd1.myworkdayjobs.com/external
 Beigene,beigene/beigene,https://beigene.wd5.myworkdayjobs.com/beigene
 Belk,belk/careers-corporate,https://belk.wd1.myworkdayjobs.com/careers-corporate
@@ -1052,6 +1055,7 @@ Medtronic,medtronic/medtroniccareers,https://medtronic.wd1.myworkdayjobs.com/med
 Meijer,meijer/fresh_thyme_stores_external_career_site,https://meijer.wd5.myworkdayjobs.com/fresh_thyme_stores_external_career_site
 Meijer,meijer/meijer,https://meijer.wd5.myworkdayjobs.com/meijer
 MEININGER,meiningerhotels/meiningerhotelscareers,https://meiningerhotels.wd103.myworkdayjobs.com/meiningerhotelscareers
+Melco Resorts & Entertainment,melcoresorts/career,https://melcoresorts.wd3.myworkdayjobs.com/career
 Memorialhealthcare,memorialhealthcare/mhs_careers,https://memorialhealthcare.wd1.myworkdayjobs.com/mhs_careers
 Memorialhermann,memorialhermann/external,https://memorialhermann.wd5.myworkdayjobs.com/external
 Menasha,menasha/menashacorp,https://menasha.wd12.myworkdayjobs.com/menashacorp
@@ -1129,6 +1133,7 @@ Mymoose,mymoose/careers,https://mymoose.wd1.myworkdayjobs.com/careers
 Mymvw,mymvw/mvw,https://mymvw.wd5.myworkdayjobs.com/mvw
 Myview,myview/careers,https://myview.wd3.myworkdayjobs.com/careers
 Myview,myview/sdm_careers,https://myview.wd3.myworkdayjobs.com/sdm_careers
+NBN Co,nbn/nbncareers,https://nbn.wd3.myworkdayjobs.com/nbncareers
 North American Partners in Anesthesia,napaanesthesia/napa_careers,https://napaanesthesia.wd1.myworkdayjobs.com/napa_careers
 Nascar,nascar/nascar,https://nascar.wd1.myworkdayjobs.com/nascar
 Nasdaq,nasdaq/global_external_site,https://nasdaq.wd1.myworkdayjobs.com/global_external_site
@@ -1348,6 +1353,7 @@ Rakuten,rakuten/rakuteninc,https://rakuten.wd1.myworkdayjobs.com/rakuteninc
 RAND,rand/external_career_site,https://rand.wd5.myworkdayjobs.com/external_career_site
 Texas Rangers,rangersmlb/rangers,https://rangersmlb.wd5.myworkdayjobs.com/rangers
 REV Sports Management,rangersmlb/revsportsmanagementcareers,https://rangersmlb.wd5.myworkdayjobs.com/revsportsmanagementcareers
+Rappi,rappi/Rappi_jobs,https://rappi.wd12.myworkdayjobs.com/Rappi_jobs
 Raymond James,raymondjames/raymondjamescareers,https://raymondjames.wd1.myworkdayjobs.com/raymondjamescareers
 Raymond James,raymondjames/raymondjamesearlycareers,https://raymondjames.wd1.myworkdayjobs.com/raymondjamesearlycareers
 Razer,razer/careers,https://razer.wd3.myworkdayjobs.com/careers
@@ -1708,6 +1714,7 @@ Jobs at UoM,unimelb/uom_external_career,https://unimelb.wd105.myworkdayjobs.com/
 Union College,unioncollege/unioncollegecareers,https://unioncollege.wd5.myworkdayjobs.com/unioncollegecareers
 Uniphore,uniphore/uniphore,https://uniphore.wd503.myworkdayjobs.com/uniphore
 Unisys,unisys/external,https://unisys.wd5.myworkdayjobs.com/external
+United Overseas Bank,uobgroup/UOBExternal,https://uobgroup.wd3.myworkdayjobs.com/UOBExternal
 Unitedtalent,unitedtalent/utaprivate,https://unitedtalent.wd5.myworkdayjobs.com/utaprivate
 TelevisaUnivision,univision/external,https://univision.wd1.myworkdayjobs.com/external
 Unum Group,unum/confidential,https://unum.wd1.myworkdayjobs.com/confidential


### PR DESCRIPTION
## Summary

- Rebuild the stale multi-provider expansion on current `main`.
- Add 12 unique tenants that return non-empty jobs through the current provider scrapers.
- Remove four proposed tenants that now return empty feeds.
- Remove PETRONAS GEES because the same Oracle tenant URL already exists on `main` as PETRONAS.

## Live validation

Every added tenant completed a full end-to-end scraper fetch on 2026-07-23:

| Provider | Tenant | Live jobs |
| --- | --- | ---: |
| Greenhouse | Bitso | 9 |
| Oracle | Fujifilm Business Innovation APAC | 1 |
| Oracle | IFM Investors | 14 |
| Oracle | MUFG Pension & Market Services | 148 |
| Oracle | People First Bank | 17 |
| Workday | ABSA Group | 101 |
| Workday | BSI Group | 271 |
| Workday | Becton Dickinson Mexico | 32 |
| Workday | Melco Resorts & Entertainment | 204 |
| Workday | NBN Co | 58 |
| Workday | Rappi | 31 |
| Workday | United Overseas Bank | 44 |

Total at validation time: **930 live jobs**.

## Removed after revalidation

- Abu Dhabi Media Network: empty Oracle feed.
- Golf Saudi: empty Oracle feed.
- Leighton Asia: empty Oracle feed.
- Qantas Airways: empty Workday feed.
- PETRONAS GEES Graduate: exact URL already present on `main`.

## Checks

- CSV integrity: 12 additions, no normalized URL or slug collisions.
- Provider-focused tests: 54 passed.
- `pytest -q` — 1,167 passed, 2 skipped, 20 deselected.
- `git diff --check`.
