### PR TITLE
Add Moka ATS scraper with 29 validated tenants

### DIFF
--- a/ats-companies/README.md
+++ b/ats-companies/README.md
@@ -43,6 +43,7 @@ Acme Corp,acme,https://acme.greenhouse.io
 | join_com | `https://join.com/companies/<slug>` |
 | lever | `https://jobs.lever.co/<slug>` |
 | mercor | seed file only — Mercor exposes no per-company endpoint |
+| moka | `https://app.mokahr.com/social-recruitment/<slug>/<site_id>` |
 | oracle | `https://<host>/hcmUI/CandidateExperience/...` |
 | personio | `https://<slug>.jobs.personio.com` |
 | pinpoint | `https://<slug>.pinpointhq.com` |

--- a/ats-companies/moka.csv
+++ b/ats-companies/moka.csv
@@ -1,0 +1,30 @@
+name,slug,url
+Trip.com Group,trip/70415,https://app.mokahr.com/social-recruitment/trip/70415
+BIGO,bigo/37723,https://app.mokahr.com/social-recruitment/bigo/37723
+SHEIN,shein/2933,https://app.mokahr.com/social-recruitment/shein/2933
+Zhihu,zhihu/78336,https://app.mokahr.com/social-recruitment/zhihu/78336
+Geely Holding Group,geely/96123,https://app.mokahr.com/social-recruitment/geely/96123
+Huya,huya/4111,https://app.mokahr.com/social-recruitment/huya/4111
+CloudWalk,cloudwalk/4871,https://app.mokahr.com/social-recruitment/cloudwalk/4871
+Tongdun Technology,tongdun/29005,https://app.mokahr.com/social-recruitment/tongdun/29005
+Audi China,audi/147989,https://app.mokahr.com/social-recruitment/audi/147989
+Manbang Group,manbang/46269,https://app.mokahr.com/social-recruitment/manbang/46269
+XPeng (Huitian),xiaopeng/67918,https://app.mokahr.com/social-recruitment/xiaopeng/67918
+Ninebot,ninebot/45626,https://app.mokahr.com/social-recruitment/ninebot/45626
+Marriott International,marriott/141002,https://app.mokahr.com/social-recruitment/marriott/141002
+Shopee,shopee/2963,https://app.mokahr.com/social-recruitment/shopee/2963
+4Paradigm,4paradigm/102013,https://app.mokahr.com/social-recruitment/4paradigm/102013
+ZTE,zte/47588,https://app.mokahr.com/social-recruitment/zte/47588
+Baicizhan,baicizhan/121,https://app.mokahr.com/social-recruitment/baicizhan/121
+VIPKid,vipkid/147402,https://app.mokahr.com/social-recruitment/vipkid/147402
+East Money,eastmoney/57970,https://app.mokahr.com/social-recruitment/eastmoney/57970
+Panasonic Group,panasonic/5215,https://app.mokahr.com/social-recruitment/panasonic/5215
+Ford China,ford/38867,https://app.mokahr.com/social-recruitment/ford/38867
+GM China,gm/123968,https://app.mokahr.com/social-recruitment/gm/123968
+Rakuten R&D China,rakuten/47725,https://app.mokahr.com/social-recruitment/rakuten/47725
+ZhongAn Insurance,zhongan/102015,https://app.mokahr.com/social-recruitment/zhongan/102015
+DeepRoute.ai,deeproute/143885,https://app.mokahr.com/social-recruitment/deeproute/143885
+Klook,hire-r1/klookcareers/100008011,https://hire-r1.mokahr.com/social-recruitment/klookcareers/100008011
+OSL,hire-r1/osl/100008006,https://hire-r1.mokahr.com/social-recruitment/osl/100008006
+Tesla APAC,hire-r1/tesla/100004142,https://hire-r1.mokahr.com/social-recruitment/tesla/100004142
+Traveloka,hire-r1/traveloka/100008526,https://hire-r1.mokahr.com/social-recruitment/traveloka/100008526

