### PR TITLE
Add ROAM Africa multi-country scraper

### DIFF
--- a/ats-companies/roamafrica.csv
+++ b/ats-companies/roamafrica.csv
@@ -1,0 +1,6 @@
+name,slug,url
+Jobberman Nigeria,jobberman-ng,https://www.jobberman.com
+BrighterMonday Kenya,brightermonday-ke,https://www.brightermonday.co.ke
+BrighterMonday Uganda,brightermonday-ug,https://www.brightermonday.co.ug
+BrighterMonday Tanzania,brightermonday-tz,https://www.brightermonday.co.tz
+Jobberman Ghana,jobberman-gh,https://www.jobberman.com.gh

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -80,6 +80,7 @@ class ATSType(StrEnum):
     THEHUB = "thehub"
     YCOMBINATOR = "ycombinator"
     WELLFOUND = "wellfound"
+    ROAMAFRICA = "roamafrica"
     # Additional multi-tenant ATSes (post-0.1)
     BAMBOOHR = "bamboohr"
     BREEZY = "breezy"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -42,6 +42,7 @@ from jobhive.scrapers.recruitee import RecruiteeScraper
 from jobhive.scrapers.recruiterbox import RecruiterboxScraper
 from jobhive.scrapers.remoteok import RemoteOKScraper
 from jobhive.scrapers.rippling import RipplingScraper
+from jobhive.scrapers.roamafrica import RoamAfricaScraper
 from jobhive.scrapers.smartrecruiters import SmartRecruitersScraper
 from jobhive.scrapers.successfactors import SuccessFactorsScraper
 from jobhive.scrapers.taleo import TaleoScraper
