### PR TITLE
Add Foundit (Monster India) scraper

### DIFF
--- a/ats-companies/foundit.csv
+++ b/ats-companies/foundit.csv
@@ -1,0 +1,6 @@
+name,slug,url
+Foundit India,in,https://www.foundit.in
+Foundit Singapore,sg,https://www.foundit.sg
+Foundit Malaysia,my,https://www.foundit.my
+Foundit Indonesia,id,https://www.foundit.id
+Foundit Philippines,ph,https://www.foundit.com.ph

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -80,6 +80,7 @@ class ATSType(StrEnum):
     THEHUB = "thehub"
     YCOMBINATOR = "ycombinator"
     WELLFOUND = "wellfound"
+    FOUNDIT = "foundit"
     # Additional multi-tenant ATSes (post-0.1)
     BAMBOOHR = "bamboohr"
     BREEZY = "breezy"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -21,6 +21,7 @@ from jobhive.scrapers.bundesagentur import BundesagenturScraper
 from jobhive.scrapers.cornerstone import CornerstoneScraper
 from jobhive.scrapers.eightfold import EightfoldScraper
 from jobhive.scrapers.eures import EuresScraper
+from jobhive.scrapers.foundit import FounditScraper
 from jobhive.scrapers.gem import GemScraper
 from jobhive.scrapers.getonbrd import GetOnBrdScraper
 from jobhive.scrapers.google import GoogleScraper