--- a/pipeline/publisher.py
+++ b/pipeline/publisher.py
@@ -536,7 +536,7 @@ ATS_DEDUP_PRIORITY: dict[str, int] = {
     # Direct employer ATSes
     "ashby": 1, "avature": 1, "bamboohr": 1, "beisen": 1, "breezy": 1, "cornerstone": 1,
     "greenhouse": 1, "gupy": 1, "icims": 1, "jazzhr": 1, "join_com": 1, "lever": 1,
-    "oracle": 1, "personio": 1, "phenom": 1, "pinpoint": 1, "recruitee": 1,
+    "moka": 1, "oracle": 1, "personio": 1, "phenom": 1, "pinpoint": 1, "recruitee": 1,
     "recruiterbox": 1, "rippling": 1, "smartrecruiters": 1,
     "successfactors": 1, "taleo": 1, "teamtailor": 1, "workable": 1,
     "workday": 1,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,8 @@ scrapers = [
     # Browserbase Sessions). cloakbrowser ships its own binary and
     # caches under ~/.cache/cloakbrowser, no separate playwright install.
     "cloakbrowser>=0.3",
+    # Moka encrypts some job-list responses with AES-CBC.
+    "pycryptodome>=3.20",
 ]
 parquet = [
     "pyarrow>=15.0",

--- a/src/ats_scrapers/models.py
+++ b/src/ats_scrapers/models.py
@@ -45,6 +45,7 @@ class ATSType(StrEnum):
     JOIN_COM = "join_com"
     LEVER = "lever"
     MERCOR = "mercor"
+    MOKA = "moka"
     ORACLE = "oracle"
     PERSONIO = "personio"
     PHENOM = "phenom"

--- a/src/ats_scrapers/resolve.py
+++ b/src/ats_scrapers/resolve.py
@@ -116,6 +116,24 @@ def resolve_careers_url(url: str) -> ResolvedCareersUrl | None:
             return ResolvedCareersUrl(ATSType.JOIN_COM, segments[1])
         return None
 
+    if host in {"app.mokahr.com", "hire-r1.mokahr.com"}:
+        segments = [segment for segment in parsed.path.split("/") if segment]
+        if (
+            len(segments) >= 3
+            and segments[0] in {"social-recruitment", "campus-recruitment"}
+            and _SLUG_RE.match(segments[1])
+            and segments[2].isdigit()
+        ):
+            prefix = "hire-r1/" if host == "hire-r1.mokahr.com" else ""
+            recruitment_type = (
+                "/campus" if segments[0] == "campus-recruitment" else ""
+            )
+            return ResolvedCareersUrl(
+                ATSType.MOKA,
+                f"{prefix}{segments[1]}/{segments[2]}{recruitment_type}",
+            )
+        return None
+
     for suffix, ats in _SUBDOMAIN_SUFFIXES.items():
         if host.endswith(suffix):
             slug = host.removesuffix(suffix)

--- a/src/ats_scrapers/scrapers/__init__.py
+++ b/src/ats_scrapers/scrapers/__init__.py
@@ -36,6 +36,7 @@ from ats_scrapers.scrapers.lever import LeverScraper
 from ats_scrapers.scrapers.manfred import ManfredScraper
 from ats_scrapers.scrapers.mercor import MercorScraper
 from ats_scrapers.scrapers.meta import MetaScraper
+from ats_scrapers.scrapers.moka import MokaScraper
 from ats_scrapers.scrapers.oracle import OracleScraper
 from ats_scrapers.scrapers.personio import PersonioScraper
 from ats_scrapers.scrapers.phenom import PhenomScraper
@@ -90,6 +91,7 @@ __all__ = [
     "ManfredScraper",
     "MercorScraper",
     "MetaScraper",
+    "MokaScraper",
     "OracleScraper",
     "PersonioScraper",
     "PhenomScraper",

--- a/src/ats_scrapers/scrapers/moka.py
+++ b/src/ats_scrapers/scrapers/moka.py
@@ -1,0 +1,403 @@
+"""Moka (mokahr.com) multi-tenant ATS scraper.
+
+Public boards use either of these forms::
+
+    https://app.mokahr.com/social-recruitment/{slug}/{site_id}
+    https://hire-r1.mokahr.com/social-recruitment/{slug}/{site_id}
+
+The job-list API returns plaintext JSON for some tenants and an AES-CBC
+envelope for others. The encrypted form carries its UTF-8 key in the
+``necromancer`` field and uses the IV embedded in Moka's public bundle.
+"""
+
+from __future__ import annotations
+
+import base64
+import html as html_mod
+import json
+import re
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from pydantic import HttpUrl
+
+from ats_scrapers.exceptions import CompanyNotFoundError, ScraperError
+from ats_scrapers.models import ATSType, EmploymentType, Job
+from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from ats_scrapers.fetch import Fetcher
+
+DEFAULT_HOST = "app.mokahr.com"
+HIRE_R1_HOST = "hire-r1.mokahr.com"
+_HOST_ALIASES = {
+    "app": DEFAULT_HOST,
+    DEFAULT_HOST: DEFAULT_HOST,
+    "hire-r1": HIRE_R1_HOST,
+    HIRE_R1_HOST: HIRE_R1_HOST,
+}
+
+API_TEMPLATE = "https://{host}/api/outer/ats-apply/website/jobs/v2"
+_DEFAULT_AES_IV = b"de7c21ed8d6f50fe"
+PAGE_SIZE = 50
+MAX_PAGES = 200
+
+_EMPLOYMENT_MAP: dict[str, EmploymentType] = {
+    "全职": "FULL_TIME",
+    "兼职": "PART_TIME",
+    "实习": "INTERN",
+    "实习生": "INTERN",
+    "外包": "CONTRACT",
+    "合同工": "CONTRACT",
+    "临时": "TEMPORARY",
+    "Full-Time": "FULL_TIME",
+    "Part-Time": "PART_TIME",
+    "Internship": "INTERN",
+    "Contract": "CONTRACT",
+    "Temporary": "TEMPORARY",
+}
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_WHITESPACE_RE = re.compile(r"\s+")
+_ASCII_RE = re.compile(r"^[\x00-\x7f\s\W]+$")
+
+
+@ScraperRegistry.register(ATSType.MOKA)
+class MokaScraper(BaseScraper):
+    """Scrape one Moka tenant encoded as ``slug/site_id``.
+
+    A leading ``hire-r1/`` pins newer tenants to Moka's second host. An
+    optional trailing ``/campus`` selects campus recruitment instead of the
+    default social-recruitment board.
+    """
+
+    ats = ATSType.MOKA
+    default_headers: ClassVar[dict[str, str]] = {
+        "User-Agent": "Mozilla/5.0",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        include_descriptions: bool = True,
+        proxy: str | None = None,
+        host: str | None = None,
+    ) -> None:
+        super().__init__(
+            company_slug,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        slug_host, slug, site_id, recruitment_type = self._parse_slug(company_slug)
+        self.slug = slug
+        self.site_id = site_id
+        self.recruitment_type = recruitment_type
+        self.host = _normalize_host(host or slug_host or DEFAULT_HOST)
+
+    async def afetch(self) -> list[Job]:
+        headers = {**self.default_headers, "Referer": self._tenant_url()}
+        async with self.make_fetcher(headers=headers) as fetch:
+            jobs: list[Job] = []
+            seen: set[str] = set()
+            offset = 0
+            for _page in range(MAX_PAGES):
+                payload = await self._fetch_page(
+                    fetch,
+                    offset=offset,
+                    limit=PAGE_SIZE,
+                )
+                page_jobs = payload.get("jobs") or []
+                if not isinstance(page_jobs, list) or not page_jobs:
+                    break
+                for item in page_jobs:
+                    if not isinstance(item, dict):
+                        continue
+                    job = self._parse_job(item)
+                    if job is None or not job.ats_id or job.ats_id in seen:
+                        continue
+                    seen.add(job.ats_id)
+                    jobs.append(job)
+
+                offset += len(page_jobs)
+                total = (payload.get("jobStats") or {}).get("total")
+                if isinstance(total, int) and offset >= total:
+                    break
+                if len(page_jobs) < PAGE_SIZE:
+                    break
+            return jobs
+
+    async def _fetch_page(
+        self,
+        fetch: Fetcher,
+        *,
+        offset: int,
+        limit: int,
+    ) -> dict[str, Any]:
+        envelope = await fetch.post_json(
+            API_TEMPLATE.format(host=self.host),
+            json={
+                "orgId": self.slug,
+                "siteId": self.site_id,
+                "limit": limit,
+                "offset": offset,
+                "needStat": True,
+                "site": self.recruitment_type,
+            },
+        )
+        return _unwrap(envelope, slug=self.company_slug)
+
+    def _parse_job(self, item: dict[str, Any]) -> Job | None:
+        raw_id = item.get("id")
+        ats_id = str(raw_id).strip() if raw_id is not None else ""
+        title = str(item.get("title") or "").strip()
+        if not ats_id or not title:
+            return None
+
+        location, country_iso = _location(item.get("locations") or [])
+        commitment = item.get("commitment")
+        return Job(
+            url=HttpUrl(self._job_url(ats_id)),
+            title=title,
+            company=self.slug,
+            ats_type=ATSType.MOKA,
+            ats_id=ats_id,
+            location=location,
+            country_iso=country_iso,
+            region="Asia" if country_iso in {"CN", "HK", "TW", "SG"} else None,
+            language=_language(item.get("multiLocale"), title),
+            employment_type=_employment_type(commitment),
+            department=_department_name(item.get("department")),
+            commitment=commitment if isinstance(commitment, str) else None,
+            description=_strip_html(item.get("jobDescription")),
+            posted_at=_parse_dt(
+                item.get("publishedAt") or item.get("openedAt") or item.get("createdAt")
+            ),
+            fetched_at=datetime.now(UTC),
+            raw=_raw_overflow(
+                item,
+                slug=self.slug,
+                site_id=self.site_id,
+                host=self.host,
+            ),
+        )
+
+    def _job_url(self, job_id: str) -> str:
+        return f"{self._tenant_url()}/job/{job_id}"
+
+    def _tenant_url(self) -> str:
+        board = (
+            "campus-recruitment"
+            if self.recruitment_type == "campus"
+            else "social-recruitment"
+        )
+        return f"https://{self.host}/{board}/{self.slug}/{self.site_id}"
+
+    @staticmethod
+    def _parse_slug(company_slug: str) -> tuple[str | None, str, int, str]:
+        parts = [part for part in company_slug.strip().strip("/").split("/") if part]
+        host: str | None = None
+        if parts and parts[0] in _HOST_ALIASES:
+            host = _HOST_ALIASES[parts.pop(0)]
+        if len(parts) < 2:
+            raise ScraperError(
+                f"Moka company_slug must be '<slug>/<siteId>', got {company_slug!r}"
+            )
+        slug = parts[0]
+        try:
+            site_id = int(parts[1])
+        except ValueError as exc:
+            raise ScraperError(f"Moka siteId must be numeric, got {parts[1]!r}") from exc
+        recruitment_type = "social"
+        if len(parts) >= 3:
+            recruitment_type = parts[2].lower()
+            if recruitment_type not in {"social", "campus"}:
+                raise ScraperError(
+                    "Moka recruitment type must be 'social' or 'campus', "
+                    f"got {parts[2]!r}"
+                )
+        if len(parts) > 3:
+            raise ScraperError(f"Moka company_slug has unexpected segments: {company_slug!r}")
+        return host, slug, site_id, recruitment_type
+
+
+def _normalize_host(host: str) -> str:
+    normalized = _HOST_ALIASES.get(host)
+    if normalized is None:
+        raise ScraperError(f"Unsupported Moka host: {host!r}")
+    return normalized
+
+
+def decrypt_moka(
+    data_b64: str,
+    necromancer: str,
+    *,
+    aes_iv: bytes = _DEFAULT_AES_IV,
+) -> dict[str, Any]:
+    """Decrypt Moka's AES-CBC + PKCS7 response envelope."""
+
+    try:
+        from Crypto.Cipher import AES
+    except ImportError as exc:  # pragma: no cover - installation failure
+        raise ScraperError(
+            "Moka scraper requires pycryptodome (install ats-scrapers[scrapers])"
+        ) from exc
+
+    key = necromancer.encode("utf-8")
+    if len(key) not in {16, 24, 32}:
+        raise ScraperError(
+            f"Moka necromancer key has invalid byte length {len(key)} (expected 16/24/32)"
+        )
+    try:
+        ciphertext = base64.b64decode(data_b64, validate=True)
+    except (ValueError, TypeError) as exc:
+        raise ScraperError(f"Moka data is not valid base64: {exc}") from exc
+    if not ciphertext or len(ciphertext) % 16:
+        raise ScraperError(
+            f"Moka ciphertext length {len(ciphertext)} is not a multiple of 16"
+        )
+
+    plaintext = AES.new(key, AES.MODE_CBC, aes_iv).decrypt(ciphertext)
+    pad_length = plaintext[-1]
+    if pad_length < 1 or pad_length > 16:
+        raise ScraperError("Moka ciphertext failed PKCS7 unpad (bad pad byte)")
+    if plaintext[-pad_length:] != bytes([pad_length]) * pad_length:
+        raise ScraperError("Moka ciphertext failed PKCS7 unpad (mismatch)")
+    try:
+        decoded = json.loads(plaintext[:-pad_length])
+    except ValueError as exc:
+        raise ScraperError(f"Moka decrypted body is not JSON: {exc}") from exc
+    if not isinstance(decoded, dict):
+        raise ScraperError("Moka decrypted body is not an object")
+    return decoded
+
+
+def _unwrap(envelope: Any, *, slug: str) -> dict[str, Any]:
+    if not isinstance(envelope, dict):
+        raise ScraperError(f"Moka returned non-object envelope: {type(envelope)}")
+    if envelope.get("necromancer") and isinstance(envelope.get("data"), str):
+        return _unwrap(
+            decrypt_moka(envelope["data"], envelope["necromancer"]),
+            slug=slug,
+        )
+    if envelope.get("success") is False or envelope.get("code") not in {None, 0}:
+        code = envelope.get("code")
+        message = envelope.get("msg") or "unknown"
+        if code == 703002:
+            raise CompanyNotFoundError(f"Moka rejected tenant {slug}: {message}")
+        raise ScraperError(f"Moka API error code={code} msg={message}")
+    data = envelope.get("data")
+    if not isinstance(data, dict):
+        raise ScraperError("Moka envelope missing 'data' object")
+    return data
+
+
+def _location(locations: Any) -> tuple[str | None, str | None]:
+    if not isinstance(locations, list):
+        return None, None
+    pieces: list[str] = []
+    seen: set[str] = set()
+    country_iso: str | None = None
+    country_map = {
+        "中国": "CN",
+        "China": "CN",
+        "香港": "HK",
+        "Hong Kong": "HK",
+        "台湾": "TW",
+        "Taiwan": "TW",
+        "新加坡": "SG",
+        "Singapore": "SG",
+    }
+    for location in locations:
+        if not isinstance(location, dict):
+            continue
+        display = ", ".join(
+            value.strip()
+            for value in (
+                location.get("cityName"),
+                location.get("provinceName"),
+                location.get("country"),
+            )
+            if isinstance(value, str) and value.strip()
+        )
+        if display and display not in seen:
+            seen.add(display)
+            pieces.append(display)
+        country = location.get("country")
+        if isinstance(country, str):
+            country_iso = country_iso or country_map.get(country)
+    return "; ".join(pieces) or None, country_iso
+
+
+def _strip_html(value: Any) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    cleaned = _HTML_TAG_RE.sub(" ", value)
+    cleaned = html_mod.unescape(cleaned)
+    return _WHITESPACE_RE.sub(" ", cleaned).strip()[:25_000] or None
+
+
+def _employment_type(commitment: Any) -> EmploymentType | None:
+    if not isinstance(commitment, str):
+        return None
+    return _EMPLOYMENT_MAP.get(commitment.strip())
+
+
+def _department_name(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    if isinstance(value, dict):
+        name = value.get("name")
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+    return None
+
+
+def _language(multi_locale: Any, title: str) -> str | None:
+    if isinstance(multi_locale, str) and multi_locale.strip():
+        try:
+            decoded = json.loads(multi_locale)
+        except ValueError:
+            decoded = {}
+        locale = decoded.get("mainLocale") if isinstance(decoded, dict) else None
+        if isinstance(locale, str) and locale:
+            return locale.split("-", 1)[0].lower()
+    return "en" if title and _ASCII_RE.match(title) else "zh"
+
+
+def _parse_dt(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed
+
+
+def _raw_overflow(
+    item: dict[str, Any],
+    *,
+    slug: str,
+    site_id: int,
+    host: str,
+) -> dict[str, Any]:
+    overflow: dict[str, Any] = {"slug": slug, "site_id": site_id, "host": host}
+    for key in (
+        "attributeId",
+        "deptId",
+        "hireMode",
+        "prior",
+        "status",
+        "salaryUnit",
+        "zhineng",
+        "campusSites",
+        "customFields",
+    ):
+        value = item.get(key)
+        if value not in (None, "", [], {}):
+            overflow[key] = value
+    return overflow

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -18,7 +18,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
     expected = {
         # Multi-tenant ATS systems
         "ashby", "avature", "beisen", "cornerstone", "eightfold", "gem", "greenhouse", "gupy",
-        "icims", "join_com", "lever", "mercor", "oracle", "personio", "phenom",
+        "icims", "join_com", "lever", "mercor", "moka", "oracle", "personio", "phenom",
         "pinpoint", "recruiterbox", "rippling", "smartrecruiters",
         "successfactors", "workable", "workday",
         # Big-tech custom careers systems

--- a/tests/test_moka.py
+++ b/tests/test_moka.py
@@ -1,0 +1,197 @@
+"""Tests for the Moka (mokahr.com) scraper."""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+
+from ats_scrapers.exceptions import CompanyNotFoundError, ScraperError
+from ats_scrapers.models import ATSType
+from ats_scrapers.scrapers import MokaScraper, ScraperRegistry
+from ats_scrapers.scrapers.moka import decrypt_moka
+
+URL_APP = "https://app.mokahr.com/api/outer/ats-apply/website/jobs/v2"
+URL_HIRE_R1 = "https://hire-r1.mokahr.com/api/outer/ats-apply/website/jobs/v2"
+KEY = "1234567890abcdef"
+EMPTY_CIPHER = (
+    "EzXcB1Inxi9rKIuYZb9XL/cjLEe0wCdwOB+BD8ot+uNfzl3LzdmG/Mkj+ipAdC9j9"
+    "foq9xMFpcVF+u4d9emRrP10dylE9SKm/c2pxowFTJU="
+)
+
+
+def job(job_id: str = "job-1", title: str = "Senior Backend Engineer") -> dict:
+    return {
+        "id": job_id,
+        "title": title,
+        "jobDescription": "<p>Build distributed systems.</p>",
+        "locations": [
+            {
+                "cityName": "上海市",
+                "provinceName": "上海",
+                "country": "中国",
+            }
+        ],
+        "publishedAt": "2026-04-30T18:29:13",
+        "status": "open",
+        "department": {"id": 1, "name": "Engineering"},
+        "commitment": "全职",
+        "multiLocale": '{"mainLocale":"zh-CN"}',
+    }
+
+
+def envelope(jobs: list[dict] | None = None, *, total: int | None = None) -> dict:
+    items = [job()] if jobs is None else jobs
+    return {
+        "code": 0,
+        "success": True,
+        "data": {
+            "jobStats": {"total": len(items) if total is None else total},
+            "jobs": items,
+        },
+    }
+
+
+def test_decrypt_moka_pinned_fixture() -> None:
+    assert decrypt_moka(EMPTY_CIPHER, KEY) == envelope([])
+
+
+def test_decrypt_moka_rejects_bad_base64() -> None:
+    with pytest.raises(ScraperError, match="not valid base64"):
+        decrypt_moka("not::base64", KEY)
+
+
+def test_decrypt_moka_rejects_short_key() -> None:
+    with pytest.raises(ScraperError, match="invalid byte length"):
+        decrypt_moka(EMPTY_CIPHER, "short")
+
+
+def test_decrypt_moka_rejects_truncated_ciphertext() -> None:
+    raw = base64.b64decode(EMPTY_CIPHER)[:-1]
+    with pytest.raises(ScraperError, match="not a multiple of 16"):
+        decrypt_moka(base64.b64encode(raw).decode(), KEY)
+
+
+def test_registry_resolves_moka() -> None:
+    assert ScraperRegistry.get(ATSType.MOKA) is MokaScraper
+
+
+@pytest.mark.parametrize(
+    ("slug", "match"),
+    [
+        ("trip", "must be"),
+        ("trip/not-a-number", "siteId must be numeric"),
+        ("trip/70415/internal", "recruitment type"),
+        ("trip/70415/social/extra", "unexpected segments"),
+    ],
+)
+def test_rejects_invalid_slugs(slug: str, match: str) -> None:
+    with pytest.raises(ScraperError, match=match):
+        MokaScraper(slug)
+
+
+def test_parses_host_and_recruitment_type() -> None:
+    scraper = MokaScraper("hire-r1/klookcareers/100008011/campus")
+    assert scraper.slug == "klookcareers"
+    assert scraper.site_id == 100008011
+    assert scraper.host == "hire-r1.mokahr.com"
+    assert scraper.recruitment_type == "campus"
+
+
+def test_rejects_unknown_host_override() -> None:
+    with pytest.raises(ScraperError, match="Unsupported Moka host"):
+        MokaScraper("trip/70415", host="evil.example")
+
+
+def test_parses_plaintext_envelope_end_to_end(httpx_mock) -> None:
+    httpx_mock.add_response(url=URL_APP, json=envelope())
+    [result] = MokaScraper("fixturecorp/12345").fetch()
+
+    assert result.ats_type is ATSType.MOKA
+    assert result.ats_id == "job-1"
+    assert result.global_id == "moka:job-1"
+    assert result.title == "Senior Backend Engineer"
+    assert result.company == "fixturecorp"
+    assert result.location == "上海市, 上海, 中国"
+    assert result.country_iso == "CN"
+    assert result.region == "Asia"
+    assert result.language == "zh"
+    assert result.employment_type == "FULL_TIME"
+    assert result.department == "Engineering"
+    assert result.description == "Build distributed systems."
+    assert result.posted_at is not None and result.posted_at.tzinfo is not None
+    assert str(result.url) == (
+        "https://app.mokahr.com/social-recruitment/fixturecorp/12345/job/job-1"
+    )
+    assert result.raw == {
+        "slug": "fixturecorp",
+        "site_id": 12345,
+        "host": "app.mokahr.com",
+        "status": "open",
+    }
+
+
+def test_decrypts_encrypted_envelope_end_to_end(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=URL_APP,
+        json={"data": EMPTY_CIPHER, "necromancer": KEY},
+    )
+    assert MokaScraper("fixturecorp/12345").fetch() == []
+
+
+def test_host_prefix_targets_hire_r1(httpx_mock) -> None:
+    httpx_mock.add_response(url=URL_HIRE_R1, json=envelope([]))
+    scraper = MokaScraper("hire-r1/klookcareers/100008011")
+    assert scraper.fetch() == []
+    [request] = httpx_mock.get_requests()
+    assert request.headers["referer"] == (
+        "https://hire-r1.mokahr.com/social-recruitment/klookcareers/100008011"
+    )
+
+
+def test_company_not_found_when_api_rejects_tenant(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=URL_APP,
+        json={"code": 703002, "msg": "未找到对应的官网", "success": False},
+    )
+    with pytest.raises(CompanyNotFoundError):
+        MokaScraper("missing/99999").fetch()
+
+
+def test_other_api_error_is_scraper_error(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=URL_APP,
+        json={"code": 500001, "msg": "boom", "success": False},
+    )
+    with pytest.raises(ScraperError, match="boom"):
+        MokaScraper("fixturecorp/12345").fetch()
+
+
+def test_paginates_and_deduplicates_jobs(httpx_mock) -> None:
+    first = [job(f"job-{index}", f"Engineer {index}") for index in range(50)]
+    second = [job("job-49", "Engineer 49"), job("job-50", "Engineer 50")]
+    httpx_mock.add_response(url=URL_APP, json=envelope(first, total=51))
+    httpx_mock.add_response(url=URL_APP, json=envelope(second, total=51))
+
+    jobs = MokaScraper("fixturecorp/12345").fetch()
+
+    assert len(jobs) == 51
+    assert jobs[-1].ats_id == "job-50"
+    requests = httpx_mock.get_requests()
+    assert json.loads(requests[0].content)["offset"] == 0
+    assert json.loads(requests[1].content)["offset"] == 50
+
+
+def test_request_body_matches_public_api(httpx_mock) -> None:
+    httpx_mock.add_response(url=URL_APP, json=envelope([]))
+    MokaScraper("fixturecorp/12345").fetch()
+    [request] = httpx_mock.get_requests()
+    assert json.loads(request.content) == {
+        "orgId": "fixturecorp",
+        "siteId": 12345,
+        "limit": 50,
+        "offset": 0,
+        "needStat": True,
+        "site": "social",
+    }

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -11,6 +11,7 @@ from ats_scrapers.scrapers import (
     AshbyScraper,
     GreenhouseScraper,
     GupyScraper,
+    MokaScraper,
     WorkdayScraper,
 )
 
@@ -28,6 +29,16 @@ RESOLVES = [
     ("https://jobs.gem.com/accel", ATSType.GEM, "accel"),
     ("https://ats.rippling.com/acme/jobs", ATSType.RIPPLING, "acme"),
     ("https://join.com/companies/acme", ATSType.JOIN_COM, "acme"),
+    (
+        "https://app.mokahr.com/social-recruitment/trip/70415/job/123",
+        ATSType.MOKA,
+        "trip/70415",
+    ),
+    (
+        "https://hire-r1.mokahr.com/campus-recruitment/klook/100008011",
+        ATSType.MOKA,
+        "hire-r1/klook/100008011/campus",
+    ),
     # Subdomain tenants
     ("https://12build.recruitee.com", ATSType.RECRUITEE, "12build"),
     ("https://1komma5.teamtailor.com/jobs", ATSType.TEAMTAILOR, "1komma5"),
@@ -107,6 +118,12 @@ def test_get_scraper_for_url_builds_scraper() -> None:
         GreenhouseScraper,
     )
     assert isinstance(get_scraper_for_url("https://petz.gupy.io"), GupyScraper)
+    assert isinstance(
+        get_scraper_for_url(
+            "https://app.mokahr.com/social-recruitment/trip/70415"
+        ),
+        MokaScraper,
+    )
     workday = get_scraper_for_url(
         "https://2020companies.wd1.myworkdayjobs.com/external_careers"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -177,6 +177,7 @@ all = [
     { name = "html2text" },
     { name = "httpcloak" },
     { name = "pyarrow" },
+    { name = "pycryptodome" },
 ]
 dev = [
     { name = "aiohttp" },
@@ -187,6 +188,7 @@ dev = [
     { name = "mypy" },
     { name = "pandas-stubs" },
     { name = "pyarrow" },
+    { name = "pycryptodome" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-httpx" },
@@ -202,6 +204,7 @@ scrapers = [
     { name = "cloakbrowser" },
     { name = "html2text" },
     { name = "httpcloak" },
+    { name = "pycryptodome" },
 ]
 test = [
     { name = "aiohttp" },
@@ -210,6 +213,7 @@ test = [
     { name = "html2text" },
     { name = "httpcloak" },
     { name = "pyarrow" },
+    { name = "pycryptodome" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-httpx" },
@@ -230,6 +234,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.0" },
     { name = "pandas-stubs", marker = "extra == 'dev'" },
     { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=15.0" },
+    { name = "pycryptodome", marker = "extra == 'scrapers'", specifier = ">=3.20" },
     { name = "pydantic", specifier = ">=2.6" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23" },
@@ -1135,6 +1140,36 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
     { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
     { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
+]
+
+[[package]]
+name = "pycryptodome"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/a6/8452177684d5e906854776276ddd34eca30d1b1e15aa1ee9cefc289a33f5/pycryptodome-3.23.0.tar.gz", hash = "sha256:447700a657182d60338bab09fdb27518f8856aecd80ae4c6bdddb67ff5da44ef", size = 4921276, upload-time = "2025-05-17T17:21:45.242Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/5d/bdb09489b63cd34a976cc9e2a8d938114f7a53a74d3dd4f125ffa49dce82/pycryptodome-3.23.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0011f7f00cdb74879142011f95133274741778abba114ceca229adbf8e62c3e4", size = 2495152, upload-time = "2025-05-17T17:20:20.833Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ce/7840250ed4cc0039c433cd41715536f926d6e86ce84e904068eb3244b6a6/pycryptodome-3.23.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:90460fc9e088ce095f9ee8356722d4f10f86e5be06e2354230a9880b9c549aae", size = 1639348, upload-time = "2025-05-17T17:20:23.171Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/991da24c55c1f688d6a3b5a11940567353f74590734ee4a64294834ae472/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4764e64b269fc83b00f682c47443c2e6e85b18273712b98aa43bcb77f8570477", size = 2184033, upload-time = "2025-05-17T17:20:25.424Z" },
+    { url = "https://files.pythonhosted.org/packages/54/16/0e11882deddf00f68b68dd4e8e442ddc30641f31afeb2bc25588124ac8de/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb8f24adb74984aa0e5d07a2368ad95276cf38051fe2dc6605cbcf482e04f2a7", size = 2270142, upload-time = "2025-05-17T17:20:27.808Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fc/4347fea23a3f95ffb931f383ff28b3f7b1fe868739182cb76718c0da86a1/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d97618c9c6684a97ef7637ba43bdf6663a2e2e77efe0f863cce97a76af396446", size = 2309384, upload-time = "2025-05-17T17:20:30.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d9/c5261780b69ce66d8cfab25d2797bd6e82ba0241804694cd48be41add5eb/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9a53a4fe5cb075075d515797d6ce2f56772ea7e6a1e5e4b96cf78a14bac3d265", size = 2183237, upload-time = "2025-05-17T17:20:33.736Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/6f/3af2ffedd5cfa08c631f89452c6648c4d779e7772dfc388c77c920ca6bbf/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:763d1d74f56f031788e5d307029caef067febf890cd1f8bf61183ae142f1a77b", size = 2343898, upload-time = "2025-05-17T17:20:36.086Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/dc/9060d807039ee5de6e2f260f72f3d70ac213993a804f5e67e0a73a56dd2f/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:954af0e2bd7cea83ce72243b14e4fb518b18f0c1649b576d114973e2073b273d", size = 2269197, upload-time = "2025-05-17T17:20:38.414Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/34/e6c8ca177cb29dcc4967fef73f5de445912f93bd0343c9c33c8e5bf8cde8/pycryptodome-3.23.0-cp313-cp313t-win32.whl", hash = "sha256:257bb3572c63ad8ba40b89f6fc9d63a2a628e9f9708d31ee26560925ebe0210a", size = 1768600, upload-time = "2025-05-17T17:20:40.688Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/1d/89756b8d7ff623ad0160f4539da571d1f594d21ee6d68be130a6eccb39a4/pycryptodome-3.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6501790c5b62a29fcb227bd6b62012181d886a767ce9ed03b303d1f22eb5c625", size = 1799740, upload-time = "2025-05-17T17:20:42.413Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/61/35a64f0feaea9fd07f0d91209e7be91726eb48c0f1bfc6720647194071e4/pycryptodome-3.23.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9a77627a330ab23ca43b48b130e202582e91cc69619947840ea4d2d1be21eb39", size = 1703685, upload-time = "2025-05-17T17:20:44.388Z" },
+    { url = "https://files.pythonhosted.org/packages/db/6c/a1f71542c969912bb0e106f64f60a56cc1f0fabecf9396f45accbe63fa68/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:187058ab80b3281b1de11c2e6842a357a1f71b42cb1e15bce373f3d238135c27", size = 2495627, upload-time = "2025-05-17T17:20:47.139Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/4e/a066527e079fc5002390c8acdd3aca431e6ea0a50ffd7201551175b47323/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:cfb5cd445280c5b0a4e6187a7ce8de5a07b5f3f897f235caa11f1f435f182843", size = 1640362, upload-time = "2025-05-17T17:20:50.392Z" },
+    { url = "https://files.pythonhosted.org/packages/50/52/adaf4c8c100a8c49d2bd058e5b551f73dfd8cb89eb4911e25a0c469b6b4e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67bd81fcbe34f43ad9422ee8fd4843c8e7198dd88dd3d40e6de42ee65fbe1490", size = 2182625, upload-time = "2025-05-17T17:20:52.866Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e9/a09476d436d0ff1402ac3867d933c61805ec2326c6ea557aeeac3825604e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8987bd3307a39bc03df5c8e0e3d8be0c4c3518b7f044b0f4c15d1aa78f52575", size = 2268954, upload-time = "2025-05-17T17:20:55.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c5/ffe6474e0c551d54cab931918127c46d70cab8f114e0c2b5a3c071c2f484/pycryptodome-3.23.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aa0698f65e5b570426fc31b8162ed4603b0c2841cbb9088e2b01641e3065915b", size = 2308534, upload-time = "2025-05-17T17:20:57.279Z" },
+    { url = "https://files.pythonhosted.org/packages/18/28/e199677fc15ecf43010f2463fde4c1a53015d1fe95fb03bca2890836603a/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:53ecbafc2b55353edcebd64bf5da94a2a2cdf5090a6915bcca6eca6cc452585a", size = 2181853, upload-time = "2025-05-17T17:20:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ea/4fdb09f2165ce1365c9eaefef36625583371ee514db58dc9b65d3a255c4c/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:156df9667ad9f2ad26255926524e1c136d6664b741547deb0a86a9acf5ea631f", size = 2342465, upload-time = "2025-05-17T17:21:03.83Z" },
+    { url = "https://files.pythonhosted.org/packages/22/82/6edc3fc42fe9284aead511394bac167693fb2b0e0395b28b8bedaa07ef04/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:dea827b4d55ee390dc89b2afe5927d4308a8b538ae91d9c6f7a5090f397af1aa", size = 2267414, upload-time = "2025-05-17T17:21:06.72Z" },
+    { url = "https://files.pythonhosted.org/packages/59/fe/aae679b64363eb78326c7fdc9d06ec3de18bac68be4b612fc1fe8902693c/pycryptodome-3.23.0-cp37-abi3-win32.whl", hash = "sha256:507dbead45474b62b2bbe318eb1c4c8ee641077532067fec9c1aa82c31f84886", size = 1768484, upload-time = "2025-05-17T17:21:08.535Z" },
+    { url = "https://files.pythonhosted.org/packages/54/2f/e97a1b8294db0daaa87012c24a7bb714147c7ade7656973fd6c736b484ff/pycryptodome-3.23.0-cp37-abi3-win_amd64.whl", hash = "sha256:c75b52aacc6c0c260f204cbdd834f76edc9fb0d8e0da9fbf8352ef58202564e2", size = 1799636, upload-time = "2025-05-17T17:21:10.393Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3d/f9441a0d798bf2b1e645adc3265e55706aead1255ccdad3856dbdcffec14/pycryptodome-3.23.0-cp37-abi3-win_arm64.whl", hash = "sha256:11eeeb6917903876f134b56ba11abe95c0b0fd5e3330def218083c7d98bbcb3c", size = 1703675, upload-time = "2025-05-17T17:21:13.146Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add an async-first Moka scraper for `app.mokahr.com` and `hire-r1.mokahr.com`
- support Moka's plaintext and AES-CBC encrypted job-list responses
- support social and campus boards, pagination, URL resolution, and canonical job fields
- add 29 live seed tenants after removing DJI's currently empty board

## Live validation

- fetched all 29 retained tenants through the rebuilt production scraper
- 29 succeeded, 0 failed, 13,214 jobs returned
- verified encrypted and plaintext tenants across both Moka hosts

## Repository validation

- full suite: 1,216 passed, 2 skipped, 20 deselected
- targeted suite: 163 passed
- strict mypy check on the new scraper and touched resolver/models: clean
- Ruff: clean
- `uv build`: wheel and source distribution built successfully
- `git diff --check`: clean

This replaces the original implementation on the retired `jobhive` package layout with a focused current-`main` port.
