### PR TITLE
Add HeadHunter (hh.ru + CIS) scraper

### DIFF
--- a/ats-companies/hhru.csv
+++ b/ats-companies/hhru.csv
@@ -1,0 +1,7 @@
+name,slug,url
+HeadHunter Belarus,by,https://hh.by
+HeadHunter Estonia,ee,https://hh.ee
+HeadHunter Kyrgyzstan,kg,https://hh.kg
+HeadHunter Kazakhstan,kz,https://hh.kz
+HeadHunter Russia,ru,https://hh.ru
+HeadHunter Uzbekistan,uz,https://hh.uz

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -80,6 +80,7 @@ class ATSType(StrEnum):
     THEHUB = "thehub"
     YCOMBINATOR = "ycombinator"
     WELLFOUND = "wellfound"
+    HH = "hh"
     # Additional multi-tenant ATSes (post-0.1)
     BAMBOOHR = "bamboohr"
     BREEZY = "breezy"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -25,6 +25,7 @@ from jobhive.scrapers.gem import GemScraper
 from jobhive.scrapers.getonbrd import GetOnBrdScraper
 from jobhive.scrapers.google import GoogleScraper
 from jobhive.scrapers.greenhouse import GreenhouseScraper
+from jobhive.scrapers.hhru import HHRuScraper
 from jobhive.scrapers.icims import iCIMSScraper
 from jobhive.scrapers.jazzhr import JazzHRScraper
 from jobhive.scrapers.jobsch import JobsChScraper
