### PR TITLE
Add Microsoft careers scraper

### DIFF
--- a/ats-companies/eightfold.csv
+++ b/ats-companies/eightfold.csv
@@ -20,7 +20,6 @@ Kraft Heinz,kraftheinz,https://kraftheinz.eightfold.ai/careers
 Lam Research,lamresearch,https://lamresearch.eightfold.ai/careers
 MercadoLibre,mercadolibre,https://mercadolibre.eightfold.ai/careers
 Micron,micron,https://micron.eightfold.ai/careers
-Microsoft,microsoft,https://microsoft.eightfold.ai/careers
 Modern Technology Solutions,mtsi-va,https://mtsi-va.eightfold.ai/careers
 Morgan Stanley,morganstanley,https://morganstanley.eightfold.ai/careers
 NTT Data,nttdata,https://nttdata.eightfold.ai/careers

--- a/ats-companies/microsoft.csv
+++ b/ats-companies/microsoft.csv
@@ -1,0 +1,2 @@
+name,slug,url
+Microsoft,microsoft,https://jobs.careers.microsoft.com

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -58,6 +58,7 @@ class ATSType(StrEnum):
     APPLE = "apple"
     GOOGLE = "google"
     META = "meta"
+    MICROSOFT = "microsoft"
     TESLA = "tesla"
     TIKTOK = "tiktok"
     UBER = "uber"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -33,6 +33,7 @@ from jobhive.scrapers.lever import LeverScraper
 from jobhive.scrapers.manfred import ManfredScraper
 from jobhive.scrapers.mercor import MercorScraper
 from jobhive.scrapers.meta import MetaScraper
+from jobhive.scrapers.microsoft import MicrosoftScraper
 from jobhive.scrapers.oracle import OracleScraper
 from jobhive.scrapers.personio import PersonioScraper
 from jobhive.scrapers.phenom import PhenomScraper
