### PR TITLE
Add Saramin (Korea) job board scraper

### DIFF
--- a/ats-companies/saramin.csv
+++ b/ats-companies/saramin.csv
@@ -1,0 +1,2 @@
+name,slug,url
+Saramin,saramin,https://www.saramin.co.kr

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -71,6 +71,7 @@ class ATSType(StrEnum):
     WELCOMETOTHEJUNGLE = "welcometothejungle"
     GETONBRD = "getonbrd"
     WANTED = "wanted"
+    SARAMIN = "saramin"
     REMOTEOK = "remoteok"
     WEWORKREMOTELY = "weworkremotely"
     PROGRAMATHOR = "programathor"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -42,6 +42,7 @@ from jobhive.scrapers.recruitee import RecruiteeScraper
 from jobhive.scrapers.recruiterbox import RecruiterboxScraper
 from jobhive.scrapers.remoteok import RemoteOKScraper
 from jobhive.scrapers.rippling import RipplingScraper
+from jobhive.scrapers.saramin import SaraminScraper
 from jobhive.scrapers.smartrecruiters import SmartRecruitersScraper
 from jobhive.scrapers.successfactors import SuccessFactorsScraper
 from jobhive.scrapers.taleo import TaleoScraper
@@ -93,6 +94,7 @@ __all__ = [
     "RecruiterboxScraper",
     "RemoteOKScraper",
     "RipplingScraper",
+    "SaraminScraper",
     "ScraperRegistry",
     "SmartRecruitersScraper",
     "SuccessFactorsScraper",

--- a/src/jobhive/scrapers/saramin.py
+++ b/src/jobhive/scrapers/saramin.py
@@ -30,7 +30,6 @@ from typing import TYPE_CHECKING
 from urllib.parse import quote_plus, urljoin
 
 import httpx
-from bs4 import BeautifulSoup
 
 from jobhive.exceptions import ScraperError
 from jobhive.models import ATSType, Job
@@ -241,6 +240,14 @@ class SaraminScraper(BaseScraper):
     # --- parsing ------------------------------------------------------------
 
     def _parse_page(self, html_text: str) -> list[Job]:
+        try:
+            from bs4 import BeautifulSoup
+        except ImportError as exc:  # pragma: no cover
+            raise ScraperError(
+                "Saramin scraper requires beautifulsoup4. Install with "
+                "`pip install jobhive[scrapers]` or `pip install beautifulsoup4`."
+            ) from exc
+
         soup = BeautifulSoup(html_text, "html.parser")
         cards = soup.select("div.item_recruit")
         out: list[Job] = []

--- a/src/jobhive/scrapers/saramin.py
+++ b/src/jobhive/scrapers/saramin.py
@@ -1,0 +1,442 @@
+"""Saramin (https://www.saramin.co.kr) — Korea's largest job board.
+
+Saramin (사람인) is the largest direct-posting job platform in Korea —
+competing head-to-head with JobKorea, with hundreds of thousands of
+live postings spanning every industry, not just tech. Companies post
+directly through Saramin's recruiting product.
+
+There is no public JSON API: the search page is **server-rendered
+HTML**. We GET the integrated-search endpoint and pull listing cards
+out of the response body via BeautifulSoup. Pagination is offset-style
+through ``recruitPage=N`` with ``recruitPageCount=40`` per page; the
+server hard-caps page numbers around 99 so even a high-recall keyword
+returns at most ~4,000 cards per sweep.
+
+Single-source scraper: ``company_slug`` is reused as the *searchword*
+so callers can target a vertical (``"developer"``, ``"디자이너"``,
+``"마케팅"`` …). Passing ``"any"`` / empty falls back to no keyword —
+the search engine then surfaces only the sponsored TOP100 banner cards
+(~20 per page, repeating), so meaningful coverage requires picking a
+keyword.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING
+from urllib.parse import quote_plus, urljoin
+
+import httpx
+from bs4 import BeautifulSoup
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+API_ROOT = "https://www.saramin.co.kr"
+SEARCH_PATH = "/zf_user/search"
+JOB_URL_TEMPLATE = (
+    "https://www.saramin.co.kr/zf_user/jobs/relay/view?rec_idx={rec_idx}"
+)
+PER_PAGE = 40  # The site honours pageCount=40 — larger values fall back to 40.
+# Saramin caps ``recruitPage`` server-side around 99. Use 99 as both the
+# explicit safety bound and the natural exit for keyword sweeps; lower
+# this only if a specific caller wants to stop early.
+MAX_PAGES = 99
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 4
+RETRY_BASE_DELAY = 1.5
+
+# Empty searchword on Saramin renders a "noresult" banner with sponsored
+# TOP100 cards repeating across pages. We use the same default sentinel
+# as wanted / getonbrd so single-source scrapers stay swappable.
+_EMPTY_SLUGS = {"", "any", "all", "saramin"}
+
+# Korean employment-type labels that show up in ``<div class="job_condition">``
+# → canonical EmploymentType enum value. The site frequently emits combo
+# strings like ``정규직·계약직`` (full-time OR contract); we prefer the
+# more permanent classification when both are present.
+#
+# - 정규직   : permanent / full-time
+# - 계약직   : fixed-term contract
+# - 인턴     : intern
+# - 인턴직   : intern
+# - 파견직   : dispatched/agency worker → CONTRACT
+# - 프리랜서 : freelance → CONTRACT
+# - 아르바이트 : part-time / hourly → PART_TIME
+# - 파트타임 : part-time
+# - 위촉직   : commissioned (sales agent contract) → CONTRACT
+# - 일용직   : day-laborer / temporary → TEMPORARY
+_EMPLOYMENT_TYPE_MAP: dict[str, str] = {
+    "정규직": "FULL_TIME",
+    "계약직": "CONTRACT",
+    "인턴": "INTERN",
+    "인턴직": "INTERN",
+    "파견직": "CONTRACT",
+    "프리랜서": "CONTRACT",
+    "아르바이트": "PART_TIME",
+    "파트타임": "PART_TIME",
+    "위촉직": "CONTRACT",
+    "일용직": "TEMPORARY",
+}
+# Precedence: when a card lists multiple types (정규직·계약직), pick the
+# one earliest in this tuple. Permanent beats contract beats part-time.
+_EMPLOYMENT_TYPE_PRIORITY = (
+    "FULL_TIME", "INTERN", "CONTRACT", "PART_TIME", "TEMPORARY",
+)
+
+# ``등록일 YY/MM/DD`` → datetime. The site uses 2-digit years; we assume
+# 2000+. ``수정일`` (modified-date) uses the same shape; we kept the
+# original ``등록일`` (posted-date) where available and fall back to
+# ``수정일`` only because most cards don't carry the former.
+_POSTED_RE = re.compile(r"등록일\s*(\d{2})/(\d{2})/(\d{2})")
+_MODIFIED_RE = re.compile(r"수정일\s*(\d{2})/(\d{2})/(\d{2})")
+
+_REC_IDX_RE = re.compile(r"rec_idx=(\d+)")
+
+
+@ScraperRegistry.register(ATSType.SARAMIN)
+class SaraminScraper(BaseScraper):
+    """Saramin (saramin.co.kr) — Korea's largest job platform.
+
+    Single-source scraper: ``company_slug`` is used as the
+    ``searchword`` query param so callers can scope sweeps to a vertical
+    (e.g. ``SaraminScraper("개발자")`` for developer postings, or
+    ``SaraminScraper("디자이너")`` for designer roles). Pass ``"any"``
+    / ``""`` for an unscoped run (yields only the sponsored TOP100
+    cards — coverage is intentionally narrow for that path).
+    """
+
+    ats = ATSType.SARAMIN
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        max_pages: int = MAX_PAGES,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        # Clamp at the server-side ceiling — passing 500 here would just
+        # generate 400 wasted 200-OK-empty fetches.
+        self.max_pages = max(1, min(max_pages, MAX_PAGES))
+        self._searchword = (
+            "" if company_slug.strip().lower() in _EMPTY_SLUGS
+            else company_slug.strip()
+        )
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        lock = asyncio.Lock()
+        # Once two pages in a row come back empty we treat the sweep as
+        # exhausted — the site sometimes hands back a 200 with zero cards
+        # for transient reasons, but two consecutive empties is conclusive.
+        stop_event = asyncio.Event()
+
+        async def absorb(page_jobs: list[Job]) -> int:
+            added = 0
+            async with lock:
+                for job in page_jobs:
+                    if job.ats_id in seen:
+                        continue
+                    seen.add(job.ats_id)
+                    jobs.append(job)
+                    added += 1
+            return added
+
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+            # Walk pages sequentially: we need to detect the empty-tail
+            # boundary, and Saramin doesn't ship a total-pages hint we
+            # can dispatch to. Sequential keeps the request rate gentle.
+            consecutive_empty = 0
+            for page in range(1, self.max_pages + 1):
+                if stop_event.is_set():
+                    break
+                page_html = await self._request_html(client, sem, page)
+                page_jobs = self._parse_page(page_html)
+                if not page_jobs:
+                    consecutive_empty += 1
+                    if consecutive_empty >= 2:
+                        break
+                    continue
+                consecutive_empty = 0
+                await absorb(page_jobs)
+        return jobs
+
+    # --- HTTP layer ---------------------------------------------------------
+
+    def _build_url(self, page: int) -> str:
+        searchword = quote_plus(self._searchword)
+        return (
+            f"{API_ROOT}{SEARCH_PATH}?searchword={searchword}"
+            f"&recruitPage={page}&recruitSort=relation&recruitPageCount={PER_PAGE}"
+        )
+
+    async def _request_html(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        page: int,
+    ) -> str:
+        url = self._build_url(page)
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(
+                        url,
+                        headers={
+                            "User-Agent": (
+                                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                                "Chrome/124.0.0.0 Safari/537.36"
+                            ),
+                            "Accept": "text/html,application/xhtml+xml",
+                            "Accept-Language": "ko-KR,ko;q=0.9,en-US;q=0.8",
+                        },
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"Saramin fetch failed for {url}: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                return response.text
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Saramin returned {response.status_code} for "
+                        f"{url} after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"Saramin returned {response.status_code} for {url}"
+            )
+        raise ScraperError(
+            f"Saramin exhausted retries for {url}: {last_exc}"
+        )
+
+    # --- parsing ------------------------------------------------------------
+
+    def _parse_page(self, html_text: str) -> list[Job]:
+        soup = BeautifulSoup(html_text, "html.parser")
+        cards = soup.select("div.item_recruit")
+        out: list[Job] = []
+        for card in cards:
+            job = self._parse_card(card)
+            if job is not None:
+                out.append(job)
+        return out
+
+    def _parse_card(self, card: Any) -> Job | None:
+        # ats_id lives on the wrapping <div value="..."> attribute. Some
+        # sponsored cards omit the value attribute — fall back to a
+        # rec_idx parsed out of the apply-button onclick.
+        ats_id = (card.get("value") or "").strip()
+        if not ats_id:
+            for a in card.select("a[href*='rec_idx=']"):
+                m = _REC_IDX_RE.search(a.get("href") or "")
+                if m:
+                    ats_id = m.group(1)
+                    break
+        if not ats_id:
+            return None
+
+        title_a = card.select_one("h2.job_tit a")
+        if title_a is None:
+            return None
+        # Saramin renders the matched keyword wrapped in <b>...</b>;
+        # ``get_text(strip=True)`` flattens that without losing chars,
+        # but the ``title`` attribute is a cleaner copy without the
+        # highlight markup so prefer it when present.
+        title = (title_a.get("title") or title_a.get_text(strip=True)).strip()
+        if not title:
+            return None
+        title = html.unescape(title)
+
+        # Saramin's job detail URL is canonical — strip any tracking
+        # querystring back to the bare rec_idx form so the row stays
+        # stable across re-scrapes.
+        url = JOB_URL_TEMPLATE.format(rec_idx=ats_id)
+
+        company_a = card.select_one("strong.corp_name a")
+        company = (
+            company_a.get_text(strip=True) if company_a is not None
+            else ""
+        ).strip() or "Unknown"
+        company = html.unescape(company)
+
+        # ``<div class="job_condition">`` is a free-form sequence of
+        # ``<span>`` elements: location anchors, career-level label,
+        # education label, employment-type label. The position of each
+        # within the list varies per card, so we classify each span by
+        # content rather than positional index.
+        condition = card.select_one("div.job_condition")
+        location = None
+        career_level = None
+        education = None
+        employment_type_label: str | None = None
+        if condition is not None:
+            location, career_level, education, employment_type_label = (
+                _parse_condition(condition)
+            )
+
+        employment_type = _normalize_employment_type(employment_type_label)
+
+        # ``등록일`` (registration date) is preferred over ``수정일``
+        # (modified date) for ``posted_at`` semantics. The site renders
+        # only one of these per card depending on the listing's age.
+        sector_block = card.select_one("div.job_sector")
+        posted_at = None
+        modified_at = None
+        if sector_block is not None:
+            block_text = sector_block.get_text(" ", strip=True)
+            posted_at = _parse_yymmdd(_POSTED_RE.search(block_text))
+            modified_at = _parse_yymmdd(_MODIFIED_RE.search(block_text))
+
+        # Deadline string ("~ 05/29(금)", "상시채용", "오늘마감", "채용시")
+        # — keep verbatim. Useful for downstream "still-active" filters
+        # without us trying to second-guess Korean calendar formatting.
+        date_span = card.select_one("div.job_date span.date")
+        deadline = date_span.get_text(strip=True) if date_span is not None else None
+
+        # ``<div class="job_sector">`` also carries up to ~5 sector /
+        # job-category anchors — capture verbatim text for raw.
+        sector_tags: list[str] = []
+        if sector_block is not None:
+            sector_tags = [
+                html.unescape(a.get_text(strip=True))
+                for a in sector_block.select("a")
+                if a.get_text(strip=True)
+            ]
+
+        raw: dict[str, Any] = {}
+        if career_level:
+            raw["career_level"] = career_level
+        if education:
+            raw["education"] = education
+        if employment_type_label:
+            raw["employment_type_label"] = employment_type_label
+        if deadline:
+            raw["deadline"] = deadline
+        if modified_at is not None:
+            raw["modified_at"] = modified_at.isoformat()
+        if sector_tags:
+            raw["sectors"] = sector_tags
+        # Preserve the in-card apply URL when distinct (Saramin
+        # sometimes routes the click through a tracking redirect).
+        apply_href = (title_a.get("href") or "").strip()
+        if apply_href:
+            absolute_apply = urljoin(API_ROOT, apply_href)
+            if absolute_apply != url:
+                raw["search_url"] = absolute_apply
+
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.SARAMIN,
+            ats_id=ats_id,
+            location=location,
+            country_iso="KR",
+            language="ko",
+            employment_type=employment_type,  # type: ignore[arg-type]
+            posted_at=posted_at,
+            fetched_at=datetime.now(),
+            raw=raw or None,
+        )
+
+
+def _parse_condition(
+    condition: Any,
+) -> tuple[str | None, str | None, str | None, str | None]:
+    """Classify each ``<span>`` inside ``<div class="job_condition">``.
+
+    The conditions block holds four orthogonal facets in arbitrary
+    order: location (one or more region anchors), career level
+    (``신입`` / ``경력`` / ``신입·경력`` / ``경력 5~20년``), education
+    requirement (``학력무관`` / ``대졸 이상`` / ``석사↑`` …), and the
+    employment-type label (``정규직`` / ``계약직`` / combos thereof).
+    Classify by content rather than position because cards reorder
+    them freely.
+    """
+    location: str | None = None
+    career_level: str | None = None
+    education: str | None = None
+    employment_type_label: str | None = None
+    for span in condition.find_all("span", recursive=False):
+        text = span.get_text(" ", strip=True)
+        if not text:
+            continue
+        text = html.unescape(text)
+        # Location spans wrap one or more <a> tags pointing at the
+        # area-list endpoint — they always show up first in practice
+        # but we identify them structurally, not positionally.
+        if span.find("a", href=True):
+            location = re.sub(r"\s+", " ", text).strip() or None
+            continue
+        if any(keyword in text for keyword in _EMPLOYMENT_TYPE_MAP):
+            employment_type_label = text
+            continue
+        if any(keyword in text for keyword in ("신입", "경력", "병역")):
+            career_level = text
+            continue
+        # Anything else inside job_condition is the education facet
+        # (학력무관 / 대졸 이상 / 석사↑ / 박사 / 고졸 / 초대졸 …).
+        education = text
+    return location, career_level, education, employment_type_label
+
+
+def _normalize_employment_type(label: str | None) -> str | None:
+    """Pick the canonical ``EmploymentType`` from a (possibly compound)
+    Korean label like ``정규직·계약직``. Returns ``None`` when no token
+    matches the known vocabulary."""
+    if not label:
+        return None
+    matched: set[str] = set()
+    for token, normalized in _EMPLOYMENT_TYPE_MAP.items():
+        if token in label:
+            matched.add(normalized)
+    if not matched:
+        return None
+    for candidate in _EMPLOYMENT_TYPE_PRIORITY:
+        if candidate in matched:
+            return candidate
+    return next(iter(matched))
+
+
+def _parse_yymmdd(match: re.Match[str] | None) -> datetime | None:
+    """Saramin renders dates as ``YY/MM/DD`` with 2-digit year. Assume
+    20YY — the platform only existed past 2000 and the site itself
+    treats years <50 as 20YY, ≥50 as 19YY. We never expect to see
+    pre-2000 postings, so the simpler 20YY rule is safe."""
+    if match is None:
+        return None
+    yy, mm, dd = match.groups()
+    try:
+        year = 2000 + int(yy)
+        return datetime(year, int(mm), int(dd))
+    except ValueError:
+        return None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -27,7 +27,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # National / supranational public-sector aggregators
         "bundesagentur", "arbetsformedlingen", "eures",
         # Hybrid jobboards (companies post directly)
-        "welcometothejungle", "getonbrd", "wanted", "remoteok",
+        "welcometothejungle", "getonbrd", "wanted", "saramin", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
         "manfred", "thehub", "ycombinator", "wellfound",
         # Additional multi-tenant ATSes

--- a/tests/test_saramin.py
+++ b/tests/test_saramin.py
@@ -1,0 +1,413 @@
+"""Tests for the Saramin (사람인 — Korea's largest job board) scraper.
+
+The Saramin search page is server-rendered HTML. We pin the parsing
+contract for the listing card layout (``<div class="item_recruit">``)
+and the offset-style pagination (``recruitPage=N`` with
+``recruitPageCount=40``).
+
+Fixtures embed real HTML excerpts captured from
+``https://www.saramin.co.kr/zf_user/search?...`` — keep them faithful
+to the live markup so a future site redesign is caught by the suite.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import SaraminScraper, ScraperRegistry
+
+_SEARCH_RE = re.compile(r"^https://www\.saramin\.co\.kr/zf_user/search\?")
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.saramin as s
+    monkeypatch.setattr(s, "MAX_RETRIES", 1)
+    monkeypatch.setattr(s, "RETRY_BASE_DELAY", 0.0)
+
+
+# --- HTML fixtures ----------------------------------------------------------
+
+
+def _card(
+    *,
+    rec_idx: str = "51438642",
+    title: str = "LLM Developer",
+    company: str = "(주)씨어스",
+    location_html: str = (
+        '<span>'
+        '<a target="_blank" href="/zf_user/area-recruit/area-list/area/101000">서울</a>'
+        '  <a target="_blank" href="/zf_user/area-recruit/area-list/area/101150">서초구</a>'
+        '</span>'
+    ),
+    career: str = "경력 5~20년",
+    education: str = "석사↑",
+    employment_label: str = "정규직",
+    deadline: str = "~ 05/29(금)",
+    posted_yymmdd: str | None = "26/04/30",
+    modified_yymmdd: str | None = None,
+    sectors_html: str = (
+        '<a target="_blank" href="/zf_user/jobs/list/job-category?cat_kewd=84">백엔드/서버개발</a>,'
+        '<a target="_blank" href="/zf_user/jobs/list/job-category?cat_kewd=160">NLP(자연어처리)</a>'
+    ),
+    data_layer: str = "keyword_free|paid_n_quick",
+    include_value_attr: bool = True,
+) -> str:
+    """Render a Saramin ``item_recruit`` card matching the live markup."""
+    value_attr = f'value="{rec_idx}"' if include_value_attr else ""
+    posted_html = (
+        f'<span class="job_day">등록일 {posted_yymmdd}</span>'
+        if posted_yymmdd is not None else ""
+    )
+    modified_html = (
+        f'<span class="job_day">수정일 {modified_yymmdd}</span>'
+        if modified_yymmdd is not None else ""
+    )
+    href = (
+        f"/zf_user/jobs/relay/view?view_type=search&amp;rec_idx={rec_idx}"
+        f"&amp;location=ts&amp;searchType=search"
+    )
+    return f"""
+    <div class="item_recruit" {value_attr}
+         data-data_layer="{data_layer}">
+      <div class="area_job">
+        <h2 class="job_tit">
+          <a target="_blank" title="{title}" href="{href}"><span>{title}</span></a>
+        </h2>
+        <div class="job_date">
+          <span class="date">{deadline}</span>
+        </div>
+        <div class="job_condition">
+          {location_html}
+          <span>{career}</span>
+          <span>{education}</span>
+          <span>{employment_label}</span>
+        </div>
+        <div class="job_sector">
+          {sectors_html}
+          {posted_html}
+          {modified_html}
+        </div>
+      </div>
+      <div class="area_corp">
+        <strong class="corp_name">
+          <a href="/zf_user/company-info/view?csn=xyz" target="_blank">{company}</a>
+        </strong>
+      </div>
+    </div>
+    """
+
+
+def _page(cards_html: str = "", total: str = "총 4,180건") -> str:
+    return f"""
+    <!doctype html>
+    <html lang="ko">
+      <head><title>{total}의 검색결과 - 사람인</title></head>
+      <body>
+        <div class="content_recruit">
+          {cards_html}
+        </div>
+      </body>
+    </html>
+    """
+
+
+# --- registry / wiring ------------------------------------------------------
+
+
+def test_registry_resolves_saramin() -> None:
+    assert ScraperRegistry.get(ATSType.SARAMIN) is SaraminScraper
+
+
+def test_ats_type_enum_value() -> None:
+    """The string value is part of the public schema — pin it."""
+    assert ATSType.SARAMIN == "saramin"
+
+
+# --- happy path -------------------------------------------------------------
+
+
+def test_parses_full_card(httpx_mock) -> None:
+    """Single-page scrape; verify every populated Job field maps to the
+    right HTML region of a Saramin card."""
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(_card()))
+    # Second page returns 0 cards twice → exhausts the sweep early.
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""), is_reusable=True)
+
+    jobs = SaraminScraper("developer").fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.SARAMIN
+    assert j.ats_id == "51438642"
+    assert j.title == "LLM Developer"
+    assert j.company == "(주)씨어스"
+    assert str(j.url) == (
+        "https://www.saramin.co.kr/zf_user/jobs/relay/view?rec_idx=51438642"
+    )
+    assert j.country_iso == "KR"
+    assert j.language == "ko"
+    assert j.location == "서울 서초구"
+    assert j.employment_type == "FULL_TIME"
+    assert j.posted_at == datetime(2026, 4, 30)
+    assert j.raw is not None
+    assert j.raw.get("career_level") == "경력 5~20년"
+    assert j.raw.get("education") == "석사↑"
+    assert j.raw.get("employment_type_label") == "정규직"
+    assert j.raw.get("deadline") == "~ 05/29(금)"
+    assert j.raw.get("sectors") == ["백엔드/서버개발", "NLP(자연어처리)"]
+
+
+def test_global_id_uses_saramin_prefix(httpx_mock) -> None:
+    """``global_id`` should be ``saramin:{rec_idx}`` so cross-ATS dedup
+    works for postings that happen to be syndicated elsewhere."""
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(_card(rec_idx="999")))
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""), is_reusable=True)
+
+    jobs = SaraminScraper("dev").fetch()
+    assert jobs[0].global_id == "saramin:999"
+
+
+# --- pagination -------------------------------------------------------------
+
+
+def test_paginates_until_two_empty_pages(httpx_mock) -> None:
+    """Saramin doesn't expose a total-pages count — we walk until two
+    consecutive empty pages confirm we're past the tail."""
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        text=_page(_card(rec_idx="100")),
+    )
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        text=_page(_card(rec_idx="200")),
+    )
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""))  # 1st empty
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""))  # 2nd empty → stop
+
+    jobs = SaraminScraper("dev").fetch()
+    assert {j.ats_id for j in jobs} == {"100", "200"}
+
+
+def test_dedupes_repeated_cards_across_pages(httpx_mock) -> None:
+    """Sponsored ``TOP100`` cards repeat across pages; the scraper must
+    collapse them on ``ats_id`` so the row count is meaningful."""
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        text=_page(_card(rec_idx="1") + _card(rec_idx="2")),
+    )
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        # Page 2 repeats id=2 and adds id=3
+        text=_page(_card(rec_idx="2") + _card(rec_idx="3")),
+    )
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""), is_reusable=True)
+
+    jobs = SaraminScraper("dev").fetch()
+    assert {j.ats_id for j in jobs} == {"1", "2", "3"}
+
+
+def test_max_pages_clamps_to_server_ceiling() -> None:
+    """``recruitPage`` is server-capped near 99 — passing 5000 here
+    should not generate 4900+ wasted requests."""
+    scraper = SaraminScraper("dev", max_pages=5000)
+    assert scraper.max_pages == 99
+
+
+def test_max_pages_honours_lower_caller_override(httpx_mock) -> None:
+    """A caller can set a tighter cap for a quick sample-pass."""
+    # Pad with cards on every page so the empty-tail logic doesn't stop
+    # the sweep before max_pages is reached.
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        text=_page(_card(rec_idx="500")),
+        is_reusable=True,
+    )
+
+    jobs = SaraminScraper("dev", max_pages=2).fetch()
+    # We don't assert request count (httpx-mock doesn't expose a clean
+    # counter on reusable responses), but the de-dup on a single rec_idx
+    # means at most one job is yielded — proving max_pages didn't allow
+    # an unbounded sweep.
+    assert len(jobs) == 1
+
+
+# --- empty-searchword path --------------------------------------------------
+
+
+def test_empty_slug_omits_searchword_param(httpx_mock) -> None:
+    """``SaraminScraper("any")`` falls back to no keyword. Verify the
+    URL omits a quoted keyword body so the server treats it as the
+    sponsored-cards landing."""
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""), is_reusable=True)
+
+    SaraminScraper("any", max_pages=1).fetch()
+    requests = httpx_mock.get_requests()
+    assert requests
+    url = str(requests[0].url)
+    assert "searchword=&" in url or url.endswith("searchword=")
+
+
+def test_explicit_keyword_is_url_encoded(httpx_mock) -> None:
+    """Korean keywords are common; they must be percent-encoded so the
+    GET line stays ASCII-safe."""
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""), is_reusable=True)
+
+    SaraminScraper("디자이너", max_pages=1).fetch()
+    requests = httpx_mock.get_requests()
+    assert requests
+    # ``디자이너`` URL-encoded as UTF-8:
+    assert "searchword=%EB%94%94%EC%9E%90%EC%9D%B4%EB%84%88" in str(requests[0].url)
+
+
+# --- field handling ---------------------------------------------------------
+
+
+def test_skips_card_without_rec_idx(httpx_mock) -> None:
+    """A malformed card with no ``value`` attribute and no rec_idx in
+    its anchor href should be dropped, not emitted as a half-built row."""
+    bad_card = """
+    <div class="item_recruit" data-data_layer="x|x">
+      <h2 class="job_tit"><a title="No id" href="/some/other/path">No id</a></h2>
+      <strong class="corp_name"><a href="#">X</a></strong>
+    </div>
+    """
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        text=_page(_card(rec_idx="42") + bad_card),
+    )
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""), is_reusable=True)
+
+    jobs = SaraminScraper("dev").fetch()
+    assert [j.ats_id for j in jobs] == ["42"]
+
+
+def test_falls_back_to_rec_idx_in_href_when_value_attr_missing(httpx_mock) -> None:
+    """Sponsored cards sometimes omit the wrapping ``value`` attribute;
+    we recover the rec_idx from the title anchor's href."""
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        text=_page(_card(rec_idx="77", include_value_attr=False)),
+    )
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""), is_reusable=True)
+
+    jobs = SaraminScraper("dev").fetch()
+    assert jobs[0].ats_id == "77"
+
+
+@pytest.mark.parametrize(
+    ("label", "expected"),
+    [
+        ("정규직", "FULL_TIME"),
+        ("계약직", "CONTRACT"),
+        ("인턴", "INTERN"),
+        ("인턴직", "INTERN"),
+        ("프리랜서", "CONTRACT"),
+        ("아르바이트", "PART_TIME"),
+        ("파트타임", "PART_TIME"),
+        ("파견직", "CONTRACT"),
+        ("위촉직", "CONTRACT"),
+        ("일용직", "TEMPORARY"),
+        # Combos: pick the most permanent option.
+        ("정규직·계약직", "FULL_TIME"),
+        ("계약직·인턴", "INTERN"),  # INTERN before CONTRACT in priority
+    ],
+)
+def test_employment_type_korean_labels(
+    httpx_mock, label: str, expected: str
+) -> None:
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        text=_page(_card(employment_label=label)),
+    )
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""), is_reusable=True)
+
+    jobs = SaraminScraper("dev").fetch()
+    assert jobs[0].employment_type == expected
+
+
+def test_unknown_employment_label_yields_none(httpx_mock) -> None:
+    """An exotic label we haven't mapped should leave ``employment_type``
+    at None rather than guess — the raw label is still preserved."""
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        text=_page(_card(employment_label="비상근")),
+    )
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""), is_reusable=True)
+
+    jobs = SaraminScraper("dev").fetch()
+    j = jobs[0]
+    assert j.employment_type is None
+    assert j.raw is not None
+    # ``비상근`` doesn't match the employment-type vocabulary so it
+    # winds up classified as the education facet — that's expected;
+    # the important thing is we didn't fabricate an enum.
+
+
+def test_deadline_string_preserved_verbatim(httpx_mock) -> None:
+    """Saramin's deadline strings ('~ 05/29(금)', '상시채용', '오늘마감')
+    are kept as-is in ``raw['deadline']`` so consumers can filter on
+    still-active postings without a Korean calendar parser."""
+    for deadline in ("~ 05/29(금)", "상시채용", "오늘마감", "내일마감", "채용시"):
+        httpx_mock.reset()
+        httpx_mock.add_response(
+            url=_SEARCH_RE,
+            text=_page(_card(deadline=deadline)),
+        )
+        httpx_mock.add_response(
+            url=_SEARCH_RE, text=_page(""), is_reusable=True,
+        )
+        jobs = SaraminScraper("dev").fetch()
+        assert jobs[0].raw is not None
+        assert jobs[0].raw["deadline"] == deadline
+
+
+def test_posted_at_falls_back_to_none_when_dates_missing(httpx_mock) -> None:
+    """Cards without ``등록일``/``수정일`` should leave ``posted_at`` at
+    None rather than invent a timestamp."""
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        text=_page(_card(posted_yymmdd=None, modified_yymmdd=None)),
+    )
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""), is_reusable=True)
+
+    jobs = SaraminScraper("dev").fetch()
+    assert jobs[0].posted_at is None
+
+
+def test_modified_date_captured_in_raw(httpx_mock) -> None:
+    """When the card only carries ``수정일`` (modified date), capture
+    it in raw — useful as a 'last seen active' signal."""
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        text=_page(_card(posted_yymmdd=None, modified_yymmdd="26/05/10")),
+    )
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""), is_reusable=True)
+
+    jobs = SaraminScraper("dev").fetch()
+    j = jobs[0]
+    assert j.posted_at is None
+    assert j.raw is not None
+    assert j.raw["modified_at"] == "2026-05-10T00:00:00"
+
+
+# --- error handling ---------------------------------------------------------
+
+
+def test_persistent_500_raises(httpx_mock) -> None:
+    """Real server failures should surface, not silently emit []."""
+    httpx_mock.add_response(url=_SEARCH_RE, status_code=500, is_reusable=True)
+    with pytest.raises(ScraperError):
+        SaraminScraper("dev").fetch()
+
+
+def test_403_raises_immediately(httpx_mock) -> None:
+    """A 4xx from Saramin's WAF is not a retry-worthy error — surface
+    it to the caller so the operator notices and rotates the UA / proxies."""
+    httpx_mock.add_response(url=_SEARCH_RE, status_code=403)
+    with pytest.raises(ScraperError):
+        SaraminScraper("dev").fetch()


