### PR TITLE
Add Job Bank Canada scraper

### DIFF
--- a/ats-companies/jobbankca.csv
+++ b/ats-companies/jobbankca.csv
@@ -1,0 +1,2 @@
+name,slug,url
+Job Bank Canada,jobbankca,https://www.jobbank.gc.ca

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -67,6 +67,7 @@ class ATSType(StrEnum):
     BUNDESAGENTUR = "bundesagentur"
     ARBETSFORMEDLINGEN = "arbetsformedlingen"
     EURES = "eures"
+    JOBBANKCA = "jobbankca"
     # Hybrid jobboards (companies post directly, not aggregated)
     WELCOMETOTHEJUNGLE = "welcometothejungle"
     GETONBRD = "getonbrd"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -27,6 +27,7 @@ from jobhive.scrapers.google import GoogleScraper
 from jobhive.scrapers.greenhouse import GreenhouseScraper
 from jobhive.scrapers.icims import iCIMSScraper
 from jobhive.scrapers.jazzhr import JazzHRScraper
+from jobhive.scrapers.jobbankca import JobBankCAScraper
 from jobhive.scrapers.jobsch import JobsChScraper
 from jobhive.scrapers.join_com import JoinComScraper
 from jobhive.scrapers.lever import LeverScraper
@@ -78,6 +79,7 @@ __all__ = [
     "GoogleScraper",
     "GreenhouseScraper",
     "JazzHRScraper",
+    "JobBankCAScraper",
     "JobsChScraper",
     "JoinComScraper",
     "LeverScraper",

--- a/src/jobhive/scrapers/jobbankca.py
+++ b/src/jobhive/scrapers/jobbankca.py
@@ -1,0 +1,411 @@
+"""Job Bank Canada (jobbank.gc.ca) scraper.
+
+Canada's federal-government job board, run by Employment and Social
+Development Canada. ~62k live postings across private and public
+sector employers. Free, unauthenticated, server-rendered HTML — there's
+no public JSON API surfaced by the site.
+
+The search endpoint paginates 25 results per page:
+
+    GET https://www.jobbank.gc.ca/jobsearch/jobsearch?searchstring=&sort=M&page=N
+
+Each result is a ``<article id="article-{id}">`` block containing the
+title (``.noctitle``), employer (``.business``), location
+(``.location``), posting date (``.date``), and salary (``.salary``) —
+plus a handful of optional flag tags (``.telework``, ``.appmethod``,
+``.postedonJB``, ``.new``). Salary is free text (``$25.00 hourly``,
+``$110,000.00 to $150,000.00 annually``) and currency is implicitly CAD.
+
+The full description lives on a per-job detail page; pulling it would
+mean 62k extra requests for marginal gain, so we leave ``description``
+empty and ship the teaser metadata only.
+
+Single-source scraper: ``company_slug`` is informational and ignored —
+every fetch returns the entire active dataset.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import logging
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SEARCH_URL = "https://www.jobbank.gc.ca/jobsearch/jobsearch"
+POSTING_URL_TEMPLATE = "https://www.jobbank.gc.ca/jobsearch/jobposting/{id}"
+PAGE_SIZE = 25  # Server renders 25 results per page; not configurable.
+PAGE_CAP = 5_000  # Safety stop; full dataset is ~2,500 pages at 25/page.
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 4
+RETRY_BASE_DELAY = 1.5
+DEFAULT_USER_AGENT = "Mozilla/5.0"
+DEFAULT_TIMEOUT = 60.0
+
+# --- Parsing primitives -----------------------------------------------------
+#
+# Job Bank's listing HTML is server-rendered JSF — verbose but stable.
+# Anchor on the unambiguous ``<article id="article-{N}">`` opener, then
+# pull each ``<li class="...">`` payload with a targeted regex. We use
+# ``html.unescape`` on every captured fragment so entities like ``&amp;``
+# round-trip cleanly into the canonical Job schema.
+
+_ARTICLE_OPEN_RE = re.compile(r'<article\s+id="article-(\d+)"', re.IGNORECASE)
+_TITLE_RE = re.compile(
+    r'<span\s+class="noctitle"[^>]*>(.*?)</span>', re.IGNORECASE | re.DOTALL
+)
+_BUSINESS_RE = re.compile(
+    r'<li\s+class="business"[^>]*>(.*?)</li>', re.IGNORECASE | re.DOTALL
+)
+_LOCATION_RE = re.compile(
+    r'<li\s+class="location"[^>]*>(.*?)</li>', re.IGNORECASE | re.DOTALL
+)
+_DATE_RE = re.compile(
+    r'<li\s+class="date"[^>]*>(.*?)</li>', re.IGNORECASE | re.DOTALL
+)
+_SALARY_RE = re.compile(
+    r'<li\s+class="salary"[^>]*>(.*?)</li>', re.IGNORECASE | re.DOTALL
+)
+_TELEWORK_RE = re.compile(
+    r'<span\s+class="telework"[^>]*>(.*?)</span>', re.IGNORECASE | re.DOTALL
+)
+_APPMETHOD_RE = re.compile(
+    r'<span\s+class="appmethod"[^>]*>(.*?)</span>', re.IGNORECASE | re.DOTALL
+)
+_POSTED_ON_JB_RE = re.compile(r'class="postedonJB"', re.IGNORECASE)
+_NEW_FLAG_RE = re.compile(r'<span\s+class="new"', re.IGNORECASE)
+_JOB_NUMBER_RE = re.compile(
+    r'<li\s+class="source"[^>]*>.*?Job\s*number:.*?(\d{3,})',
+    re.IGNORECASE | re.DOTALL,
+)
+_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"\s+")
+
+# Canadian province / territory abbreviations seen in location strings
+# like ``Calgary, AB`` or ``Burlington (ON)``. Used to set ``country_iso``
+# defensively even when the location string lacks ", Canada".
+_CA_PROVINCES = frozenset({
+    "AB", "BC", "MB", "NB", "NL", "NS", "NT", "NU",
+    "ON", "PE", "QC", "SK", "YT",
+})
+
+# English month names; the listing renders dates as ``May 08, 2026``.
+# French dates are rejected by ``_parse_date`` (returns None) since the
+# ``?lang=fra`` variant uses ``08 mai 2026`` — the language code is
+# captured separately so callers can localize if needed.
+_MONTHS_EN = {
+    "january": 1, "february": 2, "march": 3, "april": 4, "may": 5,
+    "june": 6, "july": 7, "august": 8, "september": 9, "october": 10,
+    "november": 11, "december": 12,
+    # Abbreviations that occasionally appear.
+    "jan": 1, "feb": 2, "mar": 3, "apr": 4, "jun": 6, "jul": 7,
+    "aug": 8, "sep": 9, "sept": 9, "oct": 10, "nov": 11, "dec": 12,
+}
+
+
+@ScraperRegistry.register(ATSType.JOBBANKCA)
+class JobBankCAScraper(BaseScraper):
+    """Job Bank Canada scraper. Single-source: ``company_slug`` is unused."""
+
+    ats = ATSType.JOBBANKCA
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = DEFAULT_TIMEOUT,
+        max_pages: int = PAGE_CAP,
+        language: str = "en",
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.max_pages = max_pages
+        # ``en`` (default) → english site. ``fr`` → ``?lang=fra`` variant.
+        self.language = language
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        sem = asyncio.Semaphore(MAX_CONCURRENCY)
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True,
+            headers={
+                "User-Agent": DEFAULT_USER_AGENT,
+                "Accept": "text/html,application/xhtml+xml",
+                "Accept-Language": "en-CA,en;q=0.9",
+            },
+        ) as client:
+            # Sequential paging: the cheapest termination signal is "this
+            # page returned 0 articles", which we can only observe in
+            # order. ~2,500 pages at PAGE_SIZE=25 — the per-page cost
+            # dominates, but parallel pre-fetching past the unknown last
+            # page would just waste work.
+            page = 1
+            while page <= self.max_pages:
+                html_text = await self._fetch_page(client, sem, page)
+                fetched = datetime.now()
+                page_jobs = self._parse_page(html_text, fetched_at=fetched)
+                if not page_jobs:
+                    break
+                added = 0
+                for job in page_jobs:
+                    if job.ats_id in seen:
+                        continue
+                    seen.add(job.ats_id)
+                    jobs.append(job)
+                    added += 1
+                logger.debug(
+                    "jobbankca page=%d parsed=%d new=%d cumulative=%d",
+                    page, len(page_jobs), added, len(jobs),
+                )
+                page += 1
+        return jobs
+
+    async def _fetch_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        page: int,
+    ) -> str:
+        params: dict[str, Any] = {
+            "searchstring": "",
+            "sort": "M",  # ``M`` = most recent.
+            "page": page,
+        }
+        if self.language == "fr":
+            params["lang"] = "fra"
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    r = await client.get(SEARCH_URL, params=params)
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if r.status_code == 200:
+                return r.text
+            if r.status_code == 429 or 500 <= r.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Job Bank Canada returned {r.status_code} on page={page} "
+                        f"after {MAX_RETRIES} retries"
+                    )
+                retry_after = r.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"Job Bank Canada returned {r.status_code} on page={page}"
+            )
+        raise ScraperError(
+            f"Job Bank Canada exhausted retries on page={page}: {last_exc}"
+        )
+
+    # --- parsing ------------------------------------------------------------
+
+    def _parse_page(
+        self, html_text: str, *, fetched_at: datetime | None = None,
+    ) -> list[Job]:
+        """Split the page into ``<article>`` blocks and parse each.
+
+        Blocks that fail to parse are skipped with a debug log entry —
+        we never want a single malformed listing to bring down the run.
+        """
+        jobs: list[Job] = []
+        positions = [m.start() for m in _ARTICLE_OPEN_RE.finditer(html_text)]
+        if not positions:
+            return jobs
+        positions.append(len(html_text))
+        for i in range(len(positions) - 1):
+            chunk = html_text[positions[i]:positions[i + 1]]
+            job = self._parse_job(chunk, fetched_at=fetched_at)
+            if job is not None:
+                jobs.append(job)
+        return jobs
+
+    def _parse_job(
+        self, chunk: str, *, fetched_at: datetime | None = None,
+    ) -> Job | None:
+        m = _ARTICLE_OPEN_RE.search(chunk)
+        if not m:
+            return None
+        ats_id = m.group(1).strip()
+        title = _capture_text(_TITLE_RE, chunk)
+        if not ats_id or not title:
+            return None
+
+        company = _capture_text(_BUSINESS_RE, chunk) or "Job Bank Canada"
+        location = _capture_text(_LOCATION_RE, chunk)
+        if location:
+            # Strip the leading "Location" wb-inv label that survives
+            # tag-stripping ("LocationCalgary, AB" → "Calgary, AB").
+            location = re.sub(r"^Location\s*", "", location).strip() or None
+
+        # Date renders as ``May 08, 2026`` on the English site. The
+        # ``.date`` <li> sometimes carries an ``"Expires May 22, 2026"``
+        # second line; we strip everything past the first comma+year.
+        date_raw = _capture_text(_DATE_RE, chunk)
+        posted_at = _parse_date(date_raw)
+
+        # Salary: ``Salary $42.00 to $50.00 hourly (to be negotiated)``.
+        # Drop the leading "Salary" wb-inv label before storing.
+        salary_raw = _capture_text(_SALARY_RE, chunk)
+        salary_summary = None
+        salary_currency = None
+        if salary_raw:
+            salary_summary = re.sub(r"^Salary\s*", "", salary_raw).strip() or None
+            if salary_summary and "$" in salary_summary:
+                salary_currency = "CAD"
+
+        telework = _capture_text(_TELEWORK_RE, chunk)
+        appmethod = _capture_text(_APPMETHOD_RE, chunk)
+        is_remote = _infer_is_remote(telework, title)
+
+        job_number = None
+        jn = _JOB_NUMBER_RE.search(chunk)
+        if jn:
+            job_number = jn.group(1).strip()
+
+        raw: dict[str, Any] = {"posted_text": date_raw} if date_raw else {}
+        if telework:
+            raw["telework"] = telework
+        if appmethod:
+            raw["application_method"] = appmethod
+        if _POSTED_ON_JB_RE.search(chunk):
+            raw["posted_on_job_bank"] = True
+        if _NEW_FLAG_RE.search(chunk):
+            raw["new_flag"] = True
+        if job_number and job_number != ats_id:
+            raw["jobbank_number"] = job_number
+
+        country_iso = _infer_country_iso(location)
+        language = self.language if self.language in {"en", "fr"} else "en"
+
+        return Job(
+            url=POSTING_URL_TEMPLATE.format(id=ats_id),
+            title=title,
+            company=company,
+            ats_type=ATSType.JOBBANKCA,
+            ats_id=ats_id,
+            location=location,
+            country_iso=country_iso,
+            region="North America" if country_iso == "CA" else None,
+            is_remote=is_remote,
+            salary_summary=salary_summary,
+            salary_currency=salary_currency,
+            commitment=telework or None,
+            requisition_id=job_number,
+            posted_at=posted_at,
+            fetched_at=fetched_at or datetime.now(),
+            language=language,
+            raw=raw or None,
+        )
+
+
+# --- module-level helpers ----------------------------------------------------
+
+
+def _capture_text(pattern: re.Pattern[str], chunk: str) -> str | None:
+    """Run ``pattern`` against ``chunk`` and return cleaned inner text.
+
+    Strips nested tags, collapses whitespace, unescapes HTML entities.
+    Returns ``None`` when the match is empty.
+    """
+    m = pattern.search(chunk)
+    if not m:
+        return None
+    raw = m.group(1)
+    text = _TAG_RE.sub(" ", raw)
+    text = html.unescape(text)
+    text = _WS_RE.sub(" ", text).strip()
+    return text or None
+
+
+def _parse_date(value: str | None) -> datetime | None:
+    """Parse an English Job Bank date like ``May 08, 2026``.
+
+    French dates (``08 mai 2026``) are not handled — they return None
+    and the caller leaves ``posted_at`` empty rather than guessing.
+    """
+    if not value:
+        return None
+    # Some listings include a trailing "Expires..." clause we don't
+    # care about for posted_at.
+    head = value.split("Expires", 1)[0].strip()
+    m = re.search(r"([A-Za-z]+)\s+(\d{1,2}),\s*(\d{4})", head)
+    if not m:
+        return None
+    month_name = m.group(1).lower()
+    month = _MONTHS_EN.get(month_name)
+    if month is None:
+        return None
+    try:
+        day = int(m.group(2))
+        year = int(m.group(3))
+        return datetime(year, month, day)
+    except ValueError:
+        return None
+
+
+def _infer_is_remote(telework: str | None, title: str) -> bool | None:
+    """Set ``is_remote=True`` only when the source explicitly says so.
+
+    Job Bank ships ``<span class="telework">`` with one of four
+    labels: ``On site``, ``Hybrid``, ``Remote``, ``Telework``. We
+    return ``True`` for the last two (telework is the older synonym),
+    ``False`` only for the explicit ``On site``, and ``None`` for
+    hybrid or missing flags so the downstream enrichment isn't
+    forced to commit prematurely.
+    """
+    if telework:
+        t = telework.strip().lower()
+        if "remote" in t or "telework" in t or "télétravail" in t:
+            return True
+        if t == "on site" or "sur place" in t:
+            return False
+    # Title-only fallback mirrors the schema's documented behavior:
+    # only ever assert True, never False.
+    title_lc = title.lower()
+    if "remote" in title_lc or "télétravail" in title_lc:
+        return True
+    return None
+
+
+def _infer_country_iso(location: str | None) -> str | None:
+    """Return ``"CA"`` when the location string contains a Canadian
+    province / territory code or the word ``Canada``.
+
+    Job Bank only posts Canadian jobs in practice, but we still gate on
+    a visible signal so we don't claim country for, say, a freshly
+    redesigned page where the location field is empty.
+    """
+    if not location:
+        return "CA"  # Job Bank is Canada-only; default when unknown.
+    if "Canada" in location:
+        return "CA"
+    for token in re.findall(r"\b([A-Z]{2})\b", location):
+        if token in _CA_PROVINCES:
+            return "CA"
+    # Province inside parens, e.g. ``Burlington (ON)``.
+    for token in re.findall(r"\(([A-Z]{2})\)", location):
+        if token in _CA_PROVINCES:
+            return "CA"
+    return "CA"

--- a/tests/test_jobbankca.py
+++ b/tests/test_jobbankca.py
@@ -1,0 +1,345 @@
+"""Tests for the Job Bank Canada scraper.
+
+The scraper parses server-rendered HTML — no JSON API. Fixtures here
+mirror the live ``jobsearch?searchstring=&sort=M&page=N`` markup so
+parsing regressions surface immediately.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import JobBankCAScraper, ScraperRegistry
+from jobhive.scrapers.jobbankca import (
+    _infer_country_iso,
+    _infer_is_remote,
+    _parse_date,
+)
+
+_SEARCH_RE = re.compile(r"^https://www\.jobbank\.gc\.ca/jobsearch/jobsearch")
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.jobbankca as jb
+    monkeypatch.setattr(jb, "MAX_RETRIES", 2)
+    monkeypatch.setattr(jb, "RETRY_BASE_DELAY", 0.0)
+
+
+def _article(
+    *,
+    job_id: str = "49482951",
+    title: str = "electrician, industrial",
+    business: str = "Kristian Electric Ltd",
+    location: str = "Calgary, AB",
+    date: str = "May 08, 2026",
+    salary: str = "$42.00 to $50.00 hourly (to be negotiated)",
+    telework: str | None = None,
+    appmethod: str = "Direct Apply",
+    new_flag: bool = True,
+    posted_on_jb: bool = True,
+    job_number: str | None = "3571211",
+) -> str:
+    flags = []
+    if new_flag:
+        flags.append('<span class="new">New</span>')
+    if telework:
+        flags.append(f'<span class="telework">{telework}</span>')
+    flags.append(f'<span class="appmethod">{appmethod}</span>')
+    if posted_on_jb:
+        flags.append(
+            '<span class="postedonJB">Posted on Job Bank'
+            '<span class="description">info</span></span>'
+        )
+    flag_block = (
+        f'<span class="flag">{"".join(flags)}</span>'
+        if flags else ""
+    )
+    source_li = ""
+    if job_number is not None:
+        source_li = (
+            '<li class="source">'
+            '<span class="job-source job-source-icon-16">'
+            '<span class="wb-inv">Job Bank</span></span>'
+            '<span class="wb-inv">Job number:</span>'
+            f'<span class="fa fa-hashtag"></span>{job_number}</li>'
+        )
+    return (
+        f'<article id="article-{job_id}" class="action-buttons">'
+        f'<a href="/jobsearch/jobposting/{job_id};jsessionid=ABC?source=searchresults"'
+        ' class="resultJobItem">'
+        f'<h3 class="title">{flag_block}'
+        '<span class="job-source job-source-icon-16">'
+        '<span class="wb-inv">Job Bank</span></span>'
+        f'<span class="noctitle">{title}</span></h3>'
+        '<ul class="list-unstyled">'
+        f'<li class="date">{date}</li>'
+        f'<li class="business">{business}</li>'
+        '<li class="location">'
+        '<span class="fas fa-map-marker-alt"></span> '
+        '<span class="wb-inv">Location</span>'
+        f'{location}</li>'
+        f'<li class="salary"><span class="fa fa-dollar"></span>Salary {salary}</li>'
+        f'{source_li}'
+        '</ul></a></article>'
+    )
+
+
+def _page(articles: list[str]) -> str:
+    body = "\n".join(articles)
+    return (
+        '<!DOCTYPE html><html><body>'
+        '<span class="found" id="results-count">62,139</span>'
+        f'{body}'
+        '</body></html>'
+    )
+
+
+# --- registry / wiring -------------------------------------------------------
+
+
+def test_registry_resolves_jobbankca() -> None:
+    assert ScraperRegistry.get(ATSType.JOBBANKCA) is JobBankCAScraper
+
+
+def test_ats_enum_value() -> None:
+    assert ATSType.JOBBANKCA.value == "jobbankca"
+
+
+# --- parse_job: full happy-path ---------------------------------------------
+
+
+def test_parses_full_article() -> None:
+    """Every field on a typical article block round-trips into a Job."""
+    chunk = _article(telework="On site")
+    job = JobBankCAScraper("any")._parse_job(chunk)
+    assert job is not None
+    assert job.ats_type is ATSType.JOBBANKCA
+    assert job.ats_id == "49482951"
+    assert job.title == "electrician, industrial"
+    assert job.company == "Kristian Electric Ltd"
+    assert job.location == "Calgary, AB"
+    assert str(job.url) == "https://www.jobbank.gc.ca/jobsearch/jobposting/49482951"
+    assert job.country_iso == "CA"
+    assert job.region == "North America"
+    assert job.language == "en"
+    assert job.salary_summary == "$42.00 to $50.00 hourly (to be negotiated)"
+    assert job.salary_currency == "CAD"
+    assert job.is_remote is False  # "On site" → explicit no
+    assert job.commitment == "On site"
+    assert job.requisition_id == "3571211"  # Job number, distinct from ats_id
+    assert job.posted_at is not None
+    assert job.posted_at.year == 2026
+    assert job.posted_at.month == 5
+    assert job.posted_at.day == 8
+    assert job.raw is not None
+    assert job.raw.get("application_method") == "Direct Apply"
+    assert job.raw.get("posted_on_job_bank") is True
+    assert job.raw.get("new_flag") is True
+    assert job.raw.get("jobbank_number") == "3571211"
+
+
+def test_global_id_uses_jobbankca_prefix() -> None:
+    job = JobBankCAScraper("any")._parse_job(_article(job_id="123"))
+    assert job is not None
+    assert job.global_id == "jobbankca:123"
+
+
+# --- parse_job: variations --------------------------------------------------
+
+
+def test_strips_location_wb_inv_label() -> None:
+    """The wb-inv 'Location' label collapses next to the city after
+    tag-stripping. Make sure the leading prefix gets cut."""
+    job = JobBankCAScraper("any")._parse_job(
+        _article(location="Burlington (ON)")
+    )
+    assert job is not None
+    assert job.location == "Burlington (ON)"
+    assert job.country_iso == "CA"
+
+
+def test_telework_remote_marks_is_remote_true() -> None:
+    job = JobBankCAScraper("any")._parse_job(_article(telework="Remote"))
+    assert job is not None
+    assert job.is_remote is True
+    assert job.commitment == "Remote"
+
+
+def test_hybrid_telework_leaves_is_remote_none() -> None:
+    job = JobBankCAScraper("any")._parse_job(_article(telework="Hybrid"))
+    assert job is not None
+    assert job.is_remote is None  # Hybrid: noncommittal.
+
+
+def test_missing_telework_falls_back_to_title_keyword() -> None:
+    job = JobBankCAScraper("any")._parse_job(
+        _article(title="Senior Engineer (Remote)", telework=None)
+    )
+    assert job is not None
+    assert job.is_remote is True
+
+
+def test_non_dollar_salary_keeps_summary_drops_currency() -> None:
+    """A salary string without a ``$`` shouldn't claim CAD."""
+    chunk = _article(salary="To be negotiated")
+    job = JobBankCAScraper("any")._parse_job(chunk)
+    assert job is not None
+    assert job.salary_summary == "To be negotiated"
+    assert job.salary_currency is None
+
+
+def test_job_number_omitted_when_same_as_ats_id() -> None:
+    job = JobBankCAScraper("any")._parse_job(
+        _article(job_id="3571211", job_number="3571211")
+    )
+    assert job is not None
+    assert job.requisition_id == "3571211"
+    # Don't duplicate the same id into raw — only when the two differ.
+    assert (job.raw or {}).get("jobbank_number") is None
+
+
+def test_missing_required_fields_returns_none() -> None:
+    """Articles without a title are dropped silently."""
+    chunk = '<article id="article-123" class="x"><div>broken</div></article>'
+    assert JobBankCAScraper("any")._parse_job(chunk) is None
+
+
+def test_french_language_constructor() -> None:
+    """A scraper instantiated with ``language='fr'`` tags rows accordingly."""
+    scraper = JobBankCAScraper("any", language="fr")
+    job = scraper._parse_job(_article())
+    assert job is not None
+    assert job.language == "fr"
+
+
+# --- _parse_page ------------------------------------------------------------
+
+
+def test_parse_page_extracts_all_articles() -> None:
+    html_text = _page([
+        _article(job_id="111", title="Welder"),
+        _article(job_id="222", title="Carpenter", business="Acme Co"),
+        _article(job_id="333", title="Plumber"),
+    ])
+    jobs = JobBankCAScraper("any")._parse_page(html_text)
+    assert [j.ats_id for j in jobs] == ["111", "222", "333"]
+    assert [j.title for j in jobs] == ["Welder", "Carpenter", "Plumber"]
+
+
+def test_parse_page_empty_returns_empty_list() -> None:
+    """A search page past the last result has zero ``<article>`` blocks."""
+    html_text = '<html><body><p>No results.</p></body></html>'
+    assert JobBankCAScraper("any")._parse_page(html_text) == []
+
+
+# --- pagination via fetch (httpx_mock) --------------------------------------
+
+
+def test_fetch_paginates_until_empty_page(httpx_mock) -> None:
+    """The scraper iterates pages and stops at the first empty one."""
+    httpx_mock.add_response(
+        url="https://www.jobbank.gc.ca/jobsearch/jobsearch",
+        match_params={"searchstring": "", "sort": "M", "page": "1"},
+        html=_page([_article(job_id="1001"), _article(job_id="1002")]),
+    )
+    httpx_mock.add_response(
+        url="https://www.jobbank.gc.ca/jobsearch/jobsearch",
+        match_params={"searchstring": "", "sort": "M", "page": "2"},
+        html=_page([_article(job_id="2001")]),
+    )
+    httpx_mock.add_response(
+        url="https://www.jobbank.gc.ca/jobsearch/jobsearch",
+        match_params={"searchstring": "", "sort": "M", "page": "3"},
+        html=_page([]),  # empty — termination signal
+    )
+    jobs = JobBankCAScraper("any").fetch()
+    assert {j.ats_id for j in jobs} == {"1001", "1002", "2001"}
+
+
+def test_fetch_deduplicates_repeated_ats_id(httpx_mock) -> None:
+    """Same ats_id appearing on two consecutive pages (timing race) is
+    only emitted once."""
+    httpx_mock.add_response(
+        url="https://www.jobbank.gc.ca/jobsearch/jobsearch",
+        match_params={"searchstring": "", "sort": "M", "page": "1"},
+        html=_page([_article(job_id="9999")]),
+    )
+    httpx_mock.add_response(
+        url="https://www.jobbank.gc.ca/jobsearch/jobsearch",
+        match_params={"searchstring": "", "sort": "M", "page": "2"},
+        html=_page([_article(job_id="9999")]),
+    )
+    httpx_mock.add_response(
+        url="https://www.jobbank.gc.ca/jobsearch/jobsearch",
+        match_params={"searchstring": "", "sort": "M", "page": "3"},
+        html=_page([]),
+    )
+    jobs = JobBankCAScraper("any").fetch()
+    assert [j.ats_id for j in jobs] == ["9999"]
+
+
+def test_fetch_respects_max_pages_cap(httpx_mock) -> None:
+    """``max_pages=1`` stops after a single page even if more remain."""
+    httpx_mock.add_response(
+        url="https://www.jobbank.gc.ca/jobsearch/jobsearch",
+        match_params={"searchstring": "", "sort": "M", "page": "1"},
+        html=_page([_article(job_id="42")]),
+    )
+    # Page 2 must NOT be requested — httpx_mock would error if it is.
+    jobs = JobBankCAScraper("any", max_pages=1).fetch()
+    assert [j.ats_id for j in jobs] == ["42"]
+
+
+def test_persistent_500_raises(httpx_mock) -> None:
+    httpx_mock.add_response(url=_SEARCH_RE, status_code=500, is_reusable=True)
+    with pytest.raises(ScraperError):
+        JobBankCAScraper("any").fetch()
+
+
+# --- module-level helpers ---------------------------------------------------
+
+
+@pytest.mark.parametrize("text,expected", [
+    ("May 08, 2026", (2026, 5, 8)),
+    ("January 1, 2026", (2026, 1, 1)),
+    ("Dec 31, 2025", (2025, 12, 31)),
+    ("May 08, 2026 Expires May 22, 2026", (2026, 5, 8)),
+])
+def test_parse_date_handles_english_formats(
+    text: str, expected: tuple[int, int, int]
+) -> None:
+    d = _parse_date(text)
+    assert d is not None
+    assert (d.year, d.month, d.day) == expected
+
+
+@pytest.mark.parametrize("text", [
+    None, "", "garbage", "08 mai 2026",  # French not supported in this helper.
+])
+def test_parse_date_returns_none_for_unparseable(text: str | None) -> None:
+    assert _parse_date(text) is None
+
+
+def test_infer_is_remote_explicit_telework() -> None:
+    assert _infer_is_remote("Remote", "x") is True
+    assert _infer_is_remote("Telework", "x") is True
+    assert _infer_is_remote("On site", "x") is False
+    assert _infer_is_remote("Hybrid", "x") is None
+    assert _infer_is_remote(None, "Senior Engineer") is None
+    assert _infer_is_remote(None, "Senior Engineer (Remote)") is True
+
+
+@pytest.mark.parametrize("location,expected", [
+    ("Calgary, AB", "CA"),
+    ("Burlington (ON)", "CA"),
+    ("Toronto, Canada", "CA"),
+    (None, "CA"),  # Job Bank is Canada-only.
+    ("Whitehorse, YT", "CA"),
+])
+def test_infer_country_iso(location: str | None, expected: str) -> None:
+    assert _infer_country_iso(location) == expected

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -25,7 +25,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "amazon", "apple", "google", "meta",
         "tesla", "tiktok", "uber", "usajobs",
         # National / supranational public-sector aggregators
-        "bundesagentur", "arbetsformedlingen", "eures",
+        "bundesagentur", "arbetsformedlingen", "eures", "jobbankca",
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",


### PR DESCRIPTION
## Summary

- New scraper for **Job Bank Canada** (`jobbank.gc.ca`) — Canada's federal job board run by Employment and Social Development Canada. ~62k live postings across private and public sector employers.
- Endpoint: `GET https://www.jobbank.gc.ca/jobsearch/jobsearch?searchstring=&sort=M&page=N` — server-rendered HTML; no JSON API surfaced.
- Pagination: sequential page=1..N over 25-results-per-page chunks, terminating on the first page with zero `<article id="article-{id}">` blocks (safety cap at 5,000 pages; dataset is ~2,500). Async fetch via `httpx.AsyncClient`, concurrency 4, 429/5xx retried with exponential backoff.
- Parses title, employer, location, posting date, salary summary (CAD), telework / hybrid flag, and Job Bank job number per listing. Sets `country_iso="CA"`, `region="North America"`, `language="en"` (or `"fr"` via `language="fr"` constructor kwarg → `?lang=fra` mirror). `description` is intentionally left empty — the full body lives on a per-job detail page, skipped for ROI.
- `ATSType.JOBBANKCA = "jobbankca"` added to the National public-sector job boards block.

## Test plan

- [x] `uv run pytest tests/test_jobbankca.py tests/test_models.py -x` — 94 passed
- [x] `uv run ruff check src/jobhive/scrapers/jobbankca.py tests/test_jobbankca.py` — clean
- [x] Fixture-based tests cover: full-article parse, location wb-inv label stripping, telework→`is_remote` mapping (Remote/Telework→True, On site→False, Hybrid→None), salary currency inference, job-number vs ats_id disambiguation, French-language constructor, page-level extraction, pagination termination on empty page, dedup across pages, `max_pages` cap, persistent-500 → `ScraperError`, plus parameterized helpers (`_parse_date`, `_infer_is_remote`, `_infer_country_iso`).
- [x] Manual live verification: `https://www.jobbank.gc.ca/jobsearch/jobsearch?searchstring=&sort=M&page=1` returns HTTP 200 / ~275 KB with 25 article blocks; `https://www.jobbank.gc.ca/jobsearch/jobposting/{id}` resolves cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `jobbank.gc.ca` scraper that ingests Canada’s federal Job Bank listings under `ATSType.JOBBANKCA`. Also adds a seed CSV entry for board metadata.

- **New Features**
  - New `JobBankCAScraper` (async `httpx`) scrapes `GET https://www.jobbank.gc.ca/jobsearch/jobsearch?searchstring=&sort=M&page=N` HTML.
  - Sequential pagination until the first empty page; 25 per page; cap 5,000; dedup across pages; concurrency 4 with retries/backoff for 429/5xx.
  - Extracts title, employer, location, posting date, salary summary (infers `CAD` when `$` present), telework flags → `is_remote`, and Job Bank job number; sets `country_iso="CA"`, `region="North America"`, and `language` (`"en"` default or `"fr"` via `?lang=fra`). Leaves `description` empty.
  - Added `ATSType.JOBBANKCA` and registered `JobBankCAScraper` in `jobhive.scrapers.__init__`.
  - Tests cover parsing, pagination termination, dedup, `max_pages` cap, and error handling.
  - Added seed CSV `ats-companies/jobbankca.csv` with board name, slug, and URL.

<sup>Written for commit 22d17ac8173a9a5b600f5fd027d0313d4b103df2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new `JobBankCAScraper` that scrapes Canada's federal Job Bank (`jobbank.gc.ca`) via sequential async pagination over server-rendered HTML, with retry/backoff logic, per-article regex parsing, and a comprehensive fixture-based test suite.

- New `JobBankCAScraper` registered under `ATSType.JOBBANKCA`; extracts title, employer, location, salary (with CAD inference), telework flags → `is_remote`, posting date, and job number; `description` is intentionally left empty.
- Pagination terminates on the first empty page (safety cap at 5,000 pages); dedup across pages via `seen` set; concurrency semaphore of 4 with exponential backoff for 429/5xx responses.
- Supporting files added: seed CSV `ats-companies/jobbankca.csv`, `ATSType.JOBBANKCA` enum entry, and `__init__.py` wiring.

<h3>Confidence Score: 4/5</h3>

The scraper is safe to merge for the English path; the French-language path sends a conflicting Accept-Language: en-CA header alongside ?lang=fra, which may produce mixed-language content in some responses.

The French language constructor correctly appends ?lang=fra to requests, but Accept-Language is hardcoded to en-CA in the shared client headers. Servers that use the header for content negotiation alongside the query param may return inconsistently localised content, making the language='fr' feature unreliable.

jobbankca.py — the Accept-Language header does not reflect the language constructor parameter, leaving the French-language path with conflicting locale signals.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/jobbankca.py | New scraper for Job Bank Canada; solid structure with good error handling and dedup, though the network-error retry uses linear backoff inconsistently with the exponential backoff applied to HTTP errors. |
| tests/test_jobbankca.py | Comprehensive fixture-based test suite covering happy path, field variations, pagination, dedup, max_pages cap, and persistent-500 error; autouse monkeypatch zeros retry delays for fast runs. |
| src/jobhive/models.py | Adds ATSType.JOBBANKCA = 'jobbankca' in the correct national public-sector block; change is minimal and clean. |
| src/jobhive/scrapers/__init__.py | Registers JobBankCAScraper with the correct import position and __all__ entry; alphabetical ordering maintained. |
| ats-companies/jobbankca.csv | Seed CSV with name, slug, and URL for Job Bank Canada; matches the registered ATSType.JOBBANKCA slug. |
| tests/test_models.py | Adds 'jobbankca' to the expected ATSType set; straightforward update consistent with the new enum member. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/jobhive/scrapers/jobbankca.py`, line 430-449 ([link](https://github.com/kalil0321/ats-scrapers/blob/013d948d036ca13e885b1c1778b47869bb8cf798/src/jobhive/scrapers/jobbankca.py#L430-L449)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`_infer_country_iso` docstring contradicts implementation**

   The docstring says "we don't claim country for, say, a freshly redesigned page where the location field is empty", but the very first branch returns `"CA"` for an empty/`None` location. The final fallthrough also unconditionally returns `"CA"`, meaning the function never returns `None` despite being typed `str | None`. Any caller or future test that expects `None` for an unrecognised location will silently get `"CA"` instead.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/jobhive/scrapers/jobbankca.py
   Line: 430-449

   Comment:
   **`_infer_country_iso` docstring contradicts implementation**

   The docstring says "we don't claim country for, say, a freshly redesigned page where the location field is empty", but the very first branch returns `"CA"` for an empty/`None` location. The final fallthrough also unconditionally returns `"CA"`, meaning the function never returns `None` despite being typed `str | None`. Any caller or future test that expects `None` for an unrecognised location will silently get `"CA"` instead.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/jobhive/scrapers/jobbankca.py:196-199
The `httpx.HTTPError` branch uses linear backoff (`RETRY_BASE_DELAY * attempt` → 1.5, 3.0, 4.5 s) while the 429/5xx branch uses exponential backoff (`RETRY_BASE_DELAY * 2**attempt` → 3, 6, 12 s). Network errors like connection resets typically warrant at least as aggressive backoff as rate-limit responses; using a weaker strategy here can cause rapid retries that hammer a struggling upstream.

```suggestion
                except httpx.HTTPError as exc:
                    last_exc = exc
                    await asyncio.sleep(RETRY_BASE_DELAY * (2 ** attempt))
                    continue
```


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Add ats-companies seed CSV: jobbankca.cs..."](https://github.com/kalil0321/ats-scrapers/commit/22d17ac8173a9a5b600f5fd027d0313d4b103df2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31701588)</sub>

<!-- /greptile_comment -->