### PR TITLE
Add current-generation Beisen scraper

### DIFF
--- a/ats-companies/README.md
+++ b/ats-companies/README.md
@@ -33,6 +33,7 @@ Acme Corp,acme,https://acme.greenhouse.io
 | ashby | `https://jobs.ashbyhq.com/<slug>` |
 | avature | `https://<slug>.avature.net` |
 | bamboohr | `https://<slug>.bamboohr.com/careers` |
+| beisen | `https://<slug>.zhiye.com` |
 | breezy | `https://<slug>.breezy.hr` |
 | cornerstone | `https://<slug>.csod.com` |
 | darwinbox | `https://<slug>.darwinbox.{in,com}/ms/candidate/careers` |

--- a/ats-companies/beisen.csv
+++ b/ats-companies/beisen.csv
@@ -1,0 +1,9 @@
+name,slug,url
+Chery,chery,https://chery.zhiye.com
+China Life,chinalife,https://chinalife.zhiye.com
+MediaTek,mediatek,https://mediatek.zhiye.com
+Mengniu Dairy,mengniu,https://mengniu.zhiye.com
+Mindray,mindray,https://mindray.zhiye.com
+Starbucks China,starbucks,https://starbucks.zhiye.com
+Uniqlo China,uniqlo,https://uniqlo.zhiye.com
+Vivo,vivo,https://vivo.zhiye.com

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -43,6 +43,7 @@ from ats_scrapers.scrapers import (
     AshbyScraper,
     AvatureScraper,
     BambooHRScraper,
+    BeisenScraper,
     BreezyScraper,
     BuiltInScraper,
     BundesagenturScraper,
@@ -482,6 +483,12 @@ CONFIGS: dict[str, dict[str, Any]] = {
         "slug": lambda r: _slug_col(r) or (r.get("name") or "").strip() or None,
         "csv": "ats-companies/darwinbox.csv",
         "output": "darwinbox/jobs.csv",
+    },
+    "beisen": {
+        "scraper": BeisenScraper,
+        "slug": lambda r: _slug_col(r) or (r.get("name") or "").strip() or None,
+        "csv": "ats-companies/beisen.csv",
+        "output": "beisen/jobs.csv",
     },
     "workable": {
         "scraper": WorkableScraper,

--- a/src/ats_scrapers/resolve.py
+++ b/src/ats_scrapers/resolve.py
@@ -143,6 +143,12 @@ def resolve_careers_url(url: str) -> ResolvedCareersUrl | None:
                 return ResolvedCareersUrl(ATSType.DARWINBOX, slug)
             return None
 
+    if host.endswith(".zhiye.com"):
+        tenant = host.removesuffix(".zhiye.com")
+        if _DNS_LABEL_RE.fullmatch(tenant):
+            return ResolvedCareersUrl(ATSType.BEISEN, tenant)
+        return None
+
     for suffix, ats in _SUBDOMAIN_SUFFIXES.items():
         if host.endswith(suffix):
             slug = host.removesuffix(suffix)

--- a/src/ats_scrapers/scrapers/__init__.py
+++ b/src/ats_scrapers/scrapers/__init__.py
@@ -15,6 +15,7 @@ from ats_scrapers.scrapers.ashby import AshbyScraper
 from ats_scrapers.scrapers.avature import AvatureScraper
 from ats_scrapers.scrapers.bamboohr import BambooHRScraper
 from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry, get_scraper
+from ats_scrapers.scrapers.beisen import BeisenScraper
 from ats_scrapers.scrapers.breezy import BreezyScraper
 from ats_scrapers.scrapers.builtin import BuiltInScraper
 from ats_scrapers.scrapers.bundesagentur import BundesagenturScraper
@@ -72,6 +73,7 @@ __all__ = [
     "AvatureScraper",
     "BambooHRScraper",
     "BaseScraper",
+    "BeisenScraper",
     "BreezyScraper",
     "BuiltInScraper",
     "BundesagenturScraper",

--- a/src/ats_scrapers/scrapers/beisen.py
+++ b/src/ats_scrapers/scrapers/beisen.py
@@ -1,0 +1,332 @@
+"""Beisen / iTalent (zhiye.com) multi-tenant ATS scraper.
+
+Current Beisen career sites live at ``https://{tenant}.zhiye.com``. The
+public SPA exposes its portal identifier in an inline ``BSGlobal`` object,
+then lists jobs through ``POST /api/Jobad/GetJobAdPageList``.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from pydantic import HttpUrl
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from ats_scrapers.fetch import Fetcher
+
+REGISTER_PATH = "/portal/registerSystemInfo"
+SEARCH_PATH = "/api/Jobad/GetJobAdPageList"
+PAGE_SIZE = 1000
+MAX_PAGES = 1000
+
+_TENANT_RE = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?")
+_BSGLOBAL_RE = re.compile(r"var\s+BSGlobal\s*=\s*(\{)", re.DOTALL)
+_TENANT_ID_RE = re.compile(
+    r"(?:stcms\.beisen\.com/image|portal-oss\.zhiye\.com)/(\d+)"
+)
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_BLOCK_END_RE = re.compile(r"</(?:div|li|p|tr|h[1-6])\s*>", re.IGNORECASE)
+_BREAK_RE = re.compile(r"<br\s*/?>", re.IGNORECASE)
+_HORIZONTAL_SPACE_RE = re.compile(r"[^\S\r\n]+")
+_EXCESS_NEWLINES_RE = re.compile(r"\n{3,}")
+_RECRUIT_SUFFIXES = (
+    "校园招聘",
+    "社会招聘",
+    "人才招聘",
+    "招贤纳士",
+    "招聘门户",
+    "招聘官网",
+    "招聘网站",
+    "招聘中心",
+    "招聘",
+)
+
+
+@ScraperRegistry.register(ATSType.BEISEN)
+class BeisenScraper(BaseScraper):
+    """Scrape a current-generation Beisen tenant by zhiye.com subdomain."""
+
+    ats = ATSType.BEISEN
+    default_headers: ClassVar[dict[str, str]] = {
+        "User-Agent": "Mozilla/5.0",
+        "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+    }
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        include_descriptions: bool = True,
+        proxy: str | None = None,
+        business_type: int | None = None,
+        language: str = "zh",
+        country_iso: str = "CN",
+    ) -> None:
+        super().__init__(
+            company_slug,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        slug = company_slug.strip().lower()
+        if not _TENANT_RE.fullmatch(slug):
+            raise ScraperError(
+                f"Beisen slug {company_slug!r} looks malformed; "
+                "expected a DNS-safe zhiye.com subdomain"
+            )
+        if business_type not in {None, 0, 1, 2}:
+            raise ScraperError("Beisen business_type must be 0, 1, 2, or None")
+        self.slug = slug
+        self.business_type = business_type
+        self.language = language
+        self.country_iso = country_iso.upper()
+        self.base_url = f"https://{slug}.zhiye.com"
+        self.portal_id: str | None = None
+        self.tenant_id: str | None = None
+        self.tenant_name: str | None = None
+        self.key: str | None = None
+
+    async def afetch(self) -> list[Job]:
+        async with self.make_fetcher() as fetch:
+            await self._resolve_tenant(fetch)
+            jobs: list[Job] = []
+            seen: set[str] = set()
+            total: int | None = None
+            for page_index in range(MAX_PAGES):
+                payload = await self._fetch_page(fetch, page_index)
+                items = payload.get("Data")
+                if not isinstance(items, list) or not items:
+                    break
+
+                new_count = 0
+                for item in items:
+                    if not isinstance(item, dict):
+                        continue
+                    job = self._parse_job(item)
+                    if job is None or not job.ats_id or job.ats_id in seen:
+                        continue
+                    seen.add(job.ats_id)
+                    jobs.append(job)
+                    new_count += 1
+
+                total = _coerce_int(payload.get("Count"))
+                if total is not None and len(seen) >= total:
+                    break
+                if len(items) < PAGE_SIZE:
+                    break
+                if new_count == 0:
+                    raise ScraperError(
+                        "Beisen pagination repeated a full page without new jobs "
+                        f"at page={page_index} for {self.slug!r}"
+                    )
+            else:
+                raise ScraperError(
+                    "Beisen pagination reached the safety cap "
+                    f"({MAX_PAGES} pages, {len(jobs)} of {total or 'unknown'} jobs)"
+                )
+        return jobs
+
+    async def _resolve_tenant(self, fetch: Fetcher) -> None:
+        text = await fetch.get_text(
+            f"{self.base_url}{REGISTER_PATH}",
+            headers={"Accept": "text/html,application/xhtml+xml,*/*"},
+        )
+        match = _BSGLOBAL_RE.search(text)
+        if not match:
+            raise ScraperError(
+                f"Beisen tenant {self.slug!r} did not return a BSGlobal config; "
+                "it may use the legacy portal"
+            )
+        try:
+            config, _end = json.JSONDecoder().raw_decode(text, match.start(1))
+        except ValueError as exc:
+            raise ScraperError(
+                f"Beisen BSGlobal for {self.slug!r} was not valid JSON: {exc}"
+            ) from exc
+        if not isinstance(config, dict):
+            raise ScraperError(f"Beisen BSGlobal for {self.slug!r} was not an object")
+
+        portal_id = _clean_text(config.get("PortalId"))
+        if not portal_id:
+            raise ScraperError(
+                f"Beisen tenant {self.slug!r} is missing PortalId in BSGlobal"
+            )
+        tenant_ids = _TENANT_ID_RE.findall(text)
+        self.portal_id = portal_id
+        self.key = _clean_text(config.get("Key"))
+        self.tenant_id = next(
+            (tenant_id for tenant_id in tenant_ids if tenant_id != "10000"),
+            tenant_ids[0] if tenant_ids else None,
+        )
+        filing = config.get("BeiAnInfo")
+        site_name = filing.get("SiteName") if isinstance(filing, dict) else None
+        self.tenant_name = _clean_company_name(site_name) or self.slug
+
+    async def _fetch_page(self, fetch: Fetcher, page_index: int) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "PageIndex": page_index,
+            "PageSize": PAGE_SIZE,
+            "KeyWords": "",
+            "SpecialType": 0,
+            "PortalId": self.portal_id,
+            "DisplayFields": [
+                "Category",
+                "Description",
+                "Location",
+                "Department",
+                "Salary",
+            ],
+        }
+        if self.business_type is not None:
+            body["Category"] = [str(self.business_type)]
+        payload = await fetch.post_json(
+            f"{self.base_url}{SEARCH_PATH}",
+            json=body,
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "Referer": f"{self.base_url}/social/jobs",
+            },
+        )
+        if not isinstance(payload, dict):
+            raise ScraperError(
+                f"Beisen returned a non-object payload at page={page_index}"
+            )
+        if payload.get("Code") not in {200, "200"}:
+            raise ScraperError(
+                "Beisen API failure "
+                f"at page={page_index} for {self.slug!r}: {payload!r}"
+            )
+        return payload
+
+    def _parse_job(self, item: dict[str, Any]) -> Job | None:
+        raw_id = item.get("JobAdId")
+        ats_id = str(raw_id).strip() if raw_id is not None else ""
+        title = _clean_text(item.get("JobAdName"))
+        if not ats_id or not title:
+            return None
+
+        raw: dict[str, Any] = {
+            "tenant": self.slug,
+            "portal_id": self.portal_id,
+        }
+        if self.tenant_id:
+            raw["tenant_id"] = self.tenant_id
+        if self.key:
+            raw["key"] = self.key
+        for source, destination in (
+            ("Id", "internal_id"),
+            ("OrgId", "org_id"),
+            ("Org", "org"),
+            ("Category", "category"),
+            ("CategoryId", "category_id"),
+            ("LocId", "loc_id"),
+            ("Station", "station"),
+            ("Kind", "kind"),
+            ("Degree", "degree"),
+            ("YearsOfWorking", "years_of_working"),
+            ("HeadCount", "head_count"),
+            ("ClassificationOne", "classification_1"),
+            ("ClassificationTwo", "classification_2"),
+            ("Classification3", "classification_3"),
+            ("Classification4", "classification_4"),
+        ):
+            value = item.get(source)
+            if value not in (None, "", 0, []):
+                raw[destination] = value
+
+        description = None
+        if self.include_descriptions:
+            description = _join_nonempty(
+                _clean_html(item.get("Duty")),
+                _clean_html(item.get("Require")),
+                separator="\n\n",
+            )
+        return Job(
+            url=HttpUrl(f"{self.base_url}/portal/jobs/{ats_id}"),
+            title=title,
+            company=self.tenant_name or self.slug,
+            ats_type=ATSType.BEISEN,
+            ats_id=ats_id,
+            location=_format_location(item.get("LocNames"))
+            or _clean_text(item.get("DetailAddress")),
+            country_iso=self.country_iso,
+            region="Asia" if self.country_iso in {"CN", "HK", "MO", "TW"} else None,
+            description=description,
+            salary_summary=_clean_text(item.get("Salary")),
+            department=_clean_text(item.get("Category")),
+            posted_at=_parse_date(item.get("ChangeDate"))
+            or _parse_date(item.get("PostDate")),
+            fetched_at=datetime.now(UTC),
+            language=self.language,
+            raw=raw,
+        )
+
+
+def _clean_company_name(value: object) -> str:
+    name = _clean_text(value) or ""
+    for suffix in _RECRUIT_SUFFIXES:
+        if name.endswith(suffix):
+            return name[: -len(suffix)].strip()
+    return name
+
+
+def _clean_text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _clean_html(value: object) -> str | None:
+    text = _clean_text(value)
+    if text is None:
+        return None
+    text = _BREAK_RE.sub("\n", text)
+    text = _BLOCK_END_RE.sub("\n", text)
+    text = _HTML_TAG_RE.sub("", text)
+    text = html.unescape(text).replace("\r\n", "\n").replace("\r", "\n")
+    text = "\n".join(_HORIZONTAL_SPACE_RE.sub(" ", line).strip() for line in text.split("\n"))
+    text = _EXCESS_NEWLINES_RE.sub("\n\n", text).strip()
+    return text or None
+
+
+def _join_nonempty(*values: str | None, separator: str) -> str | None:
+    parts = [value for value in values if value]
+    return separator.join(parts) if parts else None
+
+
+def _format_location(value: object) -> str | None:
+    if not isinstance(value, list):
+        return None
+    parts = [str(part).strip() for part in value if str(part).strip()]
+    return ", ".join(parts) if parts else None
+
+
+def _coerce_int(value: object) -> int | None:
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_date(value: object) -> datetime | None:
+    text = _clean_text(value)
+    if text is None or text.startswith("0001-01-01"):
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)

--- a/tests/test_beisen.py
+++ b/tests/test_beisen.py
@@ -1,0 +1,211 @@
+"""Tests for the current-generation Beisen (zhiye.com) scraper."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC
+
+import pytest
+
+import ats_scrapers.scrapers.beisen as beisen_module
+from ats_scrapers.exceptions import CompanyNotFoundError, ScraperError
+from ats_scrapers.models import ATSType
+from ats_scrapers.scrapers import BeisenScraper, ScraperRegistry
+
+REGISTER_URL = "https://fixturecorp.zhiye.com/portal/registerSystemInfo"
+SEARCH_URL = "https://fixturecorp.zhiye.com/api/Jobad/GetJobAdPageList"
+
+
+def register_html(*, site_name: str = "测试公司招聘门户") -> str:
+    config = {
+        "Key": "test-key",
+        "PortalId": "portal-123",
+        "Nested": {"value": {"deeper": True}},
+        "BeiAnInfo": {"SiteName": site_name},
+    }
+    return (
+        '<img src="https://portal-oss.zhiye.com/10000/image/default.png">'
+        '<img src="//stcms.beisen.com/image/98765/logo.png">'
+        f"<script>var BSGlobal = {json.dumps(config)}; var after = true;</script>"
+    )
+
+
+def listing(job_id: int = 123, title: str = "平台工程师") -> dict:
+    return {
+        "JobAdId": job_id,
+        "JobAdName": title,
+        "Duty": "<p>构建可靠平台。</p>",
+        "Require": "<div>三年以上经验。<br>熟悉 Python。</div>",
+        "Salary": "20-30K",
+        "LocNames": ["上海", "北京"],
+        "Category": "社会招聘",
+        "ChangeDate": "2026-07-22T09:45:48",
+        "PostDate": "0001-01-01T00:00:00",
+        "Id": "internal-123",
+        "Org": "研发中心",
+        "HeadCount": 2,
+    }
+
+
+def payload(items: list[dict], *, total: int | str | None = None) -> dict:
+    return {
+        "Code": 200,
+        "Count": len(items) if total is None else total,
+        "Data": items,
+    }
+
+
+def add_register(httpx_mock, *, site_name: str = "测试公司招聘门户") -> None:
+    httpx_mock.add_response(url=REGISTER_URL, text=register_html(site_name=site_name))
+
+
+def test_registry_resolves_beisen() -> None:
+    assert ScraperRegistry.get(ATSType.BEISEN) is BeisenScraper
+
+
+@pytest.mark.parametrize(
+    "slug",
+    ["", "bad slug", "bad_slug", "-leading", "trailing-", f"{'a' * 64}"],
+)
+def test_rejects_invalid_slugs(slug: str) -> None:
+    with pytest.raises(ScraperError, match="DNS-safe"):
+        BeisenScraper(slug)
+
+
+def test_rejects_invalid_business_type() -> None:
+    with pytest.raises(ScraperError, match="business_type"):
+        BeisenScraper("fixturecorp", business_type=3)
+
+
+def test_parses_nested_config_and_current_listing(httpx_mock) -> None:
+    add_register(httpx_mock)
+    httpx_mock.add_response(url=SEARCH_URL, json=payload([listing()]))
+
+    [result] = BeisenScraper("FixtureCorp").fetch()
+
+    assert result.ats_type is ATSType.BEISEN
+    assert result.ats_id == "123"
+    assert result.global_id == "beisen:123"
+    assert result.title == "平台工程师"
+    assert result.company == "测试公司"
+    assert result.location == "上海, 北京"
+    assert result.country_iso == "CN"
+    assert result.region == "Asia"
+    assert result.description == "构建可靠平台。\n\n三年以上经验。\n熟悉 Python。"
+    assert result.salary_summary == "20-30K"
+    assert result.department == "社会招聘"
+    assert result.posted_at is not None and result.posted_at.tzinfo is UTC
+    assert result.fetched_at.tzinfo is UTC
+    assert str(result.url) == "https://fixturecorp.zhiye.com/portal/jobs/123"
+    assert result.raw == {
+        "tenant": "fixturecorp",
+        "portal_id": "portal-123",
+        "tenant_id": "98765",
+        "key": "test-key",
+        "internal_id": "internal-123",
+        "org": "研发中心",
+        "category": "社会招聘",
+        "head_count": 2,
+    }
+
+
+def test_include_descriptions_false_omits_embedded_content(httpx_mock) -> None:
+    add_register(httpx_mock)
+    httpx_mock.add_response(url=SEARCH_URL, json=payload([listing()]))
+    [result] = BeisenScraper("fixturecorp", include_descriptions=False).fetch()
+    assert result.description is None
+
+
+def test_request_body_matches_public_api(httpx_mock) -> None:
+    add_register(httpx_mock)
+    httpx_mock.add_response(url=SEARCH_URL, json=payload([]))
+
+    BeisenScraper("fixturecorp", business_type=1).fetch()
+
+    requests = httpx_mock.get_requests()
+    assert json.loads(requests[1].content) == {
+        "PageIndex": 0,
+        "PageSize": 1000,
+        "KeyWords": "",
+        "SpecialType": 0,
+        "PortalId": "portal-123",
+        "DisplayFields": [
+            "Category",
+            "Description",
+            "Location",
+            "Department",
+            "Salary",
+        ],
+        "Category": ["1"],
+    }
+
+
+def test_paginates_and_deduplicates_jobs(httpx_mock) -> None:
+    add_register(httpx_mock)
+    first = [listing(index, f"职位 {index}") for index in range(1000)]
+    second = [listing(999, "职位 999"), listing(1000, "职位 1000")]
+    httpx_mock.add_response(url=SEARCH_URL, json=payload(first, total="1001"))
+    httpx_mock.add_response(url=SEARCH_URL, json=payload(second, total="1001"))
+
+    jobs = BeisenScraper("fixturecorp").fetch()
+
+    assert len(jobs) == 1001
+    assert jobs[-1].ats_id == "1000"
+    requests = httpx_mock.get_requests()
+    assert json.loads(requests[1].content)["PageIndex"] == 0
+    assert json.loads(requests[2].content)["PageIndex"] == 1
+
+
+def test_raises_instead_of_silently_truncating_at_page_cap(
+    httpx_mock, monkeypatch
+) -> None:
+    monkeypatch.setattr(beisen_module, "MAX_PAGES", 1)
+    add_register(httpx_mock)
+    items = [listing(index, f"职位 {index}") for index in range(1000)]
+    httpx_mock.add_response(url=SEARCH_URL, json=payload(items, total=2000))
+
+    with pytest.raises(ScraperError, match="reached the safety cap"):
+        BeisenScraper("fixturecorp").fetch()
+
+
+def test_missing_bsglobal_raises_clear_error(httpx_mock) -> None:
+    httpx_mock.add_response(url=REGISTER_URL, text="<html>legacy portal</html>")
+    with pytest.raises(ScraperError, match="BSGlobal"):
+        BeisenScraper("fixturecorp").fetch()
+
+
+def test_missing_portal_id_raises_clear_error(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=REGISTER_URL,
+        text='<script>var BSGlobal = {"BeiAnInfo":{"SiteName":"Acme"}};</script>',
+    )
+    with pytest.raises(ScraperError, match="PortalId"):
+        BeisenScraper("fixturecorp").fetch()
+
+
+def test_company_not_found_from_register_404(httpx_mock) -> None:
+    httpx_mock.add_response(url=REGISTER_URL, status_code=404)
+    with pytest.raises(CompanyNotFoundError):
+        BeisenScraper("fixturecorp").fetch()
+
+
+def test_application_failure_raises(httpx_mock) -> None:
+    add_register(httpx_mock)
+    httpx_mock.add_response(url=SEARCH_URL, json={"Code": 500, "Message": "boom"})
+    with pytest.raises(ScraperError, match="API failure"):
+        BeisenScraper("fixturecorp").fetch()
+
+
+def test_invalid_date_and_empty_suffix_name_fall_back_safely(httpx_mock) -> None:
+    add_register(httpx_mock, site_name="招聘门户")
+    item = listing()
+    item["ChangeDate"] = "not-a-date"
+    item["PostDate"] = "2026-07-20T01:02:03+08:00"
+    httpx_mock.add_response(url=SEARCH_URL, json=payload([item]))
+
+    [result] = BeisenScraper("fixturecorp").fetch()
+
+    assert result.company == "fixturecorp"
+    assert result.posted_at is not None
+    assert result.posted_at.tzinfo is UTC
+    assert result.posted_at.hour == 17

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -9,6 +9,7 @@ from ats_scrapers.exceptions import ScraperError
 from ats_scrapers.models import ATSType
 from ats_scrapers.scrapers import (
     AshbyScraper,
+    BeisenScraper,
     DarwinboxScraper,
     GreenhouseScraper,
     GupyScraper,
@@ -50,6 +51,7 @@ RESOLVES = [
         ATSType.DARWINBOX,
         "pwc.com",
     ),
+    ("https://mengniu.zhiye.com/social/jobs", ATSType.BEISEN, "mengniu"),
     # Subdomain tenants
     ("https://12build.recruitee.com", ATSType.RECRUITEE, "12build"),
     ("https://1komma5.teamtailor.com/jobs", ATSType.TEAMTAILOR, "1komma5"),
@@ -112,6 +114,8 @@ def test_icims_nonstandard_prefix_keeps_full_url() -> None:
         "https://bad_slug.darwinbox.in/ms/candidate/careers",
         f"https://{'a' * 64}.darwinbox.com/ms/candidate/careers",
         "https://trailing-.darwinbox.in/ms/candidate/careers",
+        "https://bad_slug.zhiye.com/social/jobs",
+        f"https://{'a' * 64}.zhiye.com/social/jobs",
         "not a url at all",
     ],
 )
@@ -143,6 +147,10 @@ def test_get_scraper_for_url_builds_scraper() -> None:
             "https://airtel.darwinbox.in/ms/candidate/careers"
         ),
         DarwinboxScraper,
+    )
+    assert isinstance(
+        get_scraper_for_url("https://mengniu.zhiye.com/social/jobs"),
+        BeisenScraper,
     )
     workday = get_scraper_for_url(
         "https://2020companies.wd1.myworkdayjobs.com/external_careers"

--- a/tests/test_run_pipeline_guards.py
+++ b/tests/test_run_pipeline_guards.py
@@ -48,6 +48,15 @@ def test_provider_slug_normalizers_match_current_company_csv_shape() -> None:
     assert runner.CONFIGS["darwinbox"]["slug"](darwinbox_row) == "pwc.com"
     assert runner.CONFIGS["darwinbox"]["output"] == "darwinbox/jobs.csv"
 
+    beisen_row = {
+        "name": "Mengniu Dairy",
+        "slug": "mengniu",
+        "url": "https://mengniu.zhiye.com",
+    }
+    assert runner.CONFIGS["beisen"]["scraper"] is runner.BeisenScraper
+    assert runner.CONFIGS["beisen"]["slug"](beisen_row) == "mengniu"
+    assert runner.CONFIGS["beisen"]["output"] == "beisen/jobs.csv"
+
     eightfold_row = {
         "name": "Amdocs",
         "slug": "amdocs",

--- a/tests/test_scrapers.py
+++ b/tests/test_scrapers.py
@@ -48,7 +48,7 @@ def test_registry_keys_are_valid_ats_types() -> None:
 
 def test_sources_without_scraper_adapters_are_explicit() -> None:
     registered = set(ScraperRegistry.all())
-    assert set(ATSType) - registered == {ATSType.BEISEN, ATSType.CUSTOM}
+    assert set(ATSType) - registered == {ATSType.CUSTOM}
 
 
 def test_registry_covers_core_atses() -> None:
@@ -91,9 +91,7 @@ def test_registry_returns_copy_so_external_mutation_is_safe() -> None:
 def test_has_scraper() -> None:
     assert ScraperRegistry.has_scraper("greenhouse") is True
     assert ScraperRegistry.has_scraper(ATSType.GREENHOUSE) is True
-    # A dataset source with no scraper yet (GH-185): known enum member
-    # but unregistered.
-    assert ScraperRegistry.has_scraper("beisen") is False
+    assert ScraperRegistry.has_scraper("beisen") is True
     # A source name not even in the enum must not raise.
     assert ScraperRegistry.has_scraper("futuristic_ats_9000") is False
 


### PR DESCRIPTION
## Summary
- add an async-first scraper for current `*.zhiye.com` Beisen/iTalent portals
- parse nested `BSGlobal` config structurally, then paginate the public API at 1,000 jobs per request
- add URL resolution, pipeline runner wiring, registry coverage, and eight live canonical tenants
- rebuild the old polluted branch entirely from current `main`

## Live validation
All eight seed tenants passed through the real scraper with unique IDs:

| Tenant | Jobs |
|---|---:|
| Chery | 5,066 |
| China Life | 1,195 |
| MediaTek | 56 |
| Mengniu Dairy | 99 |
| Mindray | 231 |
| Starbucks China | 26,096 |
| Uniqlo China | 1,959 |
| Vivo | 34 |
| **Total** | **34,736** |

## Validation
- `ruff check .`
- `pytest -q`: 1,262 passed, 2 skipped, 20 deselected
- wheel and sdist build successfully

The replacement also addresses the old review feedback: shared fetch retries cover transient registration failures, nested config parsing is balanced, and dead seeds are excluded.