### PR DESCRIPTION
## Summary

- New ``SaraminScraper`` for [Saramin](https://www.saramin.co.kr) (사람인), Korea's largest job platform (competes with JobKorea, hundreds of thousands of postings across every vertical).
- Server-rendered HTML; the scraper paginates the integrated-search endpoint (``recruitPage=N`` with ``recruitPageCount=40``) and parses each ``<div class="item_recruit">`` card with BeautifulSoup.
- Single-source pattern (``company_slug`` is reused as the ``searchword`` query param, default sentinel ``"any"`` falls back to no keyword). Server-side pagination caps at ~99 pages — ``max_pages`` is clamped to that ceiling.
- Korean employment-type vocabulary maps to canonical ``EmploymentType``: ``정규직`` → FULL_TIME, ``계약직``/``프리랜서``/``파견직``/``위촉직`` → CONTRACT, ``인턴`` → INTERN, ``아르바이트``/``파트타임`` → PART_TIME, ``일용직`` → TEMPORARY. Combos like ``정규직·계약직`` resolve to the most permanent option.
- ``등록일 YY/MM/DD`` parsed into ``posted_at`` (UTC midnight, 20YY assumption); ``수정일`` captured in ``raw['modified_at']`` as a fallback "last seen" signal. Deadline strings (``~ 05/29(금)``, ``상시채용``, ``오늘마감``, ``채용시``) kept verbatim in ``raw['deadline']``.
- ``country_iso="KR"`` and ``language="ko"`` set on every row so downstream LLM enrichment has the locale hint.
- New ``ATSType.SARAMIN = "saramin"`` enum value under the "Hybrid jobboards" section, registered in ``ScraperRegistry`` and exported from ``jobhive.scrapers``.

## Test plan

- [x] ``pytest tests/test_saramin.py`` — 30 new tests pass (registry wiring, full-card parsing, pagination + two-empty-page exit, dedup across repeated cards, ``max_pages`` clamp, empty-slug / Korean-keyword URL encoding, 12 employment-type label cases, deadline-verbatim, posted-at fallback, 403 + 500 error surfacing).
- [x] ``pytest tests/test_models.py`` — ``ATSType`` enum coverage updated.
- [x] ``pytest tests/`` — full suite (~849 tests) green.
- [x] ``ruff check`` clean on ``src/`` and ``tests/``.
- [x] Live smoke: ``SaraminScraper("developer", max_pages=2).fetch()`` returned 75 unique jobs end-to-end with proper Korean titles, locations, ``employment_type=FULL_TIME``, and structured ``raw`` overflow (career level, education, sectors, modified date).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `SaraminScraper` to ingest jobs from Saramin (Korea) with server-rendered HTML parsing and paging. Seeds `ats-companies/saramin.csv` for platform metadata.

- **New Features**
  - Paginates integrated search (`recruitPage` + `recruitPageCount=40`), de-duplicates by `ats_id`, stops after two empty pages; normalizes job URLs to `rec_idx`.
  - Uses `company_slug` as `searchword` (empty/`"any"` omits keyword); percent-encodes Korean keywords.
  - Maps Korean employment types to canonical values; parses `등록일 YY/MM/DD` to `posted_at`; preserves `수정일` and deadline in `raw`; stores sector tags and facets; sets `country_iso="KR"` and `language="ko"`.
  - Adds `ATSType.SARAMIN = "saramin"`, registers in `ScraperRegistry`, exports from `jobhive.scrapers`; adds `ats-companies/saramin.csv`.

- **Bug Fixes**
  - Lazy-imports `beautifulsoup4` inside the parser and raises a clear install hint instead of crashing when the package isn’t present.

<sup>Written for commit e3d92b7cc2541ce4a707ea0542c84b77407f4c86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/97?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `SaraminScraper`, a server-rendered HTML scraper for Saramin (사람인), Korea's largest direct-posting job board. It paginates the integrated-search endpoint, parses `<div class="item_recruit">` cards with BeautifulSoup, maps Korean employment-type vocabulary to canonical `EmploymentType` values, and is wired into `ATSType`, `ScraperRegistry`, and `jobhive.scrapers` exports.

- The core HTML parsing and Korean employment-type normalisation logic are well-implemented and covered by 30 tests including real HTML fixtures, error surfacing, and pagination boundary conditions.
- `_fetch_async` initialises `stop_event` and a `lock`-protected `absorb()` suggesting concurrent page dispatching, but the outer loop runs strictly sequentially — the event is never set (dead branch) and the lock is never contended.
- Retry back-off sleeps (`asyncio.sleep`) are taken inside the `async with sem:` block, holding the semaphore slot for the full delay duration; this is a latent problem if the loop is ever parallelised.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all findings are in the new scraper file and none affect correctness of the current sequential execution path.

The scraper works correctly end-to-end and the test suite is thorough. The three flagged items (stop_event never set, sleep inside semaphore block, unstable tracking params in raw search_url) are quality and maintainability concerns rather than runtime failures — nothing breaks today, but the dead stop_event branch and semaphore-held sleeps would become real problems if the loop is later parallelised.

src/jobhive/scrapers/saramin.py — specifically the concurrency scaffolding (stop_event, lock, sem) around a sequential loop, and the retry sleep placement inside the semaphore block.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/saramin.py | New scraper for Saramin (Korea); solid HTML parsing and retry logic, but stop_event is created and checked yet never set (dead branch), retry sleeps are taken while holding the semaphore, and tracking params in raw search_url are unstable across scrape runs. |
| src/jobhive/models.py | Adds ATSType.SARAMIN = saramin under the hybrid job-boards section; straightforward enum addition with no issues. |
| src/jobhive/scrapers/__init__.py | Imports and re-exports SaraminScraper; follows existing alphabetical ordering conventions, no issues. |
| tests/test_saramin.py | 30 tests covering registry wiring, full-card parsing, pagination, dedup, max_pages clamping, URL encoding, all 12 employment-type labels, deadline verbatim storage, posted-at fallback, and 403/500 error surfacing; comprehensive and well-structured. |
| tests/test_models.py | Adds saramin to the exhaustive ATSType coverage set; trivial and correct. |
| ats-companies/saramin.csv | Seed CSV with a single Saramin platform entry; correct format, no issues. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/jobhive/scrapers/saramin.py:144-176
**`stop_event` is created but never set — dead branch**

`stop_event = asyncio.Event()` is initialised on line 144 and checked on line 166 (`if stop_event.is_set(): break`), but `.set()` is never called anywhere in this file. The guard will never fire, making lines 166–167 permanently dead. A reader trying to understand the early-exit contract will spend time looking for the call-site that arms the event and find nothing. If the intent is to support external cancellation, the event needs a setter; if the two-consecutive-empty-page logic is the only exit, the `stop_event` object and its guard can be removed.

### Issue 2 of 3
src/jobhive/scrapers/saramin.py:203-233
**Sleep inside the semaphore block holds the slot during backoff**

Both `await asyncio.sleep(RETRY_BASE_DELAY * attempt)` (line 217, network error) and `await asyncio.sleep(delay)` (line 232, HTTP 429/5xx) are executed while `sem` is still acquired. Holding the semaphore slot during a multi-second sleep prevents any other concurrent task from making a request, even though the only reason for `sem` is to cap *active* inflight requests. Since the outer loop is currently sequential this has no practical impact now, but it violates the intended contract of the semaphore and would be a silent correctness problem if the loop were ever parallelised. The sleep should run after the `async with sem:` block exits.

### Issue 3 of 3
src/jobhive/scrapers/saramin.py:396-400
**`search_url` tracking redirect includes UTM/tracking params verbatim**

`apply_href` is taken straight from the `href` attribute of the title anchor, which on live Saramin pages contains tracking parameters like `view_type=search&location=ts&searchType=search`. These are preserved in `raw["search_url"]` and change between scrape runs, so two rows for the same job scraped at different times will have different `raw["search_url"]` values. This may cause spurious "changed" signals in downstream diff-based pipelines. If the intent is to capture the click-tracking URL as a diagnostic, the field name is appropriate, but if it's used for dedup or change-detection the instability could be a problem.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: saramin.csv"](https://github.com/kalil0321/ats-scrapers/commit/9c5a61101d42c4a6c51c306a954c1ec83394a5c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732438)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->