@@ -77,6 +78,7 @@ __all__ = [
     "GetOnBrdScraper",
     "GoogleScraper",
     "GreenhouseScraper",
+    "HHRuScraper",
     "JazzHRScraper",
     "JobsChScraper",
     "JoinComScraper",

--- a/src/jobhive/scrapers/hhru.py
+++ b/src/jobhive/scrapers/hhru.py
@@ -1,0 +1,579 @@
+"""HeadHunter (hh.ru / hh.kz / hh.ee / hh.uz / hh.kg / hh.by) — the
+dominant Russian + CIS job platform.
+
+HeadHunter exposes a free, well-documented REST API at
+``api.hh.{ru,kz,ee,uz,kg,by}``. The Russian property alone carries
+~1M live postings; the Kazakhstan and Estonian properties add another
+~150k + ~30k respectively, with the rest covering smaller CIS markets.
+
+The API is geo-restricted: requests from US/EU datacenter IPs return
+``{"errors":[{"type":"forbidden"}]}``. Production runs route through
+a residential proxy (Evomi). Pass ``proxy_url`` explicitly or set the
+``PROXY`` env var — both the standard ``http://user:pass@host:port``
+URL form and the 4-colon ``host:port:user:pass`` shape some providers
+ship are accepted (same helper jobs.ch / Programathor / Tesla use).
+
+The "company" in ``company_slug`` selects the country property to hit:
+``"ru"``, ``"kz"``, ``"ee"``, ``"uz"``, ``"kg"``, ``"by"``. Each shares
+the API surface — what differs is the regional emphasis (and the IP
+country the proxy needs to exit through).
+
+API caps ``(page + 1) * per_page`` at 2000 total results per query, so
+enumerating the whole ~1M corpus requires slicing the search space.
+``slice_by`` controls the slicing strategy:
+
+- ``"area"`` (default) — iterate top-level region codes
+  (1 = Moscow, 2 = Saint Petersburg, …). Cheapest fan-out with the
+  best coverage for ``ru`` and ``kz``.
+- ``"none"`` — single query, capped at 2000 results. Useful for tests
+  or for tiny markets (``ee`` returns far below the cap).
+
+Doc reference: https://github.com/hhru/api/blob/master/docs_eng/README.md
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+from collections.abc import AsyncIterator
+from datetime import datetime
+from typing import Any
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+# --- API constants ----------------------------------------------------------
+
+# Host per country property. ``company_slug`` keys into this dict to
+# pick the right one. Kept short — the keys match the canonical lower-
+# case country code we expect operators to pass.
+HOSTS: dict[str, str] = {
+    "ru": "api.hh.ru",
+    "kz": "api.hh.kz",
+    "ee": "api.hh.ee",
+    "uz": "api.hh.uz",
+    "kg": "api.headhunter.kg",
+    "by": "api.hh.by",
+}
+
+# ISO 3166-1 alpha-2 country code per host. Set on every Job so
+# downstream consumers can filter by country without parsing
+# ``area.name`` (which is Russian-language and city-level).
+COUNTRY_ISO: dict[str, str] = {
+    "ru": "RU",
+    "kz": "KZ",
+    "ee": "EE",
+    "uz": "UZ",
+    "kg": "KG",
+    "by": "BY",
+}
+
+# Locale of the listings on each property — the postings are written
+# in the country's primary language. Pinned per-host because the API
+# itself doesn't surface a language tag.
+LANGUAGE: dict[str, str] = {
+    "ru": "ru",
+    "kz": "kk",  # Kazakh — practically many listings are in Russian
+    "ee": "et",
+    "uz": "uz",
+    "kg": "ky",
+    "by": "be",
+}
+
+# Per-property top-level region codes. The full hh.ru tree is ~1000
+# nodes (countries → federal districts → oblasts → cities) but the
+# ``area`` filter supports any node — passing a parent fans out to
+# children automatically. These are the root regions that yield
+# meaningful slicing without exploding fan-out.
+#
+# References:
+# - https://api.hh.ru/areas — full tree
+# - The codes are stable and global across hh.* properties.
+AREAS: dict[str, list[str]] = {
+    # hh.ru — Russia. 113 is "Russia"; sub-regions split by federal
+    # district to keep each query under the 2000-result cap. The
+    # ones picked here are the densest federal subjects (Moscow + St
+    # Petersburg alone account for ~40% of the corpus, then a long
+    # tail of regional capitals).
+    "ru": [
+        "1",     # Moscow
+        "2",     # Saint Petersburg
+        "3",     # Yekaterinburg (Sverdlovsk Oblast)
+        "4",     # Novosibirsk
+        "66",    # Nizhny Novgorod
+        "68",    # Kazan
+        "76",    # Rostov-on-Don
+        "78",    # Samara
+        "88",    # Krasnodar
+        "104",   # Krasnoyarsk
+        "1438",  # Volgograd
+        "1646",  # Voronezh
+        "1652",  # Perm
+        "1716",  # Saratov
+        "1530",  # Ufa (Bashkortostan)
+        "1124",  # Ulyanovsk
+        "1202",  # Tver
+        "1146",  # Vladimir
+        "2114",  # Sochi
+        "2019",  # Tyumen
+    ],
+    "kz": [
+        "159",  # Almaty
+        "160",  # Astana (Nur-Sultan)
+        "161",  # Aktobe
+        "162",  # Atyrau
+        "164",  # Karaganda
+        "165",  # Kyzylorda
+        "167",  # Pavlodar
+        "172",  # Shymkent
+        "174",  # Oskemen
+    ],
+    "ee": [
+        "1486",  # Tallinn
+        "1490",  # Tartu
+        "1487",  # Narva
+    ],
+    "uz": [
+        "97",   # Tashkent
+        "2734", # Samarkand
+        "2735", # Bukhara
+    ],
+    "kg": [
+        "2470",  # Bishkek
+        "2471",  # Osh
+    ],
+    "by": [
+        "16",  # Minsk
+        "17",  # Brest
+        "18",  # Vitebsk
+        "20",  # Gomel
+        "21",  # Grodno
+        "22",  # Mogilev
+    ],
+}
+
+PER_PAGE = 100
+# API hard cap: (page + 1) * per_page <= 2000. With per_page=100 this
+# leaves us 20 pages of headroom per slice (0..19).
+MAX_PAGES_PER_SLICE = 20
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 4
+RETRY_BASE_DELAY = 1.5
+DEFAULT_TIMEOUT = 30.0
+
+# hh wants a contact email in the UA. The address is read straight off
+# the Cargo project — change if the contact owner changes.
+USER_AGENT = "jobhive/1.0 (kalil.bouzigues@gmail.com)"
+
+# Map hh ``employment.id`` values onto the canonical EmploymentType
+# enum. ``project`` / ``probation`` / ``volunteer`` collapse to
+# CONTRACT — none of them are a literal fit, but CONTRACT is the
+# closest cross-ATS bucket consumers expect when filtering "not
+# salaried full-time".
+EMPLOYMENT_MAP: dict[str, str] = {
+    "full": "FULL_TIME",
+    "part": "PART_TIME",
+    "project": "CONTRACT",
+    "probation": "CONTRACT",
+    "volunteer": "CONTRACT",
+}
+
+# Map hh ``experience.id`` to an integer year-count. ``moreThan6`` is
+# clamped to 6 — the API doesn't expose the actual upper bound.
+EXPERIENCE_MAP: dict[str, int] = {
+    "noExperience": 0,
+    "between1And3": 1,
+    "between3And6": 3,
+    "moreThan6": 6,
+}
+
+# Currency codes returned by the API → ISO 4217. ``RUR`` is the legacy
+# code for the Russian ruble — the canonical schema uses ``RUB``.
+# ``BYR`` (legacy Belarusian ruble, redenominated 2016) is mapped to
+# ``BYN``. Everything else is passed through as-is when already ISO.
+CURRENCY_MAP: dict[str, str] = {
+    "RUR": "RUB",
+    "RUB": "RUB",
+    "USD": "USD",
+    "EUR": "EUR",
+    "KZT": "KZT",
+    "BYR": "BYN",
+    "BYN": "BYN",
+    "UAH": "UAH",
+    "UZS": "UZS",
+    "KGS": "KGS",
+    "AZN": "AZN",
+    "GEL": "GEL",
+}
+
+
+def _resolve_proxy_url(raw: str | None) -> str | None:
+    """Accept the 4-colon ``host:port:user:pass`` shape some
+    residential-proxy providers ship and convert to the standard
+    ``http://user:pass@host:port`` URL httpx expects. Plain
+    ``http(s)://…`` URLs pass through.
+
+    Mirrors the helper in ``programathor.py`` and ``jobsch.py``; kept
+    local so the scraper has no internal cross-imports.
+    """
+    if not raw:
+        return None
+    raw = raw.strip()
+    m = re.match(r"^http://([^:/@]+):(\d+):([^:]+):(.+)$", raw)
+    if m:
+        host, port, user, pw = m.groups()
+        return f"http://{user}:{pw}@{host}:{port}"
+    return raw
+
+
+@ScraperRegistry.register(ATSType.HH)
+class HHRuScraper(BaseScraper):
+    """HeadHunter (hh.ru + CIS) scraper.
+
+    ``company_slug`` is the country property to hit — ``"ru"``,
+    ``"kz"``, ``"ee"``, ``"uz"``, ``"kg"``, ``"by"``. Each maps to a
+    different host but the API surface is identical.
+
+    Knobs:
+
+    - ``proxy_url`` — explicit proxy URL. Falls back to ``PROXY`` env
+      var (4-colon shape auto-converted), then to direct connection.
+      hh.ru returns 403 to US/EU datacenter IPs — pretty much always
+      needed in production from a cloud VM.
+    - ``slice_by`` — slicing strategy to fan past the 2000-result API
+      cap. ``"area"`` (default) iterates the regional codes in
+      :data:`AREAS`; ``"none"`` runs a single unsliced query.
+    - ``areas`` — explicit override of the area code list, useful for
+      testing or for narrowing the run to a single city.
+    - ``max_pages_per_slice`` — pagination ceiling within one slice.
+      The API caps at 20 (page 0..19 × per_page 100 = 2000 results).
+    """
+
+    ats = ATSType.HH
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = DEFAULT_TIMEOUT,
+        proxy_url: str | None = None,
+        slice_by: str = "area",
+        areas: list[str] | None = None,
+        max_pages_per_slice: int = MAX_PAGES_PER_SLICE,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        slug = (company_slug or "").lower().strip()
+        if slug not in HOSTS:
+            raise ScraperError(
+                f"HHRuScraper: unknown company_slug {company_slug!r}; "
+                f"expected one of {sorted(HOSTS)}"
+            )
+        self.country = slug
+        self.host = HOSTS[slug]
+        self.country_iso = COUNTRY_ISO[slug]
+        self.language = LANGUAGE[slug]
+        self.proxy_url = _resolve_proxy_url(proxy_url) or _resolve_proxy_url(
+            os.environ.get("PROXY")
+        )
+        if slice_by not in {"area", "none"}:
+            raise ScraperError(
+                f"HHRuScraper: unsupported slice_by={slice_by!r}; "
+                "expected 'area' or 'none'"
+            )
+        self.slice_by = slice_by
+        self.areas = areas if areas is not None else AREAS.get(slug, [])
+        self.max_pages_per_slice = min(max_pages_per_slice, MAX_PAGES_PER_SLICE)
+
+    # --- public entry ------------------------------------------------------
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        slices = self._build_slices()
+
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        lock = asyncio.Lock()
+
+        client_kwargs: dict[str, Any] = {
+            "timeout": self.timeout,
+            "follow_redirects": True,
+        }
+        if self.proxy_url:
+            client_kwargs["proxy"] = self.proxy_url
+            # Residential proxies occasionally MITM TLS with a CA chain
+            # that isn't in the system trust store; the requests carry
+            # no PII so the cost of disabling verify is low.
+            client_kwargs["verify"] = False
+
+        async with httpx.AsyncClient(**client_kwargs) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+
+            async def run_slice(slice_params: dict[str, str]) -> None:
+                async for item in self._iter_slice(client, sem, slice_params):
+                    job = self._build_job(item)
+                    if job is None or job.ats_id is None:
+                        continue
+                    async with lock:
+                        if job.ats_id in seen:
+                            continue
+                        seen.add(job.ats_id)
+                        jobs.append(job)
+
+            await asyncio.gather(*(run_slice(s) for s in slices))
+
+        return jobs
+
+    # --- slicing -----------------------------------------------------------
+
+    def _build_slices(self) -> list[dict[str, str]]:
+        """Cartesian product of the active slicing dimensions.
+
+        Currently a single dimension (area) → list of one-key dicts.
+        Kept dict-shaped so future ``slice_by="role"`` / ``"text"``
+        modes can slot in without changing the iteration code.
+        """
+        if self.slice_by == "none" or not self.areas:
+            return [{}]
+        return [{"area": code} for code in self.areas]
+
+    async def _iter_slice(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        slice_params: dict[str, str],
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Walk pages within a single (area / role / text) slice."""
+        page = 0
+        while page < self.max_pages_per_slice:
+            payload = await self._fetch_page(client, sem, slice_params, page)
+            items = payload.get("items") or []
+            if not items:
+                return
+            for item in items:
+                yield item
+            pages_in_slice = payload.get("pages") or 0
+            if page + 1 >= pages_in_slice:
+                return
+            page += 1
+
+    # --- HTTP --------------------------------------------------------------
+
+    async def _fetch_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        slice_params: dict[str, str],
+        page: int,
+    ) -> dict[str, Any]:
+        url = f"https://{self.host}/vacancies"
+        params: dict[str, str | int] = {
+            "per_page": PER_PAGE,
+            "page": page,
+            **slice_params,
+        }
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(
+                        url,
+                        params=params,
+                        headers={
+                            "User-Agent": USER_AGENT,
+                            "Accept": "application/json",
+                        },
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"hh.{self.country} fetch failed for {url} "
+                            f"params={params}: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                try:
+                    payload: dict[str, Any] = response.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"hh.{self.country} returned non-JSON 200 for {url} "
+                        f"params={params}: {exc}"
+                    ) from exc
+                return payload
+            if response.status_code == 403:
+                raise ScraperError(
+                    f"hh.{self.country} returned 403 for {url} — the API "
+                    "geo-blocks non-CIS IPs; set the PROXY env variable "
+                    "(or pass proxy_url) and route through a residential "
+                    "exit in Russia/CIS"
+                )
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"hh.{self.country} returned {response.status_code} "
+                        f"for {url} params={params} after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after)
+                    if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"hh.{self.country} returned {response.status_code} for {url} "
+                f"params={params}"
+            )
+        raise ScraperError(
+            f"hh.{self.country} exhausted retries for {url} params={params}: "
+            f"{last_exc}"
+        )
+
+    # --- parsing -----------------------------------------------------------
+
+    def _build_job(self, item: dict[str, Any]) -> Job | None:
+        ats_id = item.get("id")
+        url = item.get("alternate_url")
+        title = item.get("name")
+        if not ats_id or not url or not title:
+            return None
+
+        employer = item.get("employer") or {}
+        company = employer.get("name") or "Unknown"
+
+        area = item.get("area") or {}
+        location = area.get("name") or None
+
+        salary = item.get("salary") or {}
+        currency = salary.get("currency") if isinstance(salary, dict) else None
+        salary_currency: str | None = None
+        salary_min: float | None = None
+        salary_max: float | None = None
+        salary_period: str | None = None
+        if currency:
+            mapped = CURRENCY_MAP.get(currency.upper())
+            if mapped:
+                salary_currency = mapped
+                salary_period = "MONTH"
+                salary_min = _as_float(salary.get("from"))
+                salary_max = _as_float(salary.get("to"))
+
+        snippet = item.get("snippet") or {}
+        description = _join_snippet(
+            snippet.get("requirement"), snippet.get("responsibility")
+        )
+
+        employment = item.get("employment") or {}
+        emp_id = employment.get("id") if isinstance(employment, dict) else None
+        employment_type = EMPLOYMENT_MAP.get(emp_id) if emp_id else None
+        commitment = (
+            employment.get("name")
+            if isinstance(employment, dict) and employment.get("name")
+            else None
+        )
+
+        experience = item.get("experience") or {}
+        exp_id = experience.get("id") if isinstance(experience, dict) else None
+        experience_years = EXPERIENCE_MAP.get(exp_id) if exp_id else None
+
+        posted_at = _parse_published_at(item.get("published_at"))
+
+        raw: dict[str, Any] = {
+            "host": self.host,
+        }
+        if employer.get("id"):
+            raw["employer_id"] = employer["id"]
+        if area.get("id"):
+            raw["area_id"] = area["id"]
+        schedule = item.get("schedule")
+        if schedule:
+            raw["schedule"] = schedule
+        type_ = item.get("type")
+        if type_:
+            raw["type"] = type_
+        professional_roles = item.get("professional_roles")
+        if professional_roles:
+            raw["professional_roles"] = professional_roles
+
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.HH,
+            ats_id=str(ats_id),
+            location=location,
+            country_iso=self.country_iso,
+            salary_currency=salary_currency,
+            salary_period=salary_period,  # type: ignore[arg-type]
+            salary_min=salary_min,
+            salary_max=salary_max,
+            employment_type=employment_type,  # type: ignore[arg-type]
+            commitment=commitment,
+            experience=experience_years,
+            description=description,
+            posted_at=posted_at,
+            fetched_at=datetime.now(),
+            language=self.language,
+            raw=raw,
+        )
+
+
+# --- module-level helpers ---------------------------------------------------
+
+
+def _as_float(value: object) -> float | None:
+    """``salary.from`` / ``salary.to`` come back as ints when present
+    or ``null`` when not. Defensive ``float()`` since the API has been
+    known to ship occasional string values for currency conversions."""
+    if value is None:
+        return None
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _join_snippet(requirement: str | None, responsibility: str | None) -> str | None:
+    """hh.ru's ``snippet`` field carries two short HTML-marked-up
+    strings — combine into a single plain-text blob.
+
+    Highlight tags (``<highlighttext>``) wrap matched keywords when
+    the listing was returned via a text search. Strip them so the
+    description doesn't ship with markup.
+    """
+    parts = [p for p in (requirement, responsibility) if p]
+    if not parts:
+        return None
+    joined = "\n".join(parts)
+    cleaned = _HTML_TAG_RE.sub("", joined)
+    cleaned = cleaned.replace("&nbsp;", " ").replace("&amp;", "&")
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned or None
+
+
+# hh's ``published_at`` is ISO-8601 with a numeric offset:
+# ``2026-05-12T10:30:00+0300``. ``datetime.fromisoformat`` on 3.11+
+# accepts the ``+HH:MM`` form; we normalize ``+HHMM`` → ``+HH:MM``
+# before parsing.
+_TZ_OFFSET_RE = re.compile(r"([+-])(\d{2})(\d{2})$")
+
+
+def _parse_published_at(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    fixed = _TZ_OFFSET_RE.sub(r"\1\2:\3", value)
+    try:
+        return datetime.fromisoformat(fixed)
+    except ValueError:
+        return None

--- a/tests/test_hhru.py
+++ b/tests/test_hhru.py
@@ -1,0 +1,470 @@
+"""Tests for the HeadHunter (hh.ru + CIS) scraper.
+
+hh.ru exposes a JSON REST API but geo-blocks non-CIS IPs (403). These
+tests exercise:
+
+- Country-property routing (``ru`` → ``api.hh.ru``, ``kz`` → ``api.hh.kz``,
+  …) — the same scraper class hits a different host depending on the
+  ``company_slug`` argument.
+- Item parsing — every documented hh field maps onto the right ``Job``
+  slot (salary RUR → RUB, employment.id → EmploymentType,
+  experience.id → integer years, snippet → plain-text description,
+  HTML tags stripped).
+- Pagination — the scraper walks ``page=0..pages-1`` within a slice
+  and stops on empty ``items`` or when ``pages`` is exhausted.
+- Slicing — ``slice_by="area"`` fans out by region code;
+  ``slice_by="none"`` runs a single unsliced query.
+- The proxy URL helper (the 4-colon Evomi shape converts to the
+  standard URL form httpx wants).
+- 403 → ScraperError that points the operator at the proxy knob.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import HHRuScraper, ScraperRegistry
+from jobhive.scrapers.hhru import (
+    CURRENCY_MAP,
+    EMPLOYMENT_MAP,
+    EXPERIENCE_MAP,
+    HOSTS,
+    _join_snippet,
+    _parse_published_at,
+    _resolve_proxy_url,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.hhru as h
+
+    monkeypatch.setattr(h, "MAX_RETRIES", 1)
+    monkeypatch.setattr(h, "RETRY_BASE_DELAY", 0.0)
+
+
+@pytest.fixture(autouse=True)
+def _no_proxy_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The tests assume a clean env so the scraper doesn't try to
+    bounce httpx_mock through a real proxy."""
+    monkeypatch.delenv("PROXY", raising=False)
+
+
+# --- fixture helpers --------------------------------------------------------
+
+
+def _item(
+    *,
+    job_id: str = "1234567",
+    name: str = "Senior Python Developer",
+    employer_name: str = "Yandex",
+    employer_id: str = "1740",
+    area_id: str = "1",
+    area_name: str = "Москва",
+    salary: dict | None = None,
+    employment_id: str = "full",
+    employment_name: str = "Полная занятость",
+    experience_id: str = "between1And3",
+    experience_name: str = "От 1 года до 3 лет",
+    schedule_id: str = "fullDay",
+    requirement: str | None = "Опыт <highlighttext>Python</highlighttext> от 1 года.",
+    responsibility: str | None = "Разработка серверных сервисов.",
+    published_at: str = "2026-05-12T10:30:00+0300",
+    host: str = "hh.ru",
+) -> dict:
+    return {
+        "id": job_id,
+        "name": name,
+        "alternate_url": f"https://{host}/vacancy/{job_id}",
+        "employer": {"id": employer_id, "name": employer_name},
+        "area": {"id": area_id, "name": area_name},
+        "salary": salary,
+        "snippet": {"requirement": requirement, "responsibility": responsibility},
+        "employment": {"id": employment_id, "name": employment_name},
+        "experience": {"id": experience_id, "name": experience_name},
+        "schedule": {"id": schedule_id, "name": "Полный день"},
+        "type": {"id": "open", "name": "Открытая"},
+        "published_at": published_at,
+    }
+
+
+def _page(items: list[dict], *, page: int = 0, pages: int = 1) -> dict:
+    return {
+        "found": len(items),
+        "items": items,
+        "page": page,
+        "pages": pages,
+        "per_page": 100,
+        "clusters": None,
+    }
+
+
+# --- proxy URL helper -------------------------------------------------------
+
+
+def test_proxy_url_quad_colon_format_converted() -> None:
+    out = _resolve_proxy_url("http://proxy.example.com:1000:alice:secret")
+    assert out == "http://alice:secret@proxy.example.com:1000"
+
+
+def test_proxy_url_already_canonical_passes_through() -> None:
+    out = _resolve_proxy_url("http://user:pw@host.example:8080")
+    assert out == "http://user:pw@host.example:8080"
+
+
+def test_proxy_url_none_or_empty_returns_none() -> None:
+    assert _resolve_proxy_url(None) is None
+    assert _resolve_proxy_url("") is None
+
+
+# --- registry / constructor -------------------------------------------------
+
+
+def test_registry_resolves_hh() -> None:
+    assert ScraperRegistry.get(ATSType.HH) is HHRuScraper
+
+
+def test_unknown_country_slug_raises() -> None:
+    with pytest.raises(ScraperError, match="unknown company_slug"):
+        HHRuScraper("us")
+
+
+@pytest.mark.parametrize("slug, host", list(HOSTS.items()))
+def test_known_country_slugs_pick_right_host(slug: str, host: str) -> None:
+    scraper = HHRuScraper(slug)
+    assert scraper.host == host
+
+
+def test_unknown_slice_by_raises() -> None:
+    with pytest.raises(ScraperError, match="unsupported slice_by"):
+        HHRuScraper("ru", slice_by="zip")
+
+
+def test_max_pages_per_slice_is_clamped() -> None:
+    """API hard cap is 20 (2000 results) — even when the operator
+    passes a higher value, the scraper clamps."""
+    scraper = HHRuScraper("ru", max_pages_per_slice=500)
+    assert scraper.max_pages_per_slice == 20
+
+
+def test_picks_up_proxy_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROXY", "http://proxy.example.com:1000:alice:secret")
+    scraper = HHRuScraper("ru")
+    assert scraper.proxy_url == "http://alice:secret@proxy.example.com:1000"
+
+
+# --- happy path -------------------------------------------------------------
+
+
+def test_parses_full_item_ru(httpx_mock) -> None:
+    item = _item(
+        salary={"from": 200000, "to": 350000, "currency": "RUR", "gross": True},
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.hh\.ru/vacancies\?.*"),
+        json=_page([item], page=0, pages=1),
+    )
+    jobs = HHRuScraper("ru", slice_by="none").fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.HH
+    assert j.ats_id == "1234567"
+    assert str(j.url) == "https://hh.ru/vacancy/1234567"
+    assert j.title == "Senior Python Developer"
+    assert j.company == "Yandex"
+    assert j.location == "Москва"
+    assert j.country_iso == "RU"
+    assert j.language == "ru"
+    assert j.salary_currency == "RUB"  # RUR → RUB
+    assert j.salary_period == "MONTH"
+    assert j.salary_min == 200000.0
+    assert j.salary_max == 350000.0
+    assert j.employment_type == "FULL_TIME"
+    assert j.commitment == "Полная занятость"
+    assert j.experience == 1
+    assert j.description is not None
+    assert "<highlighttext>" not in j.description
+    assert "Python" in j.description
+    assert "Разработка" in j.description
+    assert j.posted_at is not None
+    assert j.posted_at.year == 2026 and j.posted_at.month == 5
+    assert j.raw is not None
+    assert j.raw["employer_id"] == "1740"
+    assert j.raw["area_id"] == "1"
+    assert j.raw["schedule"]["id"] == "fullDay"
+
+
+def test_routes_kz_to_kz_host(httpx_mock) -> None:
+    """``company_slug='kz'`` should hit api.hh.kz, set country_iso KZ,
+    language kk. The same payload shape is reused — only the host and
+    metadata change."""
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.hh\.kz/vacancies\?.*"),
+        json=_page([_item(host="hh.kz", area_id="160", area_name="Астана")]),
+    )
+    jobs = HHRuScraper("kz", slice_by="none").fetch()
+    assert len(jobs) == 1
+    assert jobs[0].country_iso == "KZ"
+    assert jobs[0].language == "kk"
+    assert str(jobs[0].url).startswith("https://hh.kz/")
+
+
+def test_routes_ee_to_ee_host(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.hh\.ee/vacancies\?.*"),
+        json=_page([_item(host="hh.ee", area_name="Tallinn")]),
+    )
+    jobs = HHRuScraper("ee", slice_by="none").fetch()
+    assert jobs[0].country_iso == "EE"
+    assert jobs[0].language == "et"
+
+
+# --- salary -----------------------------------------------------------------
+
+
+def test_salary_currency_map_covers_known_codes() -> None:
+    """Pin the legacy → ISO normalization. RUR (legacy) → RUB; BYR
+    (pre-2016 redenomination) → BYN. Everything else passes through."""
+    assert CURRENCY_MAP["RUR"] == "RUB"
+    assert CURRENCY_MAP["RUB"] == "RUB"
+    assert CURRENCY_MAP["BYR"] == "BYN"
+    assert CURRENCY_MAP["BYN"] == "BYN"
+    assert CURRENCY_MAP["USD"] == "USD"
+    assert CURRENCY_MAP["EUR"] == "EUR"
+    assert CURRENCY_MAP["KZT"] == "KZT"
+
+
+def test_salary_only_max(httpx_mock) -> None:
+    """hh.ru happily ships ranges with only one side filled in
+    (``from=None, to=200000``); the scraper should pass both through
+    as the optional ``salary_min`` / ``salary_max`` allow."""
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.hh\.ru/vacancies\?.*"),
+        json=_page([
+            _item(salary={"from": None, "to": 200000, "currency": "RUR"}),
+        ]),
+    )
+    jobs = HHRuScraper("ru", slice_by="none").fetch()
+    assert jobs[0].salary_min is None
+    assert jobs[0].salary_max == 200000.0
+    assert jobs[0].salary_currency == "RUB"
+
+
+def test_salary_missing_leaves_fields_none(httpx_mock) -> None:
+    """No ``salary`` block at all — keep all four salary fields
+    ``None`` instead of mis-defaulting to a free currency."""
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.hh\.ru/vacancies\?.*"),
+        json=_page([_item(salary=None)]),
+    )
+    jobs = HHRuScraper("ru", slice_by="none").fetch()
+    assert jobs[0].salary_currency is None
+    assert jobs[0].salary_min is None
+    assert jobs[0].salary_max is None
+    assert jobs[0].salary_period is None
+
+
+def test_unknown_currency_drops_salary(httpx_mock) -> None:
+    """Anything outside the known whitelist (e.g. obsolete codes) is
+    treated as 'no signal' — better to drop than to ship a value the
+    canonical schema can't represent."""
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.hh\.ru/vacancies\?.*"),
+        json=_page([
+            _item(salary={"from": 1000, "to": 2000, "currency": "ZZZ"}),
+        ]),
+    )
+    jobs = HHRuScraper("ru", slice_by="none").fetch()
+    assert jobs[0].salary_currency is None
+    assert jobs[0].salary_min is None
+    assert jobs[0].salary_max is None
+
+
+# --- employment / experience -----------------------------------------------
+
+
+@pytest.mark.parametrize("hh_id, expected", [
+    ("full", "FULL_TIME"),
+    ("part", "PART_TIME"),
+    ("project", "CONTRACT"),
+    ("probation", "CONTRACT"),
+    ("volunteer", "CONTRACT"),
+])
+def test_employment_map_covers_known_ids(hh_id: str, expected: str) -> None:
+    assert EMPLOYMENT_MAP[hh_id] == expected
+
+
+@pytest.mark.parametrize("hh_id, expected", [
+    ("noExperience", 0),
+    ("between1And3", 1),
+    ("between3And6", 3),
+    ("moreThan6", 6),
+])
+def test_experience_map_covers_known_ids(hh_id: str, expected: int) -> None:
+    assert EXPERIENCE_MAP[hh_id] == expected
+
+
+def test_unknown_employment_leaves_field_none(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.hh\.ru/vacancies\?.*"),
+        json=_page([_item(employment_id="other-future")]),
+    )
+    jobs = HHRuScraper("ru", slice_by="none").fetch()
+    assert jobs[0].employment_type is None
+
+
+# --- snippet / description --------------------------------------------------
+
+
+def test_join_snippet_strips_highlight_tags() -> None:
+    out = _join_snippet(
+        "Опыт <highlighttext>Python</highlighttext> от 1 года.",
+        "Разработка <highlighttext>backend</highlighttext> сервисов.",
+    )
+    assert out is not None
+    assert "<highlighttext>" not in out
+    assert "Python" in out
+    assert "backend" in out
+
+
+def test_join_snippet_both_none_returns_none() -> None:
+    assert _join_snippet(None, None) is None
+
+
+def test_join_snippet_one_side_only() -> None:
+    out = _join_snippet("Только requirement.", None)
+    assert out == "Только requirement."
+
+
+# --- published_at parsing ---------------------------------------------------
+
+
+def test_parse_published_at_handles_compact_offset() -> None:
+    """hh.ru ships ``+0300`` (no colon), older fromisoformat versions
+    rejected this — the scraper normalizes to ``+03:00``."""
+    dt = _parse_published_at("2026-05-12T10:30:00+0300")
+    assert dt is not None
+    assert dt.year == 2026 and dt.month == 5 and dt.day == 12
+    assert dt.hour == 10 and dt.minute == 30
+    assert dt.utcoffset() is not None
+
+
+def test_parse_published_at_none_returns_none() -> None:
+    assert _parse_published_at(None) is None
+    assert _parse_published_at("") is None
+
+
+def test_parse_published_at_invalid_returns_none() -> None:
+    assert _parse_published_at("yesterday") is None
+
+
+# --- pagination -------------------------------------------------------------
+
+
+def test_walks_all_pages_in_slice(httpx_mock) -> None:
+    """Three pages in a slice; the scraper hits each in sequence and
+    stops once ``pages`` is reached."""
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.hh\.ru/vacancies\?.*page=0(&|$)"),
+        json=_page([_item(job_id="a")], page=0, pages=3),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.hh\.ru/vacancies\?.*page=1(&|$)"),
+        json=_page([_item(job_id="b")], page=1, pages=3),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.hh\.ru/vacancies\?.*page=2(&|$)"),
+        json=_page([_item(job_id="c")], page=2, pages=3),
+    )
+    jobs = HHRuScraper("ru", slice_by="none").fetch()
+    assert {j.ats_id for j in jobs} == {"a", "b", "c"}
+
+
+def test_stops_when_items_empty(httpx_mock) -> None:
+    """``pages`` says 5 but page 1 ships ``items=[]`` — bail rather
+    than walk to the end."""
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.hh\.ru/vacancies\?.*page=0(&|$)"),
+        json=_page([_item(job_id="a")], page=0, pages=5),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.hh\.ru/vacancies\?.*page=1(&|$)"),
+        json=_page([], page=1, pages=5),
+    )
+    # Pages 2-4 should NEVER be requested — httpx_mock errors on
+    # un-stubbed calls.
+    jobs = HHRuScraper("ru", slice_by="none").fetch()
+    assert {j.ats_id for j in jobs} == {"a"}
+
+
+def test_deduplicates_across_slices(httpx_mock) -> None:
+    """The same job can show up under two overlapping areas (e.g. the
+    federal subject + the city). The scraper keeps the first copy."""
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.hh\.ru/vacancies\?.*"),
+        json=_page([_item(job_id="dup-1"), _item(job_id="solo-2")]),
+        is_reusable=True,
+    )
+    jobs = HHRuScraper("ru", slice_by="area", areas=["1", "2"]).fetch()
+    # Two areas × the same two items = 4 returned items but only 2 unique.
+    assert {j.ats_id for j in jobs} == {"dup-1", "solo-2"}
+
+
+# --- slicing ---------------------------------------------------------------
+
+
+def test_slice_by_area_fans_out_per_code(httpx_mock) -> None:
+    """``slice_by='area'`` queries once per area code. Each area gets
+    its own item set; the scraper merges them."""
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.hh\.ru/vacancies\?.*area=1(&|$)"),
+        json=_page([_item(job_id="moscow-1")], page=0, pages=1),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.hh\.ru/vacancies\?.*area=2(&|$)"),
+        json=_page([_item(job_id="spb-1")], page=0, pages=1),
+    )
+    jobs = HHRuScraper("ru", slice_by="area", areas=["1", "2"]).fetch()
+    assert {j.ats_id for j in jobs} == {"moscow-1", "spb-1"}
+
+
+# --- error handling --------------------------------------------------------
+
+
+def test_403_raises_with_proxy_hint(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.hh\.ru/vacancies\?.*"),
+        status_code=403,
+        is_reusable=True,
+    )
+    with pytest.raises(ScraperError, match="geo-blocks"):
+        HHRuScraper("ru", slice_by="none").fetch()
+
+
+def test_persistent_500_raises(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.hh\.ru/vacancies\?.*"),
+        status_code=500,
+        is_reusable=True,
+    )
+    with pytest.raises(ScraperError):
+        HHRuScraper("ru", slice_by="none").fetch()
+
+
+def test_skips_items_missing_required_fields(httpx_mock) -> None:
+    """Defensive: an item without ``id`` / ``alternate_url`` / ``name``
+    is dropped silently — keeps the whole batch from blowing up over
+    one malformed row."""
+    good = _item(job_id="good-1")
+    bad_no_id = {**_item(), "id": None}
+    bad_no_url = {**_item(job_id="bad-2"), "alternate_url": None}
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.hh\.ru/vacancies\?.*"),
+        json=_page([good, bad_no_id, bad_no_url]),
+    )
+    jobs = HHRuScraper("ru", slice_by="none").fetch()
+    assert {j.ats_id for j in jobs} == {"good-1"}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,7 +29,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
-        "manfred", "thehub", "ycombinator", "wellfound",
+        "manfred", "thehub", "ycombinator", "wellfound", "hh",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",
         "recruitee", "taleo", "teamtailor",


