### PR TITLE
Add Wuzzuf scraper (Egypt, MENA)

### DIFF
--- a/ats-companies/wuzzuf.csv
+++ b/ats-companies/wuzzuf.csv
@@ -1,0 +1,3 @@
+name,slug,url
+Wuzzuf Egypt,egypt,https://wuzzuf.net
+Wuzzuf Saudi Arabia,saudi-arabia,https://wuzzuf.net

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -78,6 +78,7 @@ class ATSType(StrEnum):
     JOBSCH = "jobsch"
     MANFRED = "manfred"
     THEHUB = "thehub"
+    WUZZUF = "wuzzuf"
     YCOMBINATOR = "ycombinator"
     WELLFOUND = "wellfound"
     # Additional multi-tenant ATSes (post-0.1)

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -57,6 +57,7 @@ from jobhive.scrapers.wellfound import WellfoundScraper
 from jobhive.scrapers.weworkremotely import WeWorkRemotelyScraper
 from jobhive.scrapers.workable import WorkableScraper
 from jobhive.scrapers.workday import WorkdayScraper
+from jobhive.scrapers.wuzzuf import WuzzufScraper
 from jobhive.scrapers.ycombinator import YCombinatorScraper
 
 __all__ = [
@@ -109,6 +110,7 @@ __all__ = [
     "WellfoundScraper",
     "WorkableScraper",
     "WorkdayScraper",
+    "WuzzufScraper",
     "YCombinatorScraper",
     "get_scraper",
     "iCIMSScraper",

--- a/src/jobhive/scrapers/wuzzuf.py
+++ b/src/jobhive/scrapers/wuzzuf.py
@@ -1,0 +1,664 @@
+"""Wuzzuf (https://wuzzuf.net) — Egypt + MENA direct-posting job board.
+
+Wuzzuf is Egypt's largest job platform (~5 k active postings) with a
+smaller Saudi Arabia presence (``/saudi/...``). Companies post directly
+rather than the site aggregating LinkedIn / Indeed feeds, so coverage is
+high-signal but limited in volume.
+
+The site is a Nuxt-style SSR React app: there is no public JSON API
+exposed for listings, but the server-rendered HTML at
+``/search/jobs/?filters[country][0]={Country}&start={N}`` carries every
+visible card pre-hydrated. We scrape that HTML directly.
+
+Pagination is offset-style: ``?start=0`` shows the first 15 cards,
+``?start=15`` shifts by one page, etc. The catalogue caps at ~340
+records across all categories regardless of the reported total
+(``5,415 Job Opportunities in Egypt`` in the meta), so the safety cap
+of ``MAX_PAGES=200`` is far above what's reachable today; the scraper
+stops naturally when a page returns zero job links.
+
+Multi-country handling: pass ``company_slug`` as the country segment
+(``"egypt"`` — default — ``"saudi-arabia"``, or ``"all"`` to enumerate
+every supported country). The country segment determines the search
+URL prefix (``/search/jobs`` for Egypt, ``/saudi/search/jobs`` for
+Saudi) and the ``filters[country][0]`` query value. Output rows carry
+``country_iso`` (``EG`` / ``SA``) so downstream consumers can filter
+without re-deriving from ``location`` text.
+
+The site honours ``language=en`` cookie / ``Accept-Language`` header to
+keep titles in English; without it Saudi search 302-redirects to the
+Arabic ``/ar/saudi/...`` mirror.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import re
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+BASE_URL = "https://wuzzuf.net"
+PER_PAGE = 15  # Wuzzuf renders 15 cards per ``start`` increment.
+MAX_PAGES = 200  # Safety cap. Real catalogue caps at ~23 pages today.
+MAX_CONCURRENCY = 3  # Be polite to the SSR — each page is ~600 kB HTML.
+MAX_RETRIES = 4
+RETRY_BASE_DELAY = 1.5
+
+# Country segment → (URL prefix, ``filters[country][0]`` value, ISO 3166-1).
+# Probed 2026-05-12: the ``/saudi`` prefix exists; ``/uae`` 404s. Add
+# more rows here when Wuzzuf launches additional country mirrors.
+COUNTRY_SEGMENTS: dict[str, tuple[str, str, str]] = {
+    "egypt": ("", "Egypt", "EG"),
+    "saudi-arabia": ("/saudi", "Saudi Arabia", "SA"),
+}
+
+# Currency per country — Wuzzuf rarely surfaces structured salary, but
+# when ``salary_summary`` is present we tag it with the local currency
+# so downstream parse_salary_range has a working denomination.
+_CURRENCY_BY_ISO: dict[str, str] = {
+    "EG": "EGP",
+    "SA": "SAR",
+}
+
+# Card-level regexes. Each card is one ``<div class="css-ghe2tq ..."> ... </div>``
+# block; we split on the link to the posting then peel fields off the
+# surrounding markup. The Emotion class names (``css-xxxxx``) are
+# obfuscated but stable across renders — we still anchor on structural
+# tags (``<h2>``, ``<a href=>``, ``<span>``) where possible so the
+# parser survives a CSS rename.
+_JOB_LINK_RE = re.compile(
+    r'<a[^>]*\bhref="(?P<href>(?:/[a-z-]+)?/jobs/p/(?P<id>[A-Za-z0-9]+)-[^"]+)"'
+    r'[^>]*>(?P<title>[^<]+)</a>',
+)
+_COMPANY_RE = re.compile(
+    r'href="https?://wuzzuf\.net/jobs/careers/[^"]+"[^>]*class="css-ipsyv7"[^>]*>(?P<company>[^<]+?)\s*-\s*</a>',
+)
+# Location lives in the ``css-16x61xq`` span and ships as
+# ``City, <!-- -->Country `` or ``District, City, Country``. Strip the
+# HTML comment + trailing whitespace.
+_LOCATION_RE = re.compile(
+    r'<span[^>]*class="css-16x61xq"[^>]*>(?P<loc>.*?)</span>',
+    re.DOTALL,
+)
+# Posted-at lives in ``css-eg55jf`` — ``"X minutes ago"`` / ``"1 hour ago"``
+# / ``"2 days ago"`` etc.
+_POSTED_RE = re.compile(
+    r'<div[^>]*class="css-eg55jf"[^>]*>(?P<posted>[^<]+)</div>',
+)
+# Employment-type / modality badges. ``Full Time`` / ``Part Time`` /
+# ``On-site`` / ``Remote`` / etc. render as styled pills:
+# ``<a href="/a/{slug}-Jobs-in-{Country}"><span class="css-...">label</span></a>``.
+# The ``<span>`` wrapping is what visually distinguishes a badge from
+# the level (``<a class="css-o171kl" ...>Manager</a>``) and category
+# anchors — anchor a regex on the inner ``<span>`` so we only pick
+# real pills, not every ``/a/`` link in the card body.
+_BADGE_RE = re.compile(
+    # ``/a/`` for Egypt, ``/saudi/a/`` for Saudi, etc. — match an optional
+    # country segment before the ``/a/`` so we work across mirrors.
+    r'<a[^>]*\bhref="(?:/[a-z-]+)?/a/(?P<slug>[A-Za-z][A-Za-z0-9-]*)-Jobs-in-[^"]+"[^>]*>'
+    # Zero or more inline ``<style>`` blocks (Emotion injects these on
+    # every render) interleaved with whitespace. ``\s*`` between each
+    # so synthetic / pretty-printed HTML matches too.
+    r'\s*(?:<style[^>]*>[^<]*</style>\s*)*'
+    r'<span[^>]*\bclass="css-[a-z0-9]+ [a-z0-9]+"[^>]*>(?P<label>[^<]+)</span>',
+    re.DOTALL,
+)
+# Experience label: ``<span>· 3 - 7 Yrs of Exp</span>`` (also occasionally
+# ``X+ Yrs of Exp``).
+_EXPERIENCE_RE = re.compile(
+    r'(?P<min>\d+)\s*(?:-\s*(?P<max>\d+)\s*)?(?:\+\s*)?Yrs?\s*of\s*Exp',
+    re.IGNORECASE,
+)
+# Field label is the LAST ``css-o171kl`` anchor inside the card body
+# whose href points at ``/a/{label}-Jobs-in-{Country}`` — e.g.
+# ``Accounting/Finance``. The first ``css-o171kl`` is the title anchor;
+# we filter on the ``/a/`` href to disambiguate. The label text often
+# contains ``<!-- --> · <!-- -->`` separator comments — match the
+# content lazily so they don't break the capture.
+_FIELD_RE = re.compile(
+    r'<a[^>]*class="css-o171kl"[^>]*href="(?:/[a-z-]+)?/a/(?P<slug>[^"]+?)-Jobs-in-[^"]+"[^>]*>(?P<label>.*?)</a>',
+    re.DOTALL,
+)
+# Salary — Wuzzuf rarely exposes salary on listing cards (premium
+# feature), but when present it ships verbatim inside a
+# ``<span ... data-test="salary">`` or in a ``Salary: ...`` text node.
+_SALARY_RE = re.compile(
+    r'Salary[^A-Za-z0-9]*([A-Z]{3}|EGP|SAR|USD|EUR)?\s*([0-9][0-9,\s]+(?:\s*-\s*[0-9][0-9,\s]+)?)',
+)
+
+# Seniority-level slugs that share the ``css-o171kl`` class with the
+# field anchor. We filter them out when picking the ``department``
+# label so ``Accounting/Finance`` wins over ``Manager`` /
+# ``Experienced``. Probed from Wuzzuf's listing: these are the only
+# values that appear (matching the dropdown options on the search UI).
+_LEVEL_SLUGS: frozenset[str] = frozenset({
+    "Entry-Level", "Experienced", "Manager", "Senior-Management",
+    "Director", "Intern", "Junior", "Mid-Level", "Senior",
+})
+
+# Employment-type labels → canonical enum. Wuzzuf renders these as
+# ``/a/{slug}-Jobs-in-{Country}`` anchor text; the slug is what we
+# match on (case-sensitive, hyphen-separated).
+_EMPLOYMENT_BY_LABEL: dict[str, str] = {
+    "Full-Time": "FULL_TIME",
+    "Full Time": "FULL_TIME",
+    "Part-Time": "PART_TIME",
+    "Part Time": "PART_TIME",
+    "Internship": "INTERN",
+    "Intern": "INTERN",
+    "Freelance": "CONTRACT",
+    "Contract": "CONTRACT",
+    "Contractor": "CONTRACT",
+    "Project": "CONTRACT",
+    "Shift-Based": "PART_TIME",
+    "Temporary": "TEMPORARY",
+    "Workshop": "TEMPORARY",
+}
+
+# Comment / tag stripper for cleaning location strings.
+_HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+@ScraperRegistry.register(ATSType.WUZZUF)
+class WuzzufScraper(BaseScraper):
+    """Wuzzuf (wuzzuf.net) — Egypt + Saudi Arabia direct postings.
+
+    Single-source scraper: ``company_slug`` selects the country segment
+    rather than a tenant. Supported values:
+
+    - ``"egypt"`` (default — most volume, ~340 reachable rows)
+    - ``"saudi-arabia"``
+    - ``"all"`` — fan out across every segment in ``COUNTRY_SEGMENTS``
+
+    Pass anything else to enumerate Egypt (so legacy ``"any"`` /
+    ``""`` callers keep working).
+
+    Knobs:
+
+    - ``max_pages`` (default ``MAX_PAGES``) — hard cap on
+      ``?start=`` iterations per country. The scraper also stops
+      naturally when a page returns zero job links.
+    """
+
+    ats = ATSType.WUZZUF
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        max_pages: int = MAX_PAGES,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.max_pages = max_pages
+
+    # ``company_slug`` → list of country segment keys.
+    def _resolve_countries(self) -> list[str]:
+        key = (self.company_slug or "").strip().lower()
+        if key == "all":
+            return list(COUNTRY_SEGMENTS)
+        if key in COUNTRY_SEGMENTS:
+            return [key]
+        # Legacy ``"any"`` / ``""`` / unknown → default to Egypt.
+        return ["egypt"]
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        countries = self._resolve_countries()
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        lock = asyncio.Lock()
+
+        async with httpx.AsyncClient(
+            timeout=self.timeout,
+            follow_redirects=True,
+            cookies={"language": "en"},
+            headers={
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/124.0.0.0 Safari/537.36"
+                ),
+                "Accept-Language": "en-US,en;q=0.9",
+            },
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+
+            async def absorb(parsed: list[Job]) -> int:
+                """Returns the count of *new* jobs added (post-dedup)."""
+                added = 0
+                async with lock:
+                    for job in parsed:
+                        if job.ats_id is None or job.ats_id in seen:
+                            continue
+                        seen.add(job.ats_id)
+                        jobs.append(job)
+                        added += 1
+                return added
+
+            async def per_country(country_key: str) -> None:
+                url_prefix, filter_value, country_iso = COUNTRY_SEGMENTS[
+                    country_key
+                ]
+                # Wuzzuf paginates by ``start`` not ``page``: the offset
+                # is the page index * PER_PAGE. Iterate sequentially —
+                # we stop as soon as a page returns zero links, so
+                # concurrent fan-out would waste requests past the cap.
+                for page_idx in range(self.max_pages):
+                    start = page_idx * PER_PAGE
+                    html_text = await self._fetch_listing(
+                        client, sem,
+                        url_prefix=url_prefix,
+                        filter_value=filter_value,
+                        start=start,
+                    )
+                    parsed = _parse_listing(
+                        html_text,
+                        url_prefix=url_prefix,
+                        country_iso=country_iso,
+                    )
+                    if not parsed:
+                        return
+                    new = await absorb(parsed)
+                    # If a page returned only duplicates we've already
+                    # hit the wrap-around. Stop instead of spinning.
+                    if new == 0:
+                        return
+
+            await asyncio.gather(*(per_country(c) for c in countries))
+        return jobs
+
+    # --- HTTP layer ---------------------------------------------------------
+
+    async def _fetch_listing(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        *,
+        url_prefix: str,
+        filter_value: str,
+        start: int,
+    ) -> str:
+        url = f"{BASE_URL}{url_prefix}/search/jobs/"
+        params = {
+            "filters[country][0]": filter_value,
+            "start": str(start),
+        }
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(url, params=params)
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"Wuzzuf fetch failed for {url} "
+                            f"(start={start}): {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                return response.text
+            if response.status_code == 404:
+                # ``/saudi/`` 404 if the country mirror has been retired;
+                # treat as empty.
+                return ""
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Wuzzuf returned {response.status_code} for {url} "
+                        f"(start={start}) after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"Wuzzuf returned {response.status_code} for {url} "
+                f"(start={start})"
+            )
+        raise ScraperError(
+            f"Wuzzuf exhausted retries for {url} (start={start}): {last_exc}"
+        )
+
+
+# --- HTML parsing -----------------------------------------------------------
+
+
+def _parse_listing(
+    html_text: str,
+    *,
+    url_prefix: str,
+    country_iso: str,
+) -> list[Job]:
+    """Slice listing HTML into per-card blocks and parse each one.
+
+    Wuzzuf renders each card as a self-contained ``<div class="css-ghe2tq
+    e1v1l3u10"> ... </div>`` block; rather than depend on the obfuscated
+    Emotion class name we split on the start of each card's posting
+    ``<a href="/jobs/p/...">`` anchor and treat everything up to the
+    next anchor (or end of page) as that card's body.
+    """
+    if not html_text:
+        return []
+
+    # Find every card-link match position in source order. We don't
+    # bound the slice by the next regex match — postings include several
+    # internal ``/jobs/p/`` references (apply CTA, share buttons) but
+    # they all repeat the same id, so dedup by id within a card.
+    matches = list(_JOB_LINK_RE.finditer(html_text))
+    if not matches:
+        return []
+
+    seen_ids: set[str] = set()
+    cards: list[tuple[str, str, str, str]] = []  # (id, href, title, card_html)
+
+    for i, m in enumerate(matches):
+        job_id = m.group("id")
+        if job_id in seen_ids:
+            continue
+        seen_ids.add(job_id)
+        # Card body extends from this match to the next *new* card's
+        # match position. The block usually ends just before the next
+        # ``css-ghe2tq`` div but slicing on the next link is robust.
+        end = (
+            matches[i + 1].start()
+            if i + 1 < len(matches)
+            else min(len(html_text), m.start() + 6000)
+        )
+        # Walk forward to find the next *different* job id (some apply
+        # CTAs link the same posting). If the next match shares this
+        # id, extend through it.
+        j = i + 1
+        while j < len(matches) and matches[j].group("id") == job_id:
+            end = (
+                matches[j + 1].start()
+                if j + 1 < len(matches)
+                else min(len(html_text), matches[j].start() + 6000)
+            )
+            j += 1
+        cards.append(
+            (job_id, m.group("href"), m.group("title"), html_text[m.start():end])
+        )
+
+    now = datetime.now()
+    jobs: list[Job] = []
+    for job_id, href, title_raw, card_html in cards:
+        job = _parse_card(
+            job_id=job_id,
+            href=href,
+            title_raw=title_raw,
+            card_html=card_html,
+            url_prefix=url_prefix,
+            country_iso=country_iso,
+            now=now,
+        )
+        if job is not None:
+            jobs.append(job)
+    return jobs
+
+
+def _parse_card(
+    *,
+    job_id: str,
+    href: str,
+    title_raw: str,
+    card_html: str,
+    url_prefix: str,
+    country_iso: str,
+    now: datetime,
+) -> Job | None:
+    title = _clean_text(title_raw)
+    if not title:
+        return None
+
+    company_match = _COMPANY_RE.search(card_html)
+    company = (
+        _clean_text(company_match.group("company")) if company_match
+        else "Unknown"
+    ) or "Unknown"
+
+    location = _extract_location(card_html)
+    posted_at = _extract_posted_at(card_html, now=now)
+
+    # Badge / employment_type / commitment. Each match has both a slug
+    # (URL form, ``Full-Time``) and a label (display form, ``Full Time``).
+    badge_pairs = [
+        (m.group("slug"), _clean_text(m.group("label")))
+        for m in _BADGE_RE.finditer(card_html)
+    ]
+    badge_slugs = [s for s, _ in badge_pairs]
+    badge_labels = [lbl for _, lbl in badge_pairs if lbl]
+    employment_type, commitment = _resolve_employment(badge_pairs)
+
+    # Experience min — Wuzzuf surfaces a "min - max Yrs of Exp" range;
+    # the canonical schema only carries ``experience`` (min), so the
+    # max lives in raw.
+    experience, experience_max = _extract_experience(card_html)
+
+    # Field label (the LAST ``/a/{slug}-Jobs-in-...`` anchor inside the
+    # card body that isn't an employment-type badge).
+    field_label = _extract_field_label(card_html, badge_slugs=badge_slugs)
+
+    salary_summary, salary_currency = _extract_salary(
+        card_html, country_iso=country_iso,
+    )
+
+    # Build the canonical URL. Wuzzuf serves listings at the same
+    # ``/jobs/p/{id}-...`` path regardless of the country segment in
+    # the URL prefix — Egypt uses ``/jobs/p/``, Saudi uses
+    # ``/saudi/jobs/p/``. Use the href as parsed.
+    url = href if href.startswith("http") else f"{BASE_URL}{href}"
+
+    raw: dict[str, Any] = {}
+    if experience_max is not None:
+        raw["experience_max"] = experience_max
+    if field_label:
+        raw["field_label"] = field_label
+    if badge_labels:
+        # Persist the verbatim badge display labels in case downstream
+        # wants the raw "Shift-Based" / "On-site" strings we don't map
+        # to enums.
+        raw["badges"] = badge_labels
+    if commitment and not employment_type:
+        raw["commitment_raw"] = commitment
+
+    # Wuzzuf has a "Work from Home" / "Remote" badge; surface
+    # ``is_remote=True`` when we see it (mirrors the canonical-schema
+    # rule: only ever set True, never False, from a single keyword
+    # check).
+    is_remote: bool | None = None
+    for slug in badge_slugs:
+        sl = slug.lower()
+        if sl in {"remote", "work-from-home", "telecommute", "fully-remote"}:
+            is_remote = True
+            break
+
+    return Job(
+        url=url,
+        title=title,
+        company=company,
+        ats_type=ATSType.WUZZUF,
+        ats_id=job_id,
+        location=location,
+        country_iso=country_iso,
+        is_remote=is_remote,
+        salary_summary=salary_summary,
+        salary_currency=salary_currency,
+        experience=experience,
+        employment_type=employment_type,
+        commitment=commitment,
+        department=field_label,
+        posted_at=posted_at,
+        fetched_at=now,
+        language="en",
+        raw=raw or None,
+    )
+
+
+def _extract_location(card_html: str) -> str | None:
+    m = _LOCATION_RE.search(card_html)
+    if not m:
+        return None
+    text = _HTML_COMMENT_RE.sub("", m.group("loc"))
+    text = _TAG_RE.sub("", text)
+    text = html.unescape(text)
+    # Collapse internal whitespace, then strip stray commas / spaces.
+    text = re.sub(r"\s+", " ", text).strip()
+    text = text.strip(",").strip()
+    return text or None
+
+
+def _extract_posted_at(card_html: str, *, now: datetime) -> datetime | None:
+    m = _POSTED_RE.search(card_html)
+    if not m:
+        return None
+    return _parse_relative_time(m.group("posted"), now=now)
+
+
+def _parse_relative_time(text: str, *, now: datetime) -> datetime | None:
+    """Parse ``"X minutes ago"`` / ``"X hours ago"`` / ``"X days ago"`` /
+    ``"X weeks ago"`` / ``"X months ago"`` / ``"X years ago"`` into a
+    UTC-ish datetime. Wuzzuf renders all dates in this relative form on
+    listing cards; the absolute timestamp only shows on the detail page
+    (which we don't fetch).
+    """
+    cleaned = text.strip().lower()
+    if not cleaned:
+        return None
+
+    m = re.match(
+        r"(?P<n>\d+|a|an)\s+(?P<unit>minute|hour|day|week|month|year)s?\s+ago",
+        cleaned,
+    )
+    if not m:
+        return None
+
+    n_token = m.group("n")
+    n = 1 if n_token in {"a", "an"} else int(n_token)
+    unit = m.group("unit")
+    if unit == "minute":
+        delta = timedelta(minutes=n)
+    elif unit == "hour":
+        delta = timedelta(hours=n)
+    elif unit == "day":
+        delta = timedelta(days=n)
+    elif unit == "week":
+        delta = timedelta(weeks=n)
+    elif unit == "month":
+        delta = timedelta(days=30 * n)
+    elif unit == "year":
+        delta = timedelta(days=365 * n)
+    else:
+        return None
+    return now - delta
+
+
+def _extract_experience(card_html: str) -> tuple[int | None, int | None]:
+    m = _EXPERIENCE_RE.search(card_html)
+    if not m:
+        return None, None
+    try:
+        lo = int(m.group("min"))
+    except (TypeError, ValueError):
+        return None, None
+    hi_raw = m.group("max")
+    hi = int(hi_raw) if hi_raw and hi_raw.isdigit() else None
+    return lo, hi
+
+
+def _extract_field_label(
+    card_html: str, *, badge_slugs: list[str]
+) -> str | None:
+    """Pick out the ``Accounting/Finance`` style category label.
+
+    Card body anchors with ``class="css-o171kl"`` and href
+    ``/a/{slug}-Jobs-in-{country}`` come in two flavours: the role
+    level (``Manager`` / ``Experienced`` / ``Entry Level``) and the
+    field (``Accounting/Finance``, ``IT/Software Development``). The
+    level slug also shows up earlier as a job-level filter; the field
+    is what we want for ``department``.
+
+    Strategy: iterate every ``_FIELD_RE`` match in source order, skip
+    the level (the FIRST anchor — its label is a single word like
+    ``Manager`` and matches one of the canonical seniority slugs in
+    ``_LEVEL_SLUGS``), and return the FIRST remaining anchor whose
+    slug isn't an employment-type badge. This survives a re-ordering
+    of the inner card layout.
+    """
+    badge_set = set(badge_slugs)
+    for m in _FIELD_RE.finditer(card_html):
+        slug = m.group("slug")
+        if slug in badge_set or slug in _LEVEL_SLUGS:
+            continue
+        label = _clean_text(m.group("label"))
+        # Listing labels often start with a ``· `` bullet separator —
+        # strip it so the field name is bare (``Accounting/Finance``
+        # not ``· Accounting/Finance``).
+        label = label.lstrip("·").strip()
+        if not label:
+            continue
+        return label
+    return None
+
+
+def _resolve_employment(
+    badge_pairs: list[tuple[str, str]],
+) -> tuple[str | None, str | None]:
+    """Map Wuzzuf's employment-type badge → canonical enum + verbatim
+    commitment label. The first badge that matches one of the keys in
+    ``_EMPLOYMENT_BY_LABEL`` wins; later badges (``On-Site`` /
+    ``Remote``) are positional / modality flags, not commitment.
+    """
+    for slug, label in badge_pairs:
+        if slug in _EMPLOYMENT_BY_LABEL:
+            return _EMPLOYMENT_BY_LABEL[slug], label or slug.replace("-", " ")
+        norm = slug.replace("-", " ").strip()
+        if norm in _EMPLOYMENT_BY_LABEL:
+            return _EMPLOYMENT_BY_LABEL[norm], label or norm
+        if label and label in _EMPLOYMENT_BY_LABEL:
+            return _EMPLOYMENT_BY_LABEL[label], label
+    return None, None
+
+
+def _extract_salary(
+    card_html: str, *, country_iso: str
+) -> tuple[str | None, str | None]:
+    """Wuzzuf hides salary on most cards (premium feature). When a
+    ``Salary: ...`` string is present, capture it verbatim and tag with
+    the local currency so downstream parse_salary_range can derive
+    min/max.
+    """
+    m = _SALARY_RE.search(card_html)
+    if not m:
+        return None, None
+    currency_token = (m.group(1) or "").upper().strip() or None
+    amount = m.group(2).strip()
+    summary = f"{currency_token + ' ' if currency_token else ''}{amount}"
+    currency = currency_token or _CURRENCY_BY_ISO.get(country_iso)
+    return summary, currency
+
+
+def _clean_text(text: str) -> str:
+    if not text:
+        return ""
+    cleaned = html.unescape(_TAG_RE.sub("", text))
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned

--- a/src/jobhive/scrapers/wuzzuf.py
+++ b/src/jobhive/scrapers/wuzzuf.py
@@ -237,22 +237,25 @@ class WuzzufScraper(BaseScraper):
         ) as client:
             sem = asyncio.Semaphore(MAX_CONCURRENCY)
 
-            async def absorb(parsed: list[Job]) -> int:
-                """Returns the count of *new* jobs added (post-dedup)."""
-                added = 0
+            async def absorb(parsed: list[Job]) -> None:
                 async with lock:
                     for job in parsed:
                         if job.ats_id is None or job.ats_id in seen:
                             continue
                         seen.add(job.ats_id)
                         jobs.append(job)
-                        added += 1
-                return added
 
             async def per_country(country_key: str) -> None:
                 url_prefix, filter_value, country_iso = COUNTRY_SEGMENTS[
                     country_key
                 ]
+                # Per-country wrap-around detector. The shared ``seen``
+                # set is for output dedup only — using it for the stop
+                # check would let a cross-listed ats_id (same posting on
+                # two country mirrors) make this country stop early and
+                # drop its remaining pages. Track ids this country has
+                # already seen separately so each mirror paginates fully.
+                country_seen: set[str] = set()
                 # Wuzzuf paginates by ``start`` not ``page``: the offset
                 # is the page index * PER_PAGE. Iterate sequentially —
                 # we stop as soon as a page returns zero links, so
@@ -272,11 +275,19 @@ class WuzzufScraper(BaseScraper):
                     )
                     if not parsed:
                         return
-                    new = await absorb(parsed)
-                    # If a page returned only duplicates we've already
-                    # hit the wrap-around. Stop instead of spinning.
-                    if new == 0:
+                    # If this country has already seen every id on the
+                    # page we've hit its wrap-around. Stop instead of
+                    # spinning.
+                    new_ids = [
+                        job.ats_id
+                        for job in parsed
+                        if job.ats_id is not None
+                        and job.ats_id not in country_seen
+                    ]
+                    if not new_ids:
                         return
+                    country_seen.update(new_ids)
+                    await absorb(parsed)
 
             await asyncio.gather(*(per_country(c) for c in countries))
         return jobs

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,7 +29,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
-        "manfred", "thehub", "ycombinator", "wellfound",
+        "manfred", "thehub", "wuzzuf", "ycombinator", "wellfound",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",
         "recruitee", "taleo", "teamtailor",

--- a/tests/test_wuzzuf.py
+++ b/tests/test_wuzzuf.py
@@ -1,0 +1,429 @@
+"""Tests for the Wuzzuf (Egypt + MENA) scraper.
+
+Wuzzuf has no JSON API; the scraper depends on listing HTML being
+structured the way it is in Nov 2026. Pin the parsing contract with
+fixture HTML that mirrors the real ``css-ghe2tq`` card layout — that
+includes the obfuscated Emotion class names, ``<!-- -->`` separator
+comments, and inline ``<style>`` blocks Emotion injects between the
+``<a>`` and the pill ``<span>`` of each badge.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import ScraperRegistry, WuzzufScraper
+from jobhive.scrapers.wuzzuf import (
+    _parse_listing,
+    _parse_relative_time,
+)
+
+_SEARCH_RE = re.compile(r"^https://wuzzuf\.net(?:/[a-z-]+)?/search/jobs/?")
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drop retry delay so error-handling tests finish in <1 s."""
+    import jobhive.scrapers.wuzzuf as m
+    monkeypatch.setattr(m, "RETRY_BASE_DELAY", 0.0)
+
+
+# --- HTML fixture builders --------------------------------------------------
+
+
+def _build_card(
+    *,
+    job_id: str = "kjd2l3sxp5io",
+    href_prefix: str = "",
+    title: str = "Accounting Manager",
+    company: str = "Backbone Business Support",
+    company_slug: str = "backbone-business-support-egypt-143328",
+    location: str = "Cairo, Egypt",
+    posted: str = "52 minutes ago",
+    employment_slug: str = "Full-Time",
+    employment_label: str = "Full Time",
+    modality_slug: str = "On-Site",
+    modality_label: str = "On-site",
+    level_slug: str = "Manager",
+    level_label: str = "Manager",
+    field_slug: str = "Accounting-Finance",
+    field_label: str = "Accounting/Finance",
+    experience_range: str = "7 - 12 Yrs of Exp",
+    country_filter: str = "Egypt",
+    a_prefix: str = "",
+    job_slug_tail: str = "accounting-manager-backbone-business-support-cairo-egypt",
+) -> str:
+    """Build one ``<div class="css-ghe2tq e1v1l3u10">`` card mirroring the
+    real Wuzzuf layout.
+
+    Knobs:
+    - ``href_prefix`` — ``""`` for Egypt cards (``/jobs/p/...``),
+      ``"/saudi"`` for Saudi cards (``/saudi/jobs/p/...``).
+    - ``a_prefix`` — analogous prefix for the badge / field anchor
+      hrefs (``/a/...`` vs ``/saudi/a/...``).
+    """
+    job_href = f"{href_prefix}/jobs/p/{job_id}-{job_slug_tail}"
+    employment_href = (
+        f"{a_prefix}/a/{employment_slug}-Jobs-in-"
+        f"{country_filter.replace(' ', '-')}"
+    )
+    modality_href = (
+        f"{a_prefix}/a/{modality_slug}-Jobs-in-"
+        f"{country_filter.replace(' ', '-')}"
+    )
+    level_href = (
+        f"{a_prefix}/a/{level_slug}-Jobs-in-"
+        f"{country_filter.replace(' ', '-')}"
+    )
+    field_href = (
+        f"{a_prefix}/a/{field_slug}-Jobs-in-"
+        f"{country_filter.replace(' ', '-')}"
+    )
+    # The ``<!-- -->`` separator comments are part of Wuzzuf's React
+    # render output (server-side hydration markers). Keep them.
+    return f"""
+<div class="css-ghe2tq e1v1l3u10">
+  <div class="css-pkv5jc">
+    <h2 class="css-193uk2c">
+      <a rel="noreferrer" class="css-o171kl" href="{job_href}" target="_blank">{title}</a>
+    </h2>
+    <div class="css-1k5ee52">
+      <a href="https://wuzzuf.net/jobs/careers/{company_slug}" target="_blank" rel="noreferrer" class="css-ipsyv7">{company} -</a>
+      <span class="css-16x61xq">{location.split(', ', 1)[0]}, <!-- -->{location.split(', ', 1)[1] if ', ' in location else ''} </span>
+      <div class="css-eg55jf">{posted}</div>
+    </div>
+  </div>
+  <div class="css-1rhj4yg">
+    <div class="css-5jhz9n">
+      <a class="css-a85cz4" href="{employment_href}">
+        <style data-emotion="css nmaiir">.css-nmaiir{{}}</style>
+        <style data-emotion="css uc9rga">.css-uc9rga{{}}</style>
+        <span class="css-uc9rga eoyjyou0">{employment_label}</span>
+      </a>
+      <a href="{modality_href}">
+        <style data-emotion="css 1d63l17">.css-1d63l17{{}}</style>
+        <style data-emotion="css uofntu">.css-uofntu{{}}</style>
+        <span class="css-uofntu eoyjyou0">{modality_label}</span>
+      </a>
+    </div>
+    <div>
+      <a class="css-o171kl" href="{level_href}">{level_label}</a>
+      <span>· <!-- -->{experience_range}</span>
+      <a class="css-o171kl" href="{field_href}"> <!-- -->· <!-- -->{field_label}</a>
+    </div>
+  </div>
+</div>
+""".strip()
+
+
+def _build_listing(cards: list[str]) -> str:
+    """Wrap cards in a minimal listing-page envelope."""
+    return (
+        "<!DOCTYPE html><html><head><title>x</title></head><body>"
+        + "".join(cards)
+        + "</body></html>"
+    )
+
+
+# --- registry / wiring ------------------------------------------------------
+
+
+def test_registry_resolves_wuzzuf() -> None:
+    assert ScraperRegistry.get(ATSType.WUZZUF) is WuzzufScraper
+
+
+def test_country_slug_defaults_to_egypt() -> None:
+    scraper = WuzzufScraper("anything-unknown")
+    assert scraper._resolve_countries() == ["egypt"]
+    assert WuzzufScraper("")._resolve_countries() == ["egypt"]
+    assert WuzzufScraper("egypt")._resolve_countries() == ["egypt"]
+
+
+def test_country_slug_all_fans_out() -> None:
+    scraper = WuzzufScraper("all")
+    countries = scraper._resolve_countries()
+    assert set(countries) == {"egypt", "saudi-arabia"}
+
+
+def test_country_slug_saudi_arabia() -> None:
+    assert WuzzufScraper("saudi-arabia")._resolve_countries() == ["saudi-arabia"]
+
+
+# --- parser unit tests ------------------------------------------------------
+
+
+def test_parse_listing_extracts_full_card_payload() -> None:
+    """Single Egypt card round-trips every populated Job field."""
+    html_text = _build_listing([_build_card()])
+    jobs = _parse_listing(html_text, url_prefix="", country_iso="EG")
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.WUZZUF
+    assert j.ats_id == "kjd2l3sxp5io"
+    assert j.title == "Accounting Manager"
+    assert j.company == "Backbone Business Support"
+    assert j.location == "Cairo, Egypt"
+    assert j.country_iso == "EG"
+    assert j.employment_type == "FULL_TIME"
+    assert j.commitment == "Full Time"
+    assert j.department == "Accounting/Finance"
+    assert j.experience == 7
+    assert j.raw is not None
+    assert j.raw["experience_max"] == 12
+    assert j.raw["field_label"] == "Accounting/Finance"
+    assert j.raw["badges"] == ["Full Time", "On-site"]
+    assert j.language == "en"
+    assert str(j.url) == (
+        "https://wuzzuf.net/jobs/p/kjd2l3sxp5io-accounting-manager-"
+        "backbone-business-support-cairo-egypt"
+    )
+
+
+def test_parse_listing_handles_saudi_url_prefix() -> None:
+    """Saudi cards use a ``/saudi/jobs/p/...`` href and a ``/saudi/a/...``
+    badge href. country_iso flips to SA and the URL preserves the
+    country segment."""
+    card = _build_card(
+        job_id="3pdjanoevedp",
+        href_prefix="/saudi",
+        a_prefix="/saudi",
+        title="F&B Cost Controller",
+        company="Rua Taiba",
+        company_slug="rua-taiba-company-for-hotels-saudi-arabia-143300",
+        location="Riyadh, Saudi Arabia",
+        country_filter="Saudi Arabia",
+        job_slug_tail="fb-cost-controller-riyadh-saudi-arabia",
+        field_slug="Accounting-Finance",
+        field_label="Accounting/Finance",
+    )
+    jobs = _parse_listing(
+        _build_listing([card]),
+        url_prefix="/saudi",
+        country_iso="SA",
+    )
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.country_iso == "SA"
+    assert "saudi/jobs/p/3pdjanoevedp" in str(j.url)
+    assert j.department == "Accounting/Finance"
+    assert j.employment_type == "FULL_TIME"
+
+
+def test_parse_listing_marks_remote_badge() -> None:
+    """The ``Remote`` badge flips ``is_remote=True``; ``On-site`` /
+    ``Hybrid`` leave it None (canonical-schema rule: never assert False)."""
+    remote = _build_card(
+        job_id="abc1remote000",
+        modality_slug="Remote",
+        modality_label="Remote",
+    )
+    onsite = _build_card(
+        job_id="abc2onsite000",
+        modality_slug="On-Site",
+        modality_label="On-site",
+    )
+    hybrid = _build_card(
+        job_id="abc3hybrid000",
+        modality_slug="Hybrid",
+        modality_label="Hybrid",
+    )
+    jobs = _parse_listing(
+        _build_listing([remote, onsite, hybrid]),
+        url_prefix="",
+        country_iso="EG",
+    )
+    remote_job = next(j for j in jobs if j.ats_id == "abc1remote000")
+    onsite_job = next(j for j in jobs if j.ats_id == "abc2onsite000")
+    hybrid_job = next(j for j in jobs if j.ats_id == "abc3hybrid000")
+    assert remote_job.is_remote is True
+    assert onsite_job.is_remote is None
+    assert hybrid_job.is_remote is None
+
+
+def test_parse_listing_dedupes_repeated_ids() -> None:
+    """Wuzzuf occasionally repeats a posting's ``/jobs/p/{id}`` href
+    inside the same card (apply CTA, share button) — dedup so we only
+    emit one row per unique id."""
+    card = _build_card()
+    duplicate_link = (
+        '<a href="/jobs/p/kjd2l3sxp5io-accounting-manager-backbone-business-'
+        'support-cairo-egypt">Apply now</a>'
+    )
+    jobs = _parse_listing(
+        _build_listing([card + duplicate_link]),
+        url_prefix="",
+        country_iso="EG",
+    )
+    assert len(jobs) == 1
+    assert jobs[0].ats_id == "kjd2l3sxp5io"
+
+
+def test_parse_listing_returns_empty_for_zero_card_page() -> None:
+    """Past the pagination cap Wuzzuf returns a page with the chrome
+    intact but no ``<div class='css-ghe2tq'>`` cards — the scraper
+    must treat that as EOF, not crash."""
+    empty_page = (
+        "<!DOCTYPE html><html><body>"
+        "<h1>No jobs match your filters.</h1>"
+        "</body></html>"
+    )
+    assert _parse_listing(empty_page, url_prefix="", country_iso="EG") == []
+
+
+def test_parse_listing_handles_missing_field_label() -> None:
+    """Some cards have a level (``Manager``) but no field anchor. The
+    department falls back to ``None`` instead of misclassifying the
+    level as the field."""
+    # Strip the field anchor by giving it the same slug as the level —
+    # the de-duper drops it.
+    card = _build_card(
+        field_slug="Manager",
+        field_label="Manager",  # forces the field to be filtered out
+    )
+    jobs = _parse_listing(_build_listing([card]), url_prefix="", country_iso="EG")
+    assert len(jobs) == 1
+    assert jobs[0].department is None
+
+
+# --- relative-time parsing --------------------------------------------------
+
+
+def test_parse_relative_time_minutes() -> None:
+    now = datetime(2026, 5, 12, 12, 0, 0)
+    out = _parse_relative_time("52 minutes ago", now=now)
+    assert out == now - timedelta(minutes=52)
+
+
+def test_parse_relative_time_hours_singular() -> None:
+    now = datetime(2026, 5, 12, 12, 0, 0)
+    assert _parse_relative_time("1 hour ago", now=now) == now - timedelta(hours=1)
+    assert _parse_relative_time("an hour ago", now=now) == now - timedelta(hours=1)
+
+
+def test_parse_relative_time_days() -> None:
+    now = datetime(2026, 5, 12, 12, 0, 0)
+    assert _parse_relative_time("3 days ago", now=now) == now - timedelta(days=3)
+
+
+def test_parse_relative_time_garbage_returns_none() -> None:
+    now = datetime(2026, 5, 12, 12, 0, 0)
+    assert _parse_relative_time("just now", now=now) is None
+    assert _parse_relative_time("", now=now) is None
+
+
+# --- pagination -------------------------------------------------------------
+
+
+def test_paginates_until_empty_page(httpx_mock) -> None:
+    """The scraper increments ``start`` by PER_PAGE until a page emits
+    zero ``/jobs/p/`` links. After that it stops."""
+    # First page: 2 cards.
+    page1 = _build_listing([
+        _build_card(job_id="aaaaaaaaaaaa", title="Job 1"),
+        _build_card(job_id="bbbbbbbbbbbb", title="Job 2"),
+    ])
+    # Second page: 1 card.
+    page2 = _build_listing([_build_card(job_id="cccccccccccc", title="Job 3")])
+    # Third page: zero cards → stop.
+    page3 = "<html><body><h1>No jobs</h1></body></html>"
+
+    httpx_mock.add_response(url=_SEARCH_RE, text=page1)
+    httpx_mock.add_response(url=_SEARCH_RE, text=page2)
+    httpx_mock.add_response(url=_SEARCH_RE, text=page3)
+
+    jobs = WuzzufScraper("egypt", max_pages=10).fetch()
+    assert [j.ats_id for j in jobs] == [
+        "aaaaaaaaaaaa", "bbbbbbbbbbbb", "cccccccccccc",
+    ]
+
+
+def test_paginates_stops_on_full_duplicate_page(httpx_mock) -> None:
+    """If Wuzzuf wraps and re-serves the same 15 cards we already have,
+    the scraper stops — otherwise it would spin in a loop until
+    ``max_pages``."""
+    page = _build_listing([
+        _build_card(job_id="aaaaaaaaaaaa", title="Job 1"),
+        _build_card(job_id="bbbbbbbbbbbb", title="Job 2"),
+    ])
+    # Same payload twice in a row — every id is a duplicate on the
+    # second call.
+    httpx_mock.add_response(url=_SEARCH_RE, text=page)
+    httpx_mock.add_response(url=_SEARCH_RE, text=page)
+
+    jobs = WuzzufScraper("egypt", max_pages=10).fetch()
+    assert {j.ats_id for j in jobs} == {"aaaaaaaaaaaa", "bbbbbbbbbbbb"}
+
+
+def test_max_pages_caps_iteration(httpx_mock) -> None:
+    """``max_pages`` is the safety cap. The scraper must stop after
+    that many requests even if pages keep returning new cards."""
+    page = _build_listing([_build_card(job_id="aaaaaaaaaaaa")])
+    # Add way more responses than max_pages so the cap is what stops
+    # the loop, not exhaustion. Two responses, max_pages=1.
+    httpx_mock.add_response(url=_SEARCH_RE, text=page, is_reusable=True)
+    jobs = WuzzufScraper("egypt", max_pages=1).fetch()
+    assert len(jobs) == 1
+
+
+# --- multi-country ----------------------------------------------------------
+
+
+def test_all_country_slug_hits_egypt_and_saudi(httpx_mock) -> None:
+    """``WuzzufScraper("all")`` fans out across every entry in
+    ``COUNTRY_SEGMENTS``."""
+    eg = _build_listing([_build_card(
+        job_id="aaaaaaaaaaaa", title="Egypt job",
+    )])
+    sa = _build_listing([_build_card(
+        job_id="bbbbbbbbbbbb", title="Saudi job",
+        href_prefix="/saudi", a_prefix="/saudi",
+        location="Riyadh, Saudi Arabia",
+        country_filter="Saudi Arabia",
+        job_slug_tail="saudi-job",
+    )])
+    empty = "<html><body></body></html>"
+
+    httpx_mock.add_response(
+        url=re.compile(r"^https://wuzzuf\.net/search/jobs/?"),
+        text=eg,
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://wuzzuf\.net/search/jobs/?"),
+        text=empty,
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://wuzzuf\.net/saudi/search/jobs/?"),
+        text=sa,
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://wuzzuf\.net/saudi/search/jobs/?"),
+        text=empty,
+    )
+
+    jobs = WuzzufScraper("all", max_pages=10).fetch()
+    countries = {j.country_iso for j in jobs}
+    assert countries == {"EG", "SA"}
+
+
+# --- error handling ---------------------------------------------------------
+
+
+def test_persistent_500_raises(httpx_mock) -> None:
+    """A real upstream outage must surface as ScraperError so cron
+    treats it as failure rather than ``Wuzzuf has no jobs today``."""
+    httpx_mock.add_response(url=_SEARCH_RE, status_code=500, is_reusable=True)
+    with pytest.raises(ScraperError):
+        WuzzufScraper("egypt").fetch()
+
+
+def test_404_returns_empty_not_crash(httpx_mock) -> None:
+    """``/saudi/`` 404 if Wuzzuf retires the country mirror. Treat as
+    'no data' so an ``all`` fan-out keeps the other countries' rows."""
+    httpx_mock.add_response(url=_SEARCH_RE, status_code=404, is_reusable=True)
+    jobs = WuzzufScraper("saudi-arabia").fetch()
+    assert jobs == []


### PR DESCRIPTION
## Summary

- Adds the `WuzzufScraper` for [wuzzuf.net](https://wuzzuf.net) — Egypt's largest job board, with a smaller Saudi Arabia mirror (`/saudi/...`).
- Multi-country dispatch via `company_slug`: `"egypt"` (default), `"saudi-arabia"`, or `"all"` to fan out across every supported segment.
- Pure HTML parsing — no JSON API is exposed. Cards are sliced on the `/jobs/p/{12-char-id}-{slug}` anchor pattern and field values come from a small set of regexes that anchor on stable Emotion class names (`css-o171kl`, `css-uc9rga`, `css-16x61xq`) and the country-aware `/a/{slug}-Jobs-in-{Country}` href pattern.
- Async pagination via `?start=N&filters[country][0]={Country}` (15 cards / increment); stops on first empty page or full-duplicate page; `MAX_PAGES=200` safety cap (real catalogue currently caps at ~23 pages).
- Per-card extraction: title, company, location, employment type (`Full Time`/`Part Time`/`Internship`/`Contract`/`Temporary`), commitment, department (the `Accounting/Finance` style category, filtered to exclude the level slug), experience min/max (`X - Y Yrs of Exp`), posted_at (parses `X minutes/hours/days/weeks/months ago`), `is_remote=True` for the `Remote` badge, `country_iso=EG`/`SA`, `language=en` (Wuzzuf's `language=en` cookie is sent to defeat the `/ar/...` Arabic redirect on Saudi search).
- 20 new tests in `tests/test_wuzzuf.py` covering registry wiring, country dispatch, full card payload, Saudi URL prefix, Remote badge → `is_remote=True`, duplicate dedup, empty-page handling, missing-field fallback, relative-time parsing (minutes/hours singular/days/garbage), pagination via offset, full-duplicate-page stop, `max_pages` cap, multi-country fan-out, 500 retry exhaustion, and 404 graceful-empty.

## Test plan

- [x] `uv run -- python -m pytest tests/test_wuzzuf.py` — 20 / 20 pass
- [x] `uv run -- python -m pytest` — 899 / 899 pass (no regressions)
- [x] `uv run -- ruff check .` — clean
- [x] Live smoke test against wuzzuf.net: `WuzzufScraper("egypt", max_pages=3).fetch()` → 45 rows, every field populated (title, company, location, country_iso, department, employment_type, experience, commitment, language, posted_at, url)
- [x] Live smoke test on Saudi: card URLs preserve `/saudi/jobs/p/...` segment, `country_iso="SA"`, department parsed via `/saudi/a/...` badge href

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `WuzzufScraper` for wuzzuf.net to ingest Egypt and Saudi listings from SSR HTML with async pagination and safe stop conditions. Also fixes all-country fan-out to paginate each country independently and avoid early stops when IDs overlap.

- **New Features**
  - Multi-country dispatch via `company_slug`: "egypt" (default), "saudi-arabia", or "all".
  - Parses HTML cards; paginates with `?start=N` and `filters[country][0]=...`; stops on empty or duplicate pages; `max_pages` cap.
  - Extracts title, company, location, department, employment type, commitment, experience (min/max), `posted_at`, `is_remote`, `country_iso`, `language=en`, URL; captures salary summary/currency when present.
  - Preserves Saudi `/saudi/...` URLs and sets `country_iso="SA"`; sends `language=en` cookie to avoid Arabic redirect.
  - Resilient HTTP: retries 5xx/429 with backoff; 404 returns empty.

- **Bug Fixes**
  - All-country mode: pagination stop checks now use a per-country seen set, so cross-listed IDs don’t trigger early stop; global dedup still removes duplicate rows.

<sup>Written for commit 3b4c3b6db6916bf1372b019c89281195f96509bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `WuzzufScraper` for wuzzuf.net (Egypt's largest job board), with a Saudi Arabia mirror, multi-country dispatch via `company_slug`, SSR HTML parsing, async pagination with safe stop conditions, and 20 new tests.

- The scraper parses server-rendered HTML using targeted regexes anchored on stable Emotion class names and URL slug patterns, handling dedup, remote badges, salary, experience range, relative-time `posted_at`, and country-aware ISO tagging.
- The retry logic has an inconsistency: the sleep on `httpx.HTTPError` runs while the concurrency semaphore is still held, whereas the 5xx/429 retry sleep correctly releases the semaphore first.
- Attribute-order assumptions in `_COMPANY_RE` and `_FIELD_RE` could silently produce `company=\"Unknown\"` or drop the department label if Wuzzuf's SSR re-render swaps attribute ordering.

<h3>Confidence Score: 3/5</h3>

Safe to merge for immediate use; the semaphore inconsistency and parsing fragilities won't cause failures under current conditions but add technical debt worth addressing before expanding to more countries.

The scraper works correctly for the current Egypt + Saudi configuration and all 20 tests pass. However, the HTTPError retry sleep holds the concurrency semaphore unlike the 5xx path, meaning a network outage with a third country in COUNTRY_SEGMENTS would stall all in-flight requests. The _COMPANY_RE and _FIELD_RE regexes require a specific HTML attribute order that could silently degrade data quality if Wuzzuf's SSR render order changes.

src/jobhive/scrapers/wuzzuf.py — specifically the _fetch_listing retry loop and the two company/field regexes.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/wuzzuf.py | New scraper with HTML regex parsing, async pagination, and retry logic. HTTPError retry sleep incorrectly held inside semaphore context; fallback raise after retry loop is dead code; company/field regexes assume HTML attribute order. |
| tests/test_wuzzuf.py | 20 tests covering registry, country dispatch, full card payload, Saudi URL prefix, remote badge, dedup, empty-page EOF, missing-field fallback, relative-time parsing, pagination stop conditions, multi-country fan-out, and error handling. |
| src/jobhive/models.py | Adds ATSType.WUZZUF in alphabetical order within the hybrid-jobboard block; no other changes. |
| src/jobhive/scrapers/__init__.py | Adds import and __all__ export for WuzzufScraper in correct alphabetical position; no other changes. |
| ats-companies/wuzzuf.csv | Seeds Egypt and Saudi Arabia entries sharing the same base URL, correct since the scraper uses URL prefix and country filter to distinguish them. |
| tests/test_models.py | Adds wuzzuf to the known-platform set in the ATSType completeness test; straightforward one-line change. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/jobhive/scrapers/wuzzuf.py:302-313
The `asyncio.sleep` retry delay for `httpx.HTTPError` runs while the semaphore is still held (inside the `async with sem:` block), whereas the 5xx/429 retry sleep correctly occurs after the sem is released. Holding the semaphore during a multi-second sleep starves all other in-flight requests. With `MAX_CONCURRENCY=3` and currently only 2 countries this rarely blocks anything, but adding a third country to `COUNTRY_SEGMENTS` would cause all three slots to be occupied during simultaneous network-error retries, fully stalling progress until the sleeps expire.

```suggestion
            retry_sleep: float | None = None
            async with sem:
                try:
                    response = await client.get(url, params=params)
                except httpx.HTTPError as exc:
                    last_exc = exc
                    if attempt == MAX_RETRIES:
                        raise ScraperError(
                            f"Wuzzuf fetch failed for {url} "
                            f"(start={start}): {exc}"
                        ) from exc
                    retry_sleep = RETRY_BASE_DELAY * attempt
            if retry_sleep is not None:
                await asyncio.sleep(retry_sleep)
                continue
```

### Issue 2 of 3
src/jobhive/scrapers/wuzzuf.py:337-339
This final `raise` is dead code. Every iteration of the loop either returns (200, 404), raises (last-attempt 5xx/429, network error on last attempt, or non-retriable status), or `continue`s — there is no path where the loop completes naturally. The guard is harmless but misleads readers into thinking the loop can exit without raising on the retriable paths.

```suggestion
        # Unreachable: every loop iteration either returns, raises, or continues.
        raise AssertionError("unreachable")
```

### Issue 3 of 3
src/jobhive/scrapers/wuzzuf.py:83-85
`_COMPANY_RE` requires `href` to appear before `class` in the anchor's attribute list. HTML attribute order is not guaranteed, and React/Emotion render pipelines have been observed to swap attribute positions across versions. If Wuzzuf's SSR ever emits `class="css-ipsyv7"` before `href="..."`, every card silently falls back to `company="Unknown"`. The same ordering assumption applies to `_FIELD_RE` (which requires `class` before `href`).

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: wuzzuf.csv"](https://github.com/kalil0321/ats-scrapers/commit/33faa46c6a82f203cf22cfd6e7d19bd71aa81071) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732433)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->