### PR TITLE
Add MyNavi Tenshoku Japan scraper

### DIFF
--- a/ats-companies/mynavi.csv
+++ b/ats-companies/mynavi.csv
@@ -1,0 +1,2 @@
+name,slug,url
+MyNavi Tenshoku,mynavi,https://tenshoku.mynavi.jp

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -77,6 +77,7 @@ class ATSType(StrEnum):
     BUILTIN = "builtin"
     JOBSCH = "jobsch"
     MANFRED = "manfred"
+    MYNAVI = "mynavi"
     THEHUB = "thehub"
     YCOMBINATOR = "ycombinator"
     WELLFOUND = "wellfound"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -33,6 +33,7 @@ from jobhive.scrapers.lever import LeverScraper
 from jobhive.scrapers.manfred import ManfredScraper
 from jobhive.scrapers.mercor import MercorScraper
 from jobhive.scrapers.meta import MetaScraper
+from jobhive.scrapers.mynavi import MyNaviScraper
 from jobhive.scrapers.oracle import OracleScraper
 from jobhive.scrapers.personio import PersonioScraper
 from jobhive.scrapers.phenom import PhenomScraper
@@ -84,6 +85,7 @@ __all__ = [
     "ManfredScraper",
     "MercorScraper",
     "MetaScraper",
+    "MyNaviScraper",
     "OracleScraper",
     "PersonioScraper",
     "PhenomScraper",

--- a/src/jobhive/scrapers/mynavi.py
+++ b/src/jobhive/scrapers/mynavi.py
@@ -336,10 +336,12 @@ class MyNaviScraper(BaseScraper):
             employment_label = html.unescape(emp_match.group("label").strip())
             employment_type = _EMPLOYMENT_TYPE_MAP.get(employment_label)
 
-        posted_at: datetime | None = None
+        # ``情報更新日`` is the last-edit date, not the publication date:
+        # a refreshed old posting reports a recent update date, so mapping
+        # it to ``posted_at`` would make stale jobs look newly posted.
+        # Leave ``posted_at`` None and preserve the raw update date instead.
         upd_match = _UPDATE_DATE_RE.search(body)
-        if upd_match:
-            posted_at = _parse_jp_date(upd_match.group("date"))
+        update_date = upd_match.group("date") if upd_match else None
 
         feature_tags = [
             html.unescape(t.group("tag").strip())
@@ -348,6 +350,8 @@ class MyNaviScraper(BaseScraper):
         feature_tags = [t for t in feature_tags if t]
 
         raw: dict[str, object] = {"jobinfo_slug": slug}
+        if update_date:
+            raw["update_date"] = update_date
         if feature_tags:
             raw["feature_tags"] = feature_tags
         if employment_label and employment_label not in _EMPLOYMENT_TYPE_MAP:
@@ -378,7 +382,7 @@ class MyNaviScraper(BaseScraper):
             salary_summary=salary_summary,
             salary_min=salary_min,
             salary_max=salary_max,
-            posted_at=posted_at,
+            posted_at=None,
             fetched_at=datetime.now(),
             raw=raw or None,
         )
@@ -409,15 +413,3 @@ def _parse_salary_yen(text: str | None) -> tuple[float | None, float | None]:
     if lo > hi:
         return None, None
     return lo, hi
-
-
-def _parse_jp_date(s: str) -> datetime | None:
-    """Parse ``YYYY/MM/DD`` (the MyNavi 情報更新日 format) into a
-    midnight-UTC ``datetime``. Returns ``None`` when the input doesn't
-    match — never raises so a malformed date on one card doesn't kill
-    the whole scrape.
-    """
-    try:
-        return datetime.strptime(s, "%Y/%m/%d")
-    except ValueError:
-        return None

--- a/src/jobhive/scrapers/mynavi.py
+++ b/src/jobhive/scrapers/mynavi.py
@@ -1,0 +1,423 @@
+"""MyNavi Tenshoku (``https://tenshoku.mynavi.jp``) — Japanese mid-career job
+board scraper.
+
+MyNavi Tenshoku (転職) is one of Japan's top-3 mid-career job platforms
+(~54k live postings). Companies post directly through MyNavi — not an
+aggregator of LinkedIn / Indeed feeds.
+
+There is no public JSON API: the listing pages are server-side rendered
+HTML and the in-page SPA layer only hydrates UI chrome. We parse the
+HTML directly via tight regexes against MyNavi's stable
+``cassetteRecruit`` card markup.
+
+Listing URL pattern::
+
+    https://tenshoku.mynavi.jp/list/        # page 1
+    https://tenshoku.mynavi.jp/list/pg{N}/  # subsequent pages (2..1083)
+
+Each page server-renders 50 cards (40 ``cassetteRecruit`` + 10
+``cassetteRecruitRecommend``). The two card variants share the same
+inner ``tableCondition`` schema; we parse them with a single regex pass.
+
+Single-source scraper: ``company_slug`` is informational and ignored
+(matches the wanted / eures / bundesagentur pattern). Output rows
+carry the publishing employer's name verbatim from ``cassetteRecruit__name``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING, ClassVar
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Literal
+
+    EmploymentTypeLiteral = Literal[
+        "FULL_TIME", "PART_TIME", "CONTRACT", "INTERN", "TEMPORARY"
+    ]
+
+BASE_URL = "https://tenshoku.mynavi.jp"
+LISTING_FIRST = "/list/"
+LISTING_PAGE = "/list/pg{n}/"
+
+# MyNavi caps useful pagination at ~1083 pages today (54k jobs / 50 per
+# page) but the listing exposes more sparse pages further out for
+# bookmarked filters. ``MAX_PAGES`` is a hard ceiling so a server-side
+# regression returning duplicate pages doesn't spin us forever — set
+# generously above the live total.
+MAX_PAGES = 1500
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 4
+RETRY_BASE_DELAY = 1.5
+
+# Empty pages (out-of-range) return HTTP 200 with a "Page not found"
+# template that has zero card markers. Detect via the absence of any
+# ``cassetteRecruit`` block rather than a status code.
+_NOT_FOUND_MARKER = "お探しのページは見つかりませんでした"
+
+# Map MyNavi employment-status labels → canonical Job.employment_type.
+# ``正社員`` (seishain) = regular full employment; ``契約社員`` /
+# ``派遣社員`` are fixed-term / dispatch workers (both CONTRACT under
+# our schema). ``アルバイト・パート`` is the casual hourly bucket.
+_EMPLOYMENT_TYPE_MAP: dict[str, EmploymentTypeLiteral] = {
+    "正社員": "FULL_TIME",
+    "契約社員": "CONTRACT",
+    "派遣社員": "CONTRACT",
+    "業務委託": "CONTRACT",
+    "アルバイト": "PART_TIME",
+    "パート": "PART_TIME",
+    "アルバイト・パート": "PART_TIME",
+    "インターン": "INTERN",
+    "インターンシップ": "INTERN",
+    "新卒": "FULL_TIME",
+}
+
+# Each card is one of these two variants — same inner structure.
+_CARD_RE = re.compile(
+    r'<div class="cassetteRecruit(?:Recommend)?(?:__content)? '
+    r'js__link--post"[^>]*>(?P<body>.*?)'
+    r'(?=<div class="cassetteRecruit(?:Recommend)?(?:__content)? '
+    r'js__link--post"|</body>)',
+    re.DOTALL,
+)
+# Stable per-posting key (numeric). Distinct from the company-scoped
+# ``jobinfo-{company}-{?}-{seq}`` URL slug — every card has exactly one
+# ``data-job-key``; same company across multiple postings gets a
+# different key per posting.
+_JOB_KEY_RE = re.compile(r'data-job-key="(?P<key>\d+)"')
+# Public detail URL slug. Always shaped ``jobinfo-{N}-{N}-{N}``.
+_JOBINFO_PATH_RE = re.compile(
+    r'href="(?P<href>//tenshoku\.mynavi\.jp/(?P<slug>jobinfo-\d+-\d+-\d+)[^"]*)"'
+)
+_COMPANY_RE = re.compile(
+    r'class="cassetteRecruit(?:Recommend)?__name">(?P<name>[^<]+)</'
+)
+_TITLE_RE = re.compile(
+    r'class="cassetteRecruit(?:Recommend)?__copy boxAdjust">\s*'
+    r'<a[^>]*href="[^"]*"[^>]*>(?P<title>[^<]+)</a>'
+)
+_EMPLOYMENT_RE = re.compile(
+    r'<span class="labelEmploymentStatus">(?P<label>[^<]+)</span>'
+)
+# Inner field table — same shape on both card variants.
+_TABLE_ROW_RE = re.compile(
+    r'<th class="tableCondition__head">(?P<head>[^<]+)</th>\s*'
+    r'<td class="tableCondition__body">(?P<body>[^<]*)</td>'
+)
+# 情報更新日 (info update date) — single-row block, YYYY/MM/DD.
+_UPDATE_DATE_RE = re.compile(
+    r'class="cassetteRecruit(?:Recommend)?__updateDate">[^<]*'
+    r'<span>\s*(?P<date>\d{4}/\d{1,2}/\d{1,2})\s*</span>'
+)
+# Feature tags (赤いチップ的なやつ) — multiple per card.
+_FEATURE_TAG_RE = re.compile(
+    r'class="labelCondition">(?P<tag>[^<]+)</span>'
+)
+# Salary range in 万円 (= 10,000 JPY) units. Accept both the wide and
+# narrow tilde MyNavi mixes interchangeably.
+_SALARY_RANGE_RE = re.compile(
+    r'(?P<min>\d{2,5})\s*万円\s*[～~〜]\s*(?P<max>\d{2,5})\s*万円'
+)
+
+# MyNavi card field heads we care about. ``勤務地`` is the location
+# string (free text — Japanese, prose); ``給与`` is the monthly /
+# hourly salary description and we typically prefer the structured
+# ``初年度年収`` (first-year annual income) range when both are
+# present.
+_FIELD_LOCATION = "勤務地"
+_FIELD_SALARY_FREE = "給与"
+_FIELD_SALARY_FIRST_YEAR = "初年度年収"
+_FIELD_JOB_CONTENT = "仕事内容"
+_FIELD_TARGET = "対象となる方"
+
+
+@ScraperRegistry.register(ATSType.MYNAVI)
+class MyNaviScraper(BaseScraper):
+    """MyNavi Tenshoku (tenshoku.mynavi.jp) — Japan mid-career job board.
+
+    Single-source scraper: ``company_slug`` is ignored — pass anything
+    (``"any"``, ``""``). The scraper walks the entire site pagination
+    until an empty page is returned.
+
+    To cap the walk for smoke tests, pass ``max_pages``::
+
+        MyNaviScraper("any", max_pages=2).fetch()
+    """
+
+    ats: ClassVar[ATSType] = ATSType.MYNAVI
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        max_pages: int = MAX_PAGES,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.max_pages = max_pages
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        jobs: list[Job] = []
+        seen: set[str] = set()
+
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+            for page in range(1, self.max_pages + 1):
+                path = LISTING_FIRST if page == 1 else LISTING_PAGE.format(n=page)
+                html_text = await self._request_html(client, sem, path)
+                if _NOT_FOUND_MARKER in html_text:
+                    break
+                page_jobs = list(self._parse_listing(html_text))
+                if not page_jobs:
+                    # Genuine end-of-listing — MyNavi serves the
+                    # "page not found" template on out-of-range pages,
+                    # but defensively we also bail on an empty card
+                    # pass (e.g. heading-only response).
+                    break
+                added = 0
+                for job in page_jobs:
+                    if job.ats_id in seen:
+                        continue
+                    seen.add(job.ats_id)
+                    jobs.append(job)
+                    added += 1
+                # If a page contained only duplicates we've already
+                # seen, the pagination cursor has wrapped — stop.
+                if added == 0:
+                    break
+        return jobs
+
+    # --- HTTP layer ---------------------------------------------------------
+
+    async def _request_html(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        path: str,
+    ) -> str:
+        url = f"{BASE_URL}{path}"
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(
+                        url,
+                        headers={
+                            "User-Agent": (
+                                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                                "Chrome/124.0.0.0 Safari/537.36"
+                            ),
+                            "Accept": "text/html",
+                            "Accept-Language": "ja-JP,ja;q=0.9",
+                        },
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"MyNavi fetch failed for {url}: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                return response.text
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"MyNavi returned {response.status_code} for "
+                        f"{url} after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            if response.status_code == 404:
+                # Bookmarked filter that no longer matches anything.
+                # Treat as empty rather than fatal.
+                return ""
+            raise ScraperError(
+                f"MyNavi returned {response.status_code} for {url}"
+            )
+        raise ScraperError(
+            f"MyNavi exhausted retries for {url}: {last_exc}"
+        )
+
+    # --- parsing ------------------------------------------------------------
+
+    def _parse_listing(self, html_text: str):
+        """Yield ``Job`` instances parsed from a single listing page.
+
+        Each card is delimited by an opening
+        ``cassetteRecruit[Recommend]__content js__link--post`` div.
+        The closing tag is unreliable (MyNavi mixes container divs with
+        broken/indented HTML), so we slice on the next card-opening
+        instead and let the inner regexes work on the (slightly
+        oversized) chunk.
+        """
+        for match in _CARD_RE.finditer(html_text):
+            body = match.group("body")
+            job = self._parse_card(body)
+            if job is not None:
+                yield job
+
+    def _parse_card(self, body: str) -> Job | None:
+        key_match = _JOB_KEY_RE.search(body)
+        path_match = _JOBINFO_PATH_RE.search(body)
+        title_match = _TITLE_RE.search(body)
+        company_match = _COMPANY_RE.search(body)
+        if not (path_match and title_match and company_match):
+            return None
+
+        slug = path_match.group("slug")
+        # ``data-job-key`` is the most stable per-posting identifier:
+        # unique across the whole listing and survives URL slug rewrites
+        # (which MyNavi does occasionally as the ``-{seq}`` counter ticks).
+        # Fall back to the URL slug when (rare) the button block is
+        # missing — defends against incomplete card renders.
+        ats_id = key_match.group("key") if key_match else slug
+
+        title = html.unescape(title_match.group("title").strip())
+        company = html.unescape(company_match.group("name").strip())
+        if not title or not company:
+            return None
+
+        # Build the public detail URL. ``href`` is protocol-relative
+        # (``//tenshoku.mynavi.jp/...``) — pin https.
+        href = path_match.group("href")
+        url = f"https:{href}" if href.startswith("//") else f"{BASE_URL}{href}"
+
+        fields: dict[str, str] = {}
+        for row in _TABLE_ROW_RE.finditer(body):
+            head = html.unescape(row.group("head").strip())
+            value = html.unescape(row.group("body").strip())
+            if head and value:
+                fields[head] = value
+
+        location = fields.get(_FIELD_LOCATION) or None
+        # Prefer the structured ``初年度年収`` range over the free-text
+        # ``給与`` field — it's a clean ``{min}万円～{max}万円`` pattern.
+        salary_summary = (
+            fields.get(_FIELD_SALARY_FIRST_YEAR)
+            or fields.get(_FIELD_SALARY_FREE)
+            or None
+        )
+        salary_min, salary_max = _parse_salary_yen(salary_summary)
+
+        # Card description: concatenate ``仕事内容`` and ``対象となる方``
+        # if both present — these are the two free-text teasers MyNavi
+        # surfaces on the listing card. Keep it small (~1kB) per card;
+        # the full description is on the detail page (out of scope for
+        # this scraper).
+        desc_parts = [fields.get(_FIELD_JOB_CONTENT), fields.get(_FIELD_TARGET)]
+        description = "\n\n".join(p for p in desc_parts if p) or None
+
+        emp_match = _EMPLOYMENT_RE.search(body)
+        employment_label: str | None = None
+        employment_type: EmploymentTypeLiteral | None = None
+        if emp_match:
+            employment_label = html.unescape(emp_match.group("label").strip())
+            employment_type = _EMPLOYMENT_TYPE_MAP.get(employment_label)
+
+        posted_at: datetime | None = None
+        upd_match = _UPDATE_DATE_RE.search(body)
+        if upd_match:
+            posted_at = _parse_jp_date(upd_match.group("date"))
+
+        feature_tags = [
+            html.unescape(t.group("tag").strip())
+            for t in _FEATURE_TAG_RE.finditer(body)
+        ]
+        feature_tags = [t for t in feature_tags if t]
+
+        raw: dict[str, object] = {"jobinfo_slug": slug}
+        if feature_tags:
+            raw["feature_tags"] = feature_tags
+        if employment_label and employment_label not in _EMPLOYMENT_TYPE_MAP:
+            raw["employment_label_raw"] = employment_label
+        # Preserve the free-text salary string even when we used the
+        # structured first-year range, since the prose carries monthly /
+        # bonus context the range strips.
+        if (
+            fields.get(_FIELD_SALARY_FREE)
+            and fields.get(_FIELD_SALARY_FREE) != salary_summary
+        ):
+            raw["salary_free_text"] = fields[_FIELD_SALARY_FREE]
+
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.MYNAVI,
+            ats_id=ats_id,
+            location=location,
+            country_iso="JP",
+            language="ja",
+            description=description,
+            employment_type=employment_type,
+            commitment=employment_label,
+            salary_currency="JPY" if (salary_min or salary_max) else None,
+            salary_period="YEAR" if (salary_min or salary_max) else None,
+            salary_summary=salary_summary,
+            salary_min=salary_min,
+            salary_max=salary_max,
+            posted_at=posted_at,
+            fetched_at=datetime.now(),
+            raw=raw or None,
+        )
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+def _parse_salary_yen(text: str | None) -> tuple[float | None, float | None]:
+    """Extract ``(min, max)`` in JPY from a ``{N}万円～{M}万円`` string.
+
+    MyNavi's first-year-income field uses 万 (= 10,000) consistently —
+    a ``400万円`` range bound is 4,000,000 JPY. Returns ``(None, None)``
+    when no range is found (e.g. a single-bound ``◇月給25万円〜34万円``
+    monthly figure from the free-text ``給与`` field — those need
+    different unit logic and are out of scope here).
+    """
+    if not text:
+        return None, None
+    match = _SALARY_RANGE_RE.search(text)
+    if not match:
+        return None, None
+    try:
+        lo = float(match.group("min")) * 10_000
+        hi = float(match.group("max")) * 10_000
+    except ValueError:
+        return None, None
+    if lo > hi:
+        return None, None
+    return lo, hi
+
+
+def _parse_jp_date(s: str) -> datetime | None:
+    """Parse ``YYYY/MM/DD`` (the MyNavi 情報更新日 format) into a
+    midnight-UTC ``datetime``. Returns ``None`` when the input doesn't
+    match — never raises so a malformed date on one card doesn't kill
+    the whole scrape.
+    """
+    try:
+        return datetime.strptime(s, "%Y/%m/%d")
+    except ValueError:
+        return None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,7 +29,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
-        "manfred", "thehub", "ycombinator", "wellfound",
+        "manfred", "mynavi", "thehub", "ycombinator", "wellfound",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",
         "recruitee", "taleo", "teamtailor",

--- a/tests/test_mynavi.py
+++ b/tests/test_mynavi.py
@@ -169,8 +169,12 @@ def test_parses_full_cassette_card(httpx_mock) -> None:
     assert j.country_iso == "JP"
     assert j.language == "ja"
     assert j.location is not None and "転勤なし" in j.location
-    assert j.posted_at is not None
-    assert j.posted_at.year == 2026 and j.posted_at.month == 4
+    # 情報更新日 is the last-edit date, not the publication date, so it must
+    # NOT be mapped to posted_at (a refreshed old posting would otherwise
+    # look newly posted). It's preserved verbatim in raw.update_date instead.
+    assert j.posted_at is None
+    assert j.raw is not None
+    assert j.raw.get("update_date") == "2026/04/21"
 
 
 # --- salary parsing ---------------------------------------------------------

--- a/tests/test_mynavi.py
+++ b/tests/test_mynavi.py
@@ -1,0 +1,433 @@
+"""Tests for the MyNavi Tenshoku (Japan mid-career) scraper.
+
+MyNavi has no public JSON API — listings are SSR'd HTML. These tests
+pin the card-parsing contract against real-shape HTML fixtures plus
+the ``/list/pg{n}/`` pagination walk.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import MyNaviScraper, ScraperRegistry, get_scraper
+
+# All page fetches go to ``tenshoku.mynavi.jp/list...`` — match anything
+# under that prefix so httpx_mock matches both ``/list/`` and ``/list/pgN/``.
+_LISTING_URL_RE = re.compile(r"^https://tenshoku\.mynavi\.jp/list/")
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.mynavi as m
+    monkeypatch.setattr(m, "MAX_RETRIES", 1)
+    monkeypatch.setattr(m, "RETRY_BASE_DELAY", 0.0)
+
+
+# ---------------------------------------------------------------------------
+# Fixture HTML — mirrors the production ``cassetteRecruit`` markup. Anything
+# not exercised by the tests is trimmed to keep the fixture readable, but
+# the wrapper / class names match MyNavi's live output verbatim so a
+# selector regression on either side surfaces here.
+# ---------------------------------------------------------------------------
+
+
+def _card(
+    *,
+    variant: str = "",  # "" = cassetteRecruit, "Recommend" = cassetteRecruitRecommend
+    job_key: str = "2775727",
+    jobinfo_slug: str = "jobinfo-188316-1-108",
+    href_suffix: str = "/",
+    title: str = "未経験OK！【キャリアコーディネーター】土日祝休／年間124日休",
+    company: str = "株式会社トライトキャリア | 業界大手の成長企業",
+    employment: str | None = "正社員",
+    location: str | None = "【転勤なし】 東京・大阪・名古屋・愛知 ほか",
+    job_content: str | None = "人材を求める企業と派遣先候補をつなぐマッチング業務",
+    target: str | None = "学歴・性別不問／第二新卒も歓迎",
+    salary_free: str | None = "月給28万円〜＋インセンティブ",
+    salary_first_year: str | None = "400万円～500万円",
+    update_date: str | None = "2026/04/21",
+    feature_tags: list[str] | None = None,
+) -> str:
+    cls_root = f"cassetteRecruit{variant}"
+    if feature_tags is None:
+        feature_tags = [
+            "職種・業種未経験OK", "転勤なし", "学歴不問",
+            "完全週休2日制", "第二新卒歓迎",
+        ]
+    href = f"//tenshoku.mynavi.jp/{jobinfo_slug}-1{href_suffix}"
+    emp_html = (
+        f'<span class="labelEmploymentStatus">{employment}</span>'
+        if employment else ""
+    )
+    rows: list[tuple[str, str | None]] = [
+        ("仕事内容", job_content),
+        ("対象となる方", target),
+        ("勤務地", location),
+        ("給与", salary_free),
+        ("初年度年収", salary_first_year),
+    ]
+    table_rows = "".join(
+        f'<tr><th class="tableCondition__head">{h}</th>'
+        f'<td class="tableCondition__body">{v}</td></tr>'
+        for h, v in rows if v is not None
+    )
+    feature_html = "".join(
+        f'<li class="{cls_root}__attributeLabel">'
+        f'<span class="labelCondition">{t}</span></li>'
+        for t in feature_tags
+    )
+    update_html = (
+        f'<p class="{cls_root}__updateDate">情報更新日：'
+        f'<span>{update_date}</span></p>'
+        if update_date else ""
+    )
+    return (
+        f'<div class="{cls_root}">'
+        f'<div class="{cls_root}__content js__link--post" '
+        f'data-ty="fnc_sr" data-show-no="1">'
+        f'<section class="{cls_root}__heading cassetteUseFloat">'
+        f'<h3 class="{cls_root}__name">{company}</h3>'
+        f'<p class="{cls_root}__copy boxAdjust">'
+        f'<a class="js__ga--setCookieOccName" target="_blank" '
+        f'href="{href}">{title}</a>'
+        f'{emp_html}'
+        f'</p>'
+        f'</section>'
+        f'<div class="{cls_root}__detail">'
+        f'<ul class="{cls_root}__attribute">{feature_html}</ul>'
+        f'<div class="{cls_root}__main">'
+        f'<table class="tableCondition"><tbody>{table_rows}</tbody></table>'
+        f'</div>'
+        f'</div>'
+        f'<div class="{cls_root}__bottom">'
+        f'<button class="btnInterst" data-job-key="{job_key}">気になる</button>'
+        f'{update_html}'
+        f'</div>'
+        f'</div></div>'
+    )
+
+
+def _page(cards: list[str], *, total: int = 100) -> str:
+    """Wrap cards in the minimum surrounding HTML the parser inspects."""
+    body = "".join(cards) if cards else ""
+    return (
+        '<html><body>'
+        '<div class="container__inner">'
+        '<div class="result"><div class="result__info">'
+        f'<p class="result__num"><em>{total}</em><span>件</span></p>'
+        '</div></div>'
+        f'{body}'
+        '<nav class="pager"><ul class="pager__list js__pageSubmit">'
+        '<li class="pager__item--active"><a>1</a></li>'
+        '</ul></nav>'
+        '</body></html>'
+    )
+
+
+def _empty_page() -> str:
+    """The "page not found" template MyNavi serves for out-of-range pages."""
+    return (
+        '<html><body>'
+        '<h1>お探しのページは見つかりませんでした。</h1>'
+        '</body></html>'
+    )
+
+
+# --- registry / wiring ------------------------------------------------------
+
+
+def test_registry_resolves_mynavi() -> None:
+    assert ScraperRegistry.get(ATSType.MYNAVI) is MyNaviScraper
+
+
+def test_get_scraper_by_string_returns_mynavi() -> None:
+    s = get_scraper("mynavi", "any")
+    assert isinstance(s, MyNaviScraper)
+
+
+# --- happy-path parsing -----------------------------------------------------
+
+
+def test_parses_full_cassette_card(httpx_mock) -> None:
+    """Single ``cassetteRecruit`` card — pin every field that maps from
+    a primary HTML element to a ``Job`` attribute."""
+    httpx_mock.add_response(url=_LISTING_URL_RE, html=_page([_card()]))
+    httpx_mock.add_response(url=_LISTING_URL_RE, html=_empty_page())
+
+    jobs = MyNaviScraper("any").fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.MYNAVI
+    assert j.ats_id == "2775727"
+    assert j.title.startswith("未経験OK")
+    assert "トライトキャリア" in j.company
+    assert str(j.url) == "https://tenshoku.mynavi.jp/jobinfo-188316-1-108-1/"
+    assert j.country_iso == "JP"
+    assert j.language == "ja"
+    assert j.location is not None and "転勤なし" in j.location
+    assert j.posted_at is not None
+    assert j.posted_at.year == 2026 and j.posted_at.month == 4
+
+
+# --- salary parsing ---------------------------------------------------------
+
+
+def test_parses_first_year_salary_range_in_yen(httpx_mock) -> None:
+    """``初年度年収`` is the structured first-year income field — units
+    are 万 (10,000 JPY). ``400万円～500万円`` ⇒ 4_000_000 / 5_000_000 JPY."""
+    httpx_mock.add_response(
+        url=_LISTING_URL_RE,
+        html=_page([_card(salary_first_year="400万円～500万円")]),
+    )
+    httpx_mock.add_response(url=_LISTING_URL_RE, html=_empty_page())
+    j = MyNaviScraper("any").fetch()[0]
+    assert j.salary_currency == "JPY"
+    assert j.salary_period == "YEAR"
+    assert j.salary_summary == "400万円～500万円"
+    assert j.salary_min == 4_000_000
+    assert j.salary_max == 5_000_000
+
+
+def test_accepts_wide_and_narrow_tilde_in_salary(httpx_mock) -> None:
+    """MyNavi inconsistently uses ``～`` (FULLWIDTH) and ``〜`` (WAVE
+    DASH). Both must parse."""
+    httpx_mock.add_response(
+        url=_LISTING_URL_RE,
+        html=_page([
+            _card(job_key="1", salary_first_year="300万円〜600万円"),
+            _card(job_key="2", salary_first_year="300万円～600万円"),
+        ]),
+    )
+    httpx_mock.add_response(url=_LISTING_URL_RE, html=_empty_page())
+    jobs = MyNaviScraper("any").fetch()
+    assert {j.salary_min for j in jobs} == {3_000_000}
+    assert {j.salary_max for j in jobs} == {6_000_000}
+
+
+def test_no_salary_when_first_year_field_missing(httpx_mock) -> None:
+    """When ``初年度年収`` is absent and only the free-text ``給与`` field
+    is present (often non-yen for overseas postings), we don't invent
+    a range. ``salary_summary`` falls back to the free text but
+    ``salary_min``/``salary_max`` stay ``None``."""
+    httpx_mock.add_response(
+        url=_LISTING_URL_RE,
+        html=_page([_card(
+            salary_first_year=None,
+            salary_free="月給5万バーツ〜8万バーツ",
+        )]),
+    )
+    httpx_mock.add_response(url=_LISTING_URL_RE, html=_empty_page())
+    j = MyNaviScraper("any").fetch()[0]
+    assert j.salary_summary == "月給5万バーツ〜8万バーツ"
+    assert j.salary_min is None
+    assert j.salary_max is None
+    # currency stays None when we can't parse a numeric range — we don't
+    # want a JPY label sitting on a Thai-baht posting.
+    assert j.salary_currency is None
+
+
+def test_free_text_salary_stashed_in_raw_when_distinct(httpx_mock) -> None:
+    """The free-text 給与 (monthly + bonuses) is useful context even
+    when we use the structured first-year range, so it lives in
+    ``raw.salary_free_text``."""
+    httpx_mock.add_response(
+        url=_LISTING_URL_RE,
+        html=_page([_card(
+            salary_free="月給25万円〜34万円＋賞与5.5カ月",
+            salary_first_year="400万円～950万円",
+        )]),
+    )
+    httpx_mock.add_response(url=_LISTING_URL_RE, html=_empty_page())
+    j = MyNaviScraper("any").fetch()[0]
+    assert j.raw is not None
+    assert j.raw.get("salary_free_text") == "月給25万円〜34万円＋賞与5.5カ月"
+
+
+# --- employment-type mapping ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "label, expected",
+    [
+        ("正社員", "FULL_TIME"),
+        ("契約社員", "CONTRACT"),
+        ("派遣社員", "CONTRACT"),
+        ("業務委託", "CONTRACT"),
+        ("アルバイト・パート", "PART_TIME"),
+        ("インターン", "INTERN"),
+    ],
+)
+def test_employment_label_maps_to_canonical_type(
+    label: str, expected: str, httpx_mock,
+) -> None:
+    httpx_mock.add_response(
+        url=_LISTING_URL_RE,
+        html=_page([_card(employment=label)]),
+    )
+    httpx_mock.add_response(url=_LISTING_URL_RE, html=_empty_page())
+    j = MyNaviScraper("any").fetch()[0]
+    assert j.employment_type == expected
+    # Raw Japanese label survives on ``commitment`` for downstream
+    # consumers that want the original granularity.
+    assert j.commitment == label
+
+
+def test_unknown_employment_label_preserved_in_raw(httpx_mock) -> None:
+    """If MyNavi adds a new label we don't have a mapping for, the
+    canonical ``employment_type`` stays ``None`` but the raw label is
+    kept in ``raw.employment_label_raw`` so we don't lose the signal."""
+    httpx_mock.add_response(
+        url=_LISTING_URL_RE,
+        html=_page([_card(employment="顧問")]),
+    )
+    httpx_mock.add_response(url=_LISTING_URL_RE, html=_empty_page())
+    j = MyNaviScraper("any").fetch()[0]
+    assert j.employment_type is None
+    assert j.commitment == "顧問"
+    assert j.raw is not None
+    assert j.raw.get("employment_label_raw") == "顧問"
+
+
+# --- card variants ----------------------------------------------------------
+
+
+def test_cassette_recruit_recommend_variant_is_parsed(httpx_mock) -> None:
+    """MyNavi mixes regular ``cassetteRecruit`` cards with ``Recommend``
+    sponsored variants (notice the suffixed CSS classes). Both share
+    the same inner schema and must both parse."""
+    httpx_mock.add_response(
+        url=_LISTING_URL_RE,
+        html=_page([
+            _card(variant="", job_key="100"),
+            _card(variant="Recommend", job_key="200"),
+        ]),
+    )
+    httpx_mock.add_response(url=_LISTING_URL_RE, html=_empty_page())
+    jobs = MyNaviScraper("any").fetch()
+    assert {j.ats_id for j in jobs} == {"100", "200"}
+
+
+# --- feature tags / raw -----------------------------------------------------
+
+
+def test_feature_tags_collected_into_raw(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_LISTING_URL_RE,
+        html=_page([_card(
+            feature_tags=["リモートワーク可", "上場", "学歴不問"]
+        )]),
+    )
+    httpx_mock.add_response(url=_LISTING_URL_RE, html=_empty_page())
+    j = MyNaviScraper("any").fetch()[0]
+    assert j.raw is not None
+    assert j.raw["feature_tags"] == ["リモートワーク可", "上場", "学歴不問"]
+    assert j.raw["jobinfo_slug"] == "jobinfo-188316-1-108"
+
+
+# --- description ------------------------------------------------------------
+
+
+def test_description_concatenates_job_content_and_target(httpx_mock) -> None:
+    """The listing card surfaces two prose teasers (仕事内容 / 対象となる方);
+    we join them as ``description`` because the detail page (where the
+    full description lives) is out of scope for this scraper."""
+    httpx_mock.add_response(
+        url=_LISTING_URL_RE,
+        html=_page([_card(
+            job_content="エンジニア業務",
+            target="未経験歓迎",
+        )]),
+    )
+    httpx_mock.add_response(url=_LISTING_URL_RE, html=_empty_page())
+    j = MyNaviScraper("any").fetch()[0]
+    assert j.description == "エンジニア業務\n\n未経験歓迎"
+
+
+# --- pagination -------------------------------------------------------------
+
+
+def test_walks_pagination_until_empty_page(httpx_mock) -> None:
+    """The pagination cursor is path-based (``/list/pgN/``); the walk
+    terminates when a page returns the "page not found" template."""
+    httpx_mock.add_response(
+        url=_LISTING_URL_RE,
+        html=_page([_card(job_key="1"), _card(job_key="2")]),
+    )
+    httpx_mock.add_response(
+        url=_LISTING_URL_RE,
+        html=_page([_card(job_key="3")]),
+    )
+    httpx_mock.add_response(url=_LISTING_URL_RE, html=_empty_page())
+    jobs = MyNaviScraper("any").fetch()
+    assert [j.ats_id for j in jobs] == ["1", "2", "3"]
+
+
+def test_dedupes_overlap_between_pages(httpx_mock) -> None:
+    """Defensive: when the same card surfaces on two consecutive pages
+    (server-side ordering jitter against a moving total), keep only
+    the first copy."""
+    httpx_mock.add_response(
+        url=_LISTING_URL_RE,
+        html=_page([_card(job_key="1"), _card(job_key="2")]),
+    )
+    httpx_mock.add_response(
+        url=_LISTING_URL_RE,
+        # Page 2 repeats key=2 then has a fresh key=3.
+        html=_page([_card(job_key="2"), _card(job_key="3")]),
+    )
+    httpx_mock.add_response(url=_LISTING_URL_RE, html=_empty_page())
+    jobs = MyNaviScraper("any").fetch()
+    assert [j.ats_id for j in jobs] == ["1", "2", "3"]
+
+
+def test_max_pages_caps_the_walk(httpx_mock) -> None:
+    """``max_pages`` is the smoke-test ceiling; the scraper must stop
+    even when every page keeps returning fresh cards."""
+    # Three pages of fresh cards — but max_pages=2, so the third never
+    # gets requested. Use ``is_reusable`` because httpx_mock can serve
+    # the same response twice.
+    httpx_mock.add_response(
+        url=_LISTING_URL_RE,
+        html=_page([_card(job_key="1")]),
+    )
+    httpx_mock.add_response(
+        url=_LISTING_URL_RE,
+        html=_page([_card(job_key="2")]),
+    )
+    jobs = MyNaviScraper("any", max_pages=2).fetch()
+    assert {j.ats_id for j in jobs} == {"1", "2"}
+
+
+# --- defensive --------------------------------------------------------------
+
+
+def test_skips_card_missing_required_fields(httpx_mock) -> None:
+    """Cards without a title or company should be dropped — don't emit
+    half-built rows."""
+    # Build a malformed card that has the wrapper but no title.
+    malformed = (
+        '<div class="cassetteRecruit">'
+        '<div class="cassetteRecruit__content js__link--post">'
+        '<h3 class="cassetteRecruit__name">Only Co</h3>'
+        '<button data-job-key="99">x</button>'
+        '</div></div>'
+    )
+    httpx_mock.add_response(
+        url=_LISTING_URL_RE,
+        html=_page([_card(job_key="1"), malformed]),
+    )
+    httpx_mock.add_response(url=_LISTING_URL_RE, html=_empty_page())
+    jobs = MyNaviScraper("any").fetch()
+    assert [j.ats_id for j in jobs] == ["1"]
+
+
+def test_persistent_500_raises(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_LISTING_URL_RE, status_code=500, is_reusable=True,
+    )
+    with pytest.raises(ScraperError):
+        MyNaviScraper("any").fetch()