### PR DESCRIPTION
## Summary

- New `HHRuScraper` for HeadHunter, the dominant Russian + CIS job platform (~1M postings on hh.ru, plus hh.kz ~150k, hh.ee ~30k, and the smaller hh.uz / hh.kg / hh.by properties). The API at `api.hh.{ru,kz,ee,uz,kg,by}` is public and JSON-only.
- `company_slug` selects the country property (`ru`, `kz`, `ee`, `uz`, `kg`, `by`); each maps to its own host, ISO country code, and listing language but the API surface is identical.
- Routes through the project's Evomi residential proxy (env var `PROXY`, same shape jobs.ch / Programathor / Tesla use). The `.ru` API returns 403 to US/EU datacenter IPs, so production runs need a CIS exit; the 403 path raises a `ScraperError` pointing the operator at the knob.
- The 2000-result API ceiling per query is handled by slicing on `area` (top-level region codes seeded for each property — 20 federal subjects in RU, 9 oblasts in KZ, 3 cities in EE, etc.). A `slice_by="none"` mode runs a single unsliced query for tests / tiny markets.
- Adds `ATSType.HH` and registers the scraper in `jobhive.scrapers`. Field mapping: `salary.currency=RUR → RUB`, `BYR → BYN`, monthly period, `employment.id` → canonical `EmploymentType`, `experience.id` → integer years, `snippet.requirement` + `snippet.responsibility` joined and HTML-stripped into `description`, `published_at` (`+0300` offset shape) parsed.

## Proxy note

The proxy (Vietnam exit by default on the current Evomi sub-account) authenticates fine — `api.hh.ru` returns the proxy past the auth gate — but hh still returns `403 {"errors":[{"type":"forbidden"}]}` because the exit IP isn't in the CIS. Production runs need either:
1. An Evomi sticky-session targeting Russia/Kazakhstan, or
2. A different residential pool with CIS coverage.
The scraper itself is fully wired and the `403 → ScraperError` surfaces the right hint; switching the proxy exit is a config change rather than a code change.

## Test plan

- [x] `pytest tests/test_hhru.py tests/test_models.py` — 106 passed (fixture-based, covers parsing, salary normalization, pagination, dedup-across-slices, country routing, the 403 path)
- [x] `pytest` full suite — 923 passed (the four sibling worktree files are untracked here and intentionally not staged)
- [x] `ruff check src/jobhive/scrapers/hhru.py tests/test_hhru.py src/jobhive/models.py` — clean
- [x] `mypy src/jobhive/scrapers/hhru.py src/jobhive/models.py` — clean under `strict = true`
- [ ] End-to-end run from a CIS-exit proxy — pending VPS deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `HHRuScraper` for HeadHunter (`hh.ru`, `hh.kz`, `hh.ee`, `hh.uz`, `hh.kg`, `hh.by`) with proxy support and regional slicing to work around the 2000-result cap. Registers `ATSType.HH`, expands coverage across CIS markets, and seeds six properties via `ats-companies/hhru.csv`.

- **New Features**
  - New `HHRuScraper` with host routing via `company_slug` (`ru|kz|ee|uz|kg|by`) and `slice_by="area"` (default) to paginate past the cap; supports `slice_by="none"` and custom `areas`.
  - Field normalization: salary currency (RUR→RUB, BYR→BYN) with monthly period; employment/experience mapping; merged HTML‑stripped snippet; `published_at` parsing; dedupe across slices; registered in `jobhive.scrapers` with `ATSType.HH`.
  - Proxy support via `PROXY` or `proxy_url`; returns a clear `ScraperError` on 403 with guidance.
  - Seed `ats-companies/hhru.csv` with the 6 HeadHunter properties for company setup.

- **Migration**
  - Use a CIS residential proxy in production; set `PROXY` or pass `proxy_url` (e.g., Russia/Kazakhstan exit) to avoid 403.
  - Optionally narrow scope with `areas=[...]` or set `slice_by="none"` for small markets/tests.

<sup>Written for commit 696e356d93cd158e061f3ae213b55a195029f54c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

