### PR TITLE
[codex] add Gupy scraper and 48 live tenants

### DIFF
--- a/ats-companies/gupy.csv
+++ b/ats-companies/gupy.csv
@@ -1,0 +1,49 @@
+name,slug,url
+Afya,afya,https://afya.gupy.io
+Ambev,ambev,https://ambev.gupy.io
+Americanas,americanas,https://americanas.gupy.io
+Assaí Atacadista,assai,https://assai.gupy.io
+Bemobi,bemobi,https://bemobi.gupy.io
+Boavista Tecnologia,boavista,https://boavista.gupy.io
+C&A Brasil,cea,https://cea.gupy.io
+ClickBus,clickbus,https://clickbus.gupy.io
+Cocamar,cocamar,https://cocamar.gupy.io
+Cogna Educação,cogna,https://cogna.gupy.io
+Construtora Tenda,tenda,https://tenda.gupy.io
+Creditas,creditas,https://creditas.gupy.io
+CSN,csn,https://csn.gupy.io
+CVC Corp,cvccorp,https://cvccorp.gupy.io
+Cyrela,cyrela,https://cyrela.gupy.io
+Dafiti,dafiti,https://dafiti.gupy.io
+Dexco,dexco,https://dexco.gupy.io
+EcoRodovias,ecorodovias,https://ecorodovias.gupy.io
+Fast Shop,fastshop,https://fastshop.gupy.io
+Gafisa,gafisa,https://gafisa.gupy.io
+Globo,globo,https://globo.gupy.io
+GPA,gpa,https://gpa.gupy.io
+Grupo Boticário,grupoboticario,https://grupoboticario.gupy.io
+Grupo Positivo,positivo,https://positivo.gupy.io
+Grupo Tigre,tigre,https://tigre.gupy.io
+Ipiranga,ipiranga,https://ipiranga.gupy.io
+Localiza,localiza,https://localiza.gupy.io
+Lojas Renner,renner,https://renner.gupy.io
+Minsait,minsait,https://minsait.gupy.io
+Movida,movida,https://movida.gupy.io
+Petz,petz,https://petz.gupy.io
+Porto Seguro,porto,https://porto.gupy.io
+Riachuelo,riachuelo,https://riachuelo.gupy.io
+Rumo Logística,rumolog,https://rumolog.gupy.io
+Sicredi,sicredi,https://sicredi.gupy.io
+Spread Tecnologia,spread,https://spread.gupy.io
+Stefanini,stefanini,https://stefanini.gupy.io
+Suzano,suzano,https://suzano.gupy.io
+Tecban,tecban,https://tecban.gupy.io
+Total Express,totalexpress,https://totalexpress.gupy.io
+Unidas,unidas,https://unidas.gupy.io
+Usiminas,usiminas,https://usiminas.gupy.io
+Vibra Energia,vibra,https://vibra.gupy.io
+Vivara,vivara,https://vivara.gupy.io
+Vivo,vivo,https://vivo.gupy.io
+Webmotors,webmotors,https://webmotors.gupy.io
+WEG,weg,https://weg.gupy.io
+YDUQS,yduqs,https://yduqs.gupy.io