@@ -84,6 +85,7 @@ __all__ = [
     "ManfredScraper",
     "MercorScraper",
     "MetaScraper",
+    "MicrosoftScraper",
     "OracleScraper",
     "PersonioScraper",
     "PhenomScraper",

--- a/src/jobhive/scrapers/microsoft.py
+++ b/src/jobhive/scrapers/microsoft.py
@@ -1,0 +1,106 @@
+"""Microsoft careers scraper.
+
+Microsoft retired ``jobs.careers.microsoft.com``'s in-house gcsservices
+API and now redirects every careers entrypoint to
+``apply.careers.microsoft.com/careers`` — an Eightfold AI ("PCSX") SPA.
+The public-facing host ``jobs.careers.microsoft.com/global/en/search``
+serves a 301 to that Eightfold tenant; the listing data lives behind
+the same generic PCSX search endpoint every other Eightfold tenant
+exposes:
+
+    GET https://apply.careers.microsoft.com/api/pcsx/search
+        ?domain=microsoft.com&query=&location=&start=N&sort_by=timestamp
+
+We piggyback on :class:`EightfoldScraper` for the fetch + pagination
+mechanics (count-driven concurrent fan-out, retry/backoff on 429/5xx,
+optional ``httpcloak`` fallback when a tenant sits behind Akamai) and
+re-tag the resulting rows with ``ats_type=ATSType.MICROSOFT`` so the
+public dataset gets a first-class Microsoft slot rather than burying
+~1.6k Microsoft jobs inside the generic ``eightfold`` partition.
+
+The user-visible job URL is rewritten to the canonical
+``jobs.careers.microsoft.com`` host (the SPA front-end), which is what
+Microsoft links from press releases, recruiter emails, and SERP
+results. The API host (``apply.careers.microsoft.com``) is an
+implementation detail.
+
+Operationally: direct ``curl`` to the historical
+``gcsservices.careers.microsoft.com`` endpoint now 404s from any IP
+(the domain is parked on an Azure error page). Reverse-engineering
+the live SPA confirmed the migration to PCSX.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+from jobhive.scrapers.eightfold import EightfoldScraper
+
+ClientKind = Literal["auto", "httpx", "httpcloak"]
+
+# Tenant constants. Pulled out as module-level so tests can import +
+# pin them, and so the legacy gcsservices URL stays grep-able in case
+# Microsoft ever flips back.
+API_BASE_URL = "https://apply.careers.microsoft.com"
+PUBLIC_JOB_HOST = "https://jobs.careers.microsoft.com"
+EIGHTFOLD_DOMAIN = "microsoft.com"
+COMPANY_NAME = "Microsoft"
+
+
+@ScraperRegistry.register(ATSType.MICROSOFT)
+class MicrosoftScraper(BaseScraper):
+    """Microsoft scraper. Single tenant — ``company_slug`` is ignored.
+
+    Internally delegates to :class:`EightfoldScraper` configured for the
+    Microsoft custom-domain PCSX tenant, then re-tags every emitted
+    :class:`~jobhive.models.Job` with ``ats_type=ATSType.MICROSOFT`` so
+    rows land in the Microsoft partition of the published dataset.
+    """
+
+    ats: ClassVar[ATSType] = ATSType.MICROSOFT
+
+    def __init__(
+        self,
+        company_slug: str = "microsoft",
+        *,
+        timeout: float = 30.0,
+        client_kind: ClientKind = "auto",
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        # The underlying Eightfold scraper does the actual work. We keep
+        # it as an attribute (rather than subclassing) so this class's
+        # registry entry stays cleanly bound to ATSType.MICROSOFT — a
+        # subclass would inherit ATSType.EIGHTFOLD via the class
+        # attribute and the registration decorator on the parent.
+        self._inner = EightfoldScraper(
+            company_slug,
+            timeout=timeout,
+            base_url=API_BASE_URL,
+            domain=EIGHTFOLD_DOMAIN,
+            company_name=COMPANY_NAME,
+            job_url_host=PUBLIC_JOB_HOST,
+            client_kind=client_kind,
+        )
+
+    def fetch(self) -> list[Job]:
+        jobs = self._inner.fetch()
+        # Re-tag each row: the inner scraper hard-codes
+        # ats_type=ATSType.EIGHTFOLD via its ``ats`` class attribute, but
+        # this scraper exists precisely to surface Microsoft as a
+        # first-class platform. Mutating in place keeps the Eightfold
+        # parser as the single source of truth for field mapping.
+        for job in jobs:
+            object.__setattr__(job, "ats_type", ATSType.MICROSOFT)
+            # ``global_id`` is computed at construction time from the
+            # (then) ats_type=eightfold; recompute it now so consumers
+            # see ``microsoft:<id>`` instead of ``eightfold:<id>``.
+            if job.ats_id:
+                object.__setattr__(
+                    job, "global_id", f"{ATSType.MICROSOFT.value}:{job.ats_id}"
+                )
+        return jobs
+
+
+__all__ = ["MicrosoftScraper"]

--- a/tests/test_microsoft.py
+++ b/tests/test_microsoft.py
@@ -1,0 +1,249 @@
+"""Tests for the Microsoft careers scraper.
+
+Microsoft fronts an Eightfold AI ("PCSX") tenant at
+``apply.careers.microsoft.com``; the in-house ``gcsservices`` endpoint
+was retired some time before 2026-05. ``MicrosoftScraper`` is a thin
+wrapper around :class:`EightfoldScraper` that re-tags emitted rows
+with ``ATSType.MICROSOFT`` so the dataset gets a first-class Microsoft
+partition rather than burying ~1.6k jobs in the generic
+``eightfold`` bucket.
+
+These tests pin four contracts:
+
+1. Construction defaults — the inner Eightfold scraper is wired to
+   the right tenant URLs (API host vs public job-rendering host).
+2. Registry — ``ATSType.MICROSOFT`` resolves to ``MicrosoftScraper``.
+3. Fetch happy path — listing pages are decoded into ``Job`` rows
+   tagged with ``ats_type=microsoft`` and the canonical
+   ``jobs.careers.microsoft.com`` URL.
+4. global_id is re-derived from the new ``ats_type`` so consumers see
+   ``microsoft:<id>`` rather than ``eightfold:<id>``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from jobhive.models import ATSType
+from jobhive.scrapers import MicrosoftScraper, ScraperRegistry
+from jobhive.scrapers.microsoft import (
+    API_BASE_URL,
+    COMPANY_NAME,
+    EIGHTFOLD_DOMAIN,
+    PUBLIC_JOB_HOST,
+)
+
+# The inner Eightfold scraper fires per-job ``position_details`` GETs
+# after the listing pass for description enrichment; tests that don't
+# care about descriptions ignore those.
+pytestmark = pytest.mark.httpx_mock(
+    assert_all_requests_were_expected=False,
+)
+
+
+# --- fixtures ----------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Eightfold defaults to 3 retries × 1.5s base delay — kill both so
+    a failing test doesn't take 9 s to surface."""
+    import jobhive.scrapers.eightfold as ef
+    monkeypatch.setattr(ef, "MAX_RETRIES", 1)
+    monkeypatch.setattr(ef, "RETRY_BASE_DELAY", 0.0)
+
+
+# --- helpers -----------------------------------------------------------------
+
+
+_SEARCH_URL = f"{API_BASE_URL}/api/pcsx/search"
+
+
+def _mock_url(start: int) -> str:
+    return (
+        f"{_SEARCH_URL}?domain={EIGHTFOLD_DOMAIN}"
+        f"&query=&location=&start={start}&sort_by=timestamp"
+    )
+
+
+def _position(
+    *,
+    display_id: str = "200035593",
+    title: str = "Data Center Technicians INTERN",
+    location: str = "United States, Arizona, Phoenix",
+    position_id: int = 1970393556860740,
+    posted_ts: int = 1778547915,
+) -> dict[str, Any]:
+    """Real Microsoft PCSX position payload captured 2026-05-12.
+
+    Field set mirrors what the live API actually emits — keep it close
+    so regressions surface in tests when the parser drifts away from
+    the on-wire shape."""
+    return {
+        "id": position_id,
+        "displayJobId": display_id,
+        "name": title,
+        "locations": [location],
+        "standardizedLocations": ["Phoenix, AZ, US"],
+        "postedTs": posted_ts,
+        "department": "Data Center Technicians",
+        "creationTs": 1776716846,
+        "isHot": 0,
+        "workLocationOption": "onsite",
+        "locationFlexibility": None,
+        "atsJobId": display_id,
+        "positionUrl": f"/careers/job/{position_id}",
+    }
+
+
+def _page(
+    positions: list[dict[str, Any]], *, count: int | None = None,
+) -> dict[str, Any]:
+    return {
+        "data": {
+            "positions": positions,
+            "count": count if count is not None else len(positions),
+        }
+    }
+
+
+# --- Construction & defaults ------------------------------------------------
+
+
+def test_microsoft_scraper_wires_eightfold_to_microsoft_tenant() -> None:
+    """The inner Eightfold scraper must point at the Microsoft PCSX
+    tenant (API host) and rewrite job URLs to the public host. These
+    URL constants are the single source of truth and are exposed at
+    module level so consumers (and tests) can grep for them."""
+    s = MicrosoftScraper()
+    assert s._inner.base_url == API_BASE_URL
+    assert s._inner.domain == EIGHTFOLD_DOMAIN
+    assert s._inner.company_name == COMPANY_NAME
+    assert s._inner.job_url_host == PUBLIC_JOB_HOST
+
+
+def test_microsoft_scraper_has_microsoft_ats_type() -> None:
+    """``MicrosoftScraper`` exists exclusively to surface Microsoft as a
+    first-class ATS — its ``ats`` class attribute must NOT inherit
+    ``ATSType.EIGHTFOLD`` from the underlying delegate."""
+    assert MicrosoftScraper.ats is ATSType.MICROSOFT
+
+
+def test_microsoft_scraper_ignores_company_slug() -> None:
+    """Single-tenant scraper — slug is informational. The constructor
+    must accept any string without crashing and not let it bleed into
+    the PCSX domain param."""
+    s = MicrosoftScraper("anything-here")
+    assert s.company_slug == "anything-here"
+    assert s._inner.domain == EIGHTFOLD_DOMAIN  # not "anything-here.com"
+
+
+# --- Registry ---------------------------------------------------------------
+
+
+def test_registry_resolves_microsoft() -> None:
+    assert ScraperRegistry.get(ATSType.MICROSOFT) is MicrosoftScraper
+
+
+def test_registry_resolves_microsoft_by_string() -> None:
+    """The publish pipeline looks scrapers up by the string form of
+    ``ATSType`` — pin that path too."""
+    assert ScraperRegistry.get("microsoft") is MicrosoftScraper
+
+
+# --- fetch() happy path -----------------------------------------------------
+
+
+def test_fetch_single_page_emits_microsoft_tagged_jobs(httpx_mock) -> None:
+    """count <= PAGE_SIZE → no fan-out. One PCSX search call yields the
+    full listing; each row carries ``ats_type=microsoft``."""
+    httpx_mock.add_response(
+        url=_mock_url(0),
+        json=_page([_position(display_id="200035593")], count=1),
+    )
+    jobs = MicrosoftScraper().fetch()
+    assert len(jobs) == 1
+    job = jobs[0]
+    assert job.ats_type is ATSType.MICROSOFT
+    assert job.company == "Microsoft"
+    assert job.title == "Data Center Technicians INTERN"
+    assert job.ats_id == "200035593"
+    assert str(job.url).startswith(PUBLIC_JOB_HOST)
+
+
+def test_fetch_global_id_uses_microsoft_prefix(httpx_mock) -> None:
+    """After re-tagging, ``global_id`` must reflect the new
+    ``ats_type``. Consumers route rows by the prefix — leaving it as
+    ``eightfold:`` would land Microsoft jobs in the wrong partition."""
+    httpx_mock.add_response(
+        url=_mock_url(0),
+        json=_page([_position(display_id="200099999")], count=1),
+    )
+    jobs = MicrosoftScraper().fetch()
+    assert jobs[0].global_id == "microsoft:200099999"
+
+
+def test_fetch_returns_empty_when_no_jobs(httpx_mock) -> None:
+    httpx_mock.add_response(url=_mock_url(0), json=_page([], count=0))
+    assert MicrosoftScraper().fetch() == []
+
+
+def test_fetch_fans_out_when_count_exceeds_page_size(httpx_mock) -> None:
+    """Real Microsoft listings hold ~1.6 k jobs. The Eightfold delegate
+    uses ``count`` to fan out concurrent page requests — verify the
+    Microsoft wrapper doesn't accidentally short-circuit that path."""
+    httpx_mock.add_response(
+        url=_mock_url(0),
+        json=_page(
+            [_position(display_id=f"P{i}", position_id=1000 + i) for i in range(10)],
+            count=15,
+        ),
+    )
+    httpx_mock.add_response(
+        url=_mock_url(10),
+        json=_page(
+            [_position(display_id=f"P{i}", position_id=1000 + i) for i in range(10, 15)],
+            count=15,
+        ),
+    )
+    jobs = MicrosoftScraper().fetch()
+    assert {j.ats_id for j in jobs} == {f"P{i}" for i in range(15)}
+    # Every row is tagged Microsoft, never Eightfold.
+    assert all(j.ats_type is ATSType.MICROSOFT for j in jobs)
+    assert all(j.company == "Microsoft" for j in jobs)
+
+
+def test_fetch_url_uses_public_job_host_not_api_host(httpx_mock) -> None:
+    """The Eightfold response's ``positionUrl`` is relative. The
+    canonical Microsoft careers URL lives on
+    ``jobs.careers.microsoft.com``, not the API host — verify the
+    rewrite happens for every job."""
+    httpx_mock.add_response(
+        url=_mock_url(0),
+        json=_page([_position(position_id=1234567890123456)], count=1),
+    )
+    jobs = MicrosoftScraper().fetch()
+    assert str(jobs[0].url) == (
+        f"{PUBLIC_JOB_HOST}/careers/job/1234567890123456"
+    )
+    assert API_BASE_URL not in str(jobs[0].url)
+
+
+def test_fetch_preserves_eightfold_parsed_fields(httpx_mock) -> None:
+    """Sanity-check: department, location, posted_at flow through from
+    the Eightfold parser. We don't re-test every field (those are
+    pinned in test_eightfold.py); just verify the wrapper doesn't drop
+    them."""
+    httpx_mock.add_response(
+        url=_mock_url(0),
+        json=_page([_position()], count=1),
+    )
+    job = MicrosoftScraper().fetch()[0]
+    assert job.department == "Data Center Technicians"
+    # Eightfold prefers ``standardizedLocations`` (cleaner city-state-country
+    # form) over the raw ``locations`` list — pin the contract Microsoft
+    # rows inherit from the underlying parser.
+    assert job.location == "Phoenix, AZ, US"
+    assert job.posted_at is not None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,7 +22,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "pinpoint", "recruiterbox", "rippling", "smartrecruiters",
         "successfactors", "workable", "workday",
         # Big-tech custom careers systems
-        "amazon", "apple", "google", "meta",
+        "amazon", "apple", "google", "meta", "microsoft",
         "tesla", "tiktok", "uber", "usajobs",
         # National / supranational public-sector aggregators
         "bundesagentur", "arbetsformedlingen", "eures",


### PR DESCRIPTION
## Summary

- Adds `MicrosoftScraper` as a first-class scraper registered under `ATSType.MICROSOFT`.
- Microsoft retired the in-house `gcsservices.careers.microsoft.com/search/api/v1/search` endpoint and now redirects every careers entrypoint (`jobs.careers.microsoft.com/global/en/search`) to an Eightfold AI ("PCSX") tenant at `apply.careers.microsoft.com/careers`. The new scraper delegates fetch + pagination to the existing `EightfoldScraper` (count-driven concurrent fan-out, 429/5xx retry/backoff, optional httpcloak fallback) wired to the Microsoft tenant config, then re-tags emitted `Job` rows with `ats_type=microsoft` and a `microsoft:<id>` `global_id` so the published dataset gets a dedicated Microsoft partition instead of burying ~1.6k Microsoft jobs inside the generic `eightfold` bucket.
- Public job URLs are rewritten from the API host onto the canonical `jobs.careers.microsoft.com` host (what Microsoft links from press releases / SERP).

## Notes on the historical `gcsservices` API

The prompt assumed `gcsservices.careers.microsoft.com/search/api/v1/search` was still live and required Origin/Referer/cookie handshake. Direct probes show that hostname now serves an Azure default 404 (`*.azureedge.net` cert; HTML "Page not found"). The SPA itself 301s straight to the Eightfold tenant — confirmed by following the redirect chain and inspecting the rendered HTML (`eightfold` markers, `apply.careers.microsoft.com/careers` final URL). The Eightfold PCSX endpoint works directly from our IP without cookies/CSRF/proxy, so no RAE-style capture was needed.

## Test plan

- [x] `pytest tests/test_microsoft.py tests/test_models.py -x` passes (73 tests)
- [x] `pytest tests/test_eightfold.py tests/test_scrapers.py tests/test_scrapers_extra.py tests/test_manifest.py -x` passes (147 tests — verifies the Microsoft re-tagging doesn't perturb Eightfold's own contracts)
- [x] Full unfiltered run (excluding the pre-existing pytest-asyncio gap on `test_eures_gather.py`, present on `origin/main`) shows 793 passed
- [x] `ruff check .` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a first-class Microsoft careers scraper that targets Microsoft’s Eightfold tenant and emits jobs under `ats_type=microsoft`. Uses canonical `jobs.careers.microsoft.com` links and updates seeds to avoid double-scrape.

- **New Features**
  - Added `MicrosoftScraper` under `ATSType.MICROSOFT`; delegates to `EightfoldScraper` configured for `apply.careers.microsoft.com` with `domain=microsoft.com`.
  - Re-tags jobs to `ats_type=microsoft`, recomputes `global_id` as `microsoft:<id>`, and rewrites job URLs to `jobs.careers.microsoft.com`.
  - Exported in `jobhive.scrapers`; tests cover wiring, tagging, URL rewrite, fan-out, and `global_id`.
  - Added seed `ats-companies/microsoft.csv`.

- **Bug Fixes**
  - Removed Microsoft from `ats-companies/eightfold.csv` to prevent duplicate jobs from the generic `eightfold` scraper.

<sup>Written for commit a509b90217b8b917f2426f6b3217989a5dc4d22d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `MicrosoftScraper`, a thin wrapper around `EightfoldScraper` pointed at Microsoft's PCSX tenant (`apply.careers.microsoft.com`), which re-tags emitted `Job` rows with `ats_type=microsoft` and rewrites job URLs to the canonical `jobs.careers.microsoft.com` host.

- `MicrosoftScraper.fetch()` correctly uses `object.__setattr__` to mutate `ats_type` and recompute `global_id` without re-triggering the `_populate_global_id` model validator (which would overwrite the new prefix back to `eightfold:`).
- `ATSType.MICROSOFT` is registered in `ScraperRegistry`, exported from `jobhive.scrapers`, and covered by a thorough test suite (wiring, registry, single/multi-page fan-out, `global_id` prefix, URL rewriting, and field pass-through).

<h3>Confidence Score: 4/5</h3>

Safe to merge; the delegation and re-tagging logic is correct and well-tested across all key paths.

The implementation is clean and the test coverage is thorough. The only finding is a ClientKind type alias duplicated in microsoft.py instead of imported from eightfold.py — if the canonical definition in eightfold.py ever gains a new literal, the copy here would silently diverge without a type-checker warning.

src/jobhive/scrapers/microsoft.py — the duplicated ClientKind alias is the only item worth a quick look before merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/microsoft.py | New MicrosoftScraper; delegation and re-tagging logic is correct. Minor: ClientKind duplicated from eightfold.py instead of imported. |
| tests/test_microsoft.py | Comprehensive tests covering wiring, registry, single/multi-page fetch, global_id re-tagging, URL rewriting, and field pass-through. No issues found. |
| src/jobhive/models.py | ATSType.MICROSOFT added in correct alphabetical position among big-tech entries. No issues. |
| src/jobhive/scrapers/__init__.py | MicrosoftScraper import and __all__ entry added correctly in alphabetical order. |
| tests/test_models.py | Updated exhaustive ATSType membership assertion to include "microsoft". Correct. |
| ats-companies/microsoft.csv | Seed CSV with correct name/slug/url for Microsoft. No issues. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/jobhive/scrapers/microsoft.py:36
`ClientKind` re-declared instead of imported

`ClientKind = Literal["auto", "httpx", "httpcloak"]` is already defined in `jobhive.scrapers.eightfold`. Redeclaring it here is harmless today, but if the Eightfold module ever adds a new literal (e.g. `"playwright"`), this copy will silently diverge and type-checkers won't catch it. Import the canonical alias instead: `from jobhive.scrapers.eightfold import ClientKind`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: microsoft.cs..."](https://github.com/kalil0321/ats-scrapers/commit/65675aba633e3bb8875a4750d9e8da20f14c137c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732421)</sub>

<!-- /greptile_comment -->