@@ -73,6 +74,7 @@ __all__ = [
     "CornerstoneScraper",
     "EightfoldScraper",
     "EuresScraper",
+    "FounditScraper",
     "GemScraper",
     "GetOnBrdScraper",
     "GoogleScraper",

--- a/src/jobhive/scrapers/foundit.py
+++ b/src/jobhive/scrapers/foundit.py
@@ -1,0 +1,538 @@
+"""Foundit (formerly Monster India) — India + SEA jobs aggregator.
+
+Foundit is the rebrand of Monster.com's India / APAC operations.
+It runs separate country domains, each fronted by the same backend:
+
+  - ``https://www.foundit.in/``      — India (~300k live postings)
+  - ``https://www.foundit.sg/``      — Singapore (~125k)
+  - ``https://www.foundit.my/``      — Malaysia (~35k)
+  - ``https://www.foundit.id/``      — Indonesia (~17k)
+  - ``https://www.foundit.com.ph/``  — Philippines (~37k)
+
+The whole site is fronted by **Akamai Bot Manager** (the ``_abck`` /
+``bm_sz`` cookies on the HTML pages give it away) — the SPA HTML
+returns 200 for the homepage but blocks deep search URLs with
+``Access Denied`` from ``errors.edgesuite.net``. However the JSON
+**search API** at ``/middleware/jobsearch`` is anonymous, accepts
+plain ``httpx`` (no TLS-fingerprint check), and returns the same
+structured rows the SPA renders client-side. We hit the API
+directly with a Chrome-ish ``User-Agent`` + ``Referer`` and skip the
+SPA entirely.
+
+API reverse-engineered live on 2026-05-12. Query params:
+
+    sort=1            most-recent first (0 = relevance)
+    limit=100         page size; >100 silently truncates extras
+    query=            free-text search; empty == all jobs
+    searchId=         session-id cookie; empty works for anon
+    queryDerived=true required for the no-query "all jobs" view
+    country=india     country token (matches the domain channel)
+    start=N           offset; capped around 9500 (see below)
+
+Each entry in ``jobSearchResponse.data`` carries the job id, title,
+company, location, salary range (already structured + ISO 4217
+currency), skills, experience window, qualifications, posted-at
+epoch, and the ``jdUrl`` slug. Description prose lives on the
+detail page (Next.js ``__NEXT_DATA__``) — we don't fetch per-job by
+default because the catalogue is large; downstream LLM enrichment
+fills it in.
+
+**Deep-pagination cap**: the API silently clamps ``start`` to ~9500.
+Past that, the same rows repeat with wrap-around cursors (verified
+live: ``start=10000`` returns the same payload as ``start=9500``).
+So the unrestricted ``"all jobs"`` walk tops out at ~10 000 / 300 000
+on India. Future work: bucket by ``query=`` seeds (jobsch-style)
+to recover the long tail. For now we ship the top-10k window —
+the freshest postings — and bucketing is an enhancement.
+
+Single-source scraper, multi-region: ``company_slug`` picks the
+country. Pass one of ``"in"`` (default), ``"sg"``, ``"my"``,
+``"id"``, ``"ph"``. Aliases (``"india"``, ``"singapore"``, …) are
+also accepted and canonicalised to the two-letter slug.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, EmploymentType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+log = logging.getLogger(__name__)
+
+
+# --- Country / domain map ---------------------------------------------
+
+# slug → (domain, country query token, ISO 3166-1 alpha-2, region label).
+# The ``country`` query token is what the API expects (not the slug,
+# not the alpha-2). India uses ``india``, Singapore ``singapore``, etc.
+_COUNTRY_TABLE: dict[str, tuple[str, str, str, str]] = {
+    "in": ("www.foundit.in",     "india",       "IN", "Asia"),
+    "sg": ("www.foundit.sg",     "singapore",   "SG", "Asia"),
+    "my": ("www.foundit.my",     "malaysia",    "MY", "Asia"),
+    "id": ("www.foundit.id",     "indonesia",   "ID", "Asia"),
+    "ph": ("www.foundit.com.ph", "philippines", "PH", "Asia"),
+}
+
+# Accepted alternate forms — canonicalised to the two-letter slug
+# above. Lower-cased before lookup.
+_COUNTRY_ALIASES: dict[str, str] = {
+    "india": "in",
+    "singapore": "sg",
+    "malaysia": "my",
+    "indonesia": "id",
+    "philippines": "ph",
+    "ph_ph": "ph",
+}
+
+
+# --- API knobs --------------------------------------------------------
+
+# 100 is the largest size the API honours (>100 returns the same 100
+# row payload). 100 × pages == real per-page count.
+PER_PAGE = 100
+
+# Past ``start ~= 9500`` the API silently wraps to recently-seen
+# rows. Capping at 9500 covers the freshest ~10k jobs per channel.
+# India alone has 300k+ so the long tail is left for query-seed
+# bucketing in a follow-up.
+MAX_USABLE_OFFSET = 9500
+DEFAULT_MAX_PAGES = (MAX_USABLE_OFFSET // PER_PAGE) + 1  # 96
+
+# Retry knobs. The API returns 200 reliably from residential IPs;
+# datacenter IPs can see intermittent 403 / 502 — we back off and
+# retry a small number of times then bail with whatever we have.
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1.5
+
+# Chrome-on-Linux user agent. The middleware endpoint accepts any
+# UA — even ``curl/7.x`` works — but we mirror the real SPA's
+# Chrome UA to blend in if the WAF rules tighten later.
+_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36"
+)
+
+
+# --- Mapping helpers --------------------------------------------------
+
+# Foundit's free-text employment label → our canonical enum. Lower-
+# cased and stripped before lookup. Unknown values fall through to
+# ``None``; ``raw["employment_types"]`` retains the original list.
+_EMPLOYMENT_TYPE_MAP: dict[str, EmploymentType] = {
+    "full time": "FULL_TIME",
+    "full-time": "FULL_TIME",
+    "permanent": "FULL_TIME",
+    "part time": "PART_TIME",
+    "part-time": "PART_TIME",
+    "contract": "CONTRACT",
+    "contractual": "CONTRACT",
+    "freelance": "CONTRACT",
+    "internship": "INTERN",
+    "intern": "INTERN",
+    "trainee": "INTERN",
+    "temporary": "TEMPORARY",
+    "casual": "TEMPORARY",
+    "walk in": "FULL_TIME",  # Foundit's walk-in interview convention.
+}
+
+
+@ScraperRegistry.register(ATSType.FOUNDIT)
+class FounditScraper(BaseScraper):
+    """Foundit (Monster India / APAC) — country-paginated job listings.
+
+    Constructor knobs:
+        company_slug: country selector. One of ``"in"`` (default,
+            India), ``"sg"``, ``"my"``, ``"id"``, ``"ph"`` — or the
+            full English name (``"india"``, ``"singapore"``, …).
+        max_pages: stop after this many pages even if more remain.
+            Default walks until the API's deep-pagination cap
+            (``MAX_USABLE_OFFSET / PER_PAGE``).
+    """
+
+    ats = ATSType.FOUNDIT
+
+    def __init__(
+        self,
+        company_slug: str = "in",
+        *,
+        timeout: float = 30.0,
+        max_pages: int = DEFAULT_MAX_PAGES,
+    ) -> None:
+        normalized = (company_slug or "in").lower().strip()
+        normalized = _COUNTRY_ALIASES.get(normalized, normalized)
+        if normalized not in _COUNTRY_TABLE:
+            raise ScraperError(
+                f"Foundit unknown country slug {company_slug!r}. "
+                f"Known: {sorted(_COUNTRY_TABLE)} (or aliases "
+                f"{sorted(_COUNTRY_ALIASES)})"
+            )
+        super().__init__(normalized, timeout=timeout)
+        self.country_slug = normalized
+        domain, token, iso, region = _COUNTRY_TABLE[normalized]
+        self._domain = domain
+        self._country_token = token
+        self._country_iso = iso
+        self._region = region
+        self.max_pages = max_pages
+
+    # ----- public entry point -----------------------------------------
+
+    def fetch(self) -> list[Job]:
+        fetched_at = datetime.now(tz=UTC)
+        jobs: list[Job] = []
+        seen: set[str] = set()
+        with httpx.Client(
+            timeout=self.timeout,
+            headers={
+                "Accept": "application/json",
+                "Accept-Language": "en-US,en;q=0.9",
+                "Referer": f"https://{self._domain}/",
+                "User-Agent": _USER_AGENT,
+            },
+            follow_redirects=True,
+        ) as client:
+            for page_no in range(self.max_pages):
+                start = page_no * PER_PAGE
+                if start > MAX_USABLE_OFFSET:
+                    break
+                payload = self._fetch_page(client, start)
+                if payload is None:
+                    break
+                rows = list(_iter_job_rows(payload))
+                if not rows:
+                    break
+                new_in_page = 0
+                for row in rows:
+                    job = self._parse_row(row, fetched_at=fetched_at)
+                    if job is None:
+                        continue
+                    if job.ats_id in seen:
+                        continue
+                    seen.add(job.ats_id)  # type: ignore[arg-type]
+                    jobs.append(job)
+                    new_in_page += 1
+                if new_in_page == 0:
+                    # The deep-pagination cap returns the same window
+                    # over and over; stop the moment we get zero new
+                    # rows. Cheaper than relying on the documented
+                    # MAX_USABLE_OFFSET which has drifted before.
+                    break
+        log.info(
+            "Foundit %s: fetched %d unique jobs across up to %d pages",
+            self.country_slug, len(jobs), self.max_pages,
+        )
+        return jobs
+
+    # ----- one page ---------------------------------------------------
+
+    def _fetch_page(
+        self, client: httpx.Client, start: int,
+    ) -> dict[str, Any] | None:
+        """GET one search page with retry on 429 / 5xx. Returns the
+        decoded ``jobSearchResponse`` dict or ``None`` to break the
+        pagination loop on terminal failure.
+        """
+        url = f"https://{self._domain}/middleware/jobsearch"
+        params = {
+            "sort": "1",
+            "limit": str(PER_PAGE),
+            "query": "",
+            "searchId": "",
+            "queryDerived": "true",
+            "country": self._country_token,
+            "start": str(start),
+        }
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                response = client.get(url, params=params)
+            except httpx.HTTPError as exc:
+                last_exc = exc
+                if attempt == MAX_RETRIES:
+                    log.warning(
+                        "Foundit %s start=%d transport error after %d "
+                        "retries: %s",
+                        self.country_slug, start, MAX_RETRIES, exc,
+                    )
+                    return None
+                _sleep_backoff(attempt)
+                continue
+
+            status = response.status_code
+            if status == 200:
+                try:
+                    body = response.json()
+                except ValueError:
+                    log.warning(
+                        "Foundit %s start=%d: 200 but non-JSON body — stopping",
+                        self.country_slug, start,
+                    )
+                    return None
+                if body.get("jobSearchStatus") != 200:
+                    log.info(
+                        "Foundit %s start=%d: API status=%s (%s) — stopping",
+                        self.country_slug, start,
+                        body.get("jobSearchStatus"),
+                        body.get("jobSearchStatusText"),
+                    )
+                    return None
+                return body.get("jobSearchResponse") or {}
+            if status in (429,) or 500 <= status < 600:
+                if attempt == MAX_RETRIES:
+                    log.warning(
+                        "Foundit %s start=%d returned %d after %d "
+                        "retries — stopping pagination",
+                        self.country_slug, start, status, MAX_RETRIES,
+                    )
+                    return None
+                _sleep_backoff(attempt)
+                continue
+            # Some other 4xx — surface so an operator notices.
+            log.warning(
+                "Foundit %s start=%d returned unexpected status %d — stopping",
+                self.country_slug, start, status,
+            )
+            return None
+
+        log.warning(
+            "Foundit %s start=%d exhausted retries: %s",
+            self.country_slug, start, last_exc,
+        )
+        return None
+
+    # ----- single-row parser ------------------------------------------
+
+    def _parse_row(
+        self,
+        row: dict[str, Any],
+        *,
+        fetched_at: datetime,
+    ) -> Job | None:
+        """Map one API row → ``Job``. Returns ``None`` when the row
+        lacks the bare minimum (id + title + jdUrl).
+        """
+        ats_id = _str_or_none(row.get("id")) or _str_or_none(row.get("jobId"))
+        if not ats_id:
+            return None
+        title = _clean_text(row.get("title"))
+        jd_url = _str_or_none(row.get("jdUrl")) or _str_or_none(
+            row.get("seoJdUrl")
+        )
+        if not title or not jd_url:
+            return None
+
+        url = _absolute_url(self._domain, jd_url)
+
+        company = _clean_text(row.get("companyName")) or "Unknown"
+        location = _clean_text(row.get("locations")) or None
+
+        # Posted-at: the row carries multiple timestamps; ``createdAt``
+        # is the canonical first-publish moment in epoch milliseconds.
+        posted_at = _epoch_ms_to_dt(row.get("createdAt"))
+
+        # Salary — Foundit exposes structured min/max + currency.
+        # Currency is a 3-letter ISO code (``INR``, ``SGD``, ``MYR``,
+        # ``IDR``, ``PHP``) — pass through to Job verbatim.
+        currency = _str_or_none(row.get("currencyCode"))
+        min_sal = _nested_amount(row.get("minimumSalary"))
+        max_sal = _nested_amount(row.get("maximumSalary"))
+        salary_summary = _clean_text(row.get("salary")) or None
+        # The ``hideSalary`` flag is set on confidential listings; the
+        # numeric values are still in the payload but the SPA hides
+        # them. Honour the hint so we don't surface salaries the
+        # employer chose not to publish.
+        if row.get("hideSalary"):
+            min_sal = None
+            max_sal = None
+            salary_summary = None
+            currency = None
+
+        # Employment type: a list — pick the first one we can map.
+        employment_label = None
+        emp_list = row.get("employmentTypes")
+        if isinstance(emp_list, list) and emp_list:
+            employment_label = _clean_text(emp_list[0]) or None
+        employment_type: EmploymentType | None = None
+        if employment_label:
+            employment_type = _EMPLOYMENT_TYPE_MAP.get(
+                employment_label.lower().strip(),
+            )
+
+        # Years of experience — ``minimumExperience`` is the typical
+        # "minimum years required". ``None`` when missing or zero
+        # (entry-level postings often omit it entirely).
+        experience: int | None = None
+        min_exp = row.get("minimumExperience")
+        if isinstance(min_exp, dict):
+            yrs = min_exp.get("years")
+            if isinstance(yrs, (int, float)) and yrs > 0:
+                experience = int(yrs)
+
+        # Raw overflow — keep the ATS-specific extras the canonical
+        # schema can't represent. Keep small (<5KB serialized): drop
+        # the verbose ``companyProfile`` blob (~5KB on its own).
+        raw_overflow: dict[str, object] = {
+            "industry": _clean_text(row.get("industry")) or None,
+            "experience_label": _clean_text(row.get("exp")) or None,
+            "education": list(_iter_strings(row.get("qualifications"))),
+            "skills": _split_skills(row.get("skills")),
+            "functions": list(_iter_strings(row.get("functions"))),
+            "roles": list(_iter_strings(row.get("roles"))),
+            "designations": list(_iter_strings(row.get("designations"))),
+            "employment_types": list(_iter_strings(row.get("employmentTypes"))),
+            "job_types": list(_iter_strings(row.get("jobTypes"))),
+            "country_slug": self.country_slug,
+            "channel_name": _clean_text(row.get("channelName")) or None,
+            "is_urgently_hiring": bool(row.get("isUrgentlyHiring")),
+            "kiwi_job_id": _str_or_none(row.get("kiwiJobId")),
+        }
+
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.FOUNDIT,
+            ats_id=ats_id,
+            location=location,
+            country_iso=self._country_iso,
+            region=self._region,
+            language="en",
+            salary_currency=currency,
+            salary_period="YEAR" if currency else None,
+            salary_summary=salary_summary,
+            salary_min=min_sal,
+            salary_max=max_sal,
+            experience=experience,
+            employment_type=employment_type,
+            commitment=employment_label,
+            posted_at=posted_at,
+            fetched_at=fetched_at,
+            raw=raw_overflow,
+        )
+
+
+# --- module-level helpers ---------------------------------------------
+
+
+def _iter_job_rows(payload: dict[str, Any]) -> Iterable[dict[str, Any]]:
+    """Yield the real job rows from a ``jobSearchResponse`` payload.
+
+    The API interleaves ad/banner placements (``{"index": N, "type":
+    "adsense"}``) with the actual job entries; those lack the canonical
+    fields. We filter on the presence of ``id`` / ``jobId`` since
+    every real posting carries one.
+    """
+    data = payload.get("data")
+    if not isinstance(data, list):
+        return
+    for row in data:
+        if not isinstance(row, dict):
+            continue
+        if "id" not in row and "jobId" not in row:
+            continue
+        yield row
+
+
+def _absolute_url(domain: str, path_or_url: str) -> str:
+    """Foundit's ``jdUrl`` is a site-relative path. Build the absolute
+    URL using the *country* domain (so the public dataset's URL
+    matches the channel the job lives on, not the .in default).
+    """
+    if path_or_url.startswith(("http://", "https://")):
+        return path_or_url
+    if not path_or_url.startswith("/"):
+        path_or_url = "/" + path_or_url
+    return f"https://{domain}{path_or_url}"
+
+
+def _str_or_none(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        v = value.strip()
+        return v or None
+    if isinstance(value, (int, float)):
+        return str(int(value))
+    return None
+
+
+def _clean_text(value: object) -> str | None:
+    """Strip + collapse whitespace, return None for empties. We don't
+    decode HTML entities here — Foundit's ``title`` / ``companyName``
+    are plain text in practice (the HTML-entity ones live in
+    ``companyProfile``, which we don't surface to ``Job.description``).
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _nested_amount(value: object) -> float | None:
+    """Salary fields are ``{"currency": "INR", "absoluteValue": N,
+    "absoluteMonthlyValue": M}``. We use the annualised
+    ``absoluteValue``. Zero is treated as "not set" — Foundit
+    encodes "no salary disclosed" as a 0 there.
+    """
+    if not isinstance(value, dict):
+        return None
+    amount = value.get("absoluteValue")
+    if not isinstance(amount, (int, float)):
+        return None
+    if amount <= 0:
+        return None
+    return float(amount)
+
+
+def _epoch_ms_to_dt(value: object) -> datetime | None:
+    """Foundit timestamps are epoch milliseconds — convert to UTC.
+    Returns ``None`` on missing / malformed input rather than crashing
+    the row."""
+    if not isinstance(value, (int, float)):
+        return None
+    if value <= 0:
+        return None
+    try:
+        return datetime.fromtimestamp(value / 1000.0, tz=UTC)
+    except (ValueError, OSError, OverflowError):
+        return None
+
+
+def _iter_strings(value: object) -> Iterable[str]:
+    """Yield clean non-empty strings from a list field. Drops dicts /
+    nulls silently."""
+    if not isinstance(value, list):
+        return
+    for item in value:
+        if isinstance(item, str):
+            s = item.strip()
+            if s:
+                yield s
+
+
+def _split_skills(value: object) -> list[str]:
+    """``skills`` arrives as a comma-separated string (``"Java, Python,
+    SQL"``). Split into a tidy list — keeps ``raw["skills"]`` as a
+    proper array rather than a free-text blob."""
+    if not isinstance(value, str):
+        return []
+    return [s.strip() for s in value.split(",") if s.strip()]
+
+
+def _sleep_backoff(attempt: int) -> None:
+    """Exponential backoff for transient 5xx / 429 — factored out so
+    tests can monkey-patch it to a no-op and not pay wall-clock cost.
+    """
+    time.sleep(RETRY_BASE_DELAY * (2 ** (attempt - 1)))

--- a/tests/test_foundit.py
+++ b/tests/test_foundit.py
@@ -1,0 +1,689 @@
+"""Tests for the Foundit (Monster India / APAC) scraper.
+
+Scope: country slug resolution, API row parsing (incl. structured
+salary, employment-type mapping, posted-at epoch handling, ad-row
+filtering), pagination + dedup, retry/backoff on 429/5xx, and
+registry wiring. The httpx network path is exercised via
+``pytest-httpx`` — we never hit the live site.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import FounditScraper, ScraperRegistry
+from jobhive.scrapers import foundit as f_mod
+
+# Per-country regex the httpx-mock matcher uses. We compile from the
+# scraper's canonical domain map so adding a new country here doesn't
+# silently miss the test.
+_API_RE_BY_DOMAIN: dict[str, re.Pattern[str]] = {
+    domain: re.compile(rf"^https://{re.escape(domain)}/middleware/jobsearch")
+    for (domain, _t, _i, _r) in f_mod._COUNTRY_TABLE.values()
+}
+_INDIA_RE = _API_RE_BY_DOMAIN["www.foundit.in"]
+
+
+@pytest.fixture(autouse=True)
+def _fast_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Backoff sleeps add seconds per retry — patch to a no-op so the
+    retry path doesn't cost wall-clock time."""
+    monkeypatch.setattr(f_mod, "_sleep_backoff", lambda attempt: None)
+    monkeypatch.setattr(f_mod, "MAX_RETRIES", 2)
+
+
+def _make_row(
+    *,
+    job_id: str = "49286015",
+    title: str = "Customer Service Executive",
+    company: str = "Tech Mahindra Limited",
+    locations: str = "Mumbai City, Mumbai",
+    jd_url: str = "/job/customer-service-tech-mahindra-mumbai-49286015",
+    currency: str = "INR",
+    min_salary: int = 250_000,
+    max_salary: int = 550_000,
+    salary_summary: str = "2,50,000-5,50,000 INR",
+    employment_types: list[str] | None = None,
+    min_exp_years: int = 1,
+    qualifications: list[str] | None = None,
+    skills: str = "Customer Service, Sales, Communication",
+    functions: list[str] | None = None,
+    roles: list[str] | None = None,
+    industry: str = "BPO/ITES",
+    created_at_ms: int = 1_775_488_663_000,
+    hide_salary: bool = False,
+) -> dict[str, Any]:
+    """One realistic Foundit API row. Mirrors the May 2026 payload."""
+    return {
+        "id": job_id,
+        "jobId": int(job_id) if job_id.isdigit() else 0,
+        "title": title,
+        "companyName": company,
+        "locations": locations,
+        "jdUrl": jd_url,
+        "currencyCode": currency,
+        "minimumSalary": {
+            "currency": currency,
+            "absoluteValue": min_salary,
+            "absoluteMonthlyValue": min_salary // 12,
+        },
+        "maximumSalary": {
+            "currency": currency,
+            "absoluteValue": max_salary,
+            "absoluteMonthlyValue": max_salary // 12,
+        },
+        "salary": salary_summary,
+        "hideSalary": 1 if hide_salary else 0,
+        "employmentTypes": (
+            employment_types if employment_types is not None else ["Full time"]
+        ),
+        "minimumExperience": {"years": min_exp_years},
+        "maximumExperience": {"years": min_exp_years + 4},
+        "qualifications": (
+            qualifications if qualifications is not None else ["12th Class (XII)"]
+        ),
+        "skills": skills,
+        "functions": (
+            functions if functions is not None else ["Customer Service/Call Centre/BPO"]
+        ),
+        "roles": roles if roles is not None else ["Customer Service Executive"],
+        "designations": ["Customer Service Executive"],
+        "industry": industry,
+        "exp": f"{min_exp_years}-{min_exp_years + 4} Years",
+        "createdAt": created_at_ms,
+        "channelName": "India",
+        "isUrgentlyHiring": False,
+        "kiwiJobId": "145448017",
+        "jobTypes": [],
+    }
+
+
+def _make_page(
+    rows: list[dict[str, Any]],
+    *,
+    total: int | None = None,
+    next_cursor: str | None = None,
+    previous_cursor: str | None = None,
+) -> dict[str, Any]:
+    """Wrap a list of rows in the canonical ``jobSearchStatus / response``
+    envelope the scraper expects."""
+    return {
+        "jobSearchStatus": 200,
+        "jobSearchStatusText": "OK",
+        "jobSearchResponse": {
+            "data": list(rows),
+            "meta": {
+                "paging": {
+                    "cursors": {
+                        "next": next_cursor or str(len(rows)),
+                        "previous": previous_cursor or "0",
+                    },
+                    "total": total if total is not None else len(rows),
+                    "limit": len(rows),
+                },
+                "resultId": "test-result-id",
+                "searchId": "test-search-id",
+                "version": "DEFAULT",
+                "buildVersion": "0.0.1",
+            },
+            "spellCheckApplied": False,
+            "filters": [],
+            "selectedFilters": [],
+            "filterLabels": [],
+            "spellCheck": None,
+            "apiId": "DEFAULT",
+            "IS_NEW_SEARCH_PAGE": True,
+        },
+    }
+
+
+# --- registry / construction ------------------------------------------
+
+
+def test_registry_resolves_foundit() -> None:
+    assert ScraperRegistry.get(ATSType.FOUNDIT) is FounditScraper
+
+
+def test_default_country_slug_is_india() -> None:
+    s = FounditScraper()
+    assert s.country_slug == "in"
+    assert s._country_iso == "IN"
+    assert s._domain == "www.foundit.in"
+
+
+@pytest.mark.parametrize(
+    ("slug", "iso", "domain"),
+    [
+        ("in", "IN", "www.foundit.in"),
+        ("sg", "SG", "www.foundit.sg"),
+        ("my", "MY", "www.foundit.my"),
+        ("id", "ID", "www.foundit.id"),
+        ("ph", "PH", "www.foundit.com.ph"),
+    ],
+)
+def test_known_country_slugs(slug: str, iso: str, domain: str) -> None:
+    s = FounditScraper(slug)
+    assert s._country_iso == iso
+    assert s._domain == domain
+
+
+@pytest.mark.parametrize(
+    ("alias", "expected_slug"),
+    [
+        ("india", "in"),
+        ("INDIA", "in"),
+        ("singapore", "sg"),
+        ("malaysia", "my"),
+        ("indonesia", "id"),
+        ("philippines", "ph"),
+    ],
+)
+def test_country_aliases(alias: str, expected_slug: str) -> None:
+    s = FounditScraper(alias)
+    assert s.country_slug == expected_slug
+
+
+def test_unknown_country_slug_raises() -> None:
+    with pytest.raises(ScraperError, match="unknown country slug"):
+        FounditScraper("atlantis")
+
+
+# --- parsing ----------------------------------------------------------
+
+
+def test_parses_minimal_realistic_row(httpx_mock: Any) -> None:
+    """End-to-end parse of a single canonical row. Pins the field
+    mapping the public dataset relies on."""
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([_make_row()]))
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    jobs = FounditScraper("in", max_pages=5).fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.FOUNDIT
+    assert j.ats_id == "49286015"
+    assert j.global_id == "foundit:49286015"
+    assert j.title == "Customer Service Executive"
+    assert j.company == "Tech Mahindra Limited"
+    assert str(j.url) == (
+        "https://www.foundit.in/job/customer-service-tech-mahindra-mumbai-49286015"
+    )
+    assert j.location == "Mumbai City, Mumbai"
+    assert j.country_iso == "IN"
+    assert j.region == "Asia"
+    assert j.language == "en"
+    assert j.salary_currency == "INR"
+    assert j.salary_period == "YEAR"
+    assert j.salary_min == 250_000
+    assert j.salary_max == 550_000
+    assert j.salary_summary == "2,50,000-5,50,000 INR"
+    assert j.experience == 1
+    assert j.employment_type == "FULL_TIME"
+    assert j.commitment == "Full time"
+    assert j.posted_at == datetime.fromtimestamp(1_775_488_663, tz=UTC)
+    assert j.fetched_at is not None
+    assert j.raw is not None
+    assert j.raw["industry"] == "BPO/ITES"
+    assert j.raw["experience_label"] == "1-5 Years"
+    assert j.raw["education"] == ["12th Class (XII)"]
+    assert j.raw["skills"] == ["Customer Service", "Sales", "Communication"]
+    assert j.raw["functions"] == ["Customer Service/Call Centre/BPO"]
+    assert j.raw["country_slug"] == "in"
+    assert j.raw["channel_name"] == "India"
+    assert j.raw["is_urgently_hiring"] is False
+    assert j.raw["kiwi_job_id"] == "145448017"
+
+
+def test_uses_country_domain_for_url(httpx_mock: Any) -> None:
+    """When scraping Singapore, the absolute URL must reference
+    ``www.foundit.sg`` — not the .in default. The public dataset
+    stores the channel-specific URL so consumers can link back."""
+    sg_re = _API_RE_BY_DOMAIN["www.foundit.sg"]
+    httpx_mock.add_response(
+        url=sg_re,
+        json=_make_page([_make_row(jd_url="/job/sg-engineer-101", job_id="101")]),
+    )
+    httpx_mock.add_response(url=sg_re, json=_make_page([]))
+
+    [job] = FounditScraper("sg", max_pages=5).fetch()
+    assert str(job.url).startswith("https://www.foundit.sg/")
+    assert job.country_iso == "SG"
+
+
+def test_absolute_jd_url_is_preserved(httpx_mock: Any) -> None:
+    """If the API ever switches to absolute URLs, we mustn't
+    double-prefix the host."""
+    abs_url = "https://www.foundit.in/job/external-42"
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(jd_url=abs_url, job_id="42")]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    [job] = FounditScraper("in", max_pages=5).fetch()
+    assert str(job.url) == abs_url
+
+
+@pytest.mark.parametrize(
+    ("label", "expected"),
+    [
+        ("Full time", "FULL_TIME"),
+        ("Permanent", "FULL_TIME"),
+        ("Part time", "PART_TIME"),
+        ("Contract", "CONTRACT"),
+        ("Freelance", "CONTRACT"),
+        ("Internship", "INTERN"),
+        ("Trainee", "INTERN"),
+        ("Temporary", "TEMPORARY"),
+    ],
+)
+def test_employment_type_mapping(
+    httpx_mock: Any, label: str, expected: str,
+) -> None:
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(employment_types=[label])]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    [job] = FounditScraper("in", max_pages=5).fetch()
+    assert job.employment_type == expected
+    assert job.commitment == label
+
+
+def test_employment_type_unknown_label_falls_back_to_none(
+    httpx_mock: Any,
+) -> None:
+    """An unrecognised label leaves ``employment_type`` ``None`` —
+    we don't fabricate a guess — but ``commitment`` keeps the raw
+    string so downstream consumers can see the original."""
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(employment_types=["Apprenticeship-X"])]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    [job] = FounditScraper("in", max_pages=5).fetch()
+    assert job.employment_type is None
+    assert job.commitment == "Apprenticeship-X"
+
+
+def test_employment_types_empty_list(httpx_mock: Any) -> None:
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(employment_types=[])]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    [job] = FounditScraper("in", max_pages=5).fetch()
+    assert job.employment_type is None
+    assert job.commitment is None
+
+
+def test_hide_salary_suppresses_compensation(httpx_mock: Any) -> None:
+    """Confidential listings have ``hideSalary=1``. We honour the
+    flag and skip the salary fields rather than leak values the
+    employer chose not to publish."""
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(hide_salary=True)]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    [job] = FounditScraper("in", max_pages=5).fetch()
+    assert job.salary_min is None
+    assert job.salary_max is None
+    assert job.salary_currency is None
+    assert job.salary_summary is None
+
+
+def test_zero_salary_is_treated_as_missing(httpx_mock: Any) -> None:
+    """Foundit encodes "not disclosed" as 0 in ``absoluteValue``.
+    Treat as ``None`` so downstream filters / averages aren't
+    poisoned by zero rows."""
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(min_salary=0, max_salary=0)]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    [job] = FounditScraper("in", max_pages=5).fetch()
+    assert job.salary_min is None
+    assert job.salary_max is None
+
+
+def test_zero_experience_is_treated_as_missing(httpx_mock: Any) -> None:
+    """Entry-level postings come with ``minimumExperience.years=0`` —
+    that's not a valid lower bound, treat as missing."""
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(min_exp_years=0)]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    [job] = FounditScraper("in", max_pages=5).fetch()
+    assert job.experience is None
+
+
+def test_invalid_created_at_falls_back_to_none(httpx_mock: Any) -> None:
+    """A garbage epoch must not crash the parse — ``posted_at``
+    stays ``None`` and the row still ships."""
+    row = _make_row(created_at_ms=0)
+    row["createdAt"] = None  # null in the JSON payload
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([row]))
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    [job] = FounditScraper("in", max_pages=5).fetch()
+    assert job.posted_at is None
+
+
+def test_ad_placement_rows_are_skipped(httpx_mock: Any) -> None:
+    """The API interleaves ``{"index": N, "type": "adsense"}`` /
+    ``{"type": "banner"}`` entries — those have no ``id`` field and
+    must be filtered out before parsing."""
+    rows: list[dict[str, Any]] = [
+        _make_row(job_id="1"),
+        {"index": 0, "type": "adsense"},
+        {"index": 0, "type": "banner"},
+        _make_row(job_id="2"),
+    ]
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page(rows))
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    jobs = FounditScraper("in", max_pages=5).fetch()
+    assert [j.ats_id for j in jobs] == ["1", "2"]
+
+
+def test_skips_rows_missing_required_fields(httpx_mock: Any) -> None:
+    """A row without title or jdUrl is a stub — skip cleanly rather
+    than fabricate values."""
+    valid = _make_row(job_id="1")
+    no_title = _make_row(job_id="2", title="")
+    no_jdurl = _make_row(job_id="3", jd_url="")
+    httpx_mock.add_response(
+        url=_INDIA_RE, json=_make_page([valid, no_title, no_jdurl]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    jobs = FounditScraper("in", max_pages=5).fetch()
+    assert [j.ats_id for j in jobs] == ["1"]
+
+
+def test_skips_row_with_no_id(httpx_mock: Any) -> None:
+    """Defensive: a row with neither ``id`` nor ``jobId`` is dropped
+    before reaching the parser. The page yields zero real rows so
+    pagination stops (no second request needed)."""
+    bogus = {"title": "no id", "jdUrl": "/job/x"}
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([bogus]))
+
+    jobs = FounditScraper("in", max_pages=5).fetch()
+    assert jobs == []
+
+
+def test_falls_back_to_job_id_when_id_missing(httpx_mock: Any) -> None:
+    """The API typically populates both ``id`` and ``jobId`` — if only
+    the numeric ``jobId`` is present, use it as ``ats_id``."""
+    row = _make_row(job_id="123")
+    row.pop("id")
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([row]))
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    [job] = FounditScraper("in", max_pages=5).fetch()
+    assert job.ats_id == "123"
+
+
+# --- pagination & dedup -----------------------------------------------
+
+
+def test_paginates_until_empty_page(httpx_mock: Any) -> None:
+    """Walks pages until the response yields zero rows."""
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(job_id="1")]),
+    )
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(job_id="2")]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    jobs = FounditScraper("in", max_pages=10).fetch()
+    assert [j.ats_id for j in jobs] == ["1", "2"]
+
+
+def test_pagination_offsets_are_per_page_multiples(httpx_mock: Any) -> None:
+    """Each request advances ``start`` by ``PER_PAGE`` — verify the
+    URL pattern explicitly so a regression in the offset math is
+    caught at the wire level."""
+    for i in range(3):
+        httpx_mock.add_response(
+            url=_INDIA_RE,
+            json=_make_page([_make_row(job_id=f"p{i}")]),
+        )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    FounditScraper("in", max_pages=10).fetch()
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 4
+    starts = [r.url.params["start"] for r in requests]
+    assert starts == ["0", "100", "200", "300"]
+
+
+def test_dedupes_repeated_rows_across_pages(httpx_mock: Any) -> None:
+    """Past the deep-pagination cap the API repeats the same window.
+    The dedup-by-ats_id + zero-new-rows stop condition handles this
+    without needing to know the exact cap."""
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(job_id="1"), _make_row(job_id="2")]),
+    )
+    # Page 2 returns the SAME rows — zero new == stop.
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(job_id="1"), _make_row(job_id="2")]),
+    )
+
+    jobs = FounditScraper("in", max_pages=10).fetch()
+    assert [j.ats_id for j in jobs] == ["1", "2"]
+
+
+def test_max_pages_caps_walk(httpx_mock: Any) -> None:
+    """Honour the constructor cap — useful for smoke runs."""
+    for i in range(3):
+        httpx_mock.add_response(
+            url=_INDIA_RE,
+            json=_make_page([_make_row(job_id=f"p{i}")]),
+        )
+
+    jobs = FounditScraper("in", max_pages=3).fetch()
+    assert len(jobs) == 3
+    assert len(httpx_mock.get_requests()) == 3
+
+
+def test_offset_cap_stops_walk_even_below_max_pages(
+    httpx_mock: Any, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The hard ``MAX_USABLE_OFFSET`` ceiling stops the loop before
+    a very large ``max_pages`` would otherwise burn through requests
+    against a wrap-around region."""
+    monkeypatch.setattr(f_mod, "MAX_USABLE_OFFSET", 150)
+    # MAX_USABLE_OFFSET=150 with PER_PAGE=100 → only starts 0 and 100
+    # are issued; start=200 > 150 → break before request.
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(job_id="a")]),
+    )
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(job_id="b")]),
+    )
+
+    FounditScraper("in", max_pages=99).fetch()
+    starts = [r.url.params["start"] for r in httpx_mock.get_requests()]
+    assert starts == ["0", "100"]
+
+
+# --- retry / error handling -------------------------------------------
+
+
+def test_retries_on_5xx_then_succeeds(httpx_mock: Any) -> None:
+    httpx_mock.add_response(url=_INDIA_RE, status_code=502, text="bad gateway")
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(job_id="1")]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    jobs = FounditScraper("in", max_pages=5).fetch()
+    assert [j.ats_id for j in jobs] == ["1"]
+
+
+def test_retries_on_429_then_succeeds(httpx_mock: Any) -> None:
+    httpx_mock.add_response(url=_INDIA_RE, status_code=429, text="rate limited")
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(job_id="1")]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    jobs = FounditScraper("in", max_pages=5).fetch()
+    assert [j.ats_id for j in jobs] == ["1"]
+
+
+def test_stops_pagination_after_exhausted_retries(
+    httpx_mock: Any,
+) -> None:
+    """When the per-page retry budget is exhausted on a transient
+    failure, the scraper stops pagination but returns whatever it
+    already had — partial > nothing."""
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(job_id="1")]),
+    )
+    # Page 2 always 502 — both retries fail.
+    httpx_mock.add_response(url=_INDIA_RE, status_code=502)
+    httpx_mock.add_response(url=_INDIA_RE, status_code=502)
+
+    jobs = FounditScraper("in", max_pages=5).fetch()
+    assert [j.ats_id for j in jobs] == ["1"]
+
+
+def test_4xx_other_than_429_stops_immediately(httpx_mock: Any) -> None:
+    """A 400 / 404 isn't transient — surface a stop, don't retry."""
+    httpx_mock.add_response(url=_INDIA_RE, status_code=400, text="bad request")
+
+    jobs = FounditScraper("in", max_pages=5).fetch()
+    assert jobs == []
+
+
+def test_non_json_200_stops_pagination(httpx_mock: Any) -> None:
+    """A 200 that doesn't parse as JSON shouldn't crash the scraper —
+    log a warning, stop walking, return what we have."""
+    httpx_mock.add_response(url=_INDIA_RE, status_code=200, text="<html>oops</html>")
+
+    jobs = FounditScraper("in", max_pages=5).fetch()
+    assert jobs == []
+
+
+def test_api_level_error_status_stops_pagination(httpx_mock: Any) -> None:
+    """The envelope's own ``jobSearchStatus != 200`` signals an
+    application-level error (e.g. a bad ``country`` token). Stop and
+    return what we have."""
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json={
+            "jobSearchStatus": 400,
+            "jobSearchStatusText": "Bad Request",
+            "jobSearchResponse": {},
+        },
+    )
+
+    jobs = FounditScraper("in", max_pages=5).fetch()
+    assert jobs == []
+
+
+# --- request shape ---------------------------------------------------
+
+
+def test_request_carries_required_params(httpx_mock: Any) -> None:
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    FounditScraper("in", max_pages=1).fetch()
+    [req] = httpx_mock.get_requests()
+    qs = req.url.params
+    assert qs["sort"] == "1"
+    assert qs["limit"] == "100"
+    assert qs["query"] == ""
+    assert qs["searchId"] == ""
+    assert qs["queryDerived"] == "true"
+    assert qs["country"] == "india"
+    assert qs["start"] == "0"
+
+
+def test_request_carries_browserlike_headers(httpx_mock: Any) -> None:
+    """The middleware endpoint accepts any UA in May 2026 but we
+    mirror Chrome to blend in if the WAF tightens."""
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    FounditScraper("in", max_pages=1).fetch()
+    [req] = httpx_mock.get_requests()
+    assert req.headers["Accept"] == "application/json"
+    assert req.headers["Referer"] == "https://www.foundit.in/"
+    assert "Chrome" in req.headers["User-Agent"]
+
+
+def test_singapore_uses_singapore_referer_and_country(
+    httpx_mock: Any,
+) -> None:
+    sg_re = _API_RE_BY_DOMAIN["www.foundit.sg"]
+    httpx_mock.add_response(url=sg_re, json=_make_page([]))
+
+    FounditScraper("sg", max_pages=1).fetch()
+    [req] = httpx_mock.get_requests()
+    assert req.url.params["country"] == "singapore"
+    assert req.headers["Referer"] == "https://www.foundit.sg/"
+
+
+# --- module-level helper coverage ------------------------------------
+
+
+def test_split_skills_strips_and_filters_empties() -> None:
+    out = f_mod._split_skills(" Java , , Python ,SQL")
+    assert out == ["Java", "Python", "SQL"]
+
+
+def test_split_skills_non_string_returns_empty() -> None:
+    assert f_mod._split_skills(None) == []
+    assert f_mod._split_skills(["Java"]) == []
+
+
+def test_nested_amount_handles_missing_field() -> None:
+    assert f_mod._nested_amount(None) is None
+    assert f_mod._nested_amount({"currency": "INR"}) is None
+    assert f_mod._nested_amount({"absoluteValue": "100"}) is None
+
+
+def test_epoch_ms_to_dt_roundtrips() -> None:
+    out = f_mod._epoch_ms_to_dt(1_775_488_663_000)
+    assert out == datetime.fromtimestamp(1_775_488_663, tz=UTC)
+
+
+def test_epoch_ms_to_dt_rejects_garbage() -> None:
+    assert f_mod._epoch_ms_to_dt(None) is None
+    assert f_mod._epoch_ms_to_dt("nope") is None
+    assert f_mod._epoch_ms_to_dt(-1) is None
+
+
+def test_str_or_none_int_to_str() -> None:
+    """``id`` arrives as a string in current payloads, but ``jobId`` is
+    numeric — the helper must round-trip ints to canonical strings."""
+    assert f_mod._str_or_none(49286015) == "49286015"
+    assert f_mod._str_or_none("  abc  ") == "abc"
+    assert f_mod._str_or_none("") is None
+    assert f_mod._str_or_none(None) is None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,7 +29,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
-        "manfred", "thehub", "ycombinator", "wellfound",
+        "manfred", "thehub", "ycombinator", "wellfound", "foundit",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",
         "recruitee", "taleo", "teamtailor",


### PR DESCRIPTION
## Summary
- New `FounditScraper` covering India + SEA (Singapore, Malaysia, Indonesia, Philippines) at `*.foundit.{in,sg,my,id,com.ph}` — hundreds of thousands of live postings.
- Reverse-engineered the anonymous `middleware/jobsearch` JSON endpoint on 2026-05-12. Despite Akamai Bot Manager fronting the SPA HTML, the search API accepts plain `httpx` with a Chrome-ish `User-Agent` + `Referer` — no TLS impersonation needed.
- Country selector via `company_slug` (`"in"` default, plus `"sg" / "my" / "id" / "ph"` and full-name aliases). Each country uses its own domain, so the published URLs link to the channel-correct host.
- Structured salary (ISO 4217 currency + min/max), employment-type enum mapping (Full time / Permanent / Contract / Internship / …), `posted_at` from epoch-ms `createdAt`, and ATS-specific overflow (industry, skills, functions, qualifications, kiwi job id) in `raw`.
- Honours `hideSalary` (confidential listings) and treats zero `absoluteValue` as "not disclosed".
- Filters out interleaved adsense / banner placements (rows without `id`).
- Stops pagination at the API's silent deep-paginate cap (`start ~= 9500`) via both an offset ceiling and a "zero new rows" detector — covers the freshest ~10k per channel; query-seed bucketing for the long tail is a follow-up.

## Test plan
- [x] `uv run pytest tests/test_foundit.py` — 55 passing fixture-based tests (country slugs, parsing, salary handling, employment-type mapping, ad-row filtering, pagination dedup, retry on 429/5xx, request-shape assertions, helper coverage).
- [x] `uv run pytest -q` — full suite green (934 passing).
- [x] `uv run ruff check .` clean.
- [ ] Live smoke run from a residential IP to confirm the public endpoint stays stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `FounditScraper` to ingest Foundit (Monster India) jobs across India, Singapore, Malaysia, Indonesia, and the Philippines via the anonymous `middleware/jobsearch` JSON API. Outputs structured jobs with country-correct URLs, safe pagination, and retry logic.

- New Features
  - Country selector via `company_slug` (`in` default; `sg`, `my`, `id`, `ph`; full-name aliases supported).
  - Structured salary with ISO currency; respects `hideSalary` and treats zero as not disclosed.
  - Employment type mapping; `posted_at` from epoch ms; experience years when provided.
  - Filters non-job ad rows; builds channel-specific absolute URLs.
  - Pagination capped near `start≈9500` and stops on zero new rows; `100` per page; retries on 429/5xx with backoff.
  - Wire-up: adds `ATSType.FOUNDIT`, registers `FounditScraper` in `jobhive.scrapers`, and seeds `ats-companies/foundit.csv` with country domains.

<sup>Written for commit 8c3ef7d809f73d020ecf195a336d49906a706fc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `FounditScraper` to ingest jobs from Foundit (Monster India / APAC) across five country channels via the anonymous `/middleware/jobsearch` JSON endpoint. The scraper is well-structured with country-domain routing, structured salary and employment-type parsing, safe pagination with an offset ceiling and zero-new-rows detector, and retry/backoff on 429/5xx.

- `FounditScraper` in `foundit.py` handles all five country domains, honours `hideSalary`, maps employment-type labels to the canonical enum, and converts epoch-ms timestamps — with 55 fixture-based tests covering every branch.
- Registry wiring (`ATSType.FOUNDIT`, `ScraperRegistry` registration, `__all__` export) and the seed CSV are all consistent with each other and with existing patterns in the codebase.
- Minor issues found: `salary_currency` is not cleared when both salary amounts resolve to zero (non-hidden case), leaving `Job` in a state where currency/period are set but min/max are both `None`; and the trailing `log.warning`/`return None` after the retry loop is unreachable dead code.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the core scraping logic, pagination, retry handling, and field mapping are all correct. The only changes needed are a small salary-state inconsistency and a documentation fix.

The scraper correctly implements pagination, deduplication, retry backoff, country routing, and salary/employment-type parsing. The zero-salary case leaves salary_currency set while salary_min/salary_max are both None, creating a Salary object with a currency but no amounts — an inconsistency that could confuse downstream consumers. Everything else is clean.

src/jobhive/scrapers/foundit.py — specifically the _parse_row salary-clearing logic and the dead code after the retry loop.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/foundit.py | New 538-line scraper with solid structure — pagination cap, dedup, retry/backoff, and country mapping are all correct. Two minor correctness issues: salary_currency stays set when amounts are zero (inconsistent Job state), and dead code follows the retry loop. |
| tests/test_foundit.py | Comprehensive fixture-based test suite covering all major paths — country slugs, field parsing, salary handling, dedup, retry, and request shape. Tests use pytest-httpx cleanly and fast-backoff monkeypatching is well-handled. |
| src/jobhive/models.py | Adds FOUNDIT to ATSType StrEnum in the correct section (Hybrid jobboards). No other changes. |
| src/jobhive/scrapers/__init__.py | Wires FounditScraper into the scraper registry and __all__ export, alphabetically ordered correctly. |
| ats-companies/foundit.csv | Seed CSV for five Foundit country domains. Headers and slugs match the scraper's _COUNTRY_TABLE exactly. |
| tests/test_models.py | Adds "foundit" to the exhaustive ATSType membership test — straightforward and correct. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
src/jobhive/scrapers/foundit.py:354-358
When `hideSalary` is false but both salary amounts happen to be zero (Foundit's "not disclosed" sentinel), `currency` is never cleared. The result is a `Job` with `salary_currency="INR"` and `salary_period="YEAR"` but `salary_min=None` / `salary_max=None`, which causes `Job.salary` to return a `Salary` object with a currency code but no actual amounts. Clearing `currency` when neither structured amount is present avoids this inconsistent state (the `salary_summary` display string still carries any human-readable text).

```suggestion
        if row.get("hideSalary"):
            min_sal = None
            max_sal = None
            salary_summary = None
            currency = None
        elif min_sal is None and max_sal is None:
            # Both amounts resolved to zero/missing — drop the currency
            # code too so Job.salary doesn't return a Salary with no
            # amounts. salary_summary (display text) is kept if present.
            currency = None
```

### Issue 2 of 4
src/jobhive/scrapers/foundit.py:307-311
The trailing `log.warning` / `return None` after the retry loop is unreachable. Every code path inside the loop either returns immediately (200 response, non-retryable 4xx, exhausted-retries branch on the last attempt) or calls `continue`. The loop never exits normally, so these lines are dead.

```suggestion
        # Unreachable: every path through the loop returns directly.
        # Kept as a safety net in case MAX_RETRIES is ever set to 0.
        log.warning(
            "Foundit %s start=%d exhausted retries: %s",
            self.country_slug, start, last_exc,
        )
        return None
```

### Issue 3 of 4
src/jobhive/scrapers/foundit.py:469-480
The docstring says "Strip + collapse whitespace" but the implementation only strips leading/trailing whitespace — multiple consecutive internal spaces (e.g., `"Senior  Engineer"`) are not normalised. Either remove the "collapse" claim or add the normalisation step.

```suggestion
def _clean_text(value: object) -> str | None:
    """Strip leading/trailing whitespace, return None for empties. We
    don't decode HTML entities here — Foundit's ``title`` /
    ``companyName`` are plain text in practice (the HTML-entity ones
    live in ``companyProfile``, which we don't surface to
    ``Job.description``).
    """
    if value is None:
        return None
    if not isinstance(value, str):
        return None
    cleaned = value.strip()
    return cleaned or None
```

### Issue 4 of 4
src/jobhive/scrapers/foundit.py:94
**Unexplained `ph_ph` alias** — `"ph_ph": "ph"` appears in `_COUNTRY_ALIASES` without a comment. What legacy slug or external identifier does this cover? A brief note (e.g., "legacy CSV slug" or "old Monster PH format") would help future maintainers understand why it exists.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: foundit.csv"](https://github.com/kalil0321/ats-scrapers/commit/8c3ef7d809f73d020ecf195a336d49906a706fc3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732457)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->