### PR TITLE
Add DiDi Global careers scraper

### DIFF
--- a/ats-companies/didi.csv
+++ b/ats-companies/didi.csv
@@ -1,0 +1,2 @@
+name,slug,url
+DiDi,didi,https://talent.didiglobal.com/social/

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -56,6 +56,7 @@ class ATSType(StrEnum):
     # Big-tech custom careers systems (single-tenant, bespoke APIs)
     AMAZON = "amazon"
     APPLE = "apple"
+    DIDI = "didi"
     GOOGLE = "google"
     META = "meta"
     TESLA = "tesla"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -19,6 +19,7 @@ from jobhive.scrapers.breezy import BreezyScraper
 from jobhive.scrapers.builtin import BuiltInScraper
 from jobhive.scrapers.bundesagentur import BundesagenturScraper
 from jobhive.scrapers.cornerstone import CornerstoneScraper
+from jobhive.scrapers.didi import DidiScraper
 from jobhive.scrapers.eightfold import EightfoldScraper
 from jobhive.scrapers.eures import EuresScraper
 from jobhive.scrapers.gem import GemScraper
@@ -71,6 +72,7 @@ __all__ = [
     "BuiltInScraper",
     "BundesagenturScraper",
     "CornerstoneScraper",
+    "DidiScraper",
     "EightfoldScraper",
     "EuresScraper",
     "GemScraper",

--- a/src/jobhive/scrapers/didi.py
+++ b/src/jobhive/scrapers/didi.py
@@ -261,8 +261,10 @@ class DidiScraper(BaseScraper):
         elif recruit_type is not None:
             raw["recruit_type"] = recruit_type
 
+        surface = "campus" if recruit_type == 3 else "social"
+
         return Job(
-            url=f"https://talent.didiglobal.com/social/p/{ats_id}",
+            url=f"https://talent.didiglobal.com/{surface}/p/{ats_id}",
             title=title,
             company="DiDi",
             ats_type=ATSType.DIDI,

--- a/src/jobhive/scrapers/didi.py
+++ b/src/jobhive/scrapers/didi.py
@@ -1,0 +1,349 @@
+"""DiDi Global (滴滴) careers scraper.
+
+DiDi Chuxing is the world's leading mobile transportation platform,
+operating in 18+ countries. Their public no-auth careers API at
+``talent.didiglobal.com`` exposes the full catalogue across social and
+campus recruitment.
+
+    GET https://talent.didiglobal.com/recruit-portal-service/api/job/front/list
+        ?recruitType={1|3}&page={N}&size={M}
+
+The list endpoint serves a fixed ~16-item page server-side regardless
+of the ``size`` parameter requested. ``recruitType=1`` is social
+recruitment, ``recruitType=3`` is campus; we iterate both and dedup by
+``jdId`` since DiDi mirrors many roles across both surfaces. The list
+response carries enough structured metadata (jdNo, workArea, deptName,
+jobName, refreshTime) for the canonical Job schema; the long-form
+``jobDuty`` / ``jobQualification`` fields exist only on the per-jd
+``view/{jdId}`` detail endpoint and are intentionally NOT fetched here
+to keep this a single-pass scraper. Description-text enrichment can be
+done out-of-band later.
+
+Verified 2026-05-12: total=1217 live social postings.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+API_URL = "https://talent.didiglobal.com/recruit-portal-service/api/job/front/list"
+# The server caps each response at ~16 rows regardless of the size we
+# request — keep this aligned so progress reporting and page-count
+# math match what we actually receive.
+DEFAULT_PAGE_SIZE = 16
+DEFAULT_MAX_PAGES = 500
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1.5
+
+# DiDi's own portal taxonomy. recruitType=1 is the social-hires
+# surface (the bulk of the catalogue), recruitType=3 is campus.
+# Iterating both and deduping by jdId matches what a candidate sees
+# when toggling the tabs on the live site.
+RECRUIT_TYPES: tuple[int, ...] = (1, 3)
+
+# CJK range used to decide language. We don't try to differentiate
+# Chinese vs. Japanese vs. Korean — DiDi's careers content is
+# zh-cn or English in practice.
+_CJK_RE = re.compile(r"[一-鿿]")
+
+HEADERS = {
+    "Accept": "application/json",
+    "User-Agent": "Mozilla/5.0",
+    "Referer": "https://talent.didiglobal.com/social/",
+}
+
+
+@ScraperRegistry.register(ATSType.DIDI)
+class DidiScraper(BaseScraper):
+    """DiDi Global careers scraper — single-source for the whole company.
+
+    ``company_slug`` is informational; the API is global and
+    company-wide. Pagination follows the real param shape used by the
+    portal (``recruitType`` / ``page`` / ``size``) rather than the
+    aliases sometimes documented elsewhere.
+    """
+
+    ats = ATSType.DIDI
+
+    def __init__(
+        self,
+        company_slug: str = "didi",
+        *,
+        timeout: float = 30.0,
+        page_size: int = DEFAULT_PAGE_SIZE,
+        max_pages: int = DEFAULT_MAX_PAGES,
+        recruit_types: tuple[int, ...] = RECRUIT_TYPES,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.page_size = page_size
+        self.max_pages = max_pages
+        self.recruit_types = recruit_types
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        seen: set[str] = set()
+        merged: list[Job] = []
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+            for recruit_type in self.recruit_types:
+                first = await self._fetch_page(
+                    client, sem, recruit_type=recruit_type, page=1
+                )
+                data = first.get("data") or {}
+                total = int(data.get("total") or 0)
+                items = data.get("items") or []
+                self._merge(items, recruit_type, seen, merged)
+                if total <= self.page_size or len(items) < self.page_size:
+                    continue
+
+                page_count = min(
+                    (total + self.page_size - 1) // self.page_size,
+                    self.max_pages,
+                )
+                lock = asyncio.Lock()
+
+                async def one(
+                    page: int,
+                    rt: int = recruit_type,
+                    page_lock: asyncio.Lock = lock,
+                ) -> None:
+                    payload = await self._fetch_page(
+                        client, sem, recruit_type=rt, page=page
+                    )
+                    page_items = (payload.get("data") or {}).get("items") or []
+                    async with page_lock:
+                        self._merge(page_items, rt, seen, merged)
+
+                await asyncio.gather(
+                    *(one(p) for p in range(2, page_count + 1))
+                )
+        return merged
+
+    def _merge(
+        self,
+        items: list[dict[str, Any]],
+        recruit_type: int,
+        seen: set[str],
+        out: list[Job],
+    ) -> None:
+        for item in items:
+            job = self._parse_job(item, recruit_type=recruit_type)
+            if job is None or job.ats_id in seen:
+                continue
+            seen.add(job.ats_id)
+            out.append(job)
+
+    async def _fetch_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        *,
+        recruit_type: int,
+        page: int,
+    ) -> dict[str, Any]:
+        params = {
+            "recruitType": recruit_type,
+            "page": page,
+            "size": self.page_size,
+        }
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(
+                        API_URL, params=params, headers=HEADERS
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"DiDi fetch failed at recruitType={recruit_type} "
+                            f"page={page}: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                try:
+                    payload = response.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"DiDi returned non-JSON at recruitType={recruit_type} "
+                        f"page={page}: {exc}"
+                    ) from exc
+                meta = payload.get("meta") or {}
+                # DiDi wraps app-level errors in meta.code (0 = success).
+                if meta.get("code") not in (0, None):
+                    raise ScraperError(
+                        f"DiDi returned meta.code={meta.get('code')} "
+                        f"({meta.get('message')!r}) at recruitType="
+                        f"{recruit_type} page={page}"
+                    )
+                return payload
+            if response.status_code == 429 or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"DiDi returned {response.status_code} at "
+                        f"recruitType={recruit_type} page={page} after "
+                        f"{MAX_RETRIES} retries"
+                    )
+                await asyncio.sleep(RETRY_BASE_DELAY * (2**attempt))
+                continue
+            raise ScraperError(
+                f"DiDi returned {response.status_code} at "
+                f"recruitType={recruit_type} page={page}"
+            )
+        raise ScraperError(
+            f"DiDi exhausted retries at recruitType={recruit_type} "
+            f"page={page}: {last_exc}"
+        )
+
+    def _parse_job(
+        self, item: dict[str, Any], *, recruit_type: int | None = None
+    ) -> Job | None:
+        # Prefer jdId (the portal's stable per-posting key); fall back
+        # to id only if it's ever populated.
+        ats_id_raw = item.get("jdId") if item.get("jdId") is not None else item.get("id")
+        if ats_id_raw is None:
+            return None
+        ats_id = str(ats_id_raw)
+        title = (item.get("jobName") or "").strip()
+        if not ats_id or not title:
+            return None
+
+        description = _compose_description(
+            item.get("jobDuty"), item.get("jobQualification")
+        )
+        posted_at = _parse_epoch_ms(item.get("createTime")) or _parse_refresh_time(
+            item.get("refreshTime")
+        )
+        location = _clean_str(item.get("workArea"))
+        country_iso = _infer_country_iso(location)
+        language = "zh" if _CJK_RE.search(title) else "en"
+
+        jd_no = _clean_str(item.get("jdNo"))
+        requisition_id = jd_no or None
+
+        # raw: keep the ATS-specific fields the canonical schema can't
+        # represent. ``recruit_type`` here is the *surface* this row
+        # was discovered on (1=social / 3=campus), which is more useful
+        # than the per-item recruitType field (often null in list view).
+        raw: dict[str, Any] = {}
+        for source, dest in (
+            ("labelCode", "label_codes"),
+            ("labels", "labels"),
+            ("isUrgent", "is_urgent"),
+            ("channelId", "channel_id"),
+            ("jobLevel", "job_level"),
+        ):
+            value = item.get(source)
+            if value not in (None, "", []):
+                raw[dest] = value
+        rt_value = item.get("recruitType")
+        if rt_value not in (None, ""):
+            raw["recruit_type"] = rt_value
+        elif recruit_type is not None:
+            raw["recruit_type"] = recruit_type
+
+        return Job(
+            url=f"https://talent.didiglobal.com/social/p/{ats_id}",
+            title=title,
+            company="DiDi",
+            ats_type=ATSType.DIDI,
+            ats_id=ats_id,
+            location=location,
+            country_iso=country_iso,
+            department=_clean_str(item.get("jobTypeName"))
+            or _clean_str(item.get("jobType")),
+            team=_clean_str(item.get("deptName")),
+            requisition_id=requisition_id,
+            description=description,
+            posted_at=posted_at,
+            fetched_at=datetime.now(),
+            language=language,
+            raw=raw or None,
+        )
+
+
+def _compose_description(*sources: object) -> str | None:
+    """Concatenate ``jobDuty`` + ``jobQualification`` and cap at 10kB.
+
+    Both fields are plain text from the DiDi backend, so no HTML
+    stripping is needed — just trim, drop empties, and collapse runs
+    of blank lines.
+    """
+    parts: list[str] = []
+    for src in sources:
+        if isinstance(src, str) and src.strip():
+            parts.append(src.strip())
+    if not parts:
+        return None
+    text = "\n\n".join(parts)
+    text = re.sub(r"\n{3,}", "\n\n", text).strip()
+    return text[:10_000] or None
+
+
+def _clean_str(value: object) -> str | None:
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return cleaned or None
+    if isinstance(value, int) and not isinstance(value, bool):
+        return str(value)
+    return None
+
+
+def _parse_epoch_ms(value: object) -> datetime | None:
+    """``createTime`` is documented as epoch milliseconds when present."""
+    if value is None or value == "":
+        return None
+    try:
+        # Tolerate both int and numeric str.
+        ms = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    if ms <= 0:
+        return None
+    try:
+        return datetime.fromtimestamp(ms / 1000)
+    except (OSError, OverflowError, ValueError):
+        return None
+
+
+def _parse_refresh_time(value: object) -> datetime | None:
+    """``refreshTime`` is a server-local string like
+    ``"2026-05-11 22:39:45"`` — used as a fallback when createTime
+    is null in the list payload."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return datetime.strptime(value.strip(), "%Y-%m-%d %H:%M:%S")
+    except ValueError:
+        return None
+
+
+def _infer_country_iso(location: str | None) -> str | None:
+    """Cheap CJK→CN heuristic. DiDi's domestic catalogue uses the
+    Chinese city name (``北京市``, ``上海市``), so any CJK in the
+    location string almost always means a mainland-China posting.
+    Foreign cities are left for the LLM enrichment pass downstream."""
+    if not location:
+        return None
+    if _CJK_RE.search(location):
+        return "CN"
+    return None

--- a/tests/test_didi.py
+++ b/tests/test_didi.py
@@ -1,0 +1,207 @@
+"""Tests for the DiDi Global careers scraper.
+
+Scope: ``_parse_job`` only — pagination + HTTP shape is covered by the
+live-API verification done at scrape time, mocking ``httpx`` here would
+add brittleness without protecting any contract we control.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from jobhive.models import ATSType
+from jobhive.scrapers.didi import DidiScraper
+
+# Two realistic fixtures captured from the live list endpoint on
+# 2026-05-12. First is a Chinese-language Beijing posting (the bulk of
+# the catalogue), second is an English-language posting that exercises
+# the CJK→language fall-through to ``en`` and demonstrates that
+# ``country_iso`` is left None when no CJK is present in workArea.
+_FIXTURE_ZH = {
+    "id": None,
+    "jdId": 63733,
+    "jdNo": "JR2026051100R",
+    "recruitType": None,
+    "workArea": "北京市",
+    "deptName": "Fintech Technology",
+    "deptCode": None,
+    "jobType": 3,
+    "jobName": "AI 客服产品经理 (JR2026051100R)",
+    "createTime": 1747000000000,
+    "labelCode": "AI",
+    "labelName": "",
+    "labels": ["ai", "fintech"],
+    "refreshTime": "2026-05-11 22:39:45",
+    "jobTypeName": "产品",
+    "jobDuty": "负责 AI 客服核心产品层的设计与推进。",
+    "jobQualification": "有智能客服、对话机器人产品经验。",
+    "isUrgent": 1,
+    "channelId": 7,
+    "jobLevel": "P6",
+    "recruiterLdap": None,
+    "recruiterName": None,
+    "new": False,
+}
+
+_FIXTURE_EN = {
+    "id": None,
+    "jdId": 58739,
+    "jdNo": "J250827001",
+    "recruitType": None,
+    "workArea": "Mexico City",
+    "deptName": "Project X",
+    "deptCode": None,
+    "jobType": 5,
+    "jobName": "Growth Operation Manager (J250827001)",
+    "createTime": None,
+    "labelCode": None,
+    "labelName": "",
+    "labels": None,
+    "refreshTime": "2026-05-11 22:19:23",
+    "jobTypeName": None,
+    "jobDuty": None,
+    "jobQualification": None,
+    "isUrgent": None,
+    "channelId": None,
+    "jobLevel": None,
+    "new": False,
+}
+
+
+# --- _parse_job: Chinese fixture --------------------------------------------
+
+
+def test_parse_job_chinese_uses_jdid_as_ats_id() -> None:
+    job = DidiScraper("didi")._parse_job(_FIXTURE_ZH, recruit_type=1)
+    assert job is not None
+    assert job.ats_type is ATSType.DIDI
+    assert job.ats_id == "63733"
+    assert job.global_id == "didi:63733"
+
+
+def test_parse_job_chinese_url_uses_jdid() -> None:
+    job = DidiScraper("didi")._parse_job(_FIXTURE_ZH)
+    assert job is not None
+    assert str(job.url) == "https://talent.didiglobal.com/social/p/63733"
+
+
+def test_parse_job_chinese_language_is_zh() -> None:
+    """CJK characters in the title → language='zh'."""
+    job = DidiScraper("didi")._parse_job(_FIXTURE_ZH)
+    assert job is not None
+    assert job.language == "zh"
+
+
+def test_parse_job_chinese_workarea_sets_country_iso_cn() -> None:
+    """Chinese city name in workArea triggers the CN heuristic."""
+    job = DidiScraper("didi")._parse_job(_FIXTURE_ZH)
+    assert job is not None
+    assert job.country_iso == "CN"
+    assert job.location == "北京市"
+
+
+def test_parse_job_requisition_id_from_jdno() -> None:
+    job = DidiScraper("didi")._parse_job(_FIXTURE_ZH)
+    assert job is not None
+    assert job.requisition_id == "JR2026051100R"
+
+
+def test_parse_job_posted_at_from_create_time_epoch_ms() -> None:
+    job = DidiScraper("didi")._parse_job(_FIXTURE_ZH)
+    assert job is not None
+    assert job.posted_at == datetime.fromtimestamp(1747000000000 / 1000)
+
+
+def test_parse_job_description_concatenates_duty_and_qualification() -> None:
+    job = DidiScraper("didi")._parse_job(_FIXTURE_ZH)
+    assert job is not None
+    assert job.description is not None
+    assert "负责 AI 客服核心产品层的设计与推进。" in job.description
+    assert "有智能客服、对话机器人产品经验。" in job.description
+
+
+def test_parse_job_department_from_job_type_name() -> None:
+    job = DidiScraper("didi")._parse_job(_FIXTURE_ZH)
+    assert job is not None
+    assert job.department == "产品"
+    assert job.team == "Fintech Technology"
+
+
+def test_parse_job_raw_carries_provider_specific_fields() -> None:
+    job = DidiScraper("didi")._parse_job(_FIXTURE_ZH, recruit_type=1)
+    assert job is not None
+    assert job.raw is not None
+    assert job.raw["label_codes"] == "AI"
+    assert job.raw["labels"] == ["ai", "fintech"]
+    assert job.raw["is_urgent"] == 1
+    assert job.raw["channel_id"] == 7
+    assert job.raw["job_level"] == "P6"
+    # recruit_type falls back to the surface we were iterating when
+    # the per-item field is null.
+    assert job.raw["recruit_type"] == 1
+
+
+# --- _parse_job: English fixture --------------------------------------------
+
+
+def test_parse_job_english_language_is_en() -> None:
+    """ASCII-only title → language='en'."""
+    job = DidiScraper("didi")._parse_job(_FIXTURE_EN, recruit_type=1)
+    assert job is not None
+    assert job.language == "en"
+
+
+def test_parse_job_english_workarea_leaves_country_iso_none() -> None:
+    """No CJK in workArea — leave country_iso None for downstream
+    LLM enrichment to fill from the free-text city name."""
+    job = DidiScraper("didi")._parse_job(_FIXTURE_EN)
+    assert job is not None
+    assert job.country_iso is None
+    assert job.location == "Mexico City"
+
+
+def test_parse_job_english_null_create_time_falls_back_to_refresh_time() -> None:
+    """createTime is null in the list payload for most rows; we fall
+    back to the human-readable refreshTime string."""
+    job = DidiScraper("didi")._parse_job(_FIXTURE_EN)
+    assert job is not None
+    assert job.posted_at == datetime(2026, 5, 11, 22, 19, 23)
+
+
+def test_parse_job_english_description_is_none_when_both_fields_null() -> None:
+    job = DidiScraper("didi")._parse_job(_FIXTURE_EN)
+    assert job is not None
+    assert job.description is None
+
+
+def test_parse_job_english_requisition_id_from_jdno() -> None:
+    job = DidiScraper("didi")._parse_job(_FIXTURE_EN)
+    assert job is not None
+    assert job.requisition_id == "J250827001"
+
+
+def test_parse_job_company_is_didi() -> None:
+    job = DidiScraper("didi")._parse_job(_FIXTURE_EN)
+    assert job is not None
+    assert job.company == "DiDi"
+
+
+# --- _parse_job: edge cases -------------------------------------------------
+
+
+def test_parse_job_returns_none_when_jdid_and_id_missing() -> None:
+    assert DidiScraper("didi")._parse_job({"jobName": "Engineer"}) is None
+
+
+def test_parse_job_returns_none_when_title_missing() -> None:
+    assert DidiScraper("didi")._parse_job({"jdId": 1, "jobName": ""}) is None
+
+
+def test_parse_job_falls_back_to_id_when_jdid_missing() -> None:
+    """``jdId`` is preferred, but if a future API version drops it and
+    only exposes ``id``, the scraper should still produce a row."""
+    job = DidiScraper("didi")._parse_job(
+        {"id": 99, "jobName": "Backend Engineer", "workArea": "Tokyo"}
+    )
+    assert job is not None
+    assert job.ats_id == "99"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,7 +22,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "pinpoint", "recruiterbox", "rippling", "smartrecruiters",
         "successfactors", "workable", "workday",
         # Big-tech custom careers systems
-        "amazon", "apple", "google", "meta",
+        "amazon", "apple", "didi", "google", "meta",
         "tesla", "tiktok", "uber", "usajobs",
         # National / supranational public-sector aggregators
         "bundesagentur", "arbetsformedlingen", "eures",


### PR DESCRIPTION
## Summary

Adds a single-source scraper for **DiDi Global (滴滴)**, China's leading
ride-hailing/mobility platform with operations in 18+ countries. Their
public, no-auth careers API at `talent.didiglobal.com` exposes the
full live catalogue across both social and campus recruitment surfaces.

- **Scale:** total=1217 social-recruitment postings verified live on
  2026-05-12; the scraper iterates `recruitType=1` (social) and
  `recruitType=3` (campus) and dedups by `jdId`.
- **Endpoint:** `GET https://talent.didiglobal.com/recruit-portal-service/api/job/front/list`
  with params `recruitType`, `page`, `size`. The server caps each
  response at ~16 rows regardless of requested size, so the page-count
  math and `DEFAULT_PAGE_SIZE` are aligned to 16.
- **Schema mapping:** `jdId` → `ats_id`, `jobName` → `title`,
  `workArea` → `location` (with a CJK→`CN` `country_iso` heuristic),
  `jdNo` → `requisition_id`, `deptName` → `team`,
  `jobTypeName`/`jobType` → `department`, `jobDuty` + `jobQualification`
  → `description` (10kB cap), `createTime` (epoch ms) with `refreshTime`
  string fallback → `posted_at`, CJK title detection → `language`.
- Registers `ATSType.DIDI` and `DidiScraper` via `@ScraperRegistry.register`.

Sample curl:
```
curl 'https://talent.didiglobal.com/recruit-portal-service/api/job/front/list?recruitType=1&page=1&size=16' \
  -H 'Accept: application/json' \
  -H 'User-Agent: Mozilla/5.0'
```

## Test plan

- [x] `ruff check src/jobhive/scrapers/didi.py tests/test_didi.py` passes
- [x] `pytest tests/test_didi.py tests/test_models.py -x` passes (80 tests)
- [x] Live smoke test against `talent.didiglobal.com` returns 16 parsed
      jobs on page 1 with title / location / country_iso / language /
      posted_at all populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a single-source scraper for DiDi Global careers that pulls both social and campus listings from their public API and maps them into our `Job` schema. Also seeds company metadata for DiDi.

- **New Features**
  - Scrapes `https://talent.didiglobal.com/recruit-portal-service/api/job/front/list` for `recruitType` 1 (social) and 3 (campus); paginates with server-fixed size 16, dedups by `jdId`, and includes retries.
  - Maps fields: `jdId`→`ats_id`, `jobName`→`title`, `workArea`→`location`, `jdNo`→`requisition_id`, `deptName`→`team`, `jobTypeName`/`jobType`→`department`, `createTime`/`refreshTime`→`posted_at`; sets `language` via CJK title check and `country_iso`=`CN` when location has CJK.
  - Builds job URLs as `https://talent.didiglobal.com/social/p/{jdId}` for social and `/campus/p/{jdId}` for campus; description combines duty/qualification when present (10kB cap); provider fields preserved under `raw`.
  - Adds `ATSType.DIDI` to the model enum, wires `DidiScraper` into the registry, adds parsing tests (`tests/test_didi.py`, updated `tests/test_models.py`), and seeds `ats-companies/didi.csv` (name/slug/url).

<sup>Written for commit a5d504c0af592eae283e7a04d87b0c680dbe6e42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new single-source scraper for DiDi Global's public careers API, iterating social (`recruitType=1`) and campus (`recruitType=3`) listings, deduping by `jdId`, and mapping the API schema onto the canonical `Job` model.

- **`didi.py`**: Async paginator with semaphore-controlled concurrency and retry logic; maps `jdId`→`ats_id`, `workArea`→`location` with a CJK→`CN` heuristic, and generates job URLs as `/social/p/{jdId}` for all postings regardless of recruit type.
- **`models.py` / `__init__.py`**: Registers `ATSType.DIDI` and exports `DidiScraper` in alphabetical order alongside the existing scraper fleet.
- **`tests/test_didi.py`**: Unit tests covering `_parse_job` with realistic Chinese and English fixtures, including edge cases for missing fields and fallback ID logic.

<h3>Confidence Score: 3/5</h3>

Two functional defects in the scraper core should be resolved before merging: the concurrency control holds a semaphore slot during network-error backoff, and all job URLs are hardcoded to the /social/ path even for campus postings.

The semaphore-during-sleep issue can stall the entire concurrent page-fetch pool when network errors coincide at high concurrency. The campus URL bug means every recruitType=3 posting gets a /social/ URL that likely 404s, producing bad data from day one.

src/jobhive/scrapers/didi.py — specifically the _fetch_page retry block and the URL construction in _parse_job.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/didi.py | New scraper for DiDi Global careers API; contains a semaphore-held-during-backoff bug and always generates /social/ URLs for campus postings. |
| tests/test_didi.py | Good unit-test coverage for _parse_job with realistic fixtures; no pagination or HTTP layer tests. |
| src/jobhive/models.py | Adds ATSType.DIDI to the enum in alphabetical order; no other model changes. |
| src/jobhive/scrapers/__init__.py | Imports and exports DidiScraper in the correct alphabetical position. |
| ats-companies/didi.csv | Adds DiDi company seed record with correct slug and careers URL. |
| tests/test_models.py | Adds didi to the exhaustive ATSType membership check; no other changes. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
src/jobhive/scrapers/didi.py:168-181
**Semaphore held during backoff sleep on network error**

`asyncio.sleep` at line 180 runs inside the `async with sem:` block. When `httpx.HTTPError` fires, the semaphore slot stays acquired for the entire duration of the backoff delay before `continue` releases it at the end of the `with` block. Under heavy page-count loads, all four `MAX_CONCURRENCY` slots can simultaneously enter this sleeping state and block every other concurrent page request.

### Issue 2 of 4
src/jobhive/scrapers/didi.py:265
**Campus job URLs always use the `/social/` path**

All job URLs are built as `https://talent.didiglobal.com/social/p/{ats_id}` regardless of whether the posting was discovered via `recruitType=3` (campus). DiDi's portal uses distinct URL namespaces — campus postings are typically served at `/campus/p/{jdId}`. Links to campus jobs would resolve to a wrong page. The `recruit_type` parameter is already available in `_parse_job` and should determine the path segment.

### Issue 3 of 4
src/jobhive/scrapers/didi.py:278-323
**Naive local datetimes stored in UTC fields**

`fetched_at=datetime.now()` and `datetime.fromtimestamp(ms / 1000)` both produce timezone-naive local-time datetimes. The `Job` schema documents these fields as UTC. On a machine not running in UTC, stored timestamps will be silently wrong. Prefer `datetime.now(tz=timezone.utc)` and `datetime.fromtimestamp(ms / 1000, tz=timezone.utc)`.

### Issue 4 of 4
src/jobhive/scrapers/didi.py:299
**`text[:10_000]` counts characters, not bytes**

The docstring advertises a 10 kB cap but the slice counts Unicode code points. A CJK-heavy description (3 bytes per character in UTF-8) can reach ~30 kB serialized at the 10 000-character limit.

```suggestion
    encoded = text.encode("utf-8")
    if len(encoded) > 10_000:
        text = encoded[:10_000].decode("utf-8", errors="ignore").strip()
    return text or None
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: didi.csv"](https://github.com/kalil0321/ats-scrapers/commit/c80beca5e12ce6b23546e5b9310c3380cfc87352) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732414)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->