--- a/pipeline/publisher.py
+++ b/pipeline/publisher.py
@@ -535,7 +535,7 @@ class DatasetPublisher:
 ATS_DEDUP_PRIORITY: dict[str, int] = {
     # Direct employer ATSes
     "ashby": 1, "avature": 1, "bamboohr": 1, "beisen": 1, "breezy": 1, "cornerstone": 1,
-    "greenhouse": 1, "icims": 1, "jazzhr": 1, "join_com": 1, "lever": 1,
+    "greenhouse": 1, "gupy": 1, "icims": 1, "jazzhr": 1, "join_com": 1, "lever": 1,
     "oracle": 1, "personio": 1, "phenom": 1, "pinpoint": 1, "recruitee": 1,
     "recruiterbox": 1, "rippling": 1, "smartrecruiters": 1,
     "successfactors": 1, "taleo": 1, "teamtailor": 1, "workable": 1,

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -53,6 +53,7 @@ from ats_scrapers.scrapers import (
     GetOnBrdScraper,
     GoogleScraper,
     GreenhouseScraper,
+    GupyScraper,
     InfoJobsSpainScraper,
     JazzHRScraper,
     JobsChScraper,
@@ -465,6 +466,15 @@ CONFIGS: dict[str, dict[str, Any]] = {
         "slug": _greenhouse_slug,
         "csv": "ats-companies/greenhouse.csv",
         "output": "greenhouse/jobs.csv",
+    },
+    "gupy": {
+        "scraper": GupyScraper,
+        "slug": lambda r: _slug_col(r) or (r.get("name") or "").strip() or None,
+        "csv": "ats-companies/gupy.csv",
+        "output": "gupy/jobs.csv",
+        "defer_descriptions_to_cache": True,
+        "description_cache_path": "gupy/descriptions.sqlite3",
+        "description_cache_compress": True,
     },
     "workable": {
         "scraper": WorkableScraper,

--- a/src/ats_scrapers/models.py
+++ b/src/ats_scrapers/models.py
@@ -40,6 +40,7 @@ class ATSType(StrEnum):
     EIGHTFOLD = "eightfold"
     GEM = "gem"
     GREENHOUSE = "greenhouse"
+    GUPY = "gupy"
     ICIMS = "icims"
     JOIN_COM = "join_com"
     LEVER = "lever"

--- a/src/ats_scrapers/resolve.py
+++ b/src/ats_scrapers/resolve.py
@@ -74,6 +74,7 @@ _SUBDOMAIN_SUFFIXES: dict[str, ATSType] = {
     ".teamtailor.com": ATSType.TEAMTAILOR,
     ".breezy.hr": ATSType.BREEZY,
     ".bamboohr.com": ATSType.BAMBOOHR,
+    ".gupy.io": ATSType.GUPY,
     ".jobs.personio.com": ATSType.PERSONIO,
     ".jobs.personio.de": ATSType.PERSONIO,
     ".pinpointhq.com": ATSType.PINPOINT,

--- a/src/ats_scrapers/scrapers/__init__.py
+++ b/src/ats_scrapers/scrapers/__init__.py
@@ -25,6 +25,7 @@ from ats_scrapers.scrapers.gem import GemScraper
 from ats_scrapers.scrapers.getonbrd import GetOnBrdScraper
 from ats_scrapers.scrapers.google import GoogleScraper
 from ats_scrapers.scrapers.greenhouse import GreenhouseScraper
+from ats_scrapers.scrapers.gupy import GupyScraper
 from ats_scrapers.scrapers.icims import iCIMSScraper
 from ats_scrapers.scrapers.infojobs_es import InfoJobsSpainScraper
 from ats_scrapers.scrapers.jazzhr import JazzHRScraper
@@ -79,6 +80,7 @@ __all__ = [
     "GetOnBrdScraper",
     "GoogleScraper",
     "GreenhouseScraper",
+    "GupyScraper",
     "InfoJobsSpainScraper",
     "JazzHRScraper",
     "JobsChScraper",

--- a/src/ats_scrapers/scrapers/gupy.py
+++ b/src/ats_scrapers/scrapers/gupy.py
@@ -1,0 +1,283 @@
+"""Gupy careers scraper.
+
+Gupy is a large Brazilian ATS. Public tenant boards live at
+``https://{slug}.gupy.io`` and embed their complete active-job list in the
+Next.js ``__NEXT_DATA__`` payload. Job detail pages carry descriptions and
+publication timestamps.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html as html_mod
+import json
+import re
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, ClassVar
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from ats_scrapers.fetch import Fetcher
+
+LISTING_TEMPLATE = "https://{slug}.gupy.io/"
+DETAIL_TEMPLATE = "https://{slug}.gupy.io/jobs/{job_id}"
+DETAIL_CONCURRENCY = 6
+
+_NEXT_DATA_RE = re.compile(
+    r"<script\b(?=[^>]*\bid=['\"]__NEXT_DATA__['\"])[^>]*>(.*?)</script>",
+    re.IGNORECASE | re.DOTALL,
+)
+_TAG_RE = re.compile(r"<[^>]+>")
+
+_EMPLOYMENT_TYPE_MAP = {
+    "vacancy_type_effective": "FULL_TIME",
+    "vacancy_type_associate": "FULL_TIME",
+    "vacancy_type_legal_entity": "CONTRACT",
+    "vacancy_legal_entity": "CONTRACT",
+    "vacancy_type_outsource": "CONTRACT",
+    "vacancy_type_internship": "INTERN",
+    "vacancy_type_apprentice": "INTERN",
+    "vacancy_type_temporary": "TEMPORARY",
+}
+
+
+@ScraperRegistry.register(ATSType.GUPY)
+class GupyScraper(BaseScraper):
+    """Scrape one Gupy tenant by subdomain slug."""
+
+    ats = ATSType.GUPY
+    default_headers: ClassVar[dict[str, str]] = {
+        "User-Agent": "Mozilla/5.0",
+        "Accept": "text/html,application/xhtml+xml",
+    }
+
+    async def afetch(self) -> list[Job]:
+        async with self.make_fetcher() as fetch:
+            html = await fetch.get_text(
+                LISTING_TEMPLATE.format(slug=self.company_slug)
+            )
+            page_props = self._extract_page_props(html)
+            jobs_payload = page_props.get("jobs")
+            if not isinstance(jobs_payload, list):
+                raise ScraperError(
+                    f"Gupy ({self.company_slug}) listing missing jobs array"
+                )
+
+            company = _extract_tenant_name(page_props) or self.company_slug
+            jobs: list[Job] = []
+            seen: set[str] = set()
+            for item in jobs_payload:
+                if not isinstance(item, dict):
+                    continue
+                job = self._parse_job(item, company)
+                if job is None or job.ats_id in seen:
+                    continue
+                seen.add(job.ats_id)
+                jobs.append(job)
+
+            if self.include_descriptions and jobs:
+                semaphore = asyncio.Semaphore(DETAIL_CONCURRENCY)
+                await asyncio.gather(
+                    *(
+                        self._enrich_description(fetch, semaphore, job)
+                        for job in jobs
+                    )
+                )
+            return jobs
+
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+
+        async def run() -> str | None:
+            async with self.make_fetcher() as fetch:
+                return await self._fetch_description(fetch, str(job.url))
+
+        return self._run_sync(run())
+
+    async def _enrich_description(
+        self,
+        fetch: Fetcher,
+        semaphore: asyncio.Semaphore,
+        job: Job,
+    ) -> None:
+        async with semaphore:
+            description = await self._fetch_description(fetch, str(job.url))
+        if description:
+            job.description = description
+
+    async def _fetch_description(self, fetch: Fetcher, url: str) -> str | None:
+        try:
+            html = await fetch.get_text(url)
+        except ScraperError:
+            return None
+        page_props = _safe_extract_page_props(html)
+        if page_props is None:
+            return None
+        detail = page_props.get("job")
+        if not isinstance(detail, dict):
+            return None
+        return _compose_description(detail)
+
+    def _extract_page_props(self, html: str) -> dict[str, Any]:
+        page_props = _safe_extract_page_props(html)
+        if page_props is None:
+            raise ScraperError(
+                f"Gupy ({self.company_slug}) returned HTML without "
+                "a parseable __NEXT_DATA__ block"
+            )
+        return page_props
+
+    def _parse_job(self, item: dict[str, Any], company: str) -> Job | None:
+        raw_id = item.get("id")
+        ats_id = str(raw_id).strip() if raw_id is not None else ""
+        title = str(item.get("title") or item.get("name") or "").strip()
+        if not ats_id or not title:
+            return None
+
+        workplace = (
+            item.get("workplace")
+            if isinstance(item.get("workplace"), dict)
+            else {}
+        )
+        address = (
+            workplace.get("address")
+            if isinstance(workplace.get("address"), dict)
+            else {}
+        )
+        workplace_type = workplace.get("workplaceType")
+        vacancy_type = item.get("type")
+        employment_type = (
+            _EMPLOYMENT_TYPE_MAP.get(vacancy_type)
+            if isinstance(vacancy_type, str)
+            else None
+        )
+
+        raw: dict[str, Any] = {}
+        for key in ("quickApply", "careerPageId", "careerPageUrl", "badges"):
+            value = item.get(key)
+            if value is not None:
+                raw[key] = value
+        if isinstance(workplace_type, str) and workplace_type:
+            raw["workplace_type"] = workplace_type
+        if isinstance(vacancy_type, str) and vacancy_type:
+            raw["vacancy_type"] = vacancy_type
+
+        department = item.get("department")
+        department = department.strip() if isinstance(department, str) else None
+        url = item.get("jobUrl")
+        if not isinstance(url, str) or not url.strip():
+            url = DETAIL_TEMPLATE.format(slug=self.company_slug, job_id=ats_id)
+        elif url.startswith("/"):
+            url = f"https://{self.company_slug}.gupy.io{url}"
+
+        posted_at = _parse_iso(item.get("publishedAt"))
+        country_iso = _extract_country_iso(address)
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.GUPY,
+            ats_id=ats_id,
+            location=_format_location(address),
+            country_iso=country_iso,
+            region="South America" if country_iso == "BR" else None,
+            is_remote=_extract_is_remote(workplace_type),
+            department=department,
+            employment_type=employment_type,
+            commitment=vacancy_type if isinstance(vacancy_type, str) else None,
+            language="pt",
+            posted_at=posted_at,
+            fetched_at=datetime.now(UTC),
+            raw=raw or None,
+        )
+
+
+def _safe_extract_page_props(html: str) -> dict[str, Any] | None:
+    match = _NEXT_DATA_RE.search(html)
+    if not match:
+        return None
+    try:
+        data = json.loads(match.group(1))
+    except (TypeError, ValueError):
+        return None
+    props = data.get("props") if isinstance(data, dict) else None
+    if not isinstance(props, dict):
+        return None
+    page_props = props.get("pageProps")
+    return page_props if isinstance(page_props, dict) else None
+
+
+def _extract_tenant_name(page_props: dict[str, Any]) -> str | None:
+    career_page = page_props.get("careerPage")
+    if not isinstance(career_page, dict):
+        return None
+    for key in ("publicationName", "name"):
+        value = career_page.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()[:120]
+    return None
+
+
+def _format_location(address: dict[str, Any]) -> str | None:
+    parts = [
+        value.strip()
+        for key in ("city", "state", "country")
+        if isinstance((value := address.get(key)), str) and value.strip()
+    ]
+    return ", ".join(parts) or None
+
+
+def _extract_country_iso(address: dict[str, Any]) -> str | None:
+    country = address.get("country")
+    if not isinstance(country, str) or not country.strip():
+        return "BR"
+    if country.strip().casefold() in {"brasil", "brazil"}:
+        return "BR"
+    return None
+
+
+def _extract_is_remote(workplace_type: object) -> bool | None:
+    if not isinstance(workplace_type, str):
+        return None
+    value = workplace_type.strip().casefold()
+    if value == "remote":
+        return True
+    if value == "on-site":
+        return False
+    return None
+
+
+def _compose_description(detail: dict[str, Any]) -> str | None:
+    chunks = [
+        text
+        for key in (
+            "description",
+            "responsibilities",
+            "prerequisites",
+            "relevantExperiences",
+        )
+        if isinstance((value := detail.get(key)), str)
+        and (text := _strip_html(value))
+    ]
+    return "\n\n".join(chunks)[:25_000] or None
+
+
+def _strip_html(value: str) -> str:
+    text = html_mod.unescape(value)
+    text = _TAG_RE.sub(" ", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _parse_iso(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None

--- a/tests/test_gupy.py
+++ b/tests/test_gupy.py
@@ -1,0 +1,235 @@
+"""Tests for the Gupy multi-tenant scraper."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ats_scrapers.exceptions import CompanyNotFoundError, ScraperError
+from ats_scrapers.models import ATSType
+from ats_scrapers.scrapers import GupyScraper, ScraperRegistry
+
+URL = "https://petz.gupy.io/"
+
+PAGE_PROPS = {
+    "careerPage": {
+        "name": "Petz - O Melhor Ecossistema Pet",
+        "publicationName": "Petz",
+    },
+    "jobs": [
+        {
+            "id": 1,
+            "title": "Ajudante Geral",
+            "type": "vacancy_type_effective",
+            "department": "Operações",
+            "workplace": {
+                "address": {
+                    "country": "Brasil",
+                    "state": "São Paulo",
+                    "city": "São Paulo",
+                },
+                "workplaceType": "on-site",
+            },
+            "quickApply": False,
+        },
+        {
+            "id": 2,
+            "title": "Estágio em Tecnologia",
+            "type": "vacancy_type_internship",
+            "department": "Tecnologia",
+            "workplace": {
+                "address": {"country": "Brasil", "city": "Remoto"},
+                "workplaceType": "remote",
+            },
+            "quickApply": True,
+        },
+    ],
+}
+
+
+def wrap(page_props: dict) -> str:
+    payload = {"props": {"pageProps": page_props}}
+    return (
+        '<script id="__NEXT_DATA__" type="application/json">'
+        f"{json.dumps(payload, ensure_ascii=False)}</script>"
+    )
+
+
+def test_registry_resolves_gupy() -> None:
+    assert ScraperRegistry.get(ATSType.GUPY) is GupyScraper
+
+
+def test_parses_listing(httpx_mock) -> None:
+    httpx_mock.add_response(url=URL, text=wrap(PAGE_PROPS))
+    jobs = GupyScraper("petz", include_descriptions=False).fetch()
+
+    assert len(jobs) == 2
+    first = jobs[0]
+    assert first.ats_id == "1"
+    assert first.title == "Ajudante Geral"
+    assert first.company == "Petz"
+    assert first.ats_type is ATSType.GUPY
+    assert first.global_id == "gupy:1"
+    assert first.employment_type == "FULL_TIME"
+    assert first.location == "São Paulo, São Paulo, Brasil"
+    assert first.country_iso == "BR"
+    assert first.region == "South America"
+    assert first.language == "pt"
+    assert first.is_remote is False
+    assert str(first.url) == "https://petz.gupy.io/jobs/1"
+    assert first.raw == {
+        "quickApply": False,
+        "workplace_type": "on-site",
+        "vacancy_type": "vacancy_type_effective",
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_fetch(httpx_mock) -> None:
+    httpx_mock.add_response(url=URL, text=wrap(PAGE_PROPS))
+    jobs = await GupyScraper("petz", include_descriptions=False).afetch()
+    assert [job.ats_id for job in jobs] == ["1", "2"]
+
+
+def test_enriches_descriptions_when_enabled(httpx_mock) -> None:
+    detail = {
+        "job": {
+            "description": "<p>Role intro</p>",
+            "responsibilities": "<ul><li>Build things</li></ul>",
+            "prerequisites": "Python &amp; APIs",
+        }
+    }
+    httpx_mock.add_response(url=URL, text=wrap({**PAGE_PROPS, "jobs": PAGE_PROPS["jobs"][:1]}))
+    httpx_mock.add_response(url="https://petz.gupy.io/jobs/1", text=wrap(detail))
+
+    jobs = GupyScraper("petz").fetch()
+
+    assert jobs[0].description == "Role intro\n\nBuild things\n\nPython & APIs"
+
+
+def test_get_description_fetches_one_detail(httpx_mock) -> None:
+    httpx_mock.add_response(url=URL, text=wrap(PAGE_PROPS))
+    job = GupyScraper("petz", include_descriptions=False).fetch()[0]
+    httpx_mock.add_response(
+        url="https://petz.gupy.io/jobs/1",
+        text=wrap({"job": {"description": "<p>Full body</p>"}}),
+    )
+
+    assert GupyScraper("petz").get_description(job) == "Full body"
+
+
+def test_returns_empty_live_tenant(httpx_mock) -> None:
+    httpx_mock.add_response(url=URL, text=wrap({**PAGE_PROPS, "jobs": []}))
+    assert GupyScraper("petz", include_descriptions=False).fetch() == []
+
+
+def test_company_name_falls_back_to_slug(httpx_mock) -> None:
+    httpx_mock.add_response(url=URL, text=wrap({"jobs": PAGE_PROPS["jobs"][:1]}))
+    jobs = GupyScraper("petz", include_descriptions=False).fetch()
+    assert jobs[0].company == "petz"
+
+
+def test_company_name_falls_back_to_career_page_name(httpx_mock) -> None:
+    page = {
+        "careerPage": {"name": "Petz Brasil"},
+        "jobs": PAGE_PROPS["jobs"][:1],
+    }
+    httpx_mock.add_response(url=URL, text=wrap(page))
+    jobs = GupyScraper("petz", include_descriptions=False).fetch()
+    assert jobs[0].company == "Petz Brasil"
+
+
+def test_deduplicates_jobs_by_id(httpx_mock) -> None:
+    item = PAGE_PROPS["jobs"][0]
+    httpx_mock.add_response(url=URL, text=wrap({**PAGE_PROPS, "jobs": [item, item]}))
+    jobs = GupyScraper("petz", include_descriptions=False).fetch()
+    assert len(jobs) == 1
+
+
+def test_skips_jobs_without_id_or_title(httpx_mock) -> None:
+    jobs = [
+        {"id": None, "title": "No id"},
+        {"id": 1, "title": ""},
+        PAGE_PROPS["jobs"][1],
+    ]
+    httpx_mock.add_response(url=URL, text=wrap({**PAGE_PROPS, "jobs": jobs}))
+    result = GupyScraper("petz", include_descriptions=False).fetch()
+    assert [job.ats_id for job in result] == ["2"]
+
+
+@pytest.mark.parametrize(
+    ("vacancy_type", "expected"),
+    [
+        ("vacancy_type_effective", "FULL_TIME"),
+        ("vacancy_type_associate", "FULL_TIME"),
+        ("vacancy_type_legal_entity", "CONTRACT"),
+        ("vacancy_legal_entity", "CONTRACT"),
+        ("vacancy_type_outsource", "CONTRACT"),
+        ("vacancy_type_internship", "INTERN"),
+        ("vacancy_type_apprentice", "INTERN"),
+        ("vacancy_type_temporary", "TEMPORARY"),
+        ("vacancy_type_talent_pool", None),
+    ],
+)
+def test_employment_type_mapping(httpx_mock, vacancy_type, expected) -> None:
+    item = {**PAGE_PROPS["jobs"][0], "type": vacancy_type}
+    httpx_mock.add_response(url=URL, text=wrap({**PAGE_PROPS, "jobs": [item]}))
+    job = GupyScraper("petz", include_descriptions=False).fetch()[0]
+    assert job.employment_type == expected
+    assert job.commitment == vacancy_type
+
+
+@pytest.mark.parametrize(
+    ("workplace_type", "expected"),
+    [("remote", True), ("on-site", False), ("hybrid", None), (None, None)],
+)
+def test_remote_mapping(httpx_mock, workplace_type, expected) -> None:
+    item = {
+        **PAGE_PROPS["jobs"][0],
+        "workplace": {
+            "address": {"country": "Brasil"},
+            "workplaceType": workplace_type,
+        },
+    }
+    httpx_mock.add_response(url=URL, text=wrap({**PAGE_PROPS, "jobs": [item]}))
+    job = GupyScraper("petz", include_descriptions=False).fetch()[0]
+    assert job.is_remote is expected
+
+
+def test_404_raises_company_not_found(httpx_mock) -> None:
+    httpx_mock.add_response(url=URL, status_code=404)
+    with pytest.raises(CompanyNotFoundError):
+        GupyScraper("petz", include_descriptions=False).fetch()
+
+
+def test_missing_next_data_raises(httpx_mock) -> None:
+    httpx_mock.add_response(url=URL, text="<html></html>")
+    with pytest.raises(ScraperError, match="__NEXT_DATA__"):
+        GupyScraper("petz", include_descriptions=False).fetch()
+
+
+def test_missing_jobs_array_raises(httpx_mock) -> None:
+    httpx_mock.add_response(url=URL, text=wrap({"careerPage": {}}))
+    with pytest.raises(ScraperError, match="missing jobs array"):
+        GupyScraper("petz", include_descriptions=False).fetch()
+
+
+def test_malformed_next_data_raises(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=URL,
+        text='<script id="__NEXT_DATA__" type="application/json">{</script>',
+    )
+    with pytest.raises(ScraperError, match="__NEXT_DATA__"):
+        GupyScraper("petz", include_descriptions=False).fetch()
+
+
+def test_next_data_attribute_order_is_flexible(httpx_mock) -> None:
+    payload = json.dumps({"props": {"pageProps": PAGE_PROPS}})
+    html = (
+        '<script nonce="abc" type="application/json" id="__NEXT_DATA__">'
+        f"{payload}</script>"
+    )
+    httpx_mock.add_response(url=URL, text=html)
+    jobs = GupyScraper("petz", include_descriptions=False).fetch()
+    assert len(jobs) == 2

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -17,7 +17,7 @@ from ats_scrapers.models import ATSType, Company, Job, Salary
 def test_ats_type_includes_every_supported_platform() -> None:
     expected = {
         # Multi-tenant ATS systems
-        "ashby", "avature", "beisen", "cornerstone", "eightfold", "gem", "greenhouse",
+        "ashby", "avature", "beisen", "cornerstone", "eightfold", "gem", "greenhouse", "gupy",
         "icims", "join_com", "lever", "mercor", "oracle", "personio", "phenom",
         "pinpoint", "recruiterbox", "rippling", "smartrecruiters",
         "successfactors", "workable", "workday",

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -10,6 +10,7 @@ from ats_scrapers.models import ATSType
 from ats_scrapers.scrapers import (
     AshbyScraper,
     GreenhouseScraper,
+    GupyScraper,
     WorkdayScraper,
 )
 
@@ -37,6 +38,7 @@ RESOLVES = [
     ("https://acme.applytojob.com/apply", ATSType.JAZZHR, "acme"),
     ("https://bloomberg.avature.net/careers", ATSType.AVATURE, "bloomberg"),
     ("https://nvidia.eightfold.ai/careers", ATSType.EIGHTFOLD, "nvidia"),
+    ("https://petz.gupy.io/jobs/123", ATSType.GUPY, "petz"),
     # Scheme-less input is tolerated
     ("jobs.ashbyhq.com/openai", ATSType.ASHBY, "openai"),
     ("www.jobs.lever.co/acme", ATSType.LEVER, "acme"),
@@ -104,6 +106,7 @@ def test_get_scraper_for_url_builds_scraper() -> None:
         get_scraper_for_url("https://boards.greenhouse.io/anthropic"),
         GreenhouseScraper,
     )
+    assert isinstance(get_scraper_for_url("https://petz.gupy.io"), GupyScraper)
     workday = get_scraper_for_url(
         "https://2020companies.wd1.myworkdayjobs.com/external_careers"
     )


### PR DESCRIPTION
## Summary

- Port the Gupy scraper to the current async-first `ats_scrapers` architecture.
- Use the shared fetch layer for listing and detail requests.
- Register Gupy in URL resolution, pipeline execution, model types, and cross-ATS dedup priority.
- Add 48 seed tenants that currently return non-empty live job feeds.
- Configure persistent description caching for detail-page enrichment.

## Live validation

- Revalidated every tenant proposed by the original seed PR on 2026-07-23.
- Kept **48 live tenants** producing **11,347 jobs** through the ported scraper.
- Removed six empty tenants: Burger King, CESAR, Eletrobras, Hering, iCarros, and Stone.
- Removed three dead tenants: Bling, Embraer, and Locaweb.
- Verified one live detail-page description fetch: 4,868 characters.

## Checks

- Gupy and integration-focused suite: 186 passed.
- Full suite: 1,195 passed, 2 skipped, 20 deselected.
- `ruff check .`.
- `uv build`.
- 48 CSV rows, 48 unique normalized URLs and slugs.
- `git diff --check`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Gupy as a supported ATS and integrates it throughout the scraping and publishing flow.
- Implements listing parsing and detail-page enrichment through the shared fetch layer.
- Registers Gupy in models, URL resolution, scraper exports, pipeline execution, and deduplication priority.
- Adds 48 tenant seeds plus scraper, model, and resolver tests.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because Gupy detail enrichment still drops available publication timestamps.

Jobs whose listing entries omit `publishedAt` remain without `posted_at` because the detail fetch returns only description text and discards the detail timestamp.

src/ats_scrapers/scrapers/gupy.py, tests/test_gupy.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran a focused pytest flow using a mocked Gupy listing without publishedAt and a mocked detail response containing description and publishedAt to reproduce how the timestamp and enrichment behave.
- I inspected the verbose pytest output to confirm the detail timestamp was parsed as 2026-07-20 14:35:12 UTC and that Job.posted\_at remained None, causing the timestamp assertion to fail.
- I validated a live, seeded Gupy tenant with the actual scraper to verify end-to-end behavior, observing that the listing returned jobs and the detail page included a non-empty description.
- I confirmed the endpoint path became importable and responded with 200 OK, returning 361 jobs, and that a specific job detail page also returned 200 OK with a 3,987-character description.

<a href="https://app.greptile.com/trex/runs/15590067/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/ats_scrapers/scrapers/gupy.py | Adds the Gupy adapter, but detail enrichment still fails to back-fill the publication timestamp promised by the adapter contract. |
| tests/test_gupy.py | Adds broad listing and description tests, but the requested detail-page `posted_at` back-fill remains uncovered. |
| scripts/run_pipeline.py | Registers Gupy with its tenant CSV, output path, and persistent compressed description cache. |
| src/ats_scrapers/resolve.py | Adds Gupy subdomain recognition using the resolver’s existing validated slug flow. |
| pipeline/publisher.py | Gives Gupy direct-employer priority during cross-ATS deduplication. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/ats_scrapers/scrapers/gupy.py:107-110
**Detail timestamp is discarded**

When a listing item lacks `publishedAt` but its detail page provides the publication timestamp, `_enrich_description()` assigns only the description and discards the rest of the detail payload, causing the published job to retain `posted_at=None`.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Add Gupy scraper and live seed tenants"](https://github.com/kalil0321/ats-scrapers/commit/cc511a00f6e19c51ee383069f361769a2e0bbc49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732417)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->