@@ -93,6 +94,7 @@ __all__ = [
     "RecruiterboxScraper",
     "RemoteOKScraper",
     "RipplingScraper",
+    "RoamAfricaScraper",
     "ScraperRegistry",
     "SmartRecruitersScraper",
     "SuccessFactorsScraper",

--- a/src/jobhive/scrapers/roamafrica.py
+++ b/src/jobhive/scrapers/roamafrica.py
@@ -1,0 +1,469 @@
+"""ROAM Africa — multi-country job-board scraper.
+
+ROAM Africa runs a single Laravel/Tailwind job-board template across
+five African country sites:
+
+- Jobberman Nigeria   — https://www.jobberman.com
+- BrighterMonday Kenya — https://www.brightermonday.co.ke
+- BrighterMonday Uganda — https://www.brightermonday.co.ug
+- BrighterMonday Tanzania — https://www.brightermonday.co.tz
+- Jobberman Ghana    — https://www.jobberman.com.gh
+
+All five share the same listing-card markup (``data-cy="listing-cards-components"``
+on each card, ``aria-labelledby="job-{numeric-id}-title"`` carries the
+internal listing id, salary tag spelled ``{ISO-currency} {min} - {max}``).
+A single scraper class therefore covers the entire network — the
+``company_slug`` constructor argument selects which region to crawl.
+
+Pagination is page-number based (``?page=N``). Each page returns ~16
+job cards plus a few "featured" listings repeated at the top of every
+page (we dedup by listing id). We stop when a page yields zero new
+ids OR when we hit a 404 OR the safety cap of 500 pages.
+
+The detail-page route ``/listings/{slug}`` embeds a structured
+``<script type="application/ld+json">`` ``JobPosting`` schema with
+title / description / salary / employment_type / industry /
+``datePosted`` — strictly richer than the listing card. We don't
+fetch detail pages by default (would 10x the request count for ~3k
+Nigerian jobs) but the JSON-LD parsing is exposed so a downstream
+enrichment pipeline can opt-in.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import json
+import logging
+import re
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+# Region map: company_slug → (base_url, country_iso, language).
+# Currency is derived from country_iso via _COUNTRY_CURRENCY below.
+REGIONS: dict[str, tuple[str, str, str]] = {
+    "jobberman-ng": ("https://www.jobberman.com", "NG", "en"),
+    "brightermonday-ke": ("https://www.brightermonday.co.ke", "KE", "en"),
+    "brightermonday-ug": ("https://www.brightermonday.co.ug", "UG", "en"),
+    "brightermonday-tz": ("https://www.brightermonday.co.tz", "TZ", "en"),
+    "jobberman-gh": ("https://www.jobberman.com.gh", "GH", "en"),
+}
+
+# Hard fallback: same id space the legacy `/listings/{slug}` URL uses.
+_COUNTRY_CURRENCY: dict[str, str] = {
+    "NG": "NGN",
+    "KE": "KES",
+    "UG": "UGX",
+    "TZ": "TZS",
+    "GH": "GHS",
+}
+
+# Display label on the card ↔ canonical employment_type enum.
+_EMPLOYMENT_MAP: dict[str, str] = {
+    "full time": "FULL_TIME",
+    "full-time": "FULL_TIME",
+    "part time": "PART_TIME",
+    "part-time": "PART_TIME",
+    "contract": "CONTRACT",
+    "internship": "INTERN",
+    "intern": "INTERN",
+    "temporary": "TEMPORARY",
+    "temp": "TEMPORARY",
+}
+
+# JSON-LD also uses the canonical enum spelling directly. Map them all
+# to our schema's accepted values.
+_JSONLD_EMPLOYMENT_MAP: dict[str, str] = {
+    "FULL_TIME": "FULL_TIME",
+    "PART_TIME": "PART_TIME",
+    "CONTRACTOR": "CONTRACT",
+    "CONTRACT": "CONTRACT",
+    "INTERN": "INTERN",
+    "INTERNSHIP": "INTERN",
+    "TEMPORARY": "TEMPORARY",
+}
+
+DEFAULT_MAX_PAGES = 500
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1.5
+
+_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
+# Listing card boundary — one card per ``aria-labelledby="job-{id}-title"``.
+_CARD_RE = re.compile(
+    r'aria-labelledby="job-(?P<id>\d+)-title"\s*>(?P<body>.*?)(?='
+    r'aria-labelledby="job-\d+-title"|</main>|<footer)',
+    re.DOTALL,
+)
+# The listing-card title anchor — ROAM templates put attributes in
+# different orders depending on whether the card is "featured" or
+# regular (featured anchors lead with ``href``; regular ones lead with
+# ``data-cy``). Match the whole opening tag, then pluck attributes off
+# its body so order doesn't matter.
+_TITLE_ANCHOR_RE = re.compile(
+    r'<a\b[^>]*?data-cy="listing-title-link"[^>]*?>',
+    re.DOTALL,
+)
+_HREF_ATTR_RE = re.compile(r'href="(?P<url>[^"]+/listings/[^"]+)"')
+_TITLE_ATTR_RE = re.compile(r'title="(?P<title>[^"]+)"')
+# Company sits in a teaser <p> right after the title <a>. The site
+# class-bombs every node so we anchor on ``text-link-700`` /
+# ``text-link-blue`` which are the two variants observed in the wild
+# (jobberman uses ``text-blue-700`` for company display).
+_COMPANY_RE = re.compile(
+    r'class="[^"]*text-blue-700[^"]*"[^>]*>\s*([^<]+?)\s*</p>',
+    re.DOTALL,
+)
+# The salary chip is the only ``<span>`` containing an ISO-3 currency
+# code followed by digits or "Commission".
+_SALARY_RE = re.compile(
+    r'(?P<curr>NGN|KES|UGX|TZS|GHS|USD)\s*<span[^>]*>\s*(?P<body>[^<]+?)\s*</span>',
+    re.DOTALL,
+)
+# Employment-type chip — match the badge classes used by the template.
+_BADGE_RE = re.compile(
+    r'class="[^"]*bg-brand-secondary-100[^"]*"[^>]*>\s*([^<]+?)\s*</span>',
+    re.DOTALL,
+)
+_TIME_AGO_RE = re.compile(
+    r'(\d+)\s+(hour|day|week|month|year)s?\s+ago',
+    re.IGNORECASE,
+)
+# Detail-page JSON-LD: any ``<script type="application/ld+json">`` block.
+_LD_RE = re.compile(
+    r'<script[^>]+type="application/ld\+json"[^>]*>(.*?)</script>',
+    re.DOTALL | re.IGNORECASE,
+)
+_WS_RE = re.compile(r"\s+")
+
+
+@ScraperRegistry.register(ATSType.ROAMAFRICA)
+class RoamAfricaScraper(BaseScraper):
+    """ROAM Africa multi-country job-board scraper.
+
+    The ``company_slug`` constructor argument selects which country
+    site to crawl — see :data:`REGIONS` for the supported keys
+    (``jobberman-ng``, ``brightermonday-ke``, ``brightermonday-ug``,
+    ``brightermonday-tz``, ``jobberman-gh``).
+
+    Knobs:
+
+    - ``max_pages`` — pagination ceiling, defaults to 500. Real
+      networks top out around 250 pages on Nigeria; smaller countries
+      finish in <30. The scraper stops earlier if a page returns no
+      new ids twice in a row.
+    """
+
+    ats = ATSType.ROAMAFRICA
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        max_pages: int = DEFAULT_MAX_PAGES,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        if company_slug not in REGIONS:
+            raise ScraperError(
+                f"Unknown ROAM Africa region {company_slug!r}. "
+                f"Supported: {sorted(REGIONS)}"
+            )
+        self.max_pages = max_pages
+        self._base_url, self._country_iso, self._language = REGIONS[company_slug]
+        self._currency = _COUNTRY_CURRENCY[self._country_iso]
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True,
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+            consecutive_empty = 0
+            page = 1
+            while page <= self.max_pages and consecutive_empty < 2:
+                try:
+                    page_jobs = await self._fetch_listing_page(client, sem, page)
+                except ScraperError:
+                    if page == 1:
+                        raise
+                    log.warning(
+                        "ROAM Africa %s: stopping pagination at page %d; "
+                        "keeping %d jobs collected so far.",
+                        self.company_slug, page, len(jobs),
+                    )
+                    break
+                new = 0
+                for j in page_jobs:
+                    if j.ats_id in seen:
+                        continue
+                    seen.add(j.ats_id or "")
+                    jobs.append(j)
+                    new += 1
+                consecutive_empty = 0 if new else consecutive_empty + 1
+                page += 1
+        return jobs
+
+    # --- listing pages ------------------------------------------------------
+
+    async def _fetch_listing_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        page: int,
+    ) -> list[Job]:
+        url = f"{self._base_url}/jobs?page={page}"
+        text = await self._request_html(client, sem, url)
+        return self._parse_listing(text)
+
+    def _parse_listing(self, text: str) -> list[Job]:
+        jobs: list[Job] = []
+        for match in _CARD_RE.finditer(text):
+            ats_id = match.group("id")
+            body = match.group("body")
+            job = self._parse_card(ats_id, body)
+            if job is not None:
+                jobs.append(job)
+        return jobs
+
+    def _parse_card(self, ats_id: str, body: str) -> Job | None:
+        anchor_m = _TITLE_ANCHOR_RE.search(body)
+        if not anchor_m:
+            return None
+        anchor = anchor_m.group(0)
+        href_m = _HREF_ATTR_RE.search(anchor)
+        title_m = _TITLE_ATTR_RE.search(anchor)
+        if not href_m or not title_m:
+            return None
+        url = html.unescape(href_m.group("url"))
+        title = html.unescape(title_m.group("title")).strip()
+        if not title:
+            return None
+
+        company_m = _COMPANY_RE.search(body)
+        company = (
+            _clean_text(company_m.group(1))
+            if company_m else "Unknown"
+        )
+
+        # Badge order on every ROAM card is: location, employment type,
+        # salary chip. We collect every ``bg-brand-secondary-100`` span
+        # and triage by content.
+        badges = [_clean_text(b) for b in _BADGE_RE.findall(body)]
+        location: str | None = None
+        employment_type: str | None = None
+        commitment: str | None = None
+        for chip in badges:
+            normalized = chip.lower()
+            if normalized in _EMPLOYMENT_MAP and not employment_type:
+                employment_type = _EMPLOYMENT_MAP[normalized]
+                commitment = chip
+            elif _SALARY_RE.search(chip):
+                # Salary chip is parsed separately below — skip it as a
+                # location candidate.
+                continue
+            elif location is None and chip:
+                location = chip
+
+        salary_summary: str | None = None
+        salary_min: float | None = None
+        salary_max: float | None = None
+        salary_currency: str | None = None
+        sal_m = _SALARY_RE.search(body)
+        if sal_m:
+            salary_currency = sal_m.group("curr")
+            salary_summary = (
+                f"{salary_currency} {_clean_text(sal_m.group('body'))}"
+            )
+            salary_min, salary_max = _parse_salary_range(
+                sal_m.group("body")
+            )
+
+        # "Posted N days ago" — listing card uses a plain "<N> days ago"
+        # without a "Posted" prefix; either spelling is accepted.
+        posted_at: datetime | None = None
+        posted_text: str | None = None
+        time_m = _TIME_AGO_RE.search(body)
+        if time_m:
+            posted_text = time_m.group(0)
+            posted_at = _relative_to_datetime(
+                int(time_m.group(1)), time_m.group(2).lower()
+            )
+
+        raw: dict[str, Any] = {
+            "region_key": self.company_slug,
+        }
+        if posted_text:
+            raw["posted_text"] = posted_text
+
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.ROAMAFRICA,
+            ats_id=ats_id,
+            location=location,
+            country_iso=self._country_iso,
+            region="Africa",
+            language=self._language,
+            salary_currency=salary_currency,
+            salary_period="MONTH" if salary_currency else None,
+            salary_summary=salary_summary,
+            salary_min=salary_min,
+            salary_max=salary_max,
+            employment_type=employment_type,  # type: ignore[arg-type]
+            commitment=commitment,
+            posted_at=posted_at,
+            fetched_at=datetime.now(),
+            raw=raw,
+        )
+
+    # --- detail-page JSON-LD (opt-in, used by enrichment) -------------------
+
+    @staticmethod
+    def parse_detail_jsonld(html_text: str) -> dict[str, Any] | None:
+        """Extract the ``JobPosting`` JSON-LD block from a detail page.
+
+        Returns the raw dict (so callers can pick whatever fields they
+        want), or ``None`` when the page has no ``JobPosting`` node.
+        Exposed as a staticmethod for reuse by downstream enrichment
+        without instantiating the scraper.
+        """
+        for match in _LD_RE.finditer(html_text):
+            try:
+                payload = json.loads(match.group(1))
+            except json.JSONDecodeError:
+                continue
+            graph = (
+                payload.get("@graph", [payload])
+                if isinstance(payload, dict) else payload
+            )
+            if not isinstance(graph, list):
+                graph = [graph]
+            for node in graph:
+                if isinstance(node, dict) and node.get("@type") == "JobPosting":
+                    return node
+        return None
+
+    # --- HTTP ---------------------------------------------------------------
+
+    async def _request_html(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        url: str,
+    ) -> str:
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(
+                        url, headers={
+                            "User-Agent": _USER_AGENT,
+                            "Accept": "text/html,*/*",
+                            "Accept-Language": "en-US,en;q=0.9",
+                        },
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"ROAM Africa fetch failed for {url}: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                return response.text
+            if response.status_code == 404:
+                # Past the last page → empty body so the pager treats
+                # it as "no new jobs" and stops after two such replies.
+                return ""
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"ROAM Africa returned {response.status_code} for "
+                        f"{url} after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"ROAM Africa returned {response.status_code} for {url}"
+            )
+        raise ScraperError(
+            f"ROAM Africa exhausted retries for {url}: {last_exc}"
+        )
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+def _clean_text(text: str) -> str:
+    return _WS_RE.sub(" ", html.unescape(text)).strip()
+
+
+def _parse_salary_range(body: str) -> tuple[float | None, float | None]:
+    """Pull ``min - max`` out of a ROAM salary chip body.
+
+    ROAM chips look like ``70,000 - 150,000`` (with thousand separators
+    and an em / hyphen dash). Commission-only / negotiable strings
+    have no numbers and return ``(None, None)``.
+    """
+    numbers = re.findall(r"[\d,]+(?:\.\d+)?", body)
+    if not numbers:
+        return None, None
+    try:
+        parsed = [float(n.replace(",", "")) for n in numbers]
+    except ValueError:
+        return None, None
+    parsed = [p for p in parsed if p > 0]
+    if not parsed:
+        return None, None
+    if len(parsed) == 1:
+        return parsed[0], parsed[0]
+    return parsed[0], parsed[-1]
+
+
+def _relative_to_datetime(n: int, unit: str) -> datetime:
+    """Map ``N hours/days/weeks/months/years ago`` → datetime.now() - delta.
+
+    Approximate by design — ROAM doesn't expose an absolute datetime on
+    the listing card, only on the detail page's JSON-LD. ``raw.posted_text``
+    keeps the source string so downstream consumers can re-derive.
+    """
+    now = datetime.now()
+    if unit == "hour":
+        return now - timedelta(hours=n)
+    if unit == "day":
+        return now - timedelta(days=n)
+    if unit == "week":
+        return now - timedelta(weeks=n)
+    if unit == "month":
+        return now - timedelta(days=30 * n)
+    if unit == "year":
+        return now - timedelta(days=365 * n)
+    return now

--- a/src/jobhive/scrapers/roamafrica.py
+++ b/src/jobhive/scrapers/roamafrica.py
@@ -127,13 +127,19 @@ _TITLE_ATTR_RE = re.compile(r'title="(?P<title>[^"]+)"')
 # ``text-link-blue`` which are the two variants observed in the wild
 # (jobberman uses ``text-blue-700`` for company display).
 _COMPANY_RE = re.compile(
-    r'class="[^"]*text-blue-700[^"]*"[^>]*>\s*([^<]+?)\s*</p>',
+    r'class="[^"]*(?:text-blue-700|text-link-700|text-link-blue)[^"]*"'
+    r'[^>]*>\s*([^<]+?)\s*</p>',
     re.DOTALL,
 )
-# The salary chip is the only ``<span>`` containing an ISO-3 currency
-# code followed by digits or "Commission".
+# The salary chip is an ISO-3 currency code followed by the amount
+# ("Commission" / "Confidential" for non-numeric chips). The amount is
+# sometimes wrapped in an inner ``<span>`` (raw card HTML) and sometimes
+# bare (cleaned plain text), so the wrapper is optional and the body
+# stops at the next tag or end of string. This lets the same pattern
+# match both the raw card body and a ``_clean_text``-ed badge.
 _SALARY_RE = re.compile(
-    r'(?P<curr>NGN|KES|UGX|TZS|GHS|USD)\s*<span[^>]*>\s*(?P<body>[^<]+?)\s*</span>',
+    r'(?P<curr>NGN|KES|UGX|TZS|GHS|USD)\s*(?:<span[^>]*>\s*)?'
+    r'(?P<body>[^<]+?)\s*(?:</span>|<|\Z)',
     re.DOTALL,
 )
 # Employment-type chip — match the badge classes used by the template.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -30,6 +30,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
         "manfred", "thehub", "ycombinator", "wellfound",
+        "roamafrica",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",
         "recruitee", "taleo", "teamtailor",

--- a/tests/test_roamafrica.py
+++ b/tests/test_roamafrica.py
@@ -1,0 +1,455 @@
+"""Tests for the ROAM Africa multi-country scraper.
+
+ROAM Africa runs a shared Laravel/Tailwind template across five
+country sites (Jobberman NG/GH, BrighterMonday KE/UG/TZ). Tests pin:
+
+- Region selection via ``company_slug`` → base URL, country_iso,
+  currency, language.
+- Listing-card HTML parsing for title / url / company / location /
+  employment_type / salary / posted_at.
+- Pagination cutoff (2 consecutive empty pages stops the crawl).
+- JSON-LD ``JobPosting`` detail-page helper.
+- Registry wiring.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import RoamAfricaScraper, ScraperRegistry
+from jobhive.scrapers.roamafrica import REGIONS
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.roamafrica as ra
+    monkeypatch.setattr(ra, "MAX_RETRIES", 1)
+    monkeypatch.setattr(ra, "RETRY_BASE_DELAY", 0.0)
+
+
+# A single realistic ROAM Africa job card mirroring the live HTML
+# structure (data-cy markers, badge classes, ``NGN <span>`` salary
+# chip, "N days ago" timer). One card = one regex hit on _CARD_RE.
+#
+# ``featured`` toggles the attribute ordering on the title anchor:
+# real ROAM cards put ``href`` before ``data-cy`` on featured cards
+# and the reverse on regular ones, so the parser has to handle both.
+def _card(
+    *,
+    job_id: int,
+    title: str,
+    slug: str,
+    base: str = "https://www.jobberman.com",
+    company: str = "Acme Co",
+    location: str = "Lagos & Lagos State",
+    emp_label: str = "Full Time",
+    currency: str = "NGN",
+    salary: str = "150,000 - 250,000",
+    time_ago: str = "3 days ago",
+    featured: bool = False,
+) -> str:
+    if featured:
+        anchor = f"""
+        <a
+           href="{base}/listings/{slug}"
+           class="block text-link-500"
+           data-cy="listing-title-link"
+           title="{title}">
+          <p class="text-lg font-medium break-words text-link-500">{title}</p>
+        </a>
+        """
+    else:
+        anchor = f"""
+        <a data-cy="listing-title-link"
+           href="{base}/listings/{slug}"
+           class="block text-link-500"
+           title="{title}">
+          <p class="text-lg font-medium break-words text-link-500">{title}</p>
+        </a>
+        """
+    return f"""
+    <div data-cy="listing-cards-components" aria-labelledby="job-{job_id}-title">
+      <div class="flex-1">
+        {anchor}
+        <p class="text-sm text-blue-700 inline-block mt-3">
+          {company}
+        </p>
+        <div class="flex flex-wrap mt-3 text-sm text-gray-500 md:py-0">
+          <span class="mb-3 px-3 py-1 rounded bg-brand-secondary-100 mr-2 text-gray-700">
+            {location}
+          </span>
+          <span class="mb-3 px-3 py-1 rounded bg-brand-secondary-100 mr-2 text-gray-700">{emp_label}</span>
+          <span class="mb-3 px-3 py-1 rounded bg-brand-secondary-100 mr-2 text-gray-700">
+            {currency} <span class="mr-1">{salary}</span>
+          </span>
+        </div>
+      </div>
+      <div class="ml-auto flex items-center gap-3">
+        <p class="text-sm font-normal text-gray-700">{time_ago}</p>
+      </div>
+    </div>
+    """
+
+
+def _listing_page(cards: list[str]) -> str:
+    """Wrap one or more cards in a minimal page shell."""
+    body = "\n".join(cards)
+    return f"""
+    <!DOCTYPE html>
+    <html lang="en-ng">
+      <head><title>Jobs</title></head>
+      <body>
+        <main>
+          {body}
+        </main>
+        <footer>x</footer>
+      </body>
+    </html>
+    """
+
+
+def _empty_page() -> str:
+    return _listing_page([])
+
+
+# --- registry / region wiring -----------------------------------------------
+
+
+def test_registry_resolves_roamafrica() -> None:
+    assert ScraperRegistry.get(ATSType.ROAMAFRICA) is RoamAfricaScraper
+
+
+@pytest.mark.parametrize("slug", list(REGIONS))
+def test_supported_regions_construct(slug: str) -> None:
+    s = RoamAfricaScraper(slug)
+    base, country, lang = REGIONS[slug]
+    assert s._base_url == base
+    assert s._country_iso == country
+    assert s._language == lang
+
+
+def test_unknown_region_rejected() -> None:
+    with pytest.raises(ScraperError):
+        RoamAfricaScraper("jobberman-zw")
+
+
+def test_region_currency_per_country() -> None:
+    """Each region maps to its national currency (NGN/KES/UGX/TZS/GHS)."""
+    expected = {
+        "jobberman-ng": "NGN",
+        "brightermonday-ke": "KES",
+        "brightermonday-ug": "UGX",
+        "brightermonday-tz": "TZS",
+        "jobberman-gh": "GHS",
+    }
+    for slug, currency in expected.items():
+        assert RoamAfricaScraper(slug)._currency == currency
+
+
+# --- happy path -------------------------------------------------------------
+
+
+def test_parses_listing_card_full_fields(httpx_mock) -> None:
+    """A realistic Jobberman NG card produces a complete Job row."""
+    httpx_mock.add_response(
+        url="https://www.jobberman.com/jobs?page=1",
+        text=_listing_page([
+            _card(
+                job_id=1226658,
+                title="Bar/Lounge Supervisor",
+                slug="barlounge-supervisor-k77808",
+                company="KeiOyi Investments Limited",
+                location="Port Harcourt & Rivers State",
+                emp_label="Full Time",
+                currency="NGN",
+                salary="70,000 - 150,000",
+                time_ago="3 days ago",
+            ),
+        ]),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://www\.jobberman\.com/jobs\?page=[2-9]$"),
+        text=_empty_page(), is_reusable=True,
+    )
+
+    jobs = RoamAfricaScraper("jobberman-ng").fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.ROAMAFRICA
+    assert j.ats_id == "1226658"
+    assert j.title == "Bar/Lounge Supervisor"
+    assert j.company == "KeiOyi Investments Limited"
+    assert (
+        str(j.url)
+        == "https://www.jobberman.com/listings/barlounge-supervisor-k77808"
+    )
+    assert j.location == "Port Harcourt & Rivers State"
+    assert j.country_iso == "NG"
+    assert j.region == "Africa"
+    assert j.language == "en"
+    assert j.employment_type == "FULL_TIME"
+    assert j.commitment == "Full Time"
+    assert j.salary_currency == "NGN"
+    assert j.salary_min == 70_000
+    assert j.salary_max == 150_000
+    assert j.salary_period == "MONTH"
+    assert j.salary_summary == "NGN 70,000 - 150,000"
+    assert j.posted_at is not None
+    # Approximate by design — within 1 hour of now-3-days.
+    assert datetime.now() - timedelta(days=3, hours=1) < j.posted_at
+    assert j.posted_at < datetime.now()
+    assert j.raw == {
+        "region_key": "jobberman-ng",
+        "posted_text": "3 days ago",
+    }
+    assert j.global_id == "roamafrica:1226658"
+
+
+def test_parses_brightermonday_ke_with_kes_currency(httpx_mock) -> None:
+    """Switching region changes base URL, country code, currency."""
+    httpx_mock.add_response(
+        url="https://www.brightermonday.co.ke/jobs?page=1",
+        text=_listing_page([
+            _card(
+                job_id=1174836,
+                title="Senior Backend Engineer",
+                slug="senior-backend-engineer-abcd1",
+                base="https://www.brightermonday.co.ke",
+                company="Safaricom",
+                location="Nairobi",
+                emp_label="Full Time",
+                currency="KES",
+                salary="200,000 - 400,000",
+            ),
+        ]),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://www\.brightermonday\.co\.ke/jobs\?page=[2-9]$"),
+        text=_empty_page(), is_reusable=True,
+    )
+
+    jobs = RoamAfricaScraper("brightermonday-ke").fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.country_iso == "KE"
+    assert j.salary_currency == "KES"
+    assert str(j.url).startswith("https://www.brightermonday.co.ke/listings/")
+
+
+def test_featured_card_anchor_attribute_order(httpx_mock) -> None:
+    """Featured listings put ``href`` BEFORE ``data-cy`` on the title
+    anchor; regular cards do the reverse. Parser must handle both."""
+    httpx_mock.add_response(
+        url="https://www.jobberman.com/jobs?page=1",
+        text=_listing_page([
+            _card(
+                job_id=42, title="Featured Role",
+                slug="featured-role-42", featured=True,
+            ),
+        ]),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://www\.jobberman\.com/jobs\?page=[2-9]$"),
+        text=_empty_page(), is_reusable=True,
+    )
+    jobs = RoamAfricaScraper("jobberman-ng").fetch()
+    assert len(jobs) == 1
+    assert jobs[0].title == "Featured Role"
+    assert str(jobs[0].url) == "https://www.jobberman.com/listings/featured-role-42"
+
+
+def test_handles_commission_only_salary_chip(httpx_mock) -> None:
+    """Non-numeric salary strings (Commission Only / Confidential) keep
+    summary + currency but min/max stay None."""
+    httpx_mock.add_response(
+        url="https://www.jobberman.com/jobs?page=1",
+        text=_listing_page([
+            _card(
+                job_id=999,
+                title="Sales Rep",
+                slug="sales-rep-xxx",
+                currency="NGN",
+                salary="Commission Only",
+            ),
+        ]),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://www\.jobberman\.com/jobs\?page=[2-9]$"),
+        text=_empty_page(), is_reusable=True,
+    )
+    j = RoamAfricaScraper("jobberman-ng").fetch()[0]
+    assert j.salary_currency == "NGN"
+    assert j.salary_summary == "NGN Commission Only"
+    assert j.salary_min is None
+    assert j.salary_max is None
+
+
+def test_employment_type_label_variants_map_to_enum(httpx_mock) -> None:
+    """All five badge spellings normalise to the canonical enum."""
+    httpx_mock.add_response(
+        url="https://www.jobberman.com/jobs?page=1",
+        text=_listing_page([
+            _card(job_id=1, title="A", slug="a-1", emp_label="Full Time"),
+            _card(job_id=2, title="B", slug="b-2", emp_label="Part Time"),
+            _card(job_id=3, title="C", slug="c-3", emp_label="Contract"),
+            _card(job_id=4, title="D", slug="d-4", emp_label="Internship"),
+            _card(job_id=5, title="E", slug="e-5", emp_label="Temporary"),
+        ]),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://www\.jobberman\.com/jobs\?page=[2-9]$"),
+        text=_empty_page(), is_reusable=True,
+    )
+    jobs = RoamAfricaScraper("jobberman-ng").fetch()
+    et = {j.ats_id: j.employment_type for j in jobs}
+    assert et == {
+        "1": "FULL_TIME",
+        "2": "PART_TIME",
+        "3": "CONTRACT",
+        "4": "INTERN",
+        "5": "TEMPORARY",
+    }
+
+
+def test_dedup_across_pages_by_listing_id(httpx_mock) -> None:
+    """Featured listings repeat on every page — dedup keeps each
+    listing id exactly once across the whole crawl."""
+    page1 = _listing_page([
+        _card(job_id=100, title="A", slug="a-100"),
+        _card(job_id=200, title="B", slug="b-200"),
+    ])
+    page2 = _listing_page([
+        _card(job_id=100, title="A", slug="a-100"),  # repeat
+        _card(job_id=300, title="C", slug="c-300"),
+    ])
+    httpx_mock.add_response(
+        url="https://www.jobberman.com/jobs?page=1", text=page1,
+    )
+    httpx_mock.add_response(
+        url="https://www.jobberman.com/jobs?page=2", text=page2,
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://www\.jobberman\.com/jobs\?page=[3-9]$"),
+        text=_empty_page(), is_reusable=True,
+    )
+    jobs = RoamAfricaScraper("jobberman-ng").fetch()
+    assert sorted(j.ats_id for j in jobs) == ["100", "200", "300"]
+
+
+# --- pagination -------------------------------------------------------------
+
+
+def test_stops_after_two_consecutive_empty_pages(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://www.jobberman.com/jobs?page=1",
+        text=_listing_page([_card(job_id=1, title="A", slug="a-1")]),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://www\.jobberman\.com/jobs\?page=[2-9]$"),
+        text=_empty_page(), is_reusable=True,
+    )
+    jobs = RoamAfricaScraper("jobberman-ng", max_pages=20).fetch()
+    assert {j.ats_id for j in jobs} == {"1"}
+
+
+def test_max_pages_caps_pagination(httpx_mock) -> None:
+    """Even with all-fresh pages, max_pages bounds the crawl."""
+    for p in range(1, 6):
+        httpx_mock.add_response(
+            url=f"https://www.jobberman.com/jobs?page={p}",
+            text=_listing_page([
+                _card(job_id=p * 1000, title=f"Job {p}", slug=f"j-{p}"),
+            ]),
+        )
+    jobs = RoamAfricaScraper("jobberman-ng", max_pages=5).fetch()
+    assert len(jobs) == 5
+
+
+def test_404_treated_as_end_of_pagination(httpx_mock) -> None:
+    """A 404 on page N stops the crawl gracefully, keeping prior pages."""
+    httpx_mock.add_response(
+        url="https://www.jobberman.com/jobs?page=1",
+        text=_listing_page([_card(job_id=1, title="A", slug="a-1")]),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://www\.jobberman\.com/jobs\?page=[2-9]$"),
+        status_code=404, is_reusable=True,
+    )
+    jobs = RoamAfricaScraper("jobberman-ng").fetch()
+    assert len(jobs) == 1
+
+
+# --- detail-page JSON-LD ----------------------------------------------------
+
+
+def test_parse_detail_jsonld_extracts_jobposting() -> None:
+    """The static helper finds the JobPosting node inside the page's
+    ``@graph`` and returns its raw dict for downstream enrichment."""
+    detail_html = """
+    <html><head>
+      <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {"@type": "WebPage", "name": "x"},
+          {
+            "@type": "JobPosting",
+            "title": "Bar/Lounge Supervisor",
+            "description": "<p>Run the floor.</p>",
+            "datePosted": "2026-05-11T00:00:00.000000Z",
+            "employmentType": "FULL_TIME",
+            "industry": "Hospitality",
+            "baseSalary": {
+              "@type": "MonetaryAmount",
+              "currency": "NGN",
+              "value": {"@type": "QuantitativeValue",
+                        "minValue": 70000, "maxValue": 150000,
+                        "unitText": "MONTH"}
+            }
+          }
+        ]
+      }
+      </script>
+    </head><body></body></html>
+    """
+    node = RoamAfricaScraper.parse_detail_jsonld(detail_html)
+    assert node is not None
+    assert node["title"] == "Bar/Lounge Supervisor"
+    assert node["employmentType"] == "FULL_TIME"
+    assert node["baseSalary"]["currency"] == "NGN"
+
+
+def test_parse_detail_jsonld_returns_none_when_absent() -> None:
+    assert RoamAfricaScraper.parse_detail_jsonld("<html></html>") is None
+
+
+# --- error handling ---------------------------------------------------------
+
+
+def test_persistent_500_on_page_one_raises(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=re.compile(r"^https://www\.jobberman\.com/jobs\?page=\d+$"),
+        status_code=500, is_reusable=True,
+    )
+    with pytest.raises(ScraperError):
+        RoamAfricaScraper("jobberman-ng").fetch()
+
+
+def test_500_mid_crawl_keeps_collected_jobs(httpx_mock) -> None:
+    """If a later page 500s, the scraper logs and returns the page-1
+    jobs rather than throwing them away."""
+    httpx_mock.add_response(
+        url="https://www.jobberman.com/jobs?page=1",
+        text=_listing_page([_card(job_id=1, title="A", slug="a-1")]),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://www\.jobberman\.com/jobs\?page=[2-9]$"),
+        status_code=500, is_reusable=True,
+    )
+    jobs = RoamAfricaScraper("jobberman-ng").fetch()
+    assert len(jobs) == 1


### PR DESCRIPTION
## Summary
- New `RoamAfricaScraper` covering 5 ROAM Africa country sites with a single class — Jobberman NG/GH and BrighterMonday KE/UG/TZ. The shared Laravel/Tailwind template means one HTML parser handles the entire network (~10k combined live jobs).
- `company_slug` picks the region (`jobberman-ng`, `brightermonday-ke`, `brightermonday-ug`, `brightermonday-tz`, `jobberman-gh`); region map fills `country_iso`, `language`, and ISO-4217 currency (NGN/KES/UGX/TZS/GHS) per site.
- Listing-card HTML parsing (data-cy markers, badge classes, `{CURRENCY} <span>{min} - {max}</span>` salary chip, "N days ago" timer) handles both attribute orderings used by featured vs regular cards. Page-by-page pagination with a 2-empty-page stop condition and a 500-page safety cap; 404 ends gracefully, 500 mid-crawl keeps prior pages.
- Detail-page JSON-LD `JobPosting` extraction exposed as `RoamAfricaScraper.parse_detail_jsonld(...)` for opt-in downstream enrichment (richer description, employment type, datePosted, structured salary).
- `ATSType.ROAMAFRICA = "roamafrica"` added to the enum; `__init__.py` re-exports the scraper; `test_models.py` expected-ATS set updated.

## Test plan
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run pytest` — 900 tests pass (21 new in `test_roamafrica.py`)
- [x] Live smoke test against `jobberman-ng` (16 jobs/page, real salary + posted_at), `brightermonday-ke` (16 KE jobs, country_iso=KE), `jobberman-gh` (16 GH jobs, GHS currency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `RoamAfricaScraper` to crawl ROAM Africa job boards across Jobberman NG/GH and BrighterMonday KE/UG/TZ with a single parser. Adds `ATSType.ROAMAFRICA`, registers the scraper, and seeds `ats-companies/roamafrica.csv` for region slugs and base URLs.

- **New Features**
  - Region selected via `company_slug` (`jobberman-ng`, `brightermonday-ke`, `brightermonday-ug`, `brightermonday-tz`, `jobberman-gh`) with country, language, and currency mapping; seed CSV added.
  - Parses listing cards for title, URL, company, location, employment type, and salary; converts “N days ago” to `posted_at`.
  - Pagination by page number with dedup; stops after two empty pages, handles 404 as end, retries on 5xx/429, max 500 pages; exposes `RoamAfricaScraper.parse_detail_jsonld()` for optional detail-page enrichment.

- **Bug Fixes**
  - Company selector now matches BrighterMonday variants (`text-link-700`, `text-link-blue`) in addition to Jobberman’s `text-blue-700`.
  - Salary regex handles chips rendered as plain text (no inner `<span>`), preserving currency and summary.

<sup>Written for commit 67e064d0fe4e85fbabb72a41f849376133210531. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `RoamAfricaScraper`, a single scraper class covering five ROAM Africa job boards (Jobberman NG/GH, BrighterMonday KE/UG/TZ) via regex-based HTML parsing, page-number pagination with two-empty-page stop logic, and an opt-in JSON-LD detail-page enrichment helper.

- **`_COMPANY_RE` likely drops company names for BrighterMonday sites**: the comment above the regex documents `text-link-700` / `text-link-blue` as real class variants used in the wild, but the pattern only matches `text-blue-700` (described as Jobberman-specific). All tests use the same `text-blue-700` fixture for every region, so this discrepancy is not caught.
- **`asyncio.sleep` inside `async with sem:` on `httpx.HTTPError` retry**: the semaphore slot is held through the backoff sleep, contrary to how the 429/5xx retry path is written.
- Minor: dedup check uses `j.ats_id` while insertion uses `j.ats_id or \"\"`, creating an inconsistency if `ats_id` is ever falsy.

<h3>Confidence Score: 3/5</h3>

Safe to merge for Jobberman sites, but BrighterMonday company names are likely silently wrong due to a CSS class mismatch that the tests don't cover.

The company regex comment explicitly documents multiple CSS class variants across the ROAM Africa network, but only one variant is implemented. Since BrighterMonday accounts for three of the five supported regions, every BrighterMonday job could silently land with company = Unknown. The test fixture hard-codes the Jobberman class for all regions, so the gap goes undetected in CI.

src/jobhive/scrapers/roamafrica.py (_COMPANY_RE and the httpx.HTTPError retry branch); tests/test_roamafrica.py (BrighterMonday company assertion is absent from all region tests).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/roamafrica.py | New 469-line scraper covering 5 ROAM Africa country sites. The _COMPANY_RE regex documents two CSS class variants for company display but only implements one, likely producing "Unknown" company names for all BrighterMonday listings. |
| tests/test_roamafrica.py | 21 tests covering regions, card parsing, pagination, dedup, 404/5xx error handling, and JSON-LD extraction. All BrighterMonday tests use the same text-blue-700 fixture class as Jobberman, so the _COMPANY_RE class-variant bug is not caught. |
| src/jobhive/models.py | Adds ATSType.ROAMAFRICA = "roamafrica" to the StrEnum; clean change. |
| src/jobhive/scrapers/__init__.py | Adds RoamAfricaScraper import and __all__ entry in alphabetical order; clean change. |
| ats-companies/roamafrica.csv | Seed CSV with 5 region entries matching the REGIONS dict in the scraper. |
| tests/test_models.py | Adds "roamafrica" to the expected ATSType set; straightforward update. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/jobhive/scrapers/roamafrica.py:125-132
**`_COMPANY_RE` misses documented BrighterMonday CSS class variants**

The comment above the regex explicitly states that the sites use two variants for company display — `text-link-700` / `text-link-blue` — and that *Jobberman* specifically uses `text-blue-700`. The regex, however, only matches `text-blue-700`. If BrighterMonday's live HTML uses either of the other two class names (which the comment implies it does), then `_COMPANY_RE.search(body)` returns `None` for every BrighterMonday card and every job from `brightermonday-ke`, `brightermonday-ug`, and `brightermonday-tz` silently gets `company = "Unknown"`.

The tests don't surface this because `_card()` hard-codes `text-blue-700` for all regions in the fixture, so the test fixture doesn't match what BrighterMonday actually serves.

### Issue 2 of 3
src/jobhive/scrapers/roamafrica.py:387-394
**Semaphore held across retry sleep on network error**

When `client.get()` raises `httpx.HTTPError`, the code calls `asyncio.sleep(RETRY_BASE_DELAY * attempt)` while still inside `async with sem:`. This means one semaphore slot is consumed for the entire duration of the sleep. If all `MAX_CONCURRENCY` (4) slots were acquired simultaneously (e.g., if page fetching is ever parallelised), every slot would be locked during the backoff and no new requests could start until the sleeps complete. The 429/5xx sleep path (line 412) correctly releases the semaphore before sleeping; the `httpx.HTTPError` path should do the same.

### Issue 3 of 3
src/jobhive/scrapers/roamafrica.py:217-222
**Inconsistent dedup key between check and insertion**

`j.ats_id` is checked against `seen`, but `j.ats_id or ""` is inserted. If `ats_id` were ever `None` (or empty string from a parser edge case), `None in seen` evaluates to `False` while `seen.add("")` is called instead, so subsequent `None`-id jobs would bypass the dedup check and be inserted twice. The cleaner fix is to normalise the key once: `key = j.ats_id or ""; if key in seen: continue; seen.add(key)`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: roamafrica.c..."](https://github.com/kalil0321/ats-scrapers/commit/fdf38d6ba7aac3cb170077701f30d45bfdf058fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732432)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->