--- a/uv.lock
+++ b/uv.lock
@@ -320,6 +320,19 @@ wheels = [
 ]
 
 [[package]]
+name = "cloakbrowser"
+version = "0.3.31"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "playwright" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/12/50296c1adf7f09988a8ae300f2472e8c33a9d79826980579f0aa7b938b74/cloakbrowser-0.3.31.tar.gz", hash = "sha256:7109961fc9ef0c9a288547eff6717d3cb2cc7ad7b14fecfef1221357b9a0d870", size = 5365798, upload-time = "2026-05-26T18:32:45.045Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/ba/7acb1250c0d453124f6bff0185296fa75618b0a4924cdf9ef5f27d1337ec/cloakbrowser-0.3.31-py3-none-any.whl", hash = "sha256:0496f586c9a580b03ef69dc26b931bbe3ad93b944be2750edcc423379d97d2d3", size = 76582, upload-time = "2026-05-26T18:32:43.436Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -452,6 +465,83 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/6e/802acd792aebb2256fbbee8cacf2727faaeb6f240ac11008f09eae4414bc/greenlet-3.5.1.tar.gz", hash = "sha256:5a56aeb7d5d9cc4b3a735efb5095bd4b4f6f0e4f93e5ca876d0e2315137b7829", size = 197356, upload-time = "2026-05-20T15:05:03.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/3c/ff890b466eaba2b0f5e6bdfff025f8c75f41b8ffdc3dbc3d24ad261e764a/greenlet-3.5.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:73f78f9b9f0a5c06e5c946ba1e8e36f5114923b6be109ee618c54f079c3ea14f", size = 284764, upload-time = "2026-05-20T13:09:10.204Z" },
+    { url = "https://files.pythonhosted.org/packages/81/0e/5e5457be3d256918f6a4756f073548a3f0190836e2cc94aa6d0d617a940b/greenlet-3.5.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a0cbed8bb44e23c5b199f888f4e4ce096b45ad9f25ff74a7ad0213875e936bb2", size = 603479, upload-time = "2026-05-20T14:00:04.757Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e1/f89a21d58d308298e6f275f13a1b472ed96c680b601a371b08be6a725989/greenlet-3.5.1-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a203a8bd0acb0701653d3bbb26e404854a68674139ed5cbb778830f42b09bb33", size = 615495, upload-time = "2026-05-20T14:05:40.87Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/8fd452fd81adb9ec79c8275c1375702ab0fd6bee4952da12eaa09b9508d8/greenlet-3.5.1-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ebeb75c81211f5c702576cf81f315e77e23cfdb2c7c6fcb9dd143e6de35c360", size = 623515, upload-time = "2026-05-20T14:09:07.853Z" },
+    { url = "https://files.pythonhosted.org/packages/75/de/af6cef182862d2ccd6975440d21c9058a77c3f9b469abf94e322dfd2e0e3/greenlet-3.5.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a271fcd66c74615cda6a964fda3f304267a12e50a084472218a39bb0376f563", size = 614754, upload-time = "2026-05-20T13:14:24.947Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bc/c318aa9f3ffc77320fddcee3d892be957b42e2ff947198d9450b004f3a38/greenlet-3.5.1-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:017a544f0385d441e88714160d089d6900ef46c9eff9d99b6715a5ef2d127747", size = 418439, upload-time = "2026-05-20T14:01:38.446Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c6/50e520283a9f19388a7326b05f9e8637e566003475eacaadad04f558c68d/greenlet-3.5.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ded7b068c7c31c1a8657d4fd42d886b3e051ae29f88b80c5ff9d502257b0f071", size = 1574097, upload-time = "2026-05-20T14:02:24.003Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1c/13abd1f4860d987fa5e1170a01930d6e6cd40d328de487a3c9fdaff0ffd0/greenlet-3.5.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d0932b81d72f552ded9d810d00021b64d89f2195a91ce115b893f943b7a4ab3c", size = 1641058, upload-time = "2026-05-20T13:14:31.83Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/56/5f332b7705545eac2dc01b4e9254d24a793f2656d55d5cc6b94ee59d22ae/greenlet-3.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:88e300d136eac057b2397aa1cfd7328b4c87c7eb66a09c7bc6a1292234db474e", size = 238089, upload-time = "2026-05-20T13:14:03.229Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a9/a3c2fa886c5b94863fb0e61b3bc14610b7aa94cf4f17f8741b11708305fc/greenlet-3.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:cc6ab7e555c8a112ad3a76e368e86e12a2754bcae1652a5602e133ec7b635523", size = 234989, upload-time = "2026-05-20T13:08:27.715Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/37/4549f149c9797c21b32c2683c33522af22522099de128b2406672526d005/greenlet-3.5.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:fa4f98af3a528f0c3fd592a26df7f376f93329c8f4d987f6bb979057af8bf5e2", size = 286220, upload-time = "2026-05-20T13:07:28.463Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ff/a4f436709716965eaab9f36ea7b906c8a927fbe32fb1372a2071d964f6b1/greenlet-3.5.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffea73584b216150eab159b6d12348fb253e68757974de1e2c40d8a318ac89ed", size = 601585, upload-time = "2026-05-20T14:00:06.141Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ad/54bc3fcee3ad368a61b19b67d88117f7a8c29727bf71fffdeda81fbd946e/greenlet-3.5.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1072b4f9edcc1e192d9283a66a3e68d6b84c561de33a83d7858beb9ba1effe10", size = 614215, upload-time = "2026-05-20T14:05:42.675Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/6c/de5b1b388cd2d9fbdfeab324863daba37d54e6e233ddbefd70b385a8c591/greenlet-3.5.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:89101bfd5011e069be974903cb3a4e4523845e4ece2d62dcd8d358933c0ef249", size = 620094, upload-time = "2026-05-20T14:09:09.18Z" },
+    { url = "https://files.pythonhosted.org/packages/40/69/b91cda0647df839483201545913514c2827ebea5e5ccdf931842763bc127/greenlet-3.5.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:add5217d68b31130f0beca584d7fef4878327d2e31642b66618a14eef312b63b", size = 611358, upload-time = "2026-05-20T13:14:26.37Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/43/1204baffab8a6476464795a7ccf394a3248d4f22c9f87173a15b36b6d971/greenlet-3.5.1-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:e6cd99ea59dd5d89f0c956606571d79bfe6f68c9eb7f4a4083a41a7f1587edee", size = 422782, upload-time = "2026-05-20T14:01:39.597Z" },
+    { url = "https://files.pythonhosted.org/packages/59/90/3cf77e080350cd02fa307bb2abf05df48f4482c240275bbd2c203ba8bb1c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a5ea42a752d47a145eae922b605cd1634665ac3d5ec1e72402d5048e8d60d207", size = 1570475, upload-time = "2026-05-20T14:02:25.29Z" },
+    { url = "https://files.pythonhosted.org/packages/65/2c/18cece62045e74598c3c393f70dce4a63f56222015ba29a5d4eeb04f764c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c5551170cf4f5ff5623e9af81323751979fee2c731e2287b61f73cd27257b823", size = 1635625, upload-time = "2026-05-20T13:14:34.027Z" },
+    { url = "https://files.pythonhosted.org/packages/30/f5/310d104ddf41eb5a70f4c268d22508dfb0c3c8e86fec152be34d0d2ed819/greenlet-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3c8bb982ad117d29478ef8f5533e97df21f1e2befd17a299257b0c96d1371c0b", size = 238791, upload-time = "2026-05-20T13:10:39.018Z" },
+    { url = "https://files.pythonhosted.org/packages/62/90/ceca11f504cd23a8047a3dea31919adc48df9b626dd0c13f0d858734fdfd/greenlet-3.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:80eb4b04dadc4e67df3fae179a32c4706a3f495bc7f22fc8a81115d5f5512188", size = 235580, upload-time = "2026-05-20T13:08:45.056Z" },
+    { url = "https://files.pythonhosted.org/packages/27/69/7f7e5372d998b81001899b1c0823c957aa413ba0f2662e65821611cc31e4/greenlet-3.5.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:51518ff74664078fc51bffcc6fc529b0df5ae58da192691cee765d45ce944a2b", size = 285060, upload-time = "2026-05-20T13:08:51.899Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/bf/387f9b6b865fd2ae0d0be09e0004827295a01b71be76ed350dd1e28a91a4/greenlet-3.5.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ffdb3c0bb002c99cd8f298957e046c3dbf6006b5b7cdf11a4e19194624a0a0a", size = 604370, upload-time = "2026-05-20T14:00:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f5/169ce3d4e4c67291bd18f8cbe0299c9f3e45102c7f1fb3c14780c93e4532/greenlet-3.5.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7715a5a2c3378ba602c3a440558261e13a820bb53a82693aacd7b7f6d964e283", size = 616987, upload-time = "2026-05-20T14:05:44.237Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ba/c24110c55dffa55aa6e1d98b45310da33801aeba7686ff0190fe5d46fd32/greenlet-3.5.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d40a890035c0058cadbdc4af7569800fd28a0e527a0fdbb7b5f9418f176846ce", size = 622911, upload-time = "2026-05-20T14:09:10.598Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e5/7f2e41d5273be07e77560d61ea4e56485b4d6c316d2a84518c62d1364061/greenlet-3.5.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc71ff466927a201b08305acac451ebe1aedfcea002f62f1f2f2ac2ac1e6a135", size = 613911, upload-time = "2026-05-20T13:14:27.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/7b/d20db2e8a5ad6c038702f3179b136f93f0a3d1a21a0c0777f3e470cdf4b2/greenlet-3.5.1-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:67821bb03e4e98664490edb787ff6af501194c29bbee0f5c1dfdcf1dc3d9d436", size = 425228, upload-time = "2026-05-20T14:01:40.837Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a4/fbdc67579b73615a1f91615e814303cc71e06128f7baaba87be79b8fb90c/greenlet-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cd443683db272ebaaca03af98c0b063ab30db70ea8a31a1559f35e3f7b744ccd", size = 1570689, upload-time = "2026-05-20T14:02:27.225Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b4/77abbe35078be39718a46cd49caf16bceb35662f97a34101dca28aa98e47/greenlet-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:089fff7a6ce8d9316d1f65ebc00273a56be258c1725b32b94de90a3a979557e1", size = 1635602, upload-time = "2026-05-20T13:14:36.344Z" },
+    { url = "https://files.pythonhosted.org/packages/37/f7/129f27ca700845b8ee8ca88ce7f43435a1239c2eddb7677fc938822762cf/greenlet-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:110a1ca7b49b014b097f6078272c3f4ed31af45b254de5228b79adba879f6af9", size = 238683, upload-time = "2026-05-20T13:11:50.57Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/5c/a485a36e87df8d8fd0632ee01511244f5156a20ed3746cc6599340326395/greenlet-3.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:f16ba1efc0715b680a18b8123d90dad887c6112ae3555b4b5c32c149540c6b4e", size = 235499, upload-time = "2026-05-20T13:12:42.028Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cb/c62454606daf5640369c94d8a9dd540599b1bfc090e2d2180cb77f4038d2/greenlet-3.5.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8ab31c9de8651a2facdd5c5bb0011f2380dd1a7af78ce2adf4b56095294fc07", size = 285579, upload-time = "2026-05-20T13:08:56.396Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/71/c4270398c2eba968a6071af1dfbdcaeee6ec1c24bc8b435b8cc452700da6/greenlet-3.5.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e300185139abc337ade480c327183adf42a875ac7181bfe66d7d4efea31fbea", size = 651106, upload-time = "2026-05-20T14:00:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ab/71e34b78a44ec271fb5f550c17bc46d301ddc5953890d935f270b0dcdb5a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7ffdb990dcaa0234cf9845aead5df2e3c3a8b6507d409274dd87e0d5ab05ffc2", size = 663478, upload-time = "2026-05-20T14:05:45.88Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/2d/2d80842910da44f78c286532d084b8a5c3717c844ae80ceb3858738ae89a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c09df69dc1712d131332054a858a3e5cca400967fa3a672e2324fbb0971448c", size = 667767, upload-time = "2026-05-20T14:09:12.15Z" },
+    { url = "https://files.pythonhosted.org/packages/77/96/4efd6fa5c62c85426a0c19077a586258ebc3a2a146ff2493e4312a697a22/greenlet-3.5.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2f82b3597e9d83b63408affed0b48fd0f54935edac4302237b9a837be0dae33c", size = 660800, upload-time = "2026-05-20T13:14:29.129Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d3/dad2eecedfbb1ed7050a20dcfae40c1442b74bc7423608be2c7e03ee7133/greenlet-3.5.1-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:a4764e0bfc6a4d114c865b32520805c16a990ef5f286a514413b05d5ecd6a23d", size = 470786, upload-time = "2026-05-20T14:01:42.064Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e0/6c71401a25cac7000261304e866a2f2cc04dc74810d40e2f118aa4799495/greenlet-3.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c0141e37414c10164e702b8fb1473304221ad98f71600850c6ef7ff4880feba0", size = 1617518, upload-time = "2026-05-20T14:02:28.662Z" },
+    { url = "https://files.pythonhosted.org/packages/41/26/c5c06643e8c0af9e7bf18e16cb51d0ab7625155f0392e1c9015d66d556cd/greenlet-3.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:50ae25a67bea74ea41fb14b960bc532df73eb713417b2d61892dced82fe8d3bc", size = 1681593, upload-time = "2026-05-20T13:14:39.417Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/bd/e11a108317485075e68af9d23039619b86b28130c3b50d227d42edece64b/greenlet-3.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:8a17c42330e261299766b75ac1ea32caa437a9453c8f65d16a13140db378ecd3", size = 239800, upload-time = "2026-05-20T13:09:30.128Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/8e8e8417b7bf28639a5a56356ef934d0375e1d0c70a57e04d7701e870ffe/greenlet-3.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:7b5f5fae05b8ac6d176a61b60c394a8cbdc2b5b91b81793066e68745cf165e54", size = 236862, upload-time = "2026-05-20T13:09:10.498Z" },
+    { url = "https://files.pythonhosted.org/packages/90/12/41bf27fde4d3605d3773ae57751eda182b8be2f5398011c041173b1d9534/greenlet-3.5.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:ea8da1e900d758d078810d4255d8c6aa572181896a31ec79d779eb79c3adc9ad", size = 293637, upload-time = "2026-05-20T13:12:35.529Z" },
+    { url = "https://files.pythonhosted.org/packages/44/44/ba14b23e9757707050c2f397d305bbcae62e5d7cad122f8b6baec5ae4a1f/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a19570c52a21420dcbc94e661994bc325c0b5b11304540fed514586da5dc8f2e", size = 650840, upload-time = "2026-05-20T14:00:11.079Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/37/5ddc2b686a6844f91abecef43411842426da2e1573f60b49ecf2547f4ae1/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3d955c89b75eeca4723d7cc14135f393cd47c32e2a6cb4a8e4c6e760a26b0986", size = 656416, upload-time = "2026-05-20T14:05:47.118Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/46/5987dcd1a2570ba84f3b187536b2ca3ae97613387e57f5cfa99df068fe5e/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ea37d5a157eb9493820d3792ac4ece28619a394391d2b9f2f78057d396ff0f0f", size = 656607, upload-time = "2026-05-20T14:09:13.949Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f0/d17510297c35a2992712f0bf84de3779749999f7d3d63aa1f09db7c62dbe/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2daaaebd1a5aa88c49045b6baf9310b3263796bd88db713edf37cf53e7bb4e", size = 654397, upload-time = "2026-05-20T13:14:30.696Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c1/6da0a9ddcc29d7e51ef14883fa3dc1e53b3f4ffba00582106c7bf55da1d8/greenlet-3.5.1-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:8d8a23250ea3ec7b36de8fa4b541e9e2db3ee82915cc060ab0631609ad8b28de", size = 488287, upload-time = "2026-05-20T14:01:43.143Z" },
+    { url = "https://files.pythonhosted.org/packages/37/eb/147387705bb89092645b012586e7273cb5ed3c90ef7eaf3a69173eaf0209/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bfbd69cc349e43bf3a8ae1c85548ff0718efc887615c2db16c3833d7b0b072d", size = 1614469, upload-time = "2026-05-20T14:02:30.192Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/4e/37ee0da7732b7aa9896f17e15579a9df34b9fcb9dd494f0adfa749af6623/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4378720dd888136c27215a0214d32a4d37c3852765d45bc37aad0623423cfd78", size = 1675115, upload-time = "2026-05-20T13:14:40.972Z" },
+    { url = "https://files.pythonhosted.org/packages/57/f3/97dfcf4a6eb5077f8a672234216fb5923eb89f2cab7081cb10b2cf75b605/greenlet-3.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:45718441607f9325d948db98cbc691276059316d0358c188c246da4e1d4d23d2", size = 245246, upload-time = "2026-05-20T13:12:22.646Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/73/d7f72e34b582f694f4a9b248162db7b09cc458a259ba8f0c0bfa1a34ea7d/greenlet-3.5.1-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:2baee5ca02031757ffe8cc3d69f0cc0aec7065ce362622da74f32d3bcab1c541", size = 285575, upload-time = "2026-05-20T13:12:07.043Z" },
+    { url = "https://files.pythonhosted.org/packages/df/59/fa9c6e87dc8ad27a95dabe2f29f372b733d05a8a67470f6c901ed9975655/greenlet-3.5.1-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b1ec3274918a81d3ea778b9e75b56b72b33f300edb6cf7f3a7fe1dae56683de", size = 656428, upload-time = "2026-05-20T14:00:12.556Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f9/e753408871eaa61dfe35e619cfc67512b036fde99893685d50eea9e07146/greenlet-3.5.1-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:111e2390ffffc47d5840b01711dd7fac07d4c09283d0283e7f3264b14e284c64", size = 667064, upload-time = "2026-05-20T14:05:48.662Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/74/807a047255bf1e09303627c46dc043dca596b6958a354d904f32ab382005/greenlet-3.5.1-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:10a9a1c0bfbc93d41156ffcb90c75fbc05544054faf15dcc1fdf9765f8b607f0", size = 672962, upload-time = "2026-05-20T14:09:15.532Z" },
+    { url = "https://files.pythonhosted.org/packages/96/27/5565b5b40389f1c7753003a07e21892fda8660926787036d5bc0308b8113/greenlet-3.5.1-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e630136e905fe5ff43e86945ae41220b6d1470956a39220e708110ac48d01ea5", size = 665697, upload-time = "2026-05-20T13:14:32.943Z" },
+    { url = "https://files.pythonhosted.org/packages/76/32/19d4e13225193c29b13e308015223f7d75fd3d8623d49dd19040d2ce8ec1/greenlet-3.5.1-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:ef08c1567c78074b22d1a200183d52d04a14df447bf70bcbb6a3507a48e776fc", size = 476047, upload-time = "2026-05-20T14:01:44.39Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/82/e7de4178c0c2d1c9a5a3be3cc0b33e46a85b3ee4a77c071bf7ad8600e079/greenlet-3.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:975eac34b44a7077ca4d421348455b94f0f518246a7f14bc6d2fdcfe5b584368", size = 1621256, upload-time = "2026-05-20T14:02:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/00/10/f2dddcf7dacac17dfc68691809589adad06135eb28930429cf58a6467a2f/greenlet-3.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:9ab3c3a0b2ae6198e67c898dad5215a49f9ae0d0081b3c3ec59f333e39eeca26", size = 1685956, upload-time = "2026-05-20T13:14:42.55Z" },
+    { url = "https://files.pythonhosted.org/packages/22/17/4a232b32133230ada52f70e9d7f5b65b0caef8772f01849bd8d149e7e4ca/greenlet-3.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:cbfc69be86e10dcfef5b1e6269d1d6926552aa89ee39e1de3353360c1b6989ab", size = 239802, upload-time = "2026-05-20T13:13:15.481Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ae/4e623a7e6d4d2a5f4cb8e4c82de4169fc637942caae68d6e676b8a128ac5/greenlet-3.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:92fd6d44ac5e5a887c8a5dc4a8ba0ba908527c31c12f78c6bc7dcfe8aab279f6", size = 236853, upload-time = "2026-05-20T13:15:37.301Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/57/816d9cff29119da3505b3d6a5e14a8af89006ac36f47f891ff293ee05af1/greenlet-3.5.1-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:a6fdf2433a5441ef9a95464f7c3e674775da1c8c1177fff311cee1acad4626ed", size = 293877, upload-time = "2026-05-20T13:10:19.078Z" },
+    { url = "https://files.pythonhosted.org/packages/23/a1/59b0a7c7d140ff1a75626680b9a9899b79a9176cab298b394968fb023295/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7546556f0d649f99f6a361098a55f761181bb2ea12ff150bb16d26092ad88244", size = 655333, upload-time = "2026-05-20T14:00:14.758Z" },
+    { url = "https://files.pythonhosted.org/packages/72/1b/5efe127597625042218939d01855109f352779050768b670b52edcc16a6c/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d5ee3ea898009fa898f85f9982255d35278c477bebe185beca249cab42d4526c", size = 659443, upload-time = "2026-05-20T14:05:50.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/9d/1dcdf7b95ab3cf8c7b6d7277c18a5e167312f2b362ddfcc5d5e6d8d84b43/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a57b0d05a0448eed231d59c0ceb287dde984551e54cbc51ac2d4865712838e9c", size = 659998, upload-time = "2026-05-20T14:09:16.912Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/6d/c404246ea4d22d097a7426d0efb5b781bd7eb67715f09e79001bd552ab18/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5c81f74d204d3edd136ebfd50dce53acbb776995d721a0fe801626cfc93b8cd", size = 658356, upload-time = "2026-05-20T13:14:35.091Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/c4959664fc231d587d66d8e81f2095e98056ba1954beafdcbe635e251052/greenlet-3.5.1-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:b0703c2cef53e01baec47f7a3868009913ad71ec678bbecb42a6f40895e4ce62", size = 494470, upload-time = "2026-05-20T14:01:45.611Z" },
+    { url = "https://files.pythonhosted.org/packages/51/02/f8ee37fb6d2219329f350af241c27fcf12df57e723d11f6fc6d3bacdadaa/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:2c18ef16bf6d4dd410e4dd52996888ea1497be26892fe5bbc73580aba4287b8e", size = 1619216, upload-time = "2026-05-20T14:02:33.403Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c5/3dc9475ace2c7a3680da12372cddd7f1ac874eb410a1ac48d3e9dab83782/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:17d86354f0ae6b61bf9be5148d0dd34e06c3cb7c602c671f79f29ac3b150e659", size = 1678427, upload-time = "2026-05-20T13:14:43.71Z" },
+    { url = "https://files.pythonhosted.org/packages/df/4e/750c15c317a41ffb36f0bf40b933e3d744a7dede61889f74443ea69690cf/greenlet-3.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:e7516cf6ae6b8a582c2770a0caed47b8a48373ed732c33d69a72913ae6ac923e", size = 245225, upload-time = "2026-05-20T13:13:59.366Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/fd/d3baea2eeb7b617efd47e87ca06e2ec2c6118d303aa9e918e0ce16eadc10/greenlet-3.5.1-cp315-cp315t-win_arm64.whl", hash = "sha256:5028648bf2253ec4745add746129d3904121fa7fe871a76bed23c5720573ce0a", size = 239590, upload-time = "2026-05-20T13:13:37.382Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -551,17 +641,30 @@ all = [
     { name = "aiohttp" },
     { name = "beautifulsoup4" },
     { name = "boto3" },
+    { name = "cloakbrowser" },
     { name = "firecrawl-py" },
     { name = "html2text" },
     { name = "httpcloak" },
+    { name = "polars" },
     { name = "pyarrow" },
+    { name = "rapidfuzz" },
 ]
 dev = [
+    { name = "aiohttp" },
+    { name = "beautifulsoup4" },
+    { name = "boto3" },
+    { name = "cloakbrowser" },
+    { name = "firecrawl-py" },
+    { name = "html2text" },
+    { name = "httpcloak" },
     { name = "mypy" },
     { name = "pandas-stubs" },
+    { name = "polars" },
+    { name = "pyarrow" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-httpx" },
+    { name = "rapidfuzz" },
     { name = "ruff" },
     { name = "types-boto3" },
 ]
@@ -573,13 +676,31 @@ parquet = [
 ]
 publish = [
     { name = "boto3" },
+    { name = "polars" },
     { name = "pyarrow" },
+    { name = "rapidfuzz" },
 ]
 scrapers = [
     { name = "aiohttp" },
     { name = "beautifulsoup4" },
+    { name = "cloakbrowser" },
     { name = "html2text" },
     { name = "httpcloak" },
+]
+test = [
+    { name = "aiohttp" },
+    { name = "beautifulsoup4" },
+    { name = "boto3" },
+    { name = "cloakbrowser" },
+    { name = "firecrawl-py" },
+    { name = "html2text" },
+    { name = "httpcloak" },
+    { name = "polars" },
+    { name = "pyarrow" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-httpx" },
+    { name = "rapidfuzz" },
 ]
 
 [package.metadata]
@@ -587,24 +708,29 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'scrapers'", specifier = ">=3.9" },
     { name = "beautifulsoup4", marker = "extra == 'scrapers'", specifier = ">=4.12" },
     { name = "boto3", marker = "extra == 'publish'", specifier = ">=1.34" },
+    { name = "cloakbrowser", marker = "extra == 'scrapers'", specifier = ">=0.3" },
     { name = "firecrawl-py", marker = "extra == 'discovery'", specifier = ">=1.0" },
     { name = "html2text", marker = "extra == 'scrapers'", specifier = ">=2024.0" },
     { name = "httpcloak", marker = "extra == 'scrapers'", specifier = ">=1.6" },
     { name = "httpx", specifier = ">=0.27" },
+    { name = "jobhive-py", extras = ["all"], marker = "extra == 'test'" },
     { name = "jobhive-py", extras = ["scrapers", "parquet", "publish", "discovery"], marker = "extra == 'all'" },
+    { name = "jobhive-py", extras = ["test"], marker = "extra == 'dev'" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "pandas", specifier = ">=2.0" },
     { name = "pandas-stubs", marker = "extra == 'dev'" },
+    { name = "polars", marker = "extra == 'publish'", specifier = ">=0.20" },
     { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=15.0" },
     { name = "pyarrow", marker = "extra == 'publish'", specifier = ">=15.0" },
     { name = "pydantic", specifier = ">=2.6" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
-    { name = "pytest-httpx", marker = "extra == 'dev'", specifier = ">=0.30" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23" },
+    { name = "pytest-httpx", marker = "extra == 'test'", specifier = ">=0.30" },
+    { name = "rapidfuzz", marker = "extra == 'publish'", specifier = ">=3.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
     { name = "types-boto3", marker = "extra == 'dev'" },
 ]
-provides-extras = ["scrapers", "parquet", "publish", "discovery", "all", "dev"]
+provides-extras = ["scrapers", "parquet", "publish", "discovery", "all", "test", "dev"]
 
 [[package]]
 name = "librt"
@@ -1034,12 +1160,59 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.60.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/f0/832bd9677194908da118064eef20082f2791e3d18215cc6d9391ee2c5a67/playwright-1.60.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:6a8cd0fec171fb3089e95e898c8bc8a6f35dea0b78b399e12fcc19427e91b1d7", size = 43474635, upload-time = "2026-05-18T12:00:31.969Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7b/e1d32ae8a3ed937ec2be3721c5f728b13d731a0b7c6442e0b3bec5094ac0/playwright-1.60.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:39b5420ba6145045b69ced4c5c47d4d9fe5bddfc8ff816c518913afcb25ec7a5", size = 42261327, upload-time = "2026-05-18T12:00:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/bc/23de499ded6411c188a20c5a0dea6f0cd4ed5d2b3cc6042a5dbd3ed609aa/playwright-1.60.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:2581d0e6a3392c71f91b27460c7fd093356818dc430f48153896c8aeeaef7705", size = 43474636, upload-time = "2026-05-18T12:00:39.294Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7b/1d679f4fced4ea94efadd17103856d8c565384f68382a1681264e46f5925/playwright-1.60.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:1c2bfae7884fb3fb05b853290eab8f343d524e5016f2f1def702acbbdf14c93e", size = 47467220, upload-time = "2026-05-18T12:00:43.179Z" },
+    { url = "https://files.pythonhosted.org/packages/84/c2/1528d267d4442bd2c6b8eaeab819dd52c2030bf80e89293f0ba1f687473b/playwright-1.60.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43e66564125ee31b07a58cefb21e256d62d67d8d1713e6858df7a3019d8ed353", size = 47154856, upload-time = "2026-05-18T12:00:46.715Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/4e/b008b6440a7a1624378041da94829956d4b8f7ab9ef5aad22d0dc3f2e26d/playwright-1.60.0-py3-none-win32.whl", hash = "sha256:ec94e416ea320711e0ad4bf185dcbf41833672961e90773e1885255d7db7b7e7", size = 37902157, upload-time = "2026-05-18T12:00:50.374Z" },
+    { url = "https://files.pythonhosted.org/packages/55/f0/0541524133104f9cc20bf900870ff4a736b76a23483f3a55295ddfa58409/playwright-1.60.0-py3-none-win_amd64.whl", hash = "sha256:9566821ce6030a1f9e7146a24e19355ab0d98805fd0f9be50bb3d8fef1750c02", size = 37902159, upload-time = "2026-05-18T12:00:53.728Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c8/210f282d278e4709cdd71b12a31af45a30a22ab3207b387e29b37e478713/playwright-1.60.0-py3-none-win_arm64.whl", hash = "sha256:6e4f6700a4c2250efff8e690a81d66e3855754fb587b6b87cf5c784014f91537", size = 34037981, upload-time = "2026-05-18T12:00:57.584Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "polars"
+version = "1.41.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/f9/aeda46259b0669247a160315d2d51269de9504b9dd2f70acadbcb22f46b7/polars-1.41.2.tar.gz", hash = "sha256:256d6731162371b77f3f29a55eacb8c0fc740ddb1a293a01d2ef5b5393c5c708", size = 737996, upload-time = "2026-05-29T17:39:15.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/22/28f62d24f7db56ac4343588f9362d49b7b4177e55ac47a466fe696b0099b/polars-1.41.2-py3-none-any.whl", hash = "sha256:23ce9a2910b6e3e8d4258770bf44aa17170958df7af6e85feedf4458a04d8d29", size = 833445, upload-time = "2026-05-29T17:37:05.576Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.41.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/56/54e3ea0e9b64f327179049e4742241cc6b1d3e8fa414b05a057dd26df367/polars_runtime_32-1.41.2.tar.gz", hash = "sha256:7af09ec1ab053da2c9669e8d15f809a4083a29be05db57111688b8051062af56", size = 2989474, upload-time = "2026-05-29T17:39:17.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/9b/fe72a3811c0357cdb06c67bdc7695fa1623ad47948fc523195f5ac31037f/polars_runtime_32-1.41.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:95a08346dac337357cdb825c8076df7d36da54c4caa59a5cb41d0a30691c5edd", size = 52265283, upload-time = "2026-05-29T17:37:09.407Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/93/fab9da803fd80d9e83ef88c20932f637a10bc611b20415fc322eec84bc44/polars_runtime_32-1.41.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:dedfaeec2c7f995298da7319dd9431d662e5dd1d0ec51b1459df4a0234ceff52", size = 46571222, upload-time = "2026-05-29T17:37:13.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2a/8843f34a8ac57acd058a39b87b03b580dd352a490e9dae0415e02033bdd4/polars_runtime_32-1.41.2-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:18eea22c5cc34e27f8a60950458ad81e6a9ea75e89363ca1367e14e7e7f781fc", size = 50409372, upload-time = "2026-05-29T17:37:17.875Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c6/92b352fe88cf51bd0a19fb99e1c0cbe46aa26c14dcf7995b89869cd932ae/polars_runtime_32-1.41.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2630540dfdfb0f36f9b04a07c7c2e3f50bf2ad384113263c1c812007ee9141e0", size = 56405484, upload-time = "2026-05-29T17:37:22.684Z" },
+    { url = "https://files.pythonhosted.org/packages/74/c4/bae3174c3b02f6b441d2e58594387abcd509f67a098f682a83b195f08966/polars_runtime_32-1.41.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:20e969e08f9b137e233c04cc04de73d9795f89eb77d34854e40a025965a43763", size = 50603512, upload-time = "2026-05-29T17:37:27.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ed/f2d26ae02d92c2689056838ed59e2a626326ad23c2831d58637d25f6c82a/polars_runtime_32-1.41.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e7016a3deb641b64a31447abbbee0f34bd020a6a9ae34ee6b743837def15e2a4", size = 54328561, upload-time = "2026-05-29T17:37:32.587Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/c4/9c3831cc885dc7769e59abf8f583821a5fb4403fd0e4eba0ccc6d47a3d4b/polars_runtime_32-1.41.2-cp310-abi3-win_amd64.whl", hash = "sha256:1e5e5377c315e0dcafdfb2a31adc546abbaeb3f9cb1864e6536523d2af473265", size = 51978643, upload-time = "2026-05-29T17:37:37.443Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c6/79e9f3f270270d7ed5575d92b7bfef49f01abd9275447161275b23b553a8/polars_runtime_32-1.41.2-cp310-abi3-win_arm64.whl", hash = "sha256:843d96f69d18eca53429c1198e58891db7f18111f83b9c419bb45ad9d73eaed5", size = 46006901, upload-time = "2026-05-29T17:37:42.522Z" },
 ]
 
 [[package]]
@@ -1309,6 +1482,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1378,6 +1563,85 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "rapidfuzz"
+version = "3.14.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/21/ef6157213316e85790041254259907eb722e00b03480256c0545d98acd33/rapidfuzz-3.14.5.tar.gz", hash = "sha256:ba10ac57884ce82112f7ed910b67e7fb6072d8ef2c06e30dc63c0f604a112e0e", size = 57901753, upload-time = "2026-04-07T11:16:31.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/f9/3c41a7be8855803f4f6c713b472226a98d31d41869d98f64f4ca790510d6/rapidfuzz-3.14.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e251126d48615e1f02b4a178f2cd0cd4f0332b8a019c01a2e10480f7552554b4", size = 1952372, upload-time = "2026-04-07T11:13:58.32Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/89/c2557e37531d03465193bff0ab9de70b468420a807d71a26a65100635459/rapidfuzz-3.14.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5ab449c9abd0d4e1f8145dce0798a4c822a1a1933d613c764a641bea88b8bdab", size = 1159782, upload-time = "2026-04-07T11:14:00.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b2/ffeeb7eca1a897d51b998f4c0ef0281696c3b06abcca4f88f9def708ffe1/rapidfuzz-3.14.5-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb2829fedd672dd7107267189dabe2bbe07972801d636014417c6861eb89e358", size = 1383677, upload-time = "2026-04-07T11:14:01.696Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d0/4539e42a2d596e068f7738f279638a4a74edd1fbb6f8594e2458058979c6/rapidfuzz-3.14.5-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d50e5861872935fece391351cbb5ba21d1bced277cf5e1143d207a0a35f1925", size = 3168906, upload-time = "2026-04-07T11:14:03.29Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/1c/3ec897eb9d8b05308aa8ef6ae4ed64b088ad521a3f9d8ff469e7e97bc2b0/rapidfuzz-3.14.5-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:7092a216728f80c960bd6b3807275d1ee318b168986bd5dc523349581d4890b8", size = 1478176, upload-time = "2026-04-07T11:14:04.94Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ba/970c03a12ce20a5399e22afe9f8932fd4cd1265b8a8461d0e63b00eb4eae/rapidfuzz-3.14.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9669753caef7fdc6529f6adcc5883ed98d65976445d9322e7dbdb6b697feee13", size = 2402441, upload-time = "2026-04-07T11:14:07.228Z" },
+    { url = "https://files.pythonhosted.org/packages/81/93/61d351cae60c1d0e21ba5ff1a1015ad045539ed215da9d6e302204ed887a/rapidfuzz-3.14.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:823b1b9d9230809d8edcc18872770764bfe8ef4357995e16744047c8ccf0e489", size = 2511628, upload-time = "2026-04-07T11:14:09.234Z" },
+    { url = "https://files.pythonhosted.org/packages/87/52/374d2d4f60fd98155142a869323aa221e30868cfa1f15171a0f64070c247/rapidfuzz-3.14.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f0b2af76b7e7060c09e1a0dfa9410eb19369cbe6164509bff2ef94094b54d2b6", size = 4275480, upload-time = "2026-04-07T11:14:11.332Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/04/82e7989bc9ec20a15b720a335c5cb6b0724bf6582013898f90a3280cfccd/rapidfuzz-3.14.5-cp311-cp311-win32.whl", hash = "sha256:c5801a89604c65ab4cc9e91b23bc4076d0ca80efd8c976fb63843d7879a85d7f", size = 1725627, upload-time = "2026-04-07T11:14:13.217Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b5/eca8ac5609bc9bcb02bb6ff87fa5983cc92b8772d66a431556ab8a8c178f/rapidfuzz-3.14.5-cp311-cp311-win_amd64.whl", hash = "sha256:d7ca16637c0ede8243f84074044bd0b2335a0341421f8227c85756de2d18c819", size = 1545977, upload-time = "2026-04-07T11:14:14.766Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/e1/dbf318de28f65fa2cdd0a9dfbdee380f8199eb83b19259bc4f8592551b4e/rapidfuzz-3.14.5-cp311-cp311-win_arm64.whl", hash = "sha256:8c90cdf8516d9057e502aa6003cea71cf5ec27cc44699ca52412b502a04761bb", size = 816827, upload-time = "2026-04-07T11:14:16.788Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/e3/574435c6aafb80254c191ef40d7aca2cb2bb97a095ec9395e9fa59ac307a/rapidfuzz-3.14.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0d3378f471ef440473a396ce2f8e97ee12f89a78b495540e0a5617bbfe895638", size = 1944601, upload-time = "2026-04-07T11:14:18.771Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/1f/fbad3102a255ecc112ce9a7e779bacab7fd14398217be8868dc9082ba363/rapidfuzz-3.14.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e910eebca9fd0eba245c0555e764597e8a0cccb673a92da2dc2397050725f48", size = 1164293, upload-time = "2026-04-07T11:14:20.534Z" },
+    { url = "https://files.pythonhosted.org/packages/88/37/a3eb7ff6121ed3a5f199a8c38cc86c8e481816f879cb0e0b738b078c9a7e/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01550fe5f60fd176aa66b7611289d46dc4aa4b1b904874c7b6d1d54e581c5ec1", size = 1371999, upload-time = "2026-04-07T11:14:22.63Z" },
+    { url = "https://files.pythonhosted.org/packages/79/72/97a9728c711c7c1b06e107d3f0623880fb4ef90e147ed13c551a1730e7cc/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:48bee0b91bebfaec41e1081e351000659ab7570cc4598d617aa04d5bf827f9e6", size = 3145715, upload-time = "2026-04-07T11:14:24.508Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/d5caabbea233ac90c286c87c260e49d7641467e87438a18d858e41c82e91/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:7e580cb04ad849ae9b786fa21383c6b994b6e6c1444ad1cb9f22392759d72741", size = 1456304, upload-time = "2026-04-07T11:14:26.515Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/a7/2d1a81250ac8c01a0100c026018e76f0e7a097ff63e4c553e02a6938c6fb/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:09d6c9ba091854f07817055d795d604179c12a8f308ba4c7d56f3719dfea1646", size = 2389089, upload-time = "2026-04-07T11:14:28.635Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0d/c47c3872203ae88e6506997c0b576ad731f5261daa25d559be09c9756658/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1e989f86113be66574113b9c7bdf4793f3f863d248e47d911b355e05ca6b6b10", size = 2493404, upload-time = "2026-04-07T11:14:30.577Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/2f/71e0a5a3130792146c8a200a2dd1e52aa16f7c1074012e17f2601eea9a90/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0ebd1a18e2e47bc0b292a07e6ed9c3642f8aaa672d12253885f599b50807a4f9", size = 4251709, upload-time = "2026-04-07T11:14:32.451Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/d39874901abacef325adb5b34ae416817c8486dfb4fb87c7a9b74ec5b072/rapidfuzz-3.14.5-cp312-cp312-win32.whl", hash = "sha256:9981d38a703b86f0e315a3cd229fd1906fe1d91c989ed121fb975b3c849f89f5", size = 1710069, upload-time = "2026-04-07T11:14:34.37Z" },
+    { url = "https://files.pythonhosted.org/packages/85/0b/f65572c53de8a1c704bda707f63a447b67bdbe95d7cdc70d18885e191df5/rapidfuzz-3.14.5-cp312-cp312-win_amd64.whl", hash = "sha256:d8375e3da319593389727c3187ccaf3e0e84199accc530866b8e0f2b79af05e9", size = 1540630, upload-time = "2026-04-07T11:14:36.287Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c3/143be3a578f989758cae516f3270d5cbb49783a7bfdf57cc27a670e00456/rapidfuzz-3.14.5-cp312-cp312-win_arm64.whl", hash = "sha256:478b59bb018a6780d73f33e38d0b3ec5e968a6c1ed42876b993dd456b7aa20e8", size = 813137, upload-time = "2026-04-07T11:14:38.289Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/252803f2010ba699618cdc048b6e1f7cc1f433c08b4a9a17579b92ab0142/rapidfuzz-3.14.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ebd8fd343bf8492a1e60bcb6dc99f90f74f65d98d8241a6b3e1fed225b76ecd6", size = 1940205, upload-time = "2026-04-07T11:14:40.319Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/59/b2afd98e41af9cd54554a4c1c423d84cdd60e6b1c0a09496f033b55f60ec/rapidfuzz-3.14.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6737b35d5af7479c5bf9710f7b17edd9d2c43128d974d25fb4ea653e42c64609", size = 1159639, upload-time = "2026-04-07T11:14:42.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/7aa7e62c4c516a7af322ed0c4f0774208b72d457d0cfec808bad0df12f4a/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b002c7994cc9f2bc9d9856f0fbaee6e8072c983873846c92f25cefba5b2a925f", size = 1367194, upload-time = "2026-04-07T11:14:44.25Z" },
+    { url = "https://files.pythonhosted.org/packages/90/79/2fc252a63bc91d3c3b234d0a3a6ad4ebc460037a23cdcdaf9285f986e6c9/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:17a34330cd2a538c1ce5d400b61ba358c5b72c654b928ff87b362e88f8b864c7", size = 3151805, upload-time = "2026-04-07T11:14:46.21Z" },
+    { url = "https://files.pythonhosted.org/packages/17/54/0c83508f2683ea70e2d05f8527eb07328acf7bb1e9d97a3bece5702378e7/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:95d937e74c1a7a1287dfb03b62a827be08ede10a155cf1af73bbf47f2b73ee6e", size = 1455667, upload-time = "2026-04-07T11:14:47.991Z" },
+    { url = "https://files.pythonhosted.org/packages/71/1b/070175e873177814d58850a01ebe80e20ae11e93eb4da894d563988660fa/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:46b92a9970dcc34f0096901c792644094cab49554ac3547f35e3aebbdf0a3610", size = 2388246, upload-time = "2026-04-07T11:14:50.098Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/dd/77caf7aaf9c2be050ad1f128d7c24ff0f59079aa62c5f62f9df41c0af45e/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e012177c8e8a8a0754ae0d6027d63042aa5ff036d9f40f07cb3466a6082e21b8", size = 2494333, upload-time = "2026-04-07T11:14:52.303Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/dd7e1f2aa31a8fbbfc16b0610af1d770ffaf1287490f3c8c5b1c52da264f/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a2ae6f53f99c9a0eca7a0afc5b4e45fc73bc1dd4ac74c00509031d76df80ed98", size = 4258579, upload-time = "2026-04-07T11:14:54.538Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0a/ac99e1ba347ba0e85e0bb60b74231d55fb93c0eff43f2920ccb413d0be08/rapidfuzz-3.14.5-cp313-cp313-win32.whl", hash = "sha256:4a60f0057231188e3bd30216f7b4e0f279b11fa4ec818bb6c1d9f014d1562fbc", size = 1709231, upload-time = "2026-04-07T11:14:56.524Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/cb/0e251d731b3166378644238e8f0cf9e89858c024e19f75ca9f7e3ae83fd5/rapidfuzz-3.14.5-cp313-cp313-win_amd64.whl", hash = "sha256:11bfc2ed8fbe4ab86bd516fadefab126f90e6dcadffa761739fcb304707dfd35", size = 1538519, upload-time = "2026-04-07T11:14:58.635Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6f/4548132acc947db6d5346a248e44a8b3a22d608ef30e770fb578caaf2d00/rapidfuzz-3.14.5-cp313-cp313-win_arm64.whl", hash = "sha256:b486b5218808f6f4dc471b114b1054e63553db69705c97da0271f47bd706aedd", size = 812628, upload-time = "2026-04-07T11:15:00.552Z" },
+    { url = "https://files.pythonhosted.org/packages/00/60/69b177577290c5eab892c6f75fe89c3aff3f9ae80298a78d9372b1cecb9a/rapidfuzz-3.14.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:39ef8658aaf67d51667e7bdaf7096f432333377d8302ac43c70b5df8a4cf89b8", size = 1970231, upload-time = "2026-04-07T11:15:02.603Z" },
+    { url = "https://files.pythonhosted.org/packages/48/38/2fd790052659cc4e2907b63c25433f0987864b445c1aeec1a302ef5ad948/rapidfuzz-3.14.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9ad37a0be705b544af6296da8edddc260d10a8ae5462530fc9991f66498bb1f9", size = 1194394, upload-time = "2026-04-07T11:15:04.572Z" },
+    { url = "https://files.pythonhosted.org/packages/80/f4/28430ad8472fc3536e8ebd51a864a226e979cfe924c6e3f83d111373aa74/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d45e06f60729e07d9b20c205f7e5cff90b6ef2584e852eecf46e045aea69627d", size = 1377051, upload-time = "2026-04-07T11:15:06.728Z" },
+    { url = "https://files.pythonhosted.org/packages/77/7e/9aeacabcfd1e77397968362e5b98fe14248b8307011136b17daf99752a8e/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e52da10236aa6212de71b9e170bace65b64b129c0dea7fc243d6c9ce976f5074", size = 3160565, upload-time = "2026-04-07T11:15:08.667Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f4/db4dd7be0cd2f2022117ac5407d905f435d60e48baaea313a567ad27e865/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:440d30faaf682ca496170a7f0cc5453ec942e3e079f0fd802c9a7f938dfb50a3", size = 1442113, upload-time = "2026-04-07T11:15:11.138Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/99/0e9f6aa57f3e32a767216f797e56dc96b720fcecfb9d8ee907ecc82f8d66/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:56227a61fd3d17b0cd9793132431f3a3d07c8654be96794ba9f89fe0fc8b2d09", size = 2396618, upload-time = "2026-04-07T11:15:13.154Z" },
+    { url = "https://files.pythonhosted.org/packages/60/94/44a78e39ffce17cbdd3e2b53b696acc751d5d153be0f499d052b07a4d904/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:2e83cd2e25bb4edd97b689d9979d9c3acccdaaf26ceac08212ceece202febcfa", size = 2478220, upload-time = "2026-04-07T11:15:15.193Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/df/454311469a09a507e9d784a35796742bec22e4cebe75551e2da4e0e290fd/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:af3b859726cd3374287e405e14b9634563c078c5531a4f62375508addebddad1", size = 4265027, upload-time = "2026-04-07T11:15:17.28Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/01/175465a9ab3e3b70ba669058372f009d1d49c1746e2dcd56b69df188d3a5/rapidfuzz-3.14.5-cp313-cp313t-win32.whl", hash = "sha256:8ce1d850b3c0178440efde9e884d98421b5e87ff925f364d6d79e23910d7593f", size = 1766814, upload-time = "2026-04-07T11:15:19.687Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a0/a9b84a47af06ebed94a1439eb2f02adebfb8628bcd30af1fe3e02f5ef56c/rapidfuzz-3.14.5-cp313-cp313t-win_amd64.whl", hash = "sha256:c84af70bcf34e99aee894e46a0f1ac77f17d0ef828179c387407642e2466d28a", size = 1582448, upload-time = "2026-04-07T11:15:21.98Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f1/5937800238b3f8248e70860d79f69ba8f73e764fff47e36bc9e2f26dbcc6/rapidfuzz-3.14.5-cp313-cp313t-win_arm64.whl", hash = "sha256:aac0ad28c686a5e72b81668b906c030ee28050b244544b8af68e12fb32543895", size = 832932, upload-time = "2026-04-07T11:15:24.358Z" },
+    { url = "https://files.pythonhosted.org/packages/81/41/aa3ffb3355e62e1bf91f6599b3092e866bc88487a07c524004943c7676df/rapidfuzz-3.14.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1a31cc6d7d03e7318a0974c038959c59e19c752b81115f2e9138b3331cd64d45", size = 1943327, upload-time = "2026-04-07T11:15:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e1/c2141f1840a41e07ad2db6f724945f8f8ff3065463899a22939152dd6e09/rapidfuzz-3.14.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0298d357e2bc59d572da4db0bc631009b6f8f6c9bc8c11e99a12b833f16b6575", size = 1161755, upload-time = "2026-04-07T11:15:28.659Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/07/66e753eeaa353161d1d331b7dd517bb349b0bacfebe8496d7b26be26f81f/rapidfuzz-3.14.5-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:59b3dba758661a318995655435c6ab20a04ade79fa51e75bc8dc107cac8df280", size = 1376571, upload-time = "2026-04-07T11:15:31.225Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/85/9535df0b78ba51f478c9ce7eb6d1f85535cc31fe356773b48fd9d3e563ca/rapidfuzz-3.14.5-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4900143d82071bdda533b00300c40b14b963ff826b3642cc463b6dd0f036585e", size = 3156468, upload-time = "2026-04-07T11:15:33.428Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ee/b667eb93bba6dc4e0de658edd778e1619dc4d6aab68fa5e5c7f075152735/rapidfuzz-3.14.5-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:feedf219672eef83ea6be6f3bb093bba396a8560fc75be85ba225f082903df0a", size = 1458311, upload-time = "2026-04-07T11:15:35.557Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ce/479074f5624364a48df3403c538797ef22d3ac49c19dc76c3f79fcdcc70c/rapidfuzz-3.14.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:419e4397a36e2665ec992d8d64c20ba4b2a42500c76ecadeca78a4f19cb9cc32", size = 2398228, upload-time = "2026-04-07T11:15:37.669Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/15/a8982f649150fffbdcd6f17565974501f6ab33b2795267bffbd4a7ba905b/rapidfuzz-3.14.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:97131ab2be39043054ee28d99e09efe316e6d53449b7e962dfcf3c2de8b2b246", size = 2497226, upload-time = "2026-04-07T11:15:39.857Z" },
+    { url = "https://files.pythonhosted.org/packages/19/52/5267c03ef6759831b7d4625a0c9c06e87baa2fae084b61ac9c388858317b/rapidfuzz-3.14.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:593c00dac4e30231c35bf3b4f1da8ec0998762e9e94425586a5d636fcd57f9d0", size = 4262283, upload-time = "2026-04-07T11:15:42.279Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c0/2579f343a97f5254c43bb5853baccc01488357dcb64a27bcb869b7888a4a/rapidfuzz-3.14.5-cp314-cp314-win32.whl", hash = "sha256:0084b687b02b4e569b46d8d6d4ad25659528e6081cd6d067ca453a69035f07e4", size = 1744614, upload-time = "2026-04-07T11:15:44.498Z" },
+    { url = "https://files.pythonhosted.org/packages/17/eb/8edfed1e80119dc9c35b11df4bc701eea85622ad681fff0263b6961d3224/rapidfuzz-3.14.5-cp314-cp314-win_amd64.whl", hash = "sha256:5dfa89d78f22cd773054caff44827b846161a29f2dcf7e78b8f90d086621e502", size = 1588971, upload-time = "2026-04-07T11:15:46.86Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/04/5676df93c85cfa57a3045d8047318df9f3cd58c7b8a99340dd95f874795e/rapidfuzz-3.14.5-cp314-cp314-win_arm64.whl", hash = "sha256:67f3f9d2b444268ab53e47d31bab89954888d23c04c6789f2c727e51fe4b1d13", size = 834985, upload-time = "2026-04-07T11:15:49.411Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/0d/4a8988cea658fe335048ddef8c876addff1b6daa3c9ca8ad65a5a2196e69/rapidfuzz-3.14.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:77eac0526899b3c3ad1454bb2b03cdb491d67358ec8ef0c9c48bd61b632b431d", size = 1972517, upload-time = "2026-04-07T11:15:51.819Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a3/f5cfd9965a9d9a9e32249159797c47b5d6299ea6d1629f9126b25f1c10a3/rapidfuzz-3.14.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b9c6bd754d11f6e78ac54e3d86b4b11dc1ba2f13e5fc958899574532897f5a99", size = 1196056, upload-time = "2026-04-07T11:15:54.292Z" },
+    { url = "https://files.pythonhosted.org/packages/64/07/561c2e40cfd10e6630a7b0ac5a2a813aef50d944bcd1f3d260319d659d5b/rapidfuzz-3.14.5-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:738c96944d076deeaff70e92b65696ab4f7ecb8081d7791c5403a3257dfaf8ff", size = 1374732, upload-time = "2026-04-07T11:15:56.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/39/123bb94fee40e2fb3b7c49b80827c7ef42d838e18def3fc2fef5a3cf817a/rapidfuzz-3.14.5-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4c1bca487a17fe4226b4ffb2d30e799d2b274d692cffa76bd0746f56235fca3", size = 3166902, upload-time = "2026-04-07T11:15:58.768Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0a/45716fafc9fd2e028cf20b5ac5bc704887081cd312f84edb0e325599414b/rapidfuzz-3.14.5-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:af6a90a4ed2a48fa1a2d17e9d824e6c7c950bea5bad0b707c77fd55751e6bfef", size = 1452130, upload-time = "2026-04-07T11:16:01.453Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/49/4e96c413114398481c0a5b0086af32c364a18613c9a2ea578d17c4bea4ee/rapidfuzz-3.14.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bf5018938208d4597b2e679a4f8cff9fd252f1df53583130ae56281a21801b64", size = 2396308, upload-time = "2026-04-07T11:16:03.588Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b7/49fea9fc6878d59bd259d01dd1972d9b86117992b1c66d9b16f0a65273c3/rapidfuzz-3.14.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c0919d1f89ddf91129906705723118ea09754171e4116f5a5dbc667c7bc9b261", size = 2488210, upload-time = "2026-04-07T11:16:05.871Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/44/a1f732b93ffacbdad077b7c801149549b2938e1bece6addb5ad85ed74df8/rapidfuzz-3.14.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:93d8da883a35116d6813432177f35e570db5b0a5e30ecb0cbd7cb39c815735df", size = 4270621, upload-time = "2026-04-07T11:16:08.483Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/ce/ff942d19fce5385054650bb71a58495ddda299d94661ccc4e6e7fa44868b/rapidfuzz-3.14.5-cp314-cp314t-win32.whl", hash = "sha256:0f23e37019ec07712d58976b1ab2b889f8649a7f7c2f626a2f34ea9139e79279", size = 1803950, upload-time = "2026-04-07T11:16:10.873Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/0f/9aafc63f9661222b819b391c187eed29fc90ad5935f9690e5ecc2d2047a4/rapidfuzz-3.14.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7d5ca9c7832e6879a707296d1463685f7c243a27846227044504741640caec66", size = 1632357, upload-time = "2026-04-07T11:16:13.1Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a6/51fc1b0e61e3326e1c68a61cfd0c6b3c34c843681c4b1eefbf0596f59162/rapidfuzz-3.14.5-cp314-cp314t-win_arm64.whl", hash = "sha256:3e91dcd2549b8f8d843f98ba03a17e01f3d8b72ce942adbbb6761bc58ffce813", size = 855409, upload-time = "2026-04-07T11:16:15.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/ee/e71853bf82846c5c2174b924b71d8e8099fb05ff87c958a720380b434ba3/rapidfuzz-3.14.5-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:578e6051f6d5e6200c259b47a103cf06bb875ab5814d17333fc0b5c290b22f4c", size = 1888603, upload-time = "2026-04-07T11:16:18.223Z" },
+    { url = "https://files.pythonhosted.org/packages/36/82/40f67b730f32be2ebad9f62add1571c754f52249254b2e88af094b907eee/rapidfuzz-3.14.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fbf1b8bb2695415b347f3727da1addca2acb82c9b97ac86bebf8b1bead1eb12d", size = 1120599, upload-time = "2026-04-07T11:16:20.682Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/9f/a3635cc4ec8fc6e14b46e7db1f7f8763d8c4bef33dcc124eea2e6cb2c8f3/rapidfuzz-3.14.5-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f4a8f5cc84c7ad6bffa0e9947b33eb343ad66e6b53e94fe54378a5508c5ed53", size = 1348524, upload-time = "2026-04-07T11:16:23.451Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1b/2b229520f0b48464cfcd7aa758f74551d12c9bc4ab544022a60210aab064/rapidfuzz-3.14.5-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:97c6d85283629646fa87acc22c66b30ea9d4de7f6fdf887daa2e30fa041829b5", size = 3099302, upload-time = "2026-04-07T11:16:25.858Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b5/363906b1064fc6fe611783a61764927bbd91919aaaabe8cba82151ca93ef/rapidfuzz-3.14.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:dfef96543ced67d9513a422755db422ae1dc34dade0a1485e0b43e7342ed3ebf", size = 1509889, upload-time = "2026-04-07T11:16:28.487Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `MyNaviScraper` for **tenshoku.mynavi.jp** — Japan's largest mid-career job board (~54k live postings, currently rendering 1083 pages × 50 cards).
- MyNavi has no public JSON API; the listing is server-side HTML rendering. The scraper parses the stable `cassetteRecruit` / `cassetteRecruitRecommend` card markup with tight regexes, walks `/list/pgN/` pagination until the site serves its out-of-range "page not found" template, and dedupes on the per-posting `data-job-key`.
- Japanese-specific metadata mapping:
  - `country_iso="JP"`, `language="ja"` on every row
  - `初年度年収` (first-year-income, e.g. `400万円～500万円`) → `salary_min` / `salary_max` in JPY (1万 = 10,000)
  - 雇用形態 labels (`正社員` / `契約社員` / `派遣社員` / `業務委託` / `アルバイト・パート` / `インターン`) → canonical `employment_type`; raw label preserved on `commitment`
  - 情報更新日 (info-update date, `YYYY/MM/DD`) → `posted_at`
  - Feature tags + jobinfo slug + free-text salary stashed in `raw`
- Wires `ATSType.MYNAVI = "mynavi"` (under the Hybrid jobboards group) into the enum, registry, package `__init__`, and `test_models.py`.

## Test plan

- [x] `pytest tests/test_mynavi.py` — 22 cases (registry, single-card parsing, salary parsing with both `～` and `〜` tildes, missing-salary fallback, employment-label map across 6 labels, unknown-label preservation, both card variants, feature-tag collection, description join, pagination walk, page-overlap dedup, `max_pages` cap, malformed card skipping, persistent-500 raises)
- [x] `pytest` — full suite stays green (888 passing)
- [x] `ruff check src/ tests/` — clean
- [x] Live smoke test (`MyNaviScraper("any", max_pages=2).fetch()`) — 100 unique jobs, all fields populated against the live site

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `MyNaviScraper` for `tenshoku.mynavi.jp` to scrape server‑rendered listings with pagination, dedupe, and Japanese metadata mapping. Also fixes update‑date handling and updates tests to assert `posted_at=None` with the raw date stored.

- New Features
  - New `MyNaviScraper` parsing `cassetteRecruit`/`cassetteRecruitRecommend` cards; walks `/list/pgN/`, stops on “page not found”, dedupes by `data-job-key`, supports `max_pages`.
  - Field mapping: `country_iso="JP"`, `language="ja"`, `初年度年収` (`N万円～/〜M万円`) → `salary_min`/`salary_max` (JPY), employment labels (`正社員`, `契約社員`, `派遣社員`, `業務委託`, `アルバイト・パート`, `インターン`) → canonical `employment_type`; keep raw label on `commitment`; stash feature tags and `jobinfo` slug in `raw`; fall back to `給与` for `salary_summary`.
  - Registry wiring: add `ATSType.MYNAVI = "mynavi"`, export in `jobhive.scrapers.__init__`, and seed `ats-companies/mynavi.csv`.

- Bug Fixes
  - `情報更新日` is not the publish date: leave `posted_at=None` and store it in `raw.update_date` (tests updated accordingly).

<sup>Written for commit d08c1a4475b27e52b29f84fc232b604802953208. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `MyNaviScraper` for `tenshoku.mynavi.jp`, Japan's largest mid-career board, scraping server-rendered HTML via regex against the stable `cassetteRecruit` card markup with sequential pagination, dedup by `data-job-key`, and Japanese metadata mapping (JPY salary, employment labels, `情報更新日`). The registry wiring, enum entry, seed CSV, and 22-case test suite are all correct.

- `src/jobhive/scrapers/mynavi.py` — new scraper with three minor issues: the retry `asyncio.sleep` inside the `except httpx.HTTPError` block runs while holding the semaphore (unlike the 429/5xx path which sleeps outside it); `raw or None` is unreachable since `raw` is always initialised with `jobinfo_slug`; and `_parse_jp_date`'s docstring incorrectly labels the returned naive datetime as \"midnight-UTC\".
- All supporting files (`models.py`, `__init__.py`, `test_models.py`, `mynavi.csv`) are clean additions with no issues.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the scraper is well-tested and all wiring changes are minimal. The three findings in mynavi.py are non-blocking quality improvements.

The core scraping logic, field mapping, pagination, and dedup all look correct and are backed by 22 tests. The three findings are limited to: a sleep held inside a semaphore context (harmless today since the loop is sequential), an unreachable or None branch, and an incorrect midnight-UTC docstring.

src/jobhive/scrapers/mynavi.py — retry sleep placement and dead raw or None expression are worth cleaning up before this grows concurrent request support.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/mynavi.py | New scraper for tenshoku.mynavi.jp — sequential pagination with dedup, regex-based HTML parsing, and Japanese field mapping. Three minor issues: retry sleep held inside the semaphore context, `raw or None` is unreachable dead code, and a docstring incorrectly describes the returned datetime as "midnight-UTC". |
| tests/test_mynavi.py | 22 well-structured tests covering registry wiring, card parsing, salary extraction (both tilde variants), employment-type mapping, pagination walk, dedup, max_pages cap, malformed-card skipping, and persistent 500 error handling. |
| src/jobhive/models.py | Adds `ATSType.MYNAVI = "mynavi"` in alphabetical order within the Hybrid jobboards group — clean, minimal change. |
| src/jobhive/scrapers/__init__.py | Adds import and `__all__` entry for `MyNaviScraper` in the correct alphabetical position. |
| ats-companies/mynavi.csv | New seed CSV with a single row for MyNavi Tenshoku — correct headers and URL. |
| tests/test_models.py | Adds `"mynavi"` to the expected ATSType set in the coverage test — correct placement. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/jobhive/scrapers/mynavi.py:229-236
**Retry sleep held inside semaphore context**

The `asyncio.sleep()` call on line 235 executes while the `async with sem:` context is still active, keeping the semaphore slot occupied for the entire backoff window. The 429/5xx path (lines 250–251) correctly releases the semaphore before sleeping. If `_fetch_async` is ever refactored to issue concurrent page requests instead of the current sequential loop, this inconsistency would cause the semaphore to serialize all retries, defeating the concurrency limit entirely.

### Issue 2 of 3
src/jobhive/scrapers/mynavi.py:383
`raw or None` is dead code because `raw` is initialised with `{"jobinfo_slug": slug}` on line 350, so the dict is never empty and the falsy branch is unreachable. Passing the dict directly is clearer.

```suggestion
            raw=raw,
```

### Issue 3 of 3
src/jobhive/scrapers/mynavi.py:414-419
The docstring claims the returned `datetime` is "midnight-UTC", but `datetime.strptime` produces a **naive** datetime with no timezone info — it represents midnight in whatever timezone the process runs under, not UTC.

```suggestion
def _parse_jp_date(s: str) -> datetime | None:
    """Parse ``YYYY/MM/DD`` (the MyNavi 情報更新日 format) into a
    naive midnight ``datetime``. Returns ``None`` when the input doesn't
    match — never raises so a malformed date on one card doesn't kill
    the whole scrape.
    """
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: mynavi.csv"](https://github.com/kalil0321/ats-scrapers/commit/874f72aa05d7b12beb34dd5fd104e4c2cd5097b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732448)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->