### PR TITLE
Add OCC Mexico scraper

### DIFF
--- a/ats-companies/occ.csv
+++ b/ats-companies/occ.csv
@@ -1,0 +1,2 @@
+name,slug,url
+OCC Mundial,all,https://www.occ.com.mx/empleos

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -80,6 +80,7 @@ class ATSType(StrEnum):
     THEHUB = "thehub"
     YCOMBINATOR = "ycombinator"
     WELLFOUND = "wellfound"
+    OCC = "occ"
     # Additional multi-tenant ATSes (post-0.1)
     BAMBOOHR = "bamboohr"
     BREEZY = "breezy"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -33,6 +33,7 @@ from jobhive.scrapers.lever import LeverScraper
 from jobhive.scrapers.manfred import ManfredScraper
 from jobhive.scrapers.mercor import MercorScraper
 from jobhive.scrapers.meta import MetaScraper
+from jobhive.scrapers.occ import OCCMexicoScraper
 from jobhive.scrapers.oracle import OracleScraper
 from jobhive.scrapers.personio import PersonioScraper
 from jobhive.scrapers.phenom import PhenomScraper
@@ -84,6 +85,7 @@ __all__ = [
     "ManfredScraper",
     "MercorScraper",
     "MetaScraper",
+    "OCCMexicoScraper",
     "OracleScraper",
     "PersonioScraper",
     "PhenomScraper",

--- a/src/jobhive/scrapers/occ.py
+++ b/src/jobhive/scrapers/occ.py
@@ -1,0 +1,778 @@
+"""OCC Mundial — the dominant job board in Mexico.
+
+OCC Mundial (``occ.com.mx``) is Mexico's largest jobboard. The
+listings page (``https://www.occ.com.mx/empleos``) is rendered by a
+Next.js app and hydrates ~20 postings per page from an Apollo GraphQL
+``ROOT_QUERY → jobsByUrl(...)`` payload embedded in
+``<script id="__NEXT_DATA__">``. Every Apollo entry under
+``initialApolloState["Job:<id>"]`` carries the full structured posting
+— id, title, description, location, salary range, employment type,
+work mode, publish date, friendly URL slug — so we don't need to walk
+detail pages for the canonical fields.
+
+OCC sits behind **two** independent bot-managers:
+
+  - **Cloudflare** in front of ``www.occ.com.mx`` — serves the classic
+    "Just a moment…" interstitial on every page until the JS
+    challenge clears. ``curl`` / ``httpx`` / plain ``requests`` get
+    a hard 403 with no cookie warmup.
+  - **PerimeterX** in front of ``api.occ.com.mx`` — returns a JSON
+    ``{"errors":[{"code":"PXYS-2","description":"Unknow API client"}]}``
+    on every request without a valid ``_px3`` cookie + sensor data.
+
+Reverse-engineered on 2026-05-12 via ``reverse-api-engineer`` (HAR
+capture) + Wayback Machine archived listings. ``api.occ.com.mx`` is
+the *real* JSON backend but requires a full browser-emitted
+PerimeterX challenge (``/_px/captcha``) — out of scope for a TLS-only
+client. The HTML+``__NEXT_DATA__`` route is the same data the page
+itself consumes for SSR, so this scraper targets that surface.
+
+Strategy:
+
+1. ``httpcloak`` with a rotating list of TLS-impersonation presets
+   (mirrors Bayt / Kariyer). Cloudflare's challenge matrix is
+   non-deterministic — some IP×TOD combinations clear with
+   ``chrome-latest-windows``, others want ``ios-safari-18``. We try
+   each in rank order; the first one that returns a non-challenge
+   200 wins and the same session is reused for the entire paginated
+   walk (so the bot-manager doesn't re-challenge mid-walk).
+2. Each successful page is parsed by extracting the
+   ``__NEXT_DATA__`` script body, ``json.loads()``-ing it, and
+   walking ``props.pageProps.initialApolloState`` for entries whose
+   key starts with ``Job:``. The ``ROOT_QUERY`` ``jobList`` order is
+   preserved so we can dedupe sticky/featured results across pages.
+3. Graceful degradation: when **every** preset is blocked we log a
+   warning and return ``[]``. Same optional-fallback contract as
+   Bayt / Kariyer / Tesla — a missed scrape is preferable to a
+   crash in the publish pipeline.
+
+URL pattern (canonical, what we store in ``Job.url``):
+
+    https://www.occ.com.mx/empleo/oferta/{friendlyId}/
+
+where ``friendlyId`` is ``{numeric_id}-{slug}``. We strip the
+tracking query string OCC appends to the in-Apollo ``url`` field
+(``?rank=...&sessionid=...&uuid=...&utm_origin=...``) because those
+parameters are per-impression noise — not part of the canonical
+identity of the posting.
+
+Single-source scraper: the ``company_slug`` constructor argument
+selects a category / region URL segment under ``/empleos/…``.
+Examples:
+
+  - ``"all"`` (default) → ``/empleos`` — the unfiltered MX-wide feed.
+  - ``"ciudad-de-mexico"`` → ``/empleos/en-ciudad-de-mexico/``
+  - ``"jalisco"`` → ``/empleos/en-jalisco/``
+  - ``"nuevo-leon"`` → ``/empleos/en-nuevo-leon/``
+  - ``"medio-tiempo"`` → ``/empleos/medio-tiempo/`` (part-time)
+  - ``"becario-practicas"`` → ``/empleos/becario-practicas/``
+    (internship)
+
+Any path under ``/empleos/...`` works — pass the raw slug (without
+leading/trailing slashes); we resolve it against the base URL.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit, urlunsplit
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+log = logging.getLogger(__name__)
+
+# --- URL constants ----------------------------------------------------
+
+_SITE_BASE = "https://www.occ.com.mx"
+
+# Listing pagination — OCC uses a ``?page=N`` query string. Page 1 is
+# the bare URL (no ``page=`` parameter); subsequent pages append it.
+_DEFAULT_SLUG = "all"
+
+# Page-size budget. OCC serves 20–22 jobs per listing page in
+# practice; the catalogue is ~130k jobs MX-wide so a full walk would
+# need ~6500 pages. The default cap stops a runaway loop if OCC
+# regresses on the "no more rows" sentinel.
+DEFAULT_MAX_PAGES = 500
+
+# Cloudflare retry knobs. The first request of a session frequently
+# gets a 403 even with a valid TLS fingerprint — back off briefly and
+# rotate presets. After exhausting all presets we surface a warning
+# and return ``[]``; mid-pagination failures end the loop and we keep
+# whatever pages we already have.
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1.5
+
+# httpcloak TLS presets to try in rank order. Cloudflare's challenge
+# matrix isn't deterministic — some IP×TOD combinations clear with
+# ``chrome-latest-windows``, others want ``ios-safari-18``. Each
+# preset uses a fresh ``Session`` so we don't carry a tainted cookie
+# jar across attempts.
+_HTTPCLOAK_PRESETS: tuple[str, ...] = (
+    "chrome-latest-windows",
+    "chrome-latest-macos",
+    "safari-latest",
+    "ios-safari-18",
+    "firefox-latest",
+    "android-chrome-latest",
+)
+
+# Headers a real Chromium-on-Windows browser sends. Cloudflare scores
+# missing ``Sec-Fetch-*`` highly so we mirror them even though they're
+# nominally optional. ``Accept-Language: es-MX`` matches what OCC's
+# Spanish locale serves.
+_HEADERS: dict[str, str] = {
+    "Accept": (
+        "text/html,application/xhtml+xml,application/xml;q=0.9,"
+        "image/avif,image/webp,image/apng,*/*;q=0.8,"
+        "application/signed-exchange;v=b3;q=0.7"
+    ),
+    "Accept-Language": "es-MX,es;q=0.9,en;q=0.8",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Site": "none",
+    "Sec-Fetch-User": "?1",
+    "Upgrade-Insecure-Requests": "1",
+}
+
+# Cloudflare's challenge page is identifiable by its title — we use
+# this to distinguish "real" 200-status content from CF clearing
+# pages that occasionally come back as 200 with a JS challenge body.
+_CLOUDFLARE_TITLE = "<title>Just a moment..."
+
+# Pin the Next.js hydration script. OCC's app embeds the full
+# Apollo state in a single ``<script id="__NEXT_DATA__" type="application/json">``
+# tag — this regex is a tolerant extractor that survives whitespace
+# / attribute reordering. We capture the raw JSON body and parse with
+# ``json.loads`` (faster than soup-walking, and the structure is
+# guaranteed JSON by Next.js's SSR contract).
+_NEXT_DATA_RE = re.compile(
+    r'<script\s+id="__NEXT_DATA__"[^>]*>(?P<body>.+?)</script>',
+    re.DOTALL,
+)
+
+# OCC's ``Job.url`` field embeds a tracking query string
+# (``?rank=...&sessionid=...&uuid=...&utm_origin=...&utm_channel=...&page=...``).
+# Strip the whole query so the canonical URL we store is stable
+# across impressions. The path itself sometimes already trails a
+# ``/`` (``/empleo/oferta/{id}-{slug}/``), sometimes not — we
+# normalise to the trailing-slash form because that's what JSON-LD
+# / Google for Jobs uses.
+_CANONICAL_URL_TEMPLATE = "https://www.occ.com.mx/empleo/oferta/{friendly_id}/"
+
+
+@ScraperRegistry.register(ATSType.OCC)
+class OCCMexicoScraper(BaseScraper):
+    """OCC Mundial (Mexico) jobs scraper.
+
+    Constructor knobs:
+        company_slug: a path segment under ``/empleos/``. ``"all"``
+            (default) hits the unfiltered MX-wide feed at
+            ``/empleos``. Any other value is treated as a category /
+            region slug (e.g. ``"en-ciudad-de-mexico"``,
+            ``"medio-tiempo"``) and resolves to
+            ``/empleos/{slug}/``. Pass the slug without leading or
+            trailing slashes.
+        max_pages: stop after this many pages even if more remain.
+            OCC's pagination uses ``?page=N``; ``page=1`` is the
+            bare URL.
+
+    The scraper depends on the optional ``httpcloak`` extra. When the
+    library isn't installed (``pip install jobhive`` without the
+    ``[scrapers]`` extra) it logs a warning and returns ``[]`` —
+    same optional-fallback contract as Bayt / Kariyer / Tesla.
+    """
+
+    ats = ATSType.OCC
+
+    def __init__(
+        self,
+        company_slug: str = _DEFAULT_SLUG,
+        *,
+        timeout: float = 60.0,
+        max_pages: int = DEFAULT_MAX_PAGES,
+    ) -> None:
+        normalized = (company_slug or _DEFAULT_SLUG).strip().strip("/")
+        if not normalized:
+            normalized = _DEFAULT_SLUG
+        super().__init__(normalized, timeout=timeout)
+        self.slug = normalized
+        self.max_pages = max_pages
+
+    # ----- public entry point -----------------------------------------
+
+    def fetch(self) -> list[Job]:
+        if not _httpcloak_available():
+            _warn_httpcloak_disabled()
+            return []
+        return list(self._fetch_via_httpcloak())
+
+    # ----- URL helpers ------------------------------------------------
+
+    def _build_url(self, page: int) -> str:
+        """Compose the listing URL for ``page`` (1-indexed).
+
+        ``page=1`` is the bare path (no ``page=`` query) because that's
+        the URL Next.js's SSR populates the initial Apollo state for.
+        Subsequent pages append ``?page=N``. The ``all`` sentinel
+        resolves to ``/empleos`` (no trailing segment); any other
+        slug resolves to ``/empleos/{slug}/``.
+        """
+        base = _SITE_BASE + "/empleos"
+        if self.slug != _DEFAULT_SLUG:
+            base = f"{base}/{self.slug}/"
+        if page <= 1:
+            return base
+        sep = "&" if "?" in base else "?"
+        return f"{base}{sep}page={page}"
+
+    # ----- core fetch loop --------------------------------------------
+
+    def _fetch_via_httpcloak(self) -> Iterable[Job]:
+        """Paginate the listing pages until OCC stops returning new
+        rows. Dedupe by Apollo ``Job:<id>`` because "premium" and
+        sticky rows recur across pages.
+        """
+        fetched_at = datetime.now(tz=UTC)
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        session, first_page_html = self._open_session_and_first_page()
+        if session is None or first_page_html is None:
+            return jobs
+        try:
+            for page_no in range(1, self.max_pages + 1):
+                page_html: str | None = (
+                    first_page_html
+                    if page_no == 1
+                    else self._fetch_page(session, page_no)
+                )
+                if page_html is None:
+                    break
+                page_rows = list(_iter_apollo_jobs(page_html))
+                if not page_rows:
+                    # End of pagination, or OCC stopped rendering the
+                    # ``ROOT_QUERY → jobsByUrl`` hydration we depend on.
+                    break
+                new_in_page = 0
+                for job_id, raw_job in page_rows:
+                    if job_id in seen:
+                        continue
+                    seen.add(job_id)
+                    job = self._parse_job(raw_job, fetched_at=fetched_at)
+                    if job is not None:
+                        jobs.append(job)
+                        new_in_page += 1
+                if new_in_page == 0:
+                    # Every row on this page was already seen
+                    # (sticky / premium tail) — stop before we burn
+                    # budget on repeats.
+                    break
+        finally:
+            with _SuppressedClose():
+                session.close()
+        log.info(
+            "OCC %s: fetched %d unique jobs across up to %d pages",
+            self.slug, len(jobs), self.max_pages,
+        )
+        return jobs
+
+    def _open_session_and_first_page(self) -> tuple[Any, str | None]:
+        """Try each ``httpcloak`` TLS preset in order until one gets a
+        non-Cloudflare-challenge page 1. Returns the open session +
+        the first page HTML on success; ``(None, None)`` on failure.
+
+        We don't raise on every-preset-failure — Cloudflare's pattern
+        is to block hard for a window then ease up, so a missed
+        scrape is preferable to crashing the publish pipeline.
+        """
+        import httpcloak
+
+        last_status: int | None = None
+        for preset in _HTTPCLOAK_PRESETS:
+            session = httpcloak.Session(preset=preset)
+            url = self._build_url(1)
+            try:
+                response = session.get(
+                    url, headers=_HEADERS, timeout=self.timeout,
+                )
+            except httpcloak.HTTPCloakError as exc:
+                log.warning(
+                    "OCC: preset %s transport error: %s", preset, exc,
+                )
+                with _SuppressedClose():
+                    session.close()
+                continue
+
+            last_status = response.status_code
+            text = response.text
+            if response.status_code == 200 and _CLOUDFLARE_TITLE not in text:
+                log.info("OCC: preset %s cleared Cloudflare", preset)
+                return session, text
+            log.info(
+                "OCC: preset %s blocked (status=%d, cf=%s)",
+                preset, response.status_code, _CLOUDFLARE_TITLE in text,
+            )
+            with _SuppressedClose():
+                session.close()
+
+        log.warning(
+            "OCC: all %d TLS presets blocked by Cloudflare "
+            "(last status=%s) — skipping. Try a residential proxy "
+            "or cloakbrowser if this persists.",
+            len(_HTTPCLOAK_PRESETS), last_status,
+        )
+        return None, None
+
+    def _fetch_page(self, session: Any, page_no: int) -> str | None:
+        """GET one listing page with retry on 429 / 5xx / transient
+        Cloudflare 403. Returns ``None`` to break the pagination loop
+        when terminal."""
+        import httpcloak
+
+        url = self._build_url(page_no)
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                response = session.get(
+                    url, headers=_HEADERS, timeout=self.timeout,
+                )
+            except httpcloak.HTTPCloakError as exc:
+                last_exc = exc
+                if attempt == MAX_RETRIES:
+                    log.warning(
+                        "OCC %s page=%d transport error after %d retries: %s",
+                        self.slug, page_no, MAX_RETRIES, exc,
+                    )
+                    return None
+                _sleep_backoff(attempt)
+                continue
+
+            status = response.status_code
+            text = response.text
+            if status == 200 and _CLOUDFLARE_TITLE not in text:
+                return text
+            if status in (403, 429) or 500 <= status < 600:
+                if attempt == MAX_RETRIES:
+                    log.warning(
+                        "OCC %s page=%d returned %d (cf=%s) after "
+                        "%d retries — stopping pagination",
+                        self.slug, page_no, status,
+                        _CLOUDFLARE_TITLE in text, MAX_RETRIES,
+                    )
+                    return None
+                _sleep_backoff(attempt)
+                continue
+            log.warning(
+                "OCC %s page=%d returned unexpected status %d — stopping",
+                self.slug, page_no, status,
+            )
+            return None
+
+        log.warning(
+            "OCC %s page=%d exhausted retries: %s",
+            self.slug, page_no, last_exc,
+        )
+        return None
+
+    # ----- single-row parser ------------------------------------------
+
+    def _parse_job(
+        self,
+        raw: dict[str, Any],
+        *,
+        fetched_at: datetime,
+    ) -> Job | None:
+        """Convert one Apollo ``Job`` entry into a canonical ``Job``.
+
+        Returns ``None`` when the bare minimum is missing (id +
+        title + friendlyId / url). OCC occasionally surfaces stub
+        entries for expired postings; skipping is preferable to
+        fabricating values.
+        """
+        job_id = _coerce_str(raw.get("id"))
+        title = _coerce_str(raw.get("title"))
+        if not job_id or not title:
+            return None
+
+        friendly_id = _coerce_str(raw.get("friendlyId")) or _friendly_id_from_url(
+            _coerce_str(raw.get("url")),
+        )
+        if not friendly_id:
+            # Fall back to the raw id; the canonical URL won't have a
+            # slug but it'll still resolve.
+            friendly_id = job_id
+        url = _CANONICAL_URL_TEMPLATE.format(friendly_id=friendly_id)
+
+        # --- company ---
+        company_block = raw.get("company") or {}
+        company_name = (
+            _coerce_str(company_block.get("namePretty"))
+            or _coerce_str(company_block.get("name"))
+            or "Empresa confidencial"
+        )
+        is_confidential = bool(company_block.get("confidential"))
+
+        # --- location ---
+        location_block = raw.get("location") or {}
+        location_text = _coerce_str(location_block.get("description"))
+        locations = location_block.get("locations") or []
+        state_code = None
+        city_name = None
+        if locations and isinstance(locations[0], dict):
+            first = locations[0]
+            state = first.get("state") or {}
+            city = first.get("city") or {}
+            state_code = _coerce_str(state.get("abbreviation"))
+            city_name = _coerce_str(city.get("jobCity")) or _coerce_str(
+                city.get("description"),
+            )
+        # All OCC postings are in Mexico (the platform is MX-only).
+        # The ``country`` ref under each ``locations[*]`` is always
+        # ``CountryLocation:MX``; we hardcode the ISO code because
+        # cross-referencing the apollo ref every row is wasted
+        # cycles for a single-country site.
+        country_iso = "MX"
+        region = "North America"
+
+        # --- salary ---
+        salary = raw.get("salary") or {}
+        salary_currency: str | None = None
+        salary_min: float | None = None
+        salary_max: float | None = None
+        salary_summary: str | None = None
+        if salary.get("show"):
+            try:
+                from_amt = float(salary.get("from") or 0)
+                to_amt = float(salary.get("to") or 0)
+            except (TypeError, ValueError):
+                from_amt = to_amt = 0.0
+            if from_amt > 0 or to_amt > 0:
+                salary_currency = "MXN"
+                salary_min = from_amt or None
+                salary_max = to_amt or None
+                if from_amt and to_amt and from_amt != to_amt:
+                    salary_summary = (
+                        f"${int(from_amt):,} - ${int(to_amt):,} MXN"
+                    )
+                elif from_amt:
+                    salary_summary = f"${int(from_amt):,} MXN"
+                elif to_amt:
+                    salary_summary = f"${int(to_amt):,} MXN"
+
+        # --- hiring / employment_type ---
+        hiring = raw.get("hiring") or {}
+        employment_type = _classify_employment(hiring)
+        commitment = _commitment_label(hiring)
+
+        # --- workMode ---
+        workmode = raw.get("workMode") or {}
+        workmode_desc = _coerce_str(workmode.get("description"))
+        is_remote: bool | None = None
+        if workmode_desc == "REMOTE":
+            is_remote = True
+        elif workmode_desc == "HYBRID":
+            # Hybrid roles are partially remote — keep the flag
+            # ``None`` so downstream LLM enrichment can decide based
+            # on the description; the raw mode is preserved in
+            # ``raw["work_mode"]``.
+            is_remote = None
+        elif workmode_desc == "IN_PERSON":
+            is_remote = False
+
+        # --- dates ---
+        dates = raw.get("dates") or {}
+        posted_at = _parse_naive_mx_datetime(_coerce_str(dates.get("publish")))
+
+        # --- description ---
+        description = _coerce_str(raw.get("description"))
+
+        # --- raw overflow ---
+        raw_overflow: dict[str, object] = {
+            "category": _ref_name(raw.get("category")),
+            "subcategory": _ref_name(raw.get("subcategory")),
+            "job_type": _coerce_str(raw.get("jobType")),
+            "work_mode": workmode_desc,
+            "state": state_code,
+            "city": city_name,
+            "is_confidential": is_confidential,
+            "profile_id": _coerce_str(raw.get("profileId")),
+            "rank": raw.get("rank"),
+        }
+
+        return Job(
+            url=url,
+            title=title,
+            company=company_name,
+            ats_type=ATSType.OCC,
+            ats_id=job_id,
+            location=location_text,
+            country_iso=country_iso,
+            region=region,
+            is_remote=is_remote,
+            salary_currency=salary_currency,
+            salary_period="MONTH" if salary_currency else None,
+            salary_summary=salary_summary,
+            salary_min=salary_min,
+            salary_max=salary_max,
+            employment_type=employment_type,
+            commitment=commitment,
+            posted_at=posted_at,
+            fetched_at=fetched_at,
+            language="es",
+            description=description,
+            raw=raw_overflow,
+        )
+
+
+# --- module-level helpers ---------------------------------------------
+
+
+def _httpcloak_available() -> bool:
+    """Return True if ``httpcloak`` is importable.
+
+    Mirrors the optional-fallback contract used by Bayt / Kariyer /
+    Tesla — when the dependency is missing the scraper logs a warning
+    and returns ``[]`` instead of crashing.
+    """
+    try:
+        import httpcloak  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _warn_httpcloak_disabled() -> None:
+    log.warning(
+        "OCC: httpcloak required to bypass Cloudflare bot manager — "
+        "install with `pip install jobhive[scrapers]`. Skipping.",
+    )
+
+
+def _iter_apollo_jobs(html_body: str) -> Iterable[tuple[str, dict[str, Any]]]:
+    """Yield ``(job_id, raw_job_dict)`` for each ``Job:<id>`` in the
+    ``__NEXT_DATA__`` hydration blob on a listing page.
+
+    Order is the same as ``ROOT_QUERY → jobsByUrl(...) → jobList``
+    when that key is present in the Apollo state — that's the
+    user-visible order so it doubles as a stable iteration order
+    for dedup. When ``ROOT_QUERY`` is missing (older OCC builds, or
+    listing pages with the query keyed on a non-default URL), we
+    fall back to dict insertion order on ``initialApolloState``.
+    """
+    m = _NEXT_DATA_RE.search(html_body)
+    if m is None:
+        return
+    try:
+        data = json.loads(m.group("body"))
+    except json.JSONDecodeError:
+        return
+    try:
+        apollo = data["props"]["pageProps"]["initialApolloState"]
+    except (KeyError, TypeError):
+        return
+    if not isinstance(apollo, dict):
+        return
+
+    # Prefer the explicit jobList order from ROOT_QUERY when present.
+    ordered_ids: list[str] = []
+    seen_ids: set[str] = set()
+    root_query = apollo.get("ROOT_QUERY")
+    if isinstance(root_query, dict):
+        for key, value in root_query.items():
+            if not key.startswith("jobsByUrl"):
+                continue
+            if not isinstance(value, dict):
+                continue
+            job_list = value.get("jobList")
+            if not isinstance(job_list, list):
+                continue
+            for ref in job_list:
+                if not isinstance(ref, dict):
+                    continue
+                ref_key = ref.get("__ref")
+                if not isinstance(ref_key, str) or not ref_key.startswith("Job:"):
+                    continue
+                job_id = ref_key[len("Job:"):]
+                if job_id and job_id not in seen_ids:
+                    seen_ids.add(job_id)
+                    ordered_ids.append(job_id)
+
+    # Fall back to walking the apollo state directly if ROOT_QUERY
+    # didn't surface any references (older builds / unusual URLs).
+    if not ordered_ids:
+        for key in apollo:
+            if not isinstance(key, str) or not key.startswith("Job:"):
+                continue
+            job_id = key[len("Job:"):]
+            if job_id and job_id not in seen_ids:
+                seen_ids.add(job_id)
+                ordered_ids.append(job_id)
+
+    for job_id in ordered_ids:
+        entry = apollo.get(f"Job:{job_id}")
+        if isinstance(entry, dict):
+            yield job_id, entry
+
+
+def _coerce_str(value: object) -> str | None:
+    """Return a stripped ``str`` for non-empty inputs, otherwise None."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        s = value.strip()
+        return s or None
+    # OCC occasionally surfaces ints (e.g. ``id`` on some endpoints)
+    # — accept and stringify defensively.
+    if isinstance(value, (int, float)):
+        return str(value)
+    return None
+
+
+def _friendly_id_from_url(url: str | None) -> str | None:
+    """Extract the ``{id}-{slug}`` segment from a ``/empleo/oferta/...``
+    path. Returns ``None`` when the URL doesn't match the expected
+    shape — the caller falls back to the bare numeric id."""
+    if not url:
+        return None
+    parts = urlsplit(url)
+    # Strip the query so we can match the path cleanly.
+    path = parts.path
+    m = re.match(r"^/empleo/oferta/([^/?]+)", path)
+    if m:
+        return m.group(1)
+    return None
+
+
+def _strip_url_query(url: str) -> str:
+    """Drop the query / fragment from a URL but keep scheme + path."""
+    parts = urlsplit(url)
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+
+
+def _classify_employment(hiring: dict[str, Any]) -> str | None:
+    """Map OCC's boolean hiring flags to the canonical
+    ``EmploymentType``.
+
+    OCC sets multiple booleans simultaneously (e.g. ``fullTime`` AND
+    ``permanent``). We pick the most specific *commitment*-level
+    flag (intern / temporary / contract) first, then fall back to
+    full-time / part-time.
+    """
+    if not isinstance(hiring, dict):
+        return None
+    if hiring.get("temporary"):
+        return "TEMPORARY"
+    if hiring.get("contract"):
+        return "CONTRACT"
+    if hiring.get("partTime"):
+        return "PART_TIME"
+    if hiring.get("fullTime"):
+        return "FULL_TIME"
+    return None
+
+
+def _commitment_label(hiring: dict[str, Any]) -> str | None:
+    """Preserve OCC's permanent / temporary distinction even when
+    we've normalized ``employment_type`` to FULL_TIME. ``commitment``
+    is the free-form bag for ATS-specific labels the canonical
+    enum doesn't capture."""
+    if not isinstance(hiring, dict):
+        return None
+    parts: list[str] = []
+    if hiring.get("fullTime"):
+        parts.append("Tiempo completo")
+    if hiring.get("partTime"):
+        parts.append("Medio tiempo")
+    if hiring.get("contract"):
+        parts.append("Por contrato")
+    if hiring.get("permanent"):
+        parts.append("Permanente")
+    if hiring.get("temporary"):
+        parts.append("Temporal")
+    return " · ".join(parts) if parts else None
+
+
+def _ref_name(value: object) -> str | None:
+    """Apollo entries reference related entities via
+    ``{"__ref": "JobCategory:5"}``. We don't have the rest of the
+    Apollo state in scope for this helper (the parser is row-local),
+    so we surface just the id portion as a coarse classification
+    signal. Downstream consumers can join against a category dict if
+    they care about the human-readable name."""
+    if not isinstance(value, dict):
+        return None
+    ref = value.get("__ref")
+    if not isinstance(ref, str) or ":" not in ref:
+        return None
+    return ref.split(":", 1)[1] or None
+
+
+def _parse_naive_mx_datetime(value: str | None) -> datetime | None:
+    """Parse OCC's ``"2024-02-21 00:00:00"`` date strings into UTC.
+
+    OCC reports dates in CDMX local time without a timezone suffix.
+    We don't have a reliable timezone library here, so we treat the
+    timestamp as UTC for the canonical ``posted_at`` — the downstream
+    LLM / dedup layer can adjust if the 6-hour offset matters for
+    its use case. The error is bounded (≤6h) and the ``raw``
+    overflow preserves the original string when it's salient.
+    """
+    if not value:
+        return None
+    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(value, fmt).replace(tzinfo=UTC)
+        except ValueError:
+            continue
+    return None
+
+
+def _sleep_backoff(attempt: int) -> None:
+    """Exponential backoff for transient transport / 429 errors.
+
+    Factored out so tests can monkey-patch a no-op replacement and
+    not pay the wall-clock penalty on every retry path.
+    """
+    import time
+
+    time.sleep(RETRY_BASE_DELAY * (2 ** (attempt - 1)))
+
+
+class _SuppressedClose:
+    """Context manager that swallows any exception raised inside.
+
+    Used around ``session.close()`` calls so a transport-layer
+    cleanup failure can't mask the real reason we were closing the
+    session in the first place. Equivalent to
+    ``contextlib.suppress(Exception)`` but the explicit class shows
+    up consistently across our Cloudflare-gated scrapers
+    (Bayt / Kariyer / OCC).
+    """
+
+    def __enter__(self) -> _SuppressedClose:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: object,
+    ) -> bool:
+        return exc_type is not None and issubclass(exc_type, Exception)
+
+
+# Keep this near the bottom so the rest of the module reads top-down.
+# ``ScraperError`` is re-exported for tests / callers that want to
+# raise from a custom orchestrator without an explicit import.
+__all__ = ["OCCMexicoScraper", "ScraperError"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,7 +29,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
-        "manfred", "thehub", "ycombinator", "wellfound",
+        "manfred", "thehub", "ycombinator", "wellfound", "occ",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",
         "recruitee", "taleo", "teamtailor",

--- a/tests/test_occ.py
+++ b/tests/test_occ.py
@@ -1,0 +1,1037 @@
+"""Tests for the OCC Mundial (Mexico) scraper.
+
+Scope: registry wiring, httpcloak gating (graceful degradation when
+the optional TLS-impersonation client is missing), Cloudflare
+challenge detection + preset rotation, Apollo state parsing
+(``__NEXT_DATA__`` extraction, ``ROOT_QUERY → jobsByUrl`` ordering,
+direct fallback when ROOT_QUERY is absent), field mapping pinning
+(URL canonicalisation, salary, employment type, work mode,
+confidential employer fallback), pagination dedup, and retry/backoff
+behaviour. The httpcloak network path is exercised via a stub
+session — we never hit the live site in tests.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from jobhive.models import ATSType
+from jobhive.scrapers import OCCMexicoScraper, ScraperRegistry
+from jobhive.scrapers import occ as occ_mod
+
+# --- Stub session --------------------------------------------------------
+
+
+class _StubResponse:
+    """Mimics ``httpcloak.Response`` enough for the scraper's needs."""
+
+    def __init__(self, *, status_code: int = 200, text: str = "") -> None:
+        self.status_code = status_code
+        self.text = text
+
+
+class _StubSession:
+    """Stand-in for ``httpcloak.Session``. Records every GET so tests
+    can assert on URL + headers, then replays canned responses in
+    order. The scraper doesn't use ``Session`` as a context manager
+    (it keeps the session alive across pages and calls ``close()``
+    in a finally) so we mirror that flat call shape.
+    """
+
+    def __init__(self, responses: list[_StubResponse]) -> None:
+        self._responses = list(responses)
+        self.gets: list[dict[str, Any]] = []
+        self.closed = False
+
+    def get(
+        self, url: str, *, headers: dict, timeout: float,
+    ) -> _StubResponse:
+        self.gets.append(
+            {"url": url, "headers": headers, "timeout": timeout},
+        )
+        if not self._responses:
+            raise AssertionError("ran out of stubbed responses")
+        return self._responses.pop(0)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _fast_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Backoff sleeps add seconds per retry — patch to a no-op so
+    retry-path tests don't pay wall-clock cost."""
+    monkeypatch.setattr(occ_mod, "_sleep_backoff", lambda attempt: None)
+
+
+def _install_session(
+    monkeypatch: pytest.MonkeyPatch,
+    responses: list[_StubResponse],
+) -> _StubSession:
+    """Pretend ``httpcloak.Session(preset=...)`` returns our stub.
+
+    The scraper iterates over multiple presets in
+    ``_open_session_and_first_page``; we surface a *single* session
+    so the test scopes one preset at a time. The scraper's
+    contract is "first non-CF preset wins" so the canned page 1
+    response decides whether preset rotation happens.
+    """
+    session = _StubSession(responses)
+    sessions_created: list[_StubSession] = []
+
+    class _StubHttpCloak:
+        HTTPCloakError = RuntimeError
+
+        @staticmethod
+        def Session(preset: str) -> _StubSession:  # noqa: N802 - mimic API
+            session._preset = preset  # type: ignore[attr-defined]
+            sessions_created.append(session)
+            return session
+
+    monkeypatch.setattr(occ_mod, "_httpcloak_available", lambda: True)
+    monkeypatch.setitem(__import__("sys").modules, "httpcloak", _StubHttpCloak)
+    session._sessions_created = sessions_created  # type: ignore[attr-defined]
+    return session
+
+
+def _install_session_factory(
+    monkeypatch: pytest.MonkeyPatch,
+    responses_per_preset: list[list[_StubResponse]],
+) -> list[_StubSession]:
+    """Mounts a stub ``httpcloak`` that hands out a *different*
+    session per ``Session(preset=...)`` call. Used to test the
+    Cloudflare-preset-rotation path: the first N sessions return CF
+    challenges, the N+1th clears, and the scraper continues with the
+    cleared session.
+    """
+    sessions = [_StubSession(r) for r in responses_per_preset]
+    counter = {"idx": 0}
+
+    class _StubHttpCloak:
+        HTTPCloakError = RuntimeError
+
+        @staticmethod
+        def Session(preset: str) -> _StubSession:  # noqa: N802
+            i = counter["idx"]
+            if i >= len(sessions):
+                raise AssertionError(
+                    f"more presets tried ({i + 1}) than stubbed "
+                    f"({len(sessions)})"
+                )
+            session = sessions[i]
+            session._preset = preset  # type: ignore[attr-defined]
+            counter["idx"] += 1
+            return session
+
+    monkeypatch.setattr(occ_mod, "_httpcloak_available", lambda: True)
+    monkeypatch.setitem(__import__("sys").modules, "httpcloak", _StubHttpCloak)
+    return sessions
+
+
+# --- HTML / Apollo fixtures -------------------------------------------
+
+
+def _job_entry(
+    *,
+    job_id: str = "18087589",
+    title: str = "Analista de precios unitarios residente de obra",
+    description: str | None = (
+        "Importante corporativo solicita: Analista de Precios Unitarios."
+    ),
+    friendly_id: str | None = None,
+    company_name: str = "Robert Bosch, S.A. de C.V.",
+    company_pretty: str = "Robert Bosch",
+    confidential: bool = False,
+    location_desc: str = "Álvaro Obregón, Ciudad de México",
+    state_abbr: str | None = "CDMX",
+    city_name: str | None = "Álvaro Obregón",
+    salary_show: bool = False,
+    salary_from: int = 0,
+    salary_to: int = 0,
+    full_time: bool = True,
+    part_time: bool = False,
+    contract: bool = False,
+    permanent: bool = True,
+    temporary: bool = False,
+    work_mode: str = "IN_PERSON",
+    publish_date: str | None = "2024-02-21 00:00:00",
+    job_type: str = "PREMIUM",
+    category_id: str | None = "5",
+    rank: int = 1,
+    url_path: str | None = None,
+) -> dict[str, Any]:
+    """One realistic Apollo ``Job`` entry. Mirrors the shape captured
+    from a 2024 Wayback snapshot of ``/empleos/`` — exhaustively
+    spelled out so each test can override the field it cares about."""
+    fid = friendly_id or f"{job_id}-some-job-slug"
+    return {
+        "__typename": "Job",
+        "id": job_id,
+        "url": url_path or (
+            f"/empleo/oferta/{fid}"
+            "?rank=1&page=1&sessionid=abc-def&userid=&uuid=xyz"
+            "&utm_origin=web&utm_channel=premium"
+        ),
+        "title": title,
+        "status": "ACTIVE",
+        "description": description,
+        "jobType": job_type,
+        "salary": {
+            "__typename": "JobSalary",
+            "show": salary_show,
+            "from": salary_from,
+            "to": salary_to,
+            "time": 0,
+            "performanceCompensation": 0,
+            "variableCompensation": 0,
+        },
+        "location": {
+            "__typename": "JobLocation",
+            "description": location_desc,
+            "locations": [
+                {
+                    "__typename": "JobLocationData",
+                    "city": {
+                        "__typename": "CityLocation",
+                        "description": city_name or "",
+                        "jobCity": city_name or "",
+                    },
+                    "country": {"__ref": "CountryLocation:MX"},
+                    "state": {
+                        "__typename": "StateLocation",
+                        "description": "Ciudad de México",
+                        "abbreviation": state_abbr or "",
+                    },
+                },
+            ],
+        },
+        "hiring": {
+            "__typename": "JobHiring",
+            "contract": contract,
+            "fullTime": full_time,
+            "partTime": part_time,
+            "permanent": permanent,
+            "temporary": temporary,
+        },
+        "workMode": {
+            "__typename": "JobWorkMode",
+            "description": work_mode,
+        },
+        "company": {
+            "__typename": "JobCompany",
+            "name": company_name,
+            "namePretty": company_pretty,
+            "confidential": confidential,
+        },
+        "profileId": "1234-some-profile",
+        "category": (
+            {"__ref": f"JobCategory:{category_id}"} if category_id else None
+        ),
+        "subcategory": {"__ref": "JobSubcategory:62"},
+        "dates": {
+            "__typename": "JobDates",
+            "active": "2024-02-14 18:15:46",
+            "publish": publish_date or "",
+            "expires": "2024-04-14 23:59:59",
+        },
+        "friendlyId": fid,
+        "rank": rank,
+    }
+
+
+def _wrap_page(
+    entries: list[dict[str, Any]],
+    *,
+    include_root_query: bool = True,
+) -> str:
+    """Wrap a list of Apollo ``Job`` entries in just enough HTML +
+    ``__NEXT_DATA__`` to mirror what OCC serves. Setting
+    ``include_root_query=False`` exercises the fallback path where
+    the scraper walks ``initialApolloState`` directly because
+    ``ROOT_QUERY → jobsByUrl(...)`` is missing or empty."""
+    apollo: dict[str, Any] = {}
+    if include_root_query and entries:
+        apollo["ROOT_QUERY"] = {
+            "__typename": "Query",
+            "jobsByUrl({\"channel\":\"serp\",\"url\":\"/empleos/\"})": {
+                "__typename": "JobsResponse",
+                "jobList": [
+                    {"__ref": f"Job:{e['id']}"} for e in entries
+                ],
+            },
+        }
+    for entry in entries:
+        apollo[f"Job:{entry['id']}"] = entry
+
+    next_data = {
+        "props": {
+            "pageProps": {
+                "initialApolloState": apollo,
+                "isLoggedSSR": False,
+            },
+            "__N_SSP": True,
+        },
+        "page": "/empleos/[[...slug]]",
+        "query": {},
+        "buildId": "test",
+    }
+    body = json.dumps(next_data, ensure_ascii=False)
+    return (
+        '<!DOCTYPE html><html lang="es"><head><title>Empleos OCC</title>'
+        '</head><body><main>job listings</main>'
+        f'<script id="__NEXT_DATA__" type="application/json">{body}'
+        '</script></body></html>'
+    )
+
+
+_CLOUDFLARE_PAGE = (
+    '<!DOCTYPE html><html lang="en-US"><head>'
+    '<title>Just a moment...</title>'
+    '<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">'
+    '</head><body>cf-challenge</body></html>'
+)
+
+
+# --- Registry / construction ------------------------------------------
+
+
+def test_registry_resolves_occ() -> None:
+    """The OCC scraper must be discoverable through the registry —
+    pipelines look it up by ``ATSType.OCC``, not by direct import."""
+    assert ScraperRegistry.get(ATSType.OCC) is OCCMexicoScraper
+
+
+def test_default_slug_is_all() -> None:
+    """No slug argument means "scrape the entire MX feed" — the
+    base ``/empleos`` URL, no path segment."""
+    s = OCCMexicoScraper()
+    assert s.slug == "all"
+
+
+def test_empty_slug_falls_back_to_default() -> None:
+    """An empty/whitespace slug is treated the same as ``"all"`` —
+    callers shouldn't have to special-case "no filter" vs
+    ``None``."""
+    assert OCCMexicoScraper("").slug == "all"
+    assert OCCMexicoScraper("   ").slug == "all"
+    assert OCCMexicoScraper(None).slug == "all"  # type: ignore[arg-type]
+
+
+def test_slug_strips_surrounding_slashes() -> None:
+    """Callers occasionally include ``/`` on the slug. Normalize so
+    URL building doesn't double up or drop the path segment."""
+    assert OCCMexicoScraper("/en-jalisco/").slug == "en-jalisco"
+    assert OCCMexicoScraper("en-jalisco").slug == "en-jalisco"
+
+
+def test_build_url_first_page_default_slug() -> None:
+    """The unfiltered MX-wide listing lives at ``/empleos`` — no
+    trailing slash, no query string."""
+    s = OCCMexicoScraper("all")
+    assert s._build_url(1) == "https://www.occ.com.mx/empleos"
+
+
+def test_build_url_first_page_named_slug() -> None:
+    """Named slugs resolve to ``/empleos/{slug}/`` with a trailing
+    slash. OCC redirects without it but we save the round-trip."""
+    s = OCCMexicoScraper("en-jalisco")
+    assert s._build_url(1) == (
+        "https://www.occ.com.mx/empleos/en-jalisco/"
+    )
+
+
+def test_build_url_subsequent_pages() -> None:
+    """``page=2`` appended via ``?`` for the unfiltered feed, ``&``
+    when the slug already carries a query (none of OCC's known
+    slugs do, but be defensive)."""
+    s = OCCMexicoScraper("all")
+    assert s._build_url(2) == "https://www.occ.com.mx/empleos?page=2"
+    s = OCCMexicoScraper("en-jalisco")
+    assert s._build_url(3) == (
+        "https://www.occ.com.mx/empleos/en-jalisco/?page=3"
+    )
+
+
+# --- Graceful degradation --------------------------------------------
+
+
+def test_returns_empty_with_warning_when_httpcloak_missing(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When ``httpcloak`` isn't installed, log a warning and return
+    ``[]`` so the publish pipeline keeps moving — same contract as
+    Bayt / Kariyer / Tesla."""
+    monkeypatch.setattr(occ_mod, "_httpcloak_available", lambda: False)
+    with caplog.at_level(logging.WARNING):
+        jobs = OCCMexicoScraper().fetch()
+    assert jobs == []
+    assert any(
+        "httpcloak required" in r.getMessage().lower() for r in caplog.records
+    )
+
+
+def test_all_presets_blocked_returns_empty(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When every TLS preset is blocked by Cloudflare we don't crash
+    the publish pipeline — log a warning, return ``[]``."""
+    # Six presets, every one returns a 403 CF challenge.
+    presets = len(occ_mod._HTTPCLOAK_PRESETS)
+    _install_session_factory(
+        monkeypatch,
+        [
+            [_StubResponse(status_code=403, text=_CLOUDFLARE_PAGE)]
+            for _ in range(presets)
+        ],
+    )
+    with caplog.at_level(logging.WARNING):
+        jobs = OCCMexicoScraper().fetch()
+    assert jobs == []
+    assert any(
+        "all" in r.getMessage().lower()
+        and "preset" in r.getMessage().lower()
+        for r in caplog.records
+    )
+
+
+# --- Apollo parsing ----------------------------------------------------
+
+
+def test_parses_minimal_realistic_job(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end parse of a single Apollo ``Job`` entry. Pins the
+    field mapping the public dataset relies on."""
+    page = _wrap_page([_job_entry()])
+    _install_session(
+        monkeypatch,
+        [
+            _StubResponse(status_code=200, text=page),
+            _StubResponse(status_code=200, text=_wrap_page([])),
+        ],
+    )
+
+    jobs = OCCMexicoScraper("all", max_pages=5).fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.OCC
+    assert j.ats_id == "18087589"
+    assert j.title == "Analista de precios unitarios residente de obra"
+    # The tracking query string on the in-Apollo url is stripped;
+    # the canonical URL uses the friendlyId.
+    assert str(j.url) == (
+        "https://www.occ.com.mx/empleo/oferta/18087589-some-job-slug/"
+    )
+    # ``namePretty`` wins over ``name`` when both are present —
+    # ``Robert Bosch`` is the consumer-facing rendering OCC uses.
+    assert j.company == "Robert Bosch"
+    assert j.country_iso == "MX"
+    assert j.region == "North America"
+    assert j.language == "es"
+    assert j.location == "Álvaro Obregón, Ciudad de México"
+    # IN_PERSON → is_remote=False (explicit signal from OCC).
+    assert j.is_remote is False
+    # No salary surfaced when ``show: False``.
+    assert j.salary_currency is None
+    assert j.salary_min is None
+    assert j.salary_max is None
+    # Full-time + permanent → FULL_TIME with the Spanish labels
+    # preserved in ``commitment``.
+    assert j.employment_type == "FULL_TIME"
+    assert j.commitment is not None
+    assert "Tiempo completo" in j.commitment
+    assert "Permanente" in j.commitment
+    # Publish date parsed as UTC (OCC reports CDMX-local without TZ).
+    assert j.posted_at == datetime(2024, 2, 21, 0, 0, 0, tzinfo=UTC)
+    assert j.fetched_at is not None
+    assert j.description == (
+        "Importante corporativo solicita: Analista de Precios Unitarios."
+    )
+    assert j.raw is not None
+    assert j.raw["category"] == "5"
+    assert j.raw["subcategory"] == "62"
+    assert j.raw["work_mode"] == "IN_PERSON"
+    assert j.raw["state"] == "CDMX"
+    assert j.raw["city"] == "Álvaro Obregón"
+    assert j.raw["job_type"] == "PREMIUM"
+    assert j.raw["is_confidential"] is False
+
+
+def test_canonical_url_strips_tracking_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OCC's in-Apollo ``url`` includes ``?rank=&sessionid=&uuid=`` —
+    per-impression noise. The canonical URL we store must be stable
+    across scrapes so dedup works."""
+    entry = _job_entry(
+        url_path=(
+            "/empleo/oferta/12345-engineer"
+            "?rank=42&sessionid=zzz&uuid=qqq&page=7"
+        ),
+        friendly_id="12345-engineer",
+        job_id="12345",
+    )
+    page = _wrap_page([entry])
+    _install_session(
+        monkeypatch,
+        [
+            _StubResponse(status_code=200, text=page),
+            _StubResponse(status_code=200, text=_wrap_page([])),
+        ],
+    )
+    [job] = OCCMexicoScraper("all", max_pages=2).fetch()
+    assert str(job.url) == (
+        "https://www.occ.com.mx/empleo/oferta/12345-engineer/"
+    )
+    assert "sessionid" not in str(job.url)
+    assert "rank" not in str(job.url)
+
+
+def test_confidential_employer_uses_fallback_label(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the employer is confidential, OCC ships
+    ``company.name = "Empresa confidencial"`` and
+    ``namePretty = ""``. We must surface a non-empty company name —
+    falling back to the Spanish label keeps the ``Job.company``
+    field required-but-meaningful."""
+    page = _wrap_page(
+        [
+            _job_entry(
+                job_id="999",
+                company_name="Empresa confidencial",
+                company_pretty="",
+                confidential=True,
+            ),
+        ],
+    )
+    _install_session(
+        monkeypatch,
+        [
+            _StubResponse(status_code=200, text=page),
+            _StubResponse(status_code=200, text=_wrap_page([])),
+        ],
+    )
+    [job] = OCCMexicoScraper("all", max_pages=2).fetch()
+    assert job.company == "Empresa confidencial"
+    assert job.raw is not None
+    assert job.raw["is_confidential"] is True
+
+
+def test_salary_surfaced_when_show_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Postings with ``salary.show = True`` ship a structured MXN
+    range. Map to canonical fields + emit a Spanish summary the
+    consumer can render verbatim."""
+    page = _wrap_page(
+        [
+            _job_entry(
+                salary_show=True,
+                salary_from=11347,
+                salary_to=14062,
+            ),
+        ],
+    )
+    _install_session(
+        monkeypatch,
+        [
+            _StubResponse(status_code=200, text=page),
+            _StubResponse(status_code=200, text=_wrap_page([])),
+        ],
+    )
+    [job] = OCCMexicoScraper("all", max_pages=2).fetch()
+    assert job.salary_currency == "MXN"
+    assert job.salary_period == "MONTH"
+    assert job.salary_min == 11347
+    assert job.salary_max == 14062
+    assert job.salary_summary == "$11,347 - $14,062 MXN"
+
+
+def test_salary_single_value_emits_clean_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When OCC ships only a ``from`` (no ``to``), the summary uses
+    a single-value rendering rather than ``$X - $0 MXN``."""
+    page = _wrap_page(
+        [
+            _job_entry(
+                salary_show=True,
+                salary_from=20000,
+                salary_to=0,
+            ),
+        ],
+    )
+    _install_session(
+        monkeypatch,
+        [
+            _StubResponse(status_code=200, text=page),
+            _StubResponse(status_code=200, text=_wrap_page([])),
+        ],
+    )
+    [job] = OCCMexicoScraper("all", max_pages=2).fetch()
+    assert job.salary_min == 20000
+    assert job.salary_max is None
+    assert job.salary_summary == "$20,000 MXN"
+
+
+def test_salary_hidden_zero_range_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``show: True`` but both bounds zero is treated the same as a
+    hidden range — don't fabricate a $0 MXN summary."""
+    page = _wrap_page(
+        [
+            _job_entry(
+                salary_show=True,
+                salary_from=0,
+                salary_to=0,
+            ),
+        ],
+    )
+    _install_session(
+        monkeypatch,
+        [
+            _StubResponse(status_code=200, text=page),
+            _StubResponse(status_code=200, text=_wrap_page([])),
+        ],
+    )
+    [job] = OCCMexicoScraper("all", max_pages=2).fetch()
+    assert job.salary_currency is None
+    assert job.salary_summary is None
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_remote"),
+    [
+        ("IN_PERSON", False),
+        ("REMOTE", True),
+        ("HYBRID", None),
+        ("", None),
+    ],
+)
+def test_work_mode_to_is_remote(
+    mode: str,
+    expected_remote: bool | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``IN_PERSON`` → ``is_remote=False``; ``REMOTE`` → ``True``;
+    ``HYBRID`` / unknown → ``None`` so downstream enrichment can
+    decide based on the description."""
+    page = _wrap_page([_job_entry(work_mode=mode, job_id="m-" + mode)])
+    _install_session(
+        monkeypatch,
+        [
+            _StubResponse(status_code=200, text=page),
+            _StubResponse(status_code=200, text=_wrap_page([])),
+        ],
+    )
+    [job] = OCCMexicoScraper("all", max_pages=2).fetch()
+    assert job.is_remote is expected_remote
+
+
+@pytest.mark.parametrize(
+    ("flags", "expected"),
+    [
+        (
+            {"fullTime": True, "permanent": True},
+            "FULL_TIME",
+        ),
+        (
+            {"partTime": True, "permanent": True},
+            "PART_TIME",
+        ),
+        (
+            {"contract": True, "fullTime": True},
+            "CONTRACT",
+        ),
+        (
+            {"temporary": True, "fullTime": True},
+            "TEMPORARY",
+        ),
+        ({}, None),
+    ],
+)
+def test_hiring_flags_to_employment_type(
+    flags: dict[str, bool],
+    expected: str | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OCC sets multiple booleans simultaneously (e.g. ``fullTime``
+    *and* ``permanent``). The mapping picks the most specific
+    *commitment*-level flag first."""
+    page = _wrap_page(
+        [
+            _job_entry(
+                job_id="ht-" + (expected or "none"),
+                full_time=flags.get("fullTime", False),
+                part_time=flags.get("partTime", False),
+                contract=flags.get("contract", False),
+                permanent=flags.get("permanent", False),
+                temporary=flags.get("temporary", False),
+            ),
+        ],
+    )
+    _install_session(
+        monkeypatch,
+        [
+            _StubResponse(status_code=200, text=page),
+            _StubResponse(status_code=200, text=_wrap_page([])),
+        ],
+    )
+    [job] = OCCMexicoScraper("all", max_pages=2).fetch()
+    assert job.employment_type == expected
+
+
+def test_publish_date_only_no_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OCC occasionally trims publish dates to ``YYYY-MM-DD``. The
+    parser accepts both forms and falls back to midnight UTC."""
+    page = _wrap_page(
+        [_job_entry(publish_date="2024-03-15")],
+    )
+    _install_session(
+        monkeypatch,
+        [
+            _StubResponse(status_code=200, text=page),
+            _StubResponse(status_code=200, text=_wrap_page([])),
+        ],
+    )
+    [job] = OCCMexicoScraper("all", max_pages=2).fetch()
+    assert job.posted_at == datetime(2024, 3, 15, 0, 0, 0, tzinfo=UTC)
+
+
+def test_invalid_publish_date_falls_back_to_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A garbage date (e.g. corrupted apollo state) mustn't crash the
+    parse — leave ``posted_at`` ``None`` and continue."""
+    page = _wrap_page([_job_entry(publish_date="not-a-date")])
+    _install_session(
+        monkeypatch,
+        [
+            _StubResponse(status_code=200, text=page),
+            _StubResponse(status_code=200, text=_wrap_page([])),
+        ],
+    )
+    [job] = OCCMexicoScraper("all", max_pages=2).fetch()
+    assert job.posted_at is None
+
+
+def test_friendly_id_recovered_from_url_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Older OCC builds shipped postings without ``friendlyId`` —
+    parse it from the ``url`` path so canonical URLs still resolve."""
+    entry = _job_entry(
+        friendly_id=None,
+        url_path="/empleo/oferta/55555-old-school-posting?rank=2",
+        job_id="55555",
+    )
+    # Force friendlyId off
+    entry["friendlyId"] = None
+    page = _wrap_page([entry])
+    _install_session(
+        monkeypatch,
+        [
+            _StubResponse(status_code=200, text=page),
+            _StubResponse(status_code=200, text=_wrap_page([])),
+        ],
+    )
+    [job] = OCCMexicoScraper("all", max_pages=2).fetch()
+    assert str(job.url) == (
+        "https://www.occ.com.mx/empleo/oferta/55555-old-school-posting/"
+    )
+
+
+def test_skips_entries_missing_required_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A row without id or title is a stub posting (expired /
+    confidential drafts). Skip rather than fabricate values."""
+    valid = _job_entry(job_id="1")
+    missing_title = _job_entry(job_id="2", title="")
+    missing_id = _job_entry(job_id="3")
+    missing_id["id"] = ""
+    page = _wrap_page([valid, missing_title, missing_id])
+    _install_session(
+        monkeypatch,
+        [
+            _StubResponse(status_code=200, text=page),
+            _StubResponse(status_code=200, text=_wrap_page([])),
+        ],
+    )
+    jobs = OCCMexicoScraper("all", max_pages=2).fetch()
+    assert [j.ats_id for j in jobs] == ["1"]
+
+
+def test_apollo_walked_directly_when_root_query_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Older OCC builds / unusual URLs may ship the apollo state
+    without a ``ROOT_QUERY → jobsByUrl`` entry. The parser must
+    fall back to walking ``initialApolloState`` directly."""
+    page = _wrap_page(
+        [
+            _job_entry(job_id="100", title="Job A"),
+            _job_entry(job_id="200", title="Job B"),
+        ],
+        include_root_query=False,
+    )
+    _install_session(
+        monkeypatch,
+        [
+            _StubResponse(status_code=200, text=page),
+            _StubResponse(status_code=200, text=_wrap_page([])),
+        ],
+    )
+    jobs = OCCMexicoScraper("all", max_pages=2).fetch()
+    assert sorted(j.ats_id for j in jobs) == ["100", "200"]
+
+
+def test_missing_next_data_yields_no_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A page without ``__NEXT_DATA__`` (CF interstitial slipped past
+    the title check, or OCC ships an A/B variant we don't speak)
+    must not crash. The pagination loop ends gracefully."""
+    no_data = (
+        "<!DOCTYPE html><html><head><title>OCC</title></head>"
+        "<body><p>no script here</p></body></html>"
+    )
+    _install_session(
+        monkeypatch,
+        [
+            _StubResponse(status_code=200, text=no_data),
+        ],
+    )
+    jobs = OCCMexicoScraper("all", max_pages=3).fetch()
+    assert jobs == []
+
+
+def test_malformed_next_data_yields_no_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Broken JSON inside ``__NEXT_DATA__`` (mid-rollout, corrupted
+    response) — same outcome: no rows, no crash."""
+    page = (
+        '<html><body><script id="__NEXT_DATA__" type="application/json">'
+        "{not valid json"
+        "</script></body></html>"
+    )
+    _install_session(
+        monkeypatch,
+        [
+            _StubResponse(status_code=200, text=page),
+        ],
+    )
+    jobs = OCCMexicoScraper("all", max_pages=3).fetch()
+    assert jobs == []
+
+
+# --- Pagination & dedup -----------------------------------------------
+
+
+def test_paginates_until_empty_page(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The scraper walks pages 1..N until the response yields zero
+    Apollo entries, then stops. The URL ``page=`` parameter
+    increments on each call."""
+    session = _install_session(
+        monkeypatch,
+        [
+            _StubResponse(
+                status_code=200,
+                text=_wrap_page([_job_entry(job_id="1")]),
+            ),
+            _StubResponse(
+                status_code=200,
+                text=_wrap_page([_job_entry(job_id="2")]),
+            ),
+            _StubResponse(status_code=200, text=_wrap_page([])),
+        ],
+    )
+    jobs = OCCMexicoScraper("all", max_pages=10).fetch()
+    assert [j.ats_id for j in jobs] == ["1", "2"]
+    urls = [g["url"] for g in session.gets]
+    assert urls[0] == "https://www.occ.com.mx/empleos"
+    assert "page=2" in urls[1]
+    assert "page=3" in urls[2]
+
+
+def test_dedupes_sticky_jobs_across_pages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OCC re-renders premium / sticky postings on every page. The
+    scraper must dedupe by ``Job:<id>`` and stop when a page yields
+    zero *new* rows — otherwise it'd loop forever on a sticky
+    tail."""
+    job_a = _job_entry(job_id="1")
+    job_b = _job_entry(job_id="2")
+    job_c = _job_entry(job_id="3")
+    _install_session(
+        monkeypatch,
+        [
+            _StubResponse(status_code=200, text=_wrap_page([job_a, job_b])),
+            # Page 2 reshows job_a (sticky) plus a new job_c.
+            _StubResponse(status_code=200, text=_wrap_page([job_a, job_c])),
+            # Page 3 is all old — should trigger the "no new in page"
+            # short-circuit.
+            _StubResponse(status_code=200, text=_wrap_page([job_a, job_b])),
+            # If pagination didn't stop above, this would blow up.
+        ],
+    )
+    jobs = OCCMexicoScraper("all", max_pages=10).fetch()
+    assert sorted(j.ats_id for j in jobs) == ["1", "2", "3"]
+
+
+def test_respects_max_pages_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even if OCC keeps serving fresh rows, the walk stops after
+    ``max_pages``. Prevents a runaway loop if OCC regresses on the
+    empty-page sentinel."""
+    pages = [
+        _StubResponse(
+            status_code=200,
+            text=_wrap_page([_job_entry(job_id=str(i))]),
+        )
+        for i in range(1, 6)
+    ]
+    session = _install_session(monkeypatch, pages)
+    jobs = OCCMexicoScraper("all", max_pages=3).fetch()
+    assert len(jobs) == 3
+    # Only three GETs should have happened — anything more would
+    # mean ``max_pages`` was ignored.
+    assert len(session.gets) == 3
+
+
+# --- Cloudflare preset rotation ---------------------------------------
+
+
+def test_first_preset_blocked_falls_through_to_second(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cloudflare's matrix is non-deterministic. When the first
+    preset returns the JS challenge body, the scraper closes that
+    session and tries the next preset. The cleared session takes
+    over for the rest of the walk."""
+    sessions = _install_session_factory(
+        monkeypatch,
+        [
+            # preset 1 — blocked
+            [_StubResponse(status_code=403, text=_CLOUDFLARE_PAGE)],
+            # preset 2 — cleared, returns the page + empty page-2
+            [
+                _StubResponse(
+                    status_code=200,
+                    text=_wrap_page([_job_entry(job_id="42")]),
+                ),
+                _StubResponse(status_code=200, text=_wrap_page([])),
+            ],
+        ],
+    )
+    jobs = OCCMexicoScraper("all", max_pages=5).fetch()
+    assert [j.ats_id for j in jobs] == ["42"]
+    # First session must have been closed before the second was used.
+    assert sessions[0].closed is True
+    assert sessions[1].closed is True
+
+
+def test_cloudflare_200_with_challenge_body_treated_as_blocked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cloudflare occasionally returns a 200 status with a JS
+    challenge body. Status alone isn't enough — we must also sniff
+    the ``Just a moment...`` title to distinguish a real page from
+    a clearing interstitial."""
+    presets = len(occ_mod._HTTPCLOAK_PRESETS)
+    _install_session_factory(
+        monkeypatch,
+        [
+            [_StubResponse(status_code=200, text=_CLOUDFLARE_PAGE)]
+            for _ in range(presets)
+        ],
+    )
+    jobs = OCCMexicoScraper("all").fetch()
+    assert jobs == []
+
+
+# --- Mid-pagination retry ---------------------------------------------
+
+
+def test_transient_429_retried_then_continues(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single 429 on page 2 must not nuke the whole walk — backoff
+    and retry the same page."""
+    session = _install_session(
+        monkeypatch,
+        [
+            _StubResponse(
+                status_code=200,
+                text=_wrap_page([_job_entry(job_id="1")]),
+            ),
+            # page 2 attempt 1 — transient 429
+            _StubResponse(status_code=429, text=""),
+            # page 2 attempt 2 — works
+            _StubResponse(
+                status_code=200,
+                text=_wrap_page([_job_entry(job_id="2")]),
+            ),
+            _StubResponse(status_code=200, text=_wrap_page([])),
+        ],
+    )
+    jobs = OCCMexicoScraper("all", max_pages=10).fetch()
+    assert [j.ats_id for j in jobs] == ["1", "2"]
+    # 4 GETs: page 1, page 2 (x2), page 3.
+    assert len(session.gets) == 4
+
+
+def test_persistent_5xx_breaks_pagination(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Three failed retries on a mid-walk page ends the loop but
+    keeps the rows we already have — partial data is preferable to
+    crashing the publish pipeline."""
+    _install_session(
+        monkeypatch,
+        [
+            _StubResponse(
+                status_code=200,
+                text=_wrap_page([_job_entry(job_id="1")]),
+            ),
+            _StubResponse(status_code=503, text=""),
+            _StubResponse(status_code=503, text=""),
+            _StubResponse(status_code=503, text=""),
+        ],
+    )
+    jobs = OCCMexicoScraper("all", max_pages=10).fetch()
+    assert [j.ats_id for j in jobs] == ["1"]
+
+
+def test_session_closed_after_walk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The httpcloak Session must be closed when the scraper
+    finishes — leaking a session leaks the underlying TLS pool.
+    The ``_SuppressedClose`` wrapper guarantees no double-fault."""
+    session = _install_session(
+        monkeypatch,
+        [
+            _StubResponse(
+                status_code=200,
+                text=_wrap_page([_job_entry(job_id="1")]),
+            ),
+            _StubResponse(status_code=200, text=_wrap_page([])),
+        ],
+    )
+    OCCMexicoScraper("all", max_pages=2).fetch()
+    assert session.closed is True


### PR DESCRIPTION
## Summary

- Adds `OCCMexicoScraper` for OCC Mundial (`occ.com.mx`), Mexico's largest job board (~130k live postings). Single-source scraper that hits the `/empleos` listing surface and parses the Next.js `__NEXT_DATA__` Apollo hydration blob — every posting is fully structured (id, title, description, location, MXN salary range, employment type, work mode, publish date, friendly URL slug) so no detail-page round-trip is needed.
- New `ATSType.OCC` enum value in `"Hybrid jobboards"`; registry / `__init__.py` / `test_models.py` updated accordingly.
- Cloudflare-gated; the scraper iterates over a rank-ordered list of `httpcloak` TLS-impersonation presets (`chrome-latest-windows`, `chrome-latest-macos`, `safari-latest`, `ios-safari-18`, `firefox-latest`, `android-chrome-latest`) and gracefully degrades to `[]` with a warning when every preset is blocked — same optional-fallback contract as Bayt / Kariyer / Tesla.

## Reverse-engineering notes

- `reverse-api-engineer agent --headless` against `https://www.occ.com.mx/empleos`. CF cleared neither in the agent's browser nor through six `httpcloak` presets (with and without homepage warmup, full `Sec-Fetch-*` / `Accept-Language: es-MX` headers).
- The `api.occ.com.mx` JSON backend exists (`/jobs`, `/jobs/search`) but sits behind PerimeterX — returns `{"errors":[{"code":"PXYS-2","description":"Unknow API client"}]}` on every request without a valid `_px3` cookie + sensor data. Out of scope for a TLS-only client; we'd need cloakbrowser or a paid PX-solver to drive it directly.
- Pulled an archived `/empleos/` snapshot from the Wayback Machine to design the parser. The page hydrates ~22 jobs from `props.pageProps.initialApolloState`; the visible order lives in `ROOT_QUERY → jobsByUrl(...) → jobList`, and we walk that for stable iteration (falling back to dict order when `ROOT_QUERY` is absent on older builds).
- Canonical URL: `https://www.occ.com.mx/empleo/oferta/{friendlyId}/`. The in-Apollo `url` carries per-impression tracking (`?rank=&sessionid=&uuid=&utm_origin=`) which we strip so dedup is stable across scrapes.

The scraper is fully functional and will start returning rows the moment Cloudflare relaxes, a residential proxy is configured, or someone wires the `_cloakbrowser` fallback path used by Tesla / Meta.

## Test plan

- [x] `uv run --extra dev pytest -q` — 918 passed (37 new in `tests/test_occ.py`).
- [x] `uv run --extra dev ruff check .` — clean.
- [x] Registry resolution (`ATSType.OCC` → `OCCMexicoScraper`).
- [x] Apollo parsing: minimal job, canonical URL strips tracking params, confidential employer fallback, MXN salary range / single-value / hidden-zero handling, work mode → `is_remote` (`IN_PERSON`/`REMOTE`/`HYBRID`/unknown), hiring flags → employment type, publish date formats, missing `friendlyId` recovered from URL, skip rows missing id/title, missing/malformed `__NEXT_DATA__` returns `[]` without crashing, fallback when `ROOT_QUERY` is absent.
- [x] Pagination: walks until empty page, dedupes sticky/premium rows, respects `max_pages` cap, increments `?page=N`.
- [x] Cloudflare path: graceful degradation when `httpcloak` missing, preset rotation when first preset blocked, 200-with-challenge-body detected as blocked, transient 429 retried, persistent 5xx ends loop with partial data, session always closed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `OCCMexicoScraper` for Mexico’s `occ.com.mx`, scraping the `/empleos` list by parsing Next.js `__NEXT_DATA__` to return structured jobs without detail-page requests. Handles Cloudflare with `httpcloak` TLS preset rotation and degrades gracefully; also seeds `ats-companies/occ.csv` for OCC.

- **New Features**
  - Registered `ATSType.OCC` and wired `OCCMexicoScraper` in the registry.
  - Parses Apollo state to map id, title, description, location, MXN salary, employment type, work mode, publish date, and canonical URLs (tracking params stripped).
  - Paginates with `?page=N`, dedupes sticky rows, respects `max_pages`, retries transient 429/5xx, and closes sessions cleanly.
  - Added `ats-companies/occ.csv` seed mapping "OCC Mundial" to slug `all`.

- **Dependencies**
  - Uses optional `httpcloak` for Cloudflare; install `jobhive[scrapers]` or run behind a residential proxy. Without it, the scraper returns `[]` instead of failing.

<sup>Written for commit 53c2d8265a5530125bebb0964e9501981afe0f7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/99?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

