### PR TITLE
Add Hiredly MY and Green Japan scrapers

### DIFF
--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -80,6 +80,8 @@ class ATSType(StrEnum):
     THEHUB = "thehub"
     YCOMBINATOR = "ycombinator"
     WELLFOUND = "wellfound"
+    HIREDLY = "hiredly"
+    GREENJAPAN = "greenjapan"
     # Additional multi-tenant ATSes (post-0.1)
     BAMBOOHR = "bamboohr"
     BREEZY = "breezy"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -25,6 +25,8 @@ from jobhive.scrapers.gem import GemScraper
 from jobhive.scrapers.getonbrd import GetOnBrdScraper
 from jobhive.scrapers.google import GoogleScraper
 from jobhive.scrapers.greenhouse import GreenhouseScraper
+from jobhive.scrapers.greenjapan import GreenJapanScraper
+from jobhive.scrapers.hiredly import HiredlyScraper
 from jobhive.scrapers.icims import iCIMSScraper
 from jobhive.scrapers.jazzhr import JazzHRScraper
 from jobhive.scrapers.jobsch import JobsChScraper
@@ -76,7 +78,9 @@ __all__ = [
     "GemScraper",
     "GetOnBrdScraper",
     "GoogleScraper",
+    "GreenJapanScraper",
     "GreenhouseScraper",
+    "HiredlyScraper",
     "JazzHRScraper",
     "JobsChScraper",
     "JoinComScraper",

--- a/src/jobhive/scrapers/greenjapan.py
+++ b/src/jobhive/scrapers/greenjapan.py
@@ -1,0 +1,474 @@
+"""Green Japan (https://www.green-japan.com) — Japanese tech jobs scraper.
+
+Green is the largest direct-employer tech jobs board in Japan
+(~29.6k active postings across ~4k companies, verified 2026-05-11).
+The ``/search_key`` and ``/search`` SSR pages embed the same job
+listing data inside the standard Next.js ``__NEXT_DATA__`` script at
+``props.pageProps.defaultSearchJobOfferData`` — ``jobOffers`` (20 per
+page) and ``totalJobOfferCount`` (the absolute total we paginate
+against).
+
+We hit the underlying ``_next/data/{buildId}/search.json?page=N`` JSON
+endpoint after a one-shot HTML discovery for the ``buildId``. Falls
+back to HTML scraping if the data endpoint 404's (stale buildId);
+re-discovers and resumes from the same page.
+
+Single-source scraper: ``company_slug`` is informational and ignored
+(matches the bundesagentur / eures / wanted pattern).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+log = logging.getLogger(__name__)
+
+API_ROOT = "https://www.green-japan.com"
+LISTING_PATH = "/search_key"
+PER_PAGE = 20  # site renders 20 items per page; not configurable
+DEFAULT_MAX_PAGES = 2000  # ~40k jobs ceiling, site currently ~29.6k
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1.5
+
+_BUILD_ID_RE = re.compile(r'"buildId"\s*:\s*"([^"]+)"')
+_NEXT_DATA_RE = re.compile(
+    r'<script id="__NEXT_DATA__"[^>]*>(.*?)</script>', re.DOTALL,
+)
+
+
+@ScraperRegistry.register(ATSType.GREENJAPAN)
+class GreenJapanScraper(BaseScraper):
+    """Green Japan (green-japan.com) — single-source scraper.
+
+    ``company_slug`` is ignored. Pass anything (``"any"``, ``""``) —
+    the scraper walks every active posting up to ``totalJobOfferCount``.
+
+    Knobs:
+    - ``max_pages`` — pagination cap (default 2000, ~40k jobs).
+    """
+
+    ats = ATSType.GREENJAPAN
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        max_pages: int = DEFAULT_MAX_PAGES,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.max_pages = max_pages
+        self._build_id: str | None = None
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        lock = asyncio.Lock()
+
+        async def absorb(items: list[dict[str, Any]]) -> int:
+            new = 0
+            async with lock:
+                for item in items:
+                    job = self._parse(item)
+                    if job is None or job.ats_id in seen:
+                        continue
+                    seen.add(job.ats_id)
+                    jobs.append(job)
+                    new += 1
+            return new
+
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+            # Discover buildId and grab page-1 data in the same HTML
+            # fetch — saves one round-trip.
+            self._build_id, first_items, total = (
+                await self._discover_and_first_page(client, sem)
+            )
+            await absorb(first_items)
+            if total is None:
+                # Defensive: keep paging until empty if the total is
+                # missing for some reason.
+                page_count = self.max_pages
+            else:
+                page_count = min(
+                    (total + PER_PAGE - 1) // PER_PAGE,
+                    self.max_pages,
+                )
+
+            consecutive_empty = 0
+            page = 2
+            while page <= page_count and consecutive_empty < 2:
+                items = await self._fetch_page(client, sem, page=page)
+                if not items:
+                    consecutive_empty += 1
+                else:
+                    consecutive_empty = 0
+                    await absorb(items)
+                page += 1
+        return jobs
+
+    # --- build-id + first-page discovery ----------------------------------
+
+    async def _discover_and_first_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+    ) -> tuple[str, list[dict[str, Any]], int | None]:
+        url = f"{API_ROOT}{LISTING_PATH}"
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(
+                        url, headers=_listing_headers(),
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"Green Japan discovery failed: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                text = response.text
+                build_match = _BUILD_ID_RE.search(text)
+                if not build_match:
+                    raise ScraperError(
+                        "Green Japan: could not locate buildId in HTML"
+                    )
+                build_id = build_match.group(1)
+                items, total = _parse_next_data(text)
+                return build_id, items, total
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Green Japan /search_key returned "
+                        f"{response.status_code} after {MAX_RETRIES} retries"
+                    )
+                await asyncio.sleep(RETRY_BASE_DELAY * (2**attempt))
+                continue
+            raise ScraperError(
+                f"Green Japan /search_key returned {response.status_code}"
+            )
+        raise ScraperError(
+            f"Green Japan discovery exhausted retries: {last_exc}"
+        )
+
+    async def _rediscover_build_id(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+    ) -> str:
+        build_id, _items, _total = await self._discover_and_first_page(
+            client, sem,
+        )
+        return build_id
+
+    # --- listing pages ----------------------------------------------------
+
+    async def _fetch_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        *,
+        page: int,
+    ) -> list[dict[str, Any]]:
+        rediscovered = False
+        for _ in range(2):
+            payload = await self._fetch_data_page(
+                client, sem, page=page,
+            )
+            if payload is _STALE_BUILD:
+                if rediscovered:
+                    raise ScraperError(
+                        f"Green Japan: build rotated twice for page={page}"
+                    )
+                log.info(
+                    "Green Japan: stale buildId=%s at page=%d, "
+                    "re-discovering",
+                    self._build_id, page,
+                )
+                self._build_id = await self._rediscover_build_id(
+                    client, sem,
+                )
+                rediscovered = True
+                continue
+            return _extract_jobs(payload)
+        return []
+
+    async def _fetch_data_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        *,
+        page: int,
+    ) -> dict[str, Any] | object:
+        assert self._build_id is not None
+        url = (
+            f"{API_ROOT}/_next/data/{self._build_id}"
+            f"/search.json?page={page}"
+        )
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(
+                        url, headers=_data_headers(),
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"Green Japan fetch failed at page={page}: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                try:
+                    return response.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"Green Japan returned non-JSON at page={page}: {exc}"
+                    ) from exc
+            if response.status_code == 404:
+                return _STALE_BUILD
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Green Japan returned {response.status_code} at "
+                        f"page={page} after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after)
+                    if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2**attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"Green Japan returned {response.status_code} at "
+                f"page={page}"
+            )
+        raise ScraperError(
+            f"Green Japan exhausted retries at page={page}: {last_exc}"
+        )
+
+    # --- parsing ----------------------------------------------------------
+
+    def _parse(self, item: dict[str, Any]) -> Job | None:
+        raw_id = item.get("id")
+        if raw_id is None:
+            return None
+        ats_id = str(raw_id)
+        # Green uses ``name`` for the role title; ``title`` is a marketing
+        # tagline ("賞与実績…"). Fall back to ``title`` if ``name`` is
+        # missing.
+        title = (item.get("name") or item.get("title") or "").strip()
+        if not ats_id or not title:
+            return None
+
+        company_obj = item.get("company") or {}
+        company_name = (company_obj.get("name") or "").strip() or "Unknown"
+
+        # Job URL: per the listing payload, ``jobOfferUrl`` is the
+        # canonical ``/company/{cid}/job/{jid}`` path. Fall back to the
+        # bare ``/job/{id}`` form when missing.
+        job_url_path = (item.get("jobOfferUrl") or "").strip()
+        if job_url_path.startswith("/"):
+            url = f"{API_ROOT}{job_url_path}"
+        else:
+            url = f"{API_ROOT}/job/{ats_id}"
+
+        salary_summary = (item.get("salary") or "").strip() or None
+        sal_min, sal_max = _parse_jpy_salary(salary_summary)
+
+        raw: dict[str, Any] = {}
+        if isinstance(item.get("areaName"), str) and item["areaName"].strip():
+            raw["area"] = item["areaName"].strip()
+        skill_names = item.get("skillNames")
+        if isinstance(skill_names, list) and skill_names:
+            raw["skills"] = [
+                s for s in skill_names if isinstance(s, str) and s
+            ]
+        tag_names = item.get("tagNames")
+        if isinstance(tag_names, list) and tag_names:
+            raw["tags"] = [
+                t for t in tag_names if isinstance(t, str) and t
+            ]
+        client_business = item.get("clientBusiness")
+        if isinstance(client_business, dict):
+            cb_name = client_business.get("name")
+            if isinstance(cb_name, str) and cb_name.strip():
+                raw["industry"] = cb_name.strip()
+        if company_obj.get("id") is not None:
+            raw["company_id"] = company_obj["id"]
+        if isinstance(company_obj.get("title"), str) and company_obj["title"].strip():
+            raw["company_tagline"] = company_obj["title"].strip()
+        # Keep the marketing tagline distinct from the role name so
+        # downstream consumers can still surface it.
+        if isinstance(item.get("title"), str) and item["title"].strip():
+            tagline = item["title"].strip()
+            if tagline != title:
+                raw["headline"] = tagline
+
+        return Job(
+            url=url,
+            title=title,
+            company=company_name,
+            ats_type=ATSType.GREENJAPAN,
+            ats_id=ats_id,
+            location=_format_location(item.get("areaName")),
+            country_iso="JP",
+            region="Asia",
+            language="ja",
+            salary_summary=salary_summary,
+            salary_currency="JPY" if salary_summary else None,
+            salary_period="YEAR" if salary_summary else None,
+            salary_min=sal_min,
+            salary_max=sal_max,
+            posted_at=_parse_unix_timestamp(
+                item.get("jobOfferUpdatedAtTimestamp")
+            ),
+            fetched_at=datetime.now(),
+            raw=raw or None,
+        )
+
+
+_STALE_BUILD = object()
+
+
+def _extract_jobs(payload: dict[str, Any] | object) -> list[dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return []
+    page_props = payload.get("pageProps") or {}
+    dso = page_props.get("defaultSearchJobOfferData") or {}
+    items = dso.get("jobOffers")
+    return items if isinstance(items, list) else []
+
+
+def _parse_next_data(html: str) -> tuple[list[dict[str, Any]], int | None]:
+    """Pull the embedded ``__NEXT_DATA__`` JSON out of an HTML page
+    and return the (jobs, totalCount) tuple from it."""
+    match = _NEXT_DATA_RE.search(html)
+    if not match:
+        return [], None
+    try:
+        payload = json.loads(match.group(1))
+    except json.JSONDecodeError:
+        return [], None
+    if not isinstance(payload, dict):
+        return [], None
+    items = _extract_jobs(payload.get("props") or {})
+    dso = (
+        ((payload.get("props") or {}).get("pageProps") or {})
+        .get("defaultSearchJobOfferData") or {}
+    )
+    total = dso.get("totalJobOfferCount")
+    if not isinstance(total, int) or total < 0:
+        total = None
+    return items, total
+
+
+def _listing_headers() -> dict[str, str]:
+    return {
+        "User-Agent": (
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+        ),
+        "Accept": "text/html,application/xhtml+xml",
+        "Accept-Language": "ja,en;q=0.9",
+    }
+
+
+def _data_headers() -> dict[str, str]:
+    return {
+        "User-Agent": (
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+        ),
+        "Accept": "application/json",
+        "Accept-Language": "ja,en;q=0.9",
+        "Referer": f"{API_ROOT}{LISTING_PATH}",
+    }
+
+
+def _format_location(value: object) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    parts = [p.strip() for p in value.split(",") if p.strip()]
+    if not parts:
+        return None
+    return ", ".join(parts)
+
+
+# Match common Japanese salary formats:
+#   "410万円〜800万円"       → 4.1M - 8M JPY (both bounds carry the unit)
+#   "300〜600万円"           → 3M - 6M JPY (range with one shared 万円 suffix)
+#   "500万円以上"            → 5M JPY, min only
+#   "500万円"                 → 5M JPY, single value
+_RANGE_BOTH_UNIT_RE = re.compile(
+    r"(\d+(?:[.,]\d+)?)\s*万円\s*[〜~\-–]\s*(\d+(?:[.,]\d+)?)\s*万円",
+)
+_RANGE_SHARED_UNIT_RE = re.compile(
+    r"(\d+(?:[.,]\d+)?)\s*[〜~\-–]\s*(\d+(?:[.,]\d+)?)\s*万円",
+)
+_SINGLE_RE = re.compile(r"(\d+(?:[.,]\d+)?)\s*万円")
+
+
+def _parse_jpy_salary(value: str | None) -> tuple[float | None, float | None]:
+    """Green Japan reports salary as Japanese 万円 (10,000 JPY) ranges.
+
+    Returns ``(min_jpy, max_jpy)`` with both bounds in absolute JPY,
+    or ``(None, None)`` if no recognizable range is present."""
+    if not value:
+        return None, None
+    for regex in (_RANGE_BOTH_UNIT_RE, _RANGE_SHARED_UNIT_RE):
+        match = regex.search(value)
+        if match:
+            try:
+                low = float(match.group(1).replace(",", "")) * 10_000
+                high = float(match.group(2).replace(",", "")) * 10_000
+            except ValueError:
+                continue
+            return low, high
+    match = _SINGLE_RE.search(value)
+    if match:
+        try:
+            low = float(match.group(1).replace(",", "")) * 10_000
+        except ValueError:
+            return None, None
+        return low, None
+    return None, None
+
+
+def _parse_unix_timestamp(value: object) -> datetime | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)) and value > 0:
+        try:
+            return datetime.fromtimestamp(int(value), tz=UTC)
+        except (OverflowError, OSError, ValueError):
+            return None
+    return None

--- a/src/jobhive/scrapers/hiredly.py
+++ b/src/jobhive/scrapers/hiredly.py
@@ -1,0 +1,448 @@
+"""Hiredly Malaysia (https://my.hiredly.com) — direct-employer jobs board.
+
+Hiredly is a Malaysian direct-posting jobs platform — companies post
+their own roles, it's not aggregated from LinkedIn / Indeed. The
+``/jobs`` index page is a Next.js SSR app: the same job objects that
+the browser renders are also served verbatim as JSON from the
+``_next/data/{buildId}/jobs.json`` endpoint, which is what we hit.
+
+The ``buildId`` is the Next.js per-deployment hash that appears both
+inline on the HTML page and in the data URL. We discover it once by
+fetching ``/jobs`` and grepping ``"buildId":"…"`` out of the HTML.
+If a deploy happens mid-walk the data endpoint starts returning 404 —
+we re-discover the build and resume from the same page.
+
+Single-source scraper: ``company_slug`` is informational and ignored
+(matches the bundesagentur / eures / getonbrd / wanted pattern).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+log = logging.getLogger(__name__)
+
+API_ROOT = "https://my.hiredly.com"
+LISTING_PATH = "/jobs"
+PER_PAGE = 30  # site renders 30 items per page; not configurable
+DEFAULT_MAX_PAGES = 400  # ~12k jobs ceiling; site currently sits ~6k
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1.5
+
+_BUILD_ID_RE = re.compile(r'"buildId"\s*:\s*"([^"]+)"')
+
+
+@ScraperRegistry.register(ATSType.HIREDLY)
+class HiredlyScraper(BaseScraper):
+    """Hiredly Malaysia (my.hiredly.com) — single-source scraper.
+
+    ``company_slug`` is ignored. Pass anything (``"any"``, ``""``) —
+    the scraper walks every job on the site until the page is empty.
+
+    Knobs:
+    - ``max_pages`` — pagination cap (default 400, ~12k jobs).
+    """
+
+    ats = ATSType.HIREDLY
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        max_pages: int = DEFAULT_MAX_PAGES,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.max_pages = max_pages
+        self._build_id: str | None = None
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        lock = asyncio.Lock()
+
+        async def absorb(items: list[dict[str, Any]]) -> int:
+            new = 0
+            async with lock:
+                for item in items:
+                    job = self._parse(item)
+                    if job is None or job.ats_id in seen:
+                        continue
+                    seen.add(job.ats_id)
+                    jobs.append(job)
+                    new += 1
+            return new
+
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+            self._build_id = await self._discover_build_id(client, sem)
+            consecutive_empty = 0
+            page = 1
+            while page <= self.max_pages and consecutive_empty < 2:
+                items = await self._fetch_page(client, sem, page=page)
+                if not items:
+                    consecutive_empty += 1
+                else:
+                    consecutive_empty = 0
+                    await absorb(items)
+                page += 1
+        return jobs
+
+    # --- build-id discovery -------------------------------------------------
+
+    async def _discover_build_id(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+    ) -> str:
+        url = f"{API_ROOT}{LISTING_PATH}"
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(
+                        url, headers=_listing_headers(),
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"Hiredly buildId discovery failed: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                match = _BUILD_ID_RE.search(response.text)
+                if not match:
+                    raise ScraperError(
+                        "Hiredly: could not locate buildId in /jobs HTML"
+                    )
+                return match.group(1)
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Hiredly /jobs returned {response.status_code} "
+                        f"after {MAX_RETRIES} retries"
+                    )
+                await asyncio.sleep(RETRY_BASE_DELAY * (2**attempt))
+                continue
+            raise ScraperError(
+                f"Hiredly /jobs returned {response.status_code}"
+            )
+        raise ScraperError(
+            f"Hiredly buildId discovery exhausted retries: {last_exc}"
+        )
+
+    # --- listing pages ------------------------------------------------------
+
+    async def _fetch_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        *,
+        page: int,
+    ) -> list[dict[str, Any]]:
+        # If the build was rotated mid-walk we re-discover it once and
+        # retry the same page before treating the 404 as fatal.
+        rediscovered = False
+        for _ in range(2):
+            payload = await self._fetch_data_page(
+                client, sem, page=page,
+            )
+            if payload is _STALE_BUILD:
+                if rediscovered:
+                    raise ScraperError(
+                        f"Hiredly: build rotated twice for page={page}"
+                    )
+                log.info(
+                    "Hiredly: stale buildId=%s detected at page=%d, "
+                    "re-discovering",
+                    self._build_id, page,
+                )
+                self._build_id = await self._discover_build_id(client, sem)
+                rediscovered = True
+                continue
+            return _extract_jobs(payload)
+        return []
+
+    async def _fetch_data_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        *,
+        page: int,
+    ) -> dict[str, Any] | object:
+        assert self._build_id is not None
+        url = (
+            f"{API_ROOT}/_next/data/{self._build_id}/jobs.json?page={page}"
+        )
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(
+                        url, headers=_data_headers(),
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"Hiredly fetch failed at page={page}: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                try:
+                    return response.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"Hiredly returned non-JSON at page={page}: {exc}"
+                    ) from exc
+            if response.status_code == 404:
+                # Stale buildId — caller re-discovers and retries.
+                return _STALE_BUILD
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Hiredly returned {response.status_code} at "
+                        f"page={page} after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after)
+                    if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2**attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"Hiredly returned {response.status_code} at page={page}"
+            )
+        raise ScraperError(
+            f"Hiredly exhausted retries at page={page}: {last_exc}"
+        )
+
+    # --- parsing ------------------------------------------------------------
+
+    def _parse(self, item: dict[str, Any]) -> Job | None:
+        raw_id = item.get("id")
+        title = (item.get("title") or "").strip()
+        if not raw_id or not title:
+            return None
+        ats_id = str(raw_id)
+        slug = (item.get("slug") or "").strip()
+        # Hiredly's public URL is ``/jobs/{slug}`` — the slug already
+        # starts with ``jobs-malaysia-{company}-job-{role}``. Fall
+        # back to the UUID-based path when the slug is missing.
+        url = (
+            f"{API_ROOT}/jobs/{slug}" if slug
+            else f"{API_ROOT}/jobs/{ats_id}"
+        )
+
+        company_obj = item.get("company") or {}
+        company_name = (company_obj.get("name") or "").strip() or "Unknown"
+
+        salary_summary = (item.get("salary") or "").strip() or None
+        sal_min, sal_max = _parse_salary_range(salary_summary)
+
+        employment_type = _employment_type(item.get("jobType"))
+        location = _format_location(item)
+
+        raw: dict[str, Any] = {}
+        category = item.get("category")
+        if isinstance(category, str) and category.strip():
+            raw["category"] = category.strip()
+        skills_raw = item.get("skills") or []
+        if isinstance(skills_raw, list):
+            skills = [
+                s.get("name").strip()
+                for s in skills_raw
+                if isinstance(s, dict)
+                and isinstance(s.get("name"), str)
+                and s["name"].strip()
+            ]
+            if skills:
+                raw["skills"] = skills
+        tracks_raw = item.get("tracks") or []
+        if isinstance(tracks_raw, list):
+            tracks = [
+                t.get("title").strip()
+                for t in tracks_raw
+                if isinstance(t, dict)
+                and isinstance(t.get("title"), str)
+                and t["title"].strip()
+            ]
+            if tracks:
+                raw["tracks"] = tracks
+        career_level = item.get("careerLevel")
+        if isinstance(career_level, str) and career_level.strip():
+            raw["career_level"] = career_level.strip()
+        if company_obj.get("slug"):
+            raw["company_slug"] = company_obj["slug"]
+        if company_obj.get("id"):
+            raw["company_id"] = company_obj["id"]
+        if item.get("gptSummary"):
+            raw["gpt_summary"] = item["gptSummary"]
+        if item.get("stateRegion"):
+            raw["state_region"] = item["stateRegion"]
+
+        return Job(
+            url=url,
+            title=title,
+            company=company_name,
+            ats_type=ATSType.HIREDLY,
+            ats_id=ats_id,
+            location=location,
+            country_iso="MY",
+            language="en",
+            salary_summary=salary_summary,
+            salary_currency="MYR" if salary_summary else None,
+            salary_period="MONTH" if salary_summary else None,
+            salary_min=sal_min,
+            salary_max=sal_max,
+            employment_type=employment_type,
+            commitment=(item.get("jobType") or None),
+            experience=_to_int(item.get("minYearsExperience")),
+            posted_at=_parse_date(item.get("activeAt")),
+            fetched_at=datetime.now(),
+            raw=raw or None,
+        )
+
+
+# Sentinel returned by ``_fetch_data_page`` on 404 (stale buildId).
+_STALE_BUILD = object()
+
+
+def _extract_jobs(payload: dict[str, Any] | object) -> list[dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return []
+    page_props = payload.get("pageProps") or {}
+    jobs = page_props.get("jobs")
+    return jobs if isinstance(jobs, list) else []
+
+
+def _listing_headers() -> dict[str, str]:
+    return {
+        "User-Agent": (
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+        ),
+        "Accept": "text/html,application/xhtml+xml",
+    }
+
+
+def _data_headers() -> dict[str, str]:
+    return {
+        "User-Agent": (
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+        ),
+        "Accept": "application/json",
+        "Referer": f"{API_ROOT}/jobs",
+    }
+
+
+def _employment_type(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower().replace("-", "_").replace(" ", "_")
+    return {
+        "full_time": "FULL_TIME",
+        "part_time": "PART_TIME",
+        "contract": "CONTRACT",
+        "internship": "INTERN",
+        "intern": "INTERN",
+        "temporary": "TEMPORARY",
+    }.get(normalized)
+
+
+def _format_location(item: dict[str, Any]) -> str | None:
+    """Hiredly serves a verbose street address in ``location``; the
+    ``stateRegion`` field is the human-friendly Malaysian state. Prefer
+    the state when both are present (consumers care about ``Selangor``
+    not the full Jalan address), but fall back to the longer string."""
+    state = item.get("stateRegion")
+    if isinstance(state, str) and state.strip():
+        return state.strip()
+    loc = item.get("location")
+    if isinstance(loc, str) and loc.strip():
+        return loc.strip()
+    return None
+
+
+def _parse_salary_range(value: str | None) -> tuple[float | None, float | None]:
+    """Hiredly's ``salary`` is plain ``"3000 - 4000"`` (MYR/month).
+    Some postings only set the lower bound or leave it empty. Returns
+    ``(None, None)`` when the string isn't a recognizable range."""
+    if not value:
+        return None, None
+    match = re.match(
+        r"\s*(\d+(?:[.,]\d+)?)\s*(?:-|–|to)\s*(\d+(?:[.,]\d+)?)\s*$",
+        value,
+    )
+    if match:
+        try:
+            return (
+                float(match.group(1).replace(",", "")),
+                float(match.group(2).replace(",", "")),
+            )
+        except ValueError:
+            return None, None
+    single = re.match(r"\s*(\d+(?:[.,]\d+)?)\s*$", value)
+    if single:
+        try:
+            v = float(single.group(1).replace(",", ""))
+            return v, v
+        except ValueError:
+            return None, None
+    return None, None
+
+
+def _parse_date(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    # Hiredly returns ISO-8601 with a +08:00 offset (Malaysia time).
+    try:
+        # Python's fromisoformat handles ``+08:00`` from 3.11 onward.
+        return datetime.fromisoformat(text)
+    except ValueError:
+        pass
+    # Fallback: drop everything after the timezone if it's malformed.
+    try:
+        return datetime.fromisoformat(text.split("+")[0].split("Z")[0])
+    except ValueError:
+        return None
+
+
+def _to_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            return int(value.strip())
+        except ValueError:
+            return None
+    return None
+

--- a/tests/test_greenjapan.py
+++ b/tests/test_greenjapan.py
@@ -1,0 +1,295 @@
+"""Tests for the Green Japan scraper.
+
+Green-Japan is a Next.js SSR site whose listing payload is reachable in
+two equivalent forms: embedded in the ``__NEXT_DATA__`` script on the
+``/search_key`` HTML page, and as JSON at ``_next/data/{buildId}/
+search.json?page=N``. The scraper grabs both buildId and page-1 from
+the HTML in one shot, then walks the JSON endpoint for the remaining
+pages. ``defaultSearchJobOfferData.totalJobOfferCount`` decides when to
+stop.
+
+Tests cover:
+- HTML discovery seeds buildId + page-1 jobs + total
+- Subsequent pages use the JSON endpoint
+- A 404 on the JSON endpoint triggers re-discovery and resumes
+- Mapping of the embedded jobOffer fields → Job slots (skills, salary)
+- The total-count cap stops pagination before any tail-empty walk
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import GreenJapanScraper, ScraperRegistry
+from jobhive.scrapers.greenjapan import (
+    _parse_jpy_salary,
+    _parse_unix_timestamp,
+)
+
+_LISTING_URL = "https://www.green-japan.com/search_key"
+_DATA_RE = re.compile(
+    r"^https://www\.green-japan\.com/_next/data/[^/]+/search\.json\?page=\d+$"
+)
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.greenjapan as g
+    monkeypatch.setattr(g, "MAX_RETRIES", 1)
+    monkeypatch.setattr(g, "RETRY_BASE_DELAY", 0.0)
+
+
+def _job(
+    *,
+    id: int = 235863,
+    name: str = "システム開発エンジニア",
+    title: str | None = "賞与実績 5.2ヶ月分",
+    company_name: str = "株式会社 D・Ace",
+    company_id: int = 9939,
+    company_title: str = "「楽する」ために工夫し楽しむ。",
+    salary: str = "410万円〜800万円",
+    area_name: str = "東京都, 神奈川県, 千葉県",
+    skill_names: list[str] | None = None,
+    tag_names: list[str] | None = None,
+    industry: str = "自由で効率的なシステム開発サービス",
+    updated_at: int = 1778459021,
+    job_offer_url: str | None = None,
+) -> dict:
+    skill_names = skill_names if skill_names is not None else [
+        "Python", "TypeScript", "Go",
+    ]
+    tag_names = tag_names if tag_names is not None else ["リモート勤務の相談可"]
+    payload: dict = {
+        "id": id,
+        "name": name,
+        "company": {
+            "id": company_id,
+            "name": company_name,
+            "title": company_title,
+        },
+        "salary": salary,
+        "areaName": area_name,
+        "skillNames": skill_names,
+        "tagNames": tag_names,
+        "clientBusiness": {"name": industry},
+        "jobOfferUpdatedAtTimestamp": updated_at,
+        "jobOfferUrl": (
+            job_offer_url
+            if job_offer_url is not None
+            else f"/company/{company_id}/job/{id}"
+        ),
+    }
+    if title is not None:
+        payload["title"] = title
+    return payload
+
+
+def _next_data(
+    *, build_id: str = "buildA", jobs: list[dict], total: int | None = None,
+) -> dict:
+    """Shape of the JSON Next.js embeds in ``__NEXT_DATA__``."""
+    dso: dict = {"jobOffers": jobs, "searchId": "x"}
+    if total is not None:
+        dso["totalJobOfferCount"] = total
+    return {
+        "props": {
+            "pageProps": {
+                "currentPage": 1,
+                "defaultSearchJobOfferData": dso,
+            }
+        },
+        "page": "/search",
+        "query": {},
+        "buildId": build_id,
+    }
+
+
+def _listing_html(
+    *, build_id: str = "buildA", jobs: list[dict], total: int | None = None,
+) -> str:
+    payload = _next_data(build_id=build_id, jobs=jobs, total=total)
+    return (
+        "<html><head></head><body>"
+        '<script id="__NEXT_DATA__" type="application/json">'
+        + json.dumps(payload, ensure_ascii=False)
+        + "</script></body></html>"
+    )
+
+
+def _data_response(jobs: list[dict], *, total: int | None = None) -> dict:
+    """Shape of a ``_next/data/.../search.json`` response."""
+    dso: dict = {"jobOffers": jobs}
+    if total is not None:
+        dso["totalJobOfferCount"] = total
+    return {
+        "pageProps": {
+            "currentPage": 1,
+            "defaultSearchJobOfferData": dso,
+        }
+    }
+
+
+# --- registry ---------------------------------------------------------------
+
+
+def test_registry_resolves_greenjapan() -> None:
+    assert ScraperRegistry.get(ATSType.GREENJAPAN) is GreenJapanScraper
+
+
+# --- happy path -------------------------------------------------------------
+
+
+def test_discovers_build_id_and_walks_pages(httpx_mock) -> None:
+    # 20 jobs in page 1 (HTML), 10 in page 2 (JSON) → total=30
+    page1_jobs = [_job(id=i) for i in range(1, 21)]
+    page2_jobs = [_job(id=i) for i in range(21, 31)]
+    httpx_mock.add_response(
+        url=_LISTING_URL,
+        text=_listing_html(jobs=page1_jobs, total=30),
+    )
+    httpx_mock.add_response(
+        url="https://www.green-japan.com/_next/data/buildA/search.json?page=2",
+        json=_data_response(page2_jobs, total=30),
+    )
+
+    jobs = GreenJapanScraper("any").fetch()
+    assert {int(j.ats_id) for j in jobs} == set(range(1, 31))
+
+
+def test_maps_payload_fields_to_canonical_slots(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_LISTING_URL,
+        text=_listing_html(jobs=[_job()], total=1),
+    )
+
+    jobs = GreenJapanScraper("any").fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.GREENJAPAN
+    assert j.ats_id == "235863"
+    assert j.title == "システム開発エンジニア"
+    assert j.company == "株式会社 D・Ace"
+    assert j.country_iso == "JP"
+    assert j.region == "Asia"
+    assert j.language == "ja"
+    assert j.location == "東京都, 神奈川県, 千葉県"
+    assert str(j.url) == "https://www.green-japan.com/company/9939/job/235863"
+    assert j.salary_summary == "410万円〜800万円"
+    assert j.salary_currency == "JPY"
+    assert j.salary_period == "YEAR"
+    assert j.salary_min == 4_100_000.0
+    assert j.salary_max == 8_000_000.0
+    assert j.posted_at is not None
+    assert j.raw is not None
+    assert j.raw["skills"] == ["Python", "TypeScript", "Go"]
+    assert j.raw["tags"] == ["リモート勤務の相談可"]
+    assert j.raw["industry"] == "自由で効率的なシステム開発サービス"
+    assert j.raw["company_id"] == 9939
+    # headline is the marketing tagline distinct from the role name
+    assert j.raw["headline"] == "賞与実績 5.2ヶ月分"
+
+
+def test_uses_total_count_to_stop_pagination(httpx_mock) -> None:
+    """``totalJobOfferCount`` is the source of truth — we shouldn't
+    keep paging when we've already collected ``ceil(total/PER_PAGE)``
+    pages."""
+    httpx_mock.add_response(
+        url=_LISTING_URL,
+        text=_listing_html(jobs=[_job(id=1)], total=1),
+    )
+    # If the scraper tried page 2, httpx_mock would error out — there's
+    # no stub for it. Total=1 with PER_PAGE=20 means one page.
+    jobs = GreenJapanScraper("any").fetch()
+    assert len(jobs) == 1
+
+
+def test_max_pages_caps_walk(httpx_mock) -> None:
+    """When the total would imply 5 pages but max_pages=2, we cap."""
+    page1_jobs = [_job(id=i) for i in range(1, 21)]
+    httpx_mock.add_response(
+        url=_LISTING_URL,
+        text=_listing_html(jobs=page1_jobs, total=100),
+    )
+    page2_jobs = [_job(id=i) for i in range(21, 41)]
+    httpx_mock.add_response(
+        url=_DATA_RE,
+        json=_data_response(page2_jobs, total=100),
+    )
+    jobs = GreenJapanScraper("any", max_pages=2).fetch()
+    assert len(jobs) == 40
+
+
+# --- buildId rotation -------------------------------------------------------
+
+
+def test_re_discovers_build_id_on_404(httpx_mock) -> None:
+    page1_jobs = [_job(id=i) for i in range(1, 21)]
+    httpx_mock.add_response(
+        url=_LISTING_URL,
+        text=_listing_html(build_id="buildA", jobs=page1_jobs, total=30),
+    )
+    # First page-2 call: 404 because the build rotated.
+    httpx_mock.add_response(
+        url="https://www.green-japan.com/_next/data/buildA/search.json?page=2",
+        status_code=404,
+    )
+    # Re-discovery serves the new buildId.
+    httpx_mock.add_response(
+        url=_LISTING_URL,
+        text=_listing_html(build_id="buildB", jobs=page1_jobs, total=30),
+    )
+    httpx_mock.add_response(
+        url="https://www.green-japan.com/_next/data/buildB/search.json?page=2",
+        json=_data_response(
+            [_job(id=i) for i in range(21, 31)],
+            total=30,
+        ),
+    )
+    jobs = GreenJapanScraper("any").fetch()
+    assert {int(j.ats_id) for j in jobs} == set(range(1, 31))
+
+
+def test_missing_build_id_raises(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_LISTING_URL, text="<html>no nextjs here</html>",
+    )
+    with pytest.raises(ScraperError, match="buildId"):
+        GreenJapanScraper("any").fetch()
+
+
+def test_500_on_listing_raises(httpx_mock) -> None:
+    httpx_mock.add_response(url=_LISTING_URL, status_code=500, is_reusable=True)
+    with pytest.raises(ScraperError):
+        GreenJapanScraper("any").fetch()
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("410万円〜800万円", (4_100_000.0, 8_000_000.0)),
+    ("300〜600万円", (3_000_000.0, 6_000_000.0)),
+    ("500万円以上", (5_000_000.0, None)),
+    ("給与応相談", (None, None)),
+    ("", (None, None)),
+    (None, (None, None)),
+])
+def test_parse_jpy_salary(raw, expected) -> None:
+    assert _parse_jpy_salary(raw) == expected
+
+
+def test_parse_unix_timestamp_handles_ints() -> None:
+    dt = _parse_unix_timestamp(1778459021)
+    assert dt is not None
+    assert dt.year >= 2026
+
+
+def test_parse_unix_timestamp_rejects_garbage() -> None:
+    assert _parse_unix_timestamp(0) is None
+    assert _parse_unix_timestamp(None) is None
+    assert _parse_unix_timestamp("not a timestamp") is None

--- a/tests/test_hiredly.py
+++ b/tests/test_hiredly.py
@@ -1,0 +1,299 @@
+"""Tests for the Hiredly Malaysia scraper.
+
+Hiredly serves the same Next.js page-props payload on the ``/jobs`` HTML
+page and on ``_next/data/{buildId}/jobs.json``. Tests cover:
+
+- The buildId is discovered from the initial HTML fetch
+- The data endpoint is hit per-page with the discovered buildId
+- A 404 mid-walk triggers re-discovery (buildId rotation) and resumes
+- Job-payload mapping → Job model fields (title, slug→url, salary…)
+- Pagination terminates on consecutive empty pages
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import HiredlyScraper, ScraperRegistry
+from jobhive.scrapers.hiredly import (
+    _employment_type,
+    _parse_salary_range,
+)
+
+_LISTING_URL = "https://my.hiredly.com/jobs"
+_DATA_RE = re.compile(
+    r"^https://my\.hiredly\.com/_next/data/[^/]+/jobs\.json\?page=\d+$"
+)
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.hiredly as h
+    monkeypatch.setattr(h, "MAX_RETRIES", 1)
+    monkeypatch.setattr(h, "RETRY_BASE_DELAY", 0.0)
+
+
+def _listing_html(build_id: str = "buildA") -> str:
+    """Minimal HTML page that embeds the buildId in the same shape
+    Next.js emits on the real my.hiredly.com page."""
+    return (
+        "<html><head></head><body>"
+        '<script id="__NEXT_DATA__" type="application/json">'
+        + json.dumps({"buildId": build_id})
+        + "</script></body></html>"
+    )
+
+
+def _job(
+    *,
+    id: str = "4d8c9f48-563c-4360-82b7-51dfb8156b87",
+    title: str = "Sales Executive (Interior / Renovation)",
+    slug: str = "jobs-malaysia-yz-job-sales-executive",
+    company_name: str = "YZ HORIZON SDN BHD (SPACE MAKERS)",
+    company_slug: str = "yz-horizon-sdn-bhd-space-makers",
+    company_id: str = "b98c8f65-5b12-439e-b345-2be4d9553eb0",
+    state_region: str = "Selangor",
+    location: str = "13 Jalan P2/3, Semenyih, Selangor",
+    salary: str = "3000 - 4000",
+    job_type: str = "Full-Time",
+    active_at: str = "2026-04-30T18:46:00+08:00",
+    skills: list[str] | None = None,
+    tracks: list[str] | None = None,
+    career_level: str = "Junior Executive",
+    gpt_summary: str | None = "Great role at SPACE MAKERS.",
+    min_years_experience: int = 0,
+    category: str = "organic",
+) -> dict:
+    skills = skills if skills is not None else [
+        "Sales Management", "Negotiation",
+    ]
+    tracks = tracks if tracks is not None else ["Business Development"]
+    return {
+        "id": id,
+        "title": title,
+        "slug": slug,
+        "company": {
+            "id": company_id,
+            "name": company_name,
+            "slug": company_slug,
+        },
+        "stateRegion": state_region,
+        "location": location,
+        "salary": salary,
+        "jobType": job_type,
+        "activeAt": active_at,
+        "skills": [{"name": s} for s in skills],
+        "tracks": [{"id": str(i), "title": t} for i, t in enumerate(tracks)],
+        "careerLevel": career_level,
+        "gptSummary": gpt_summary,
+        "minYearsExperience": str(min_years_experience),
+        "category": category,
+    }
+
+
+def _data_response(jobs: list[dict]) -> dict:
+    return {"pageProps": {"jobs": jobs}, "__N_SSP": True}
+
+
+# --- registry ---------------------------------------------------------------
+
+
+def test_registry_resolves_hiredly() -> None:
+    assert ScraperRegistry.get(ATSType.HIREDLY) is HiredlyScraper
+
+
+# --- buildId discovery + happy path ----------------------------------------
+
+
+def test_discovers_build_id_and_walks_pages(httpx_mock) -> None:
+    httpx_mock.add_response(url=_LISTING_URL, text=_listing_html("buildA"))
+    httpx_mock.add_response(
+        url="https://my.hiredly.com/_next/data/buildA/jobs.json?page=1",
+        json=_data_response([_job(id="job-1", slug="jobs-malaysia-x-job-a")]),
+    )
+    httpx_mock.add_response(
+        url="https://my.hiredly.com/_next/data/buildA/jobs.json?page=2",
+        json=_data_response([]),
+    )
+    httpx_mock.add_response(
+        url="https://my.hiredly.com/_next/data/buildA/jobs.json?page=3",
+        json=_data_response([]),
+    )
+
+    jobs = HiredlyScraper("any").fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.HIREDLY
+    assert j.ats_id == "job-1"
+    assert j.title == "Sales Executive (Interior / Renovation)"
+    assert str(j.url) == (
+        "https://my.hiredly.com/jobs/jobs-malaysia-x-job-a"
+    )
+    assert j.country_iso == "MY"
+    assert j.language == "en"
+
+
+def test_maps_payload_fields_to_canonical_slots(httpx_mock) -> None:
+    httpx_mock.add_response(url=_LISTING_URL, text=_listing_html())
+    httpx_mock.add_response(
+        url=_DATA_RE,
+        json=_data_response([_job()]),
+    )
+    # Subsequent empty pages terminate pagination.
+    httpx_mock.add_response(url=_DATA_RE, json=_data_response([]),
+                            is_reusable=True)
+
+    jobs = HiredlyScraper("any").fetch()
+    j = jobs[0]
+    assert j.company == "YZ HORIZON SDN BHD (SPACE MAKERS)"
+    assert j.location == "Selangor"  # stateRegion preferred over street
+    assert j.salary_summary == "3000 - 4000"
+    assert j.salary_currency == "MYR"
+    assert j.salary_period == "MONTH"
+    assert j.salary_min == 3000.0
+    assert j.salary_max == 4000.0
+    assert j.employment_type == "FULL_TIME"
+    assert j.commitment == "Full-Time"
+    assert j.posted_at is not None
+    assert j.raw is not None
+    assert j.raw["skills"] == ["Sales Management", "Negotiation"]
+    assert j.raw["tracks"] == ["Business Development"]
+    assert j.raw["company_slug"] == "yz-horizon-sdn-bhd-space-makers"
+    assert j.raw["career_level"] == "Junior Executive"
+    assert j.raw["state_region"] == "Selangor"
+
+
+def test_falls_back_to_location_when_state_region_missing(httpx_mock) -> None:
+    httpx_mock.add_response(url=_LISTING_URL, text=_listing_html())
+    httpx_mock.add_response(
+        url=_DATA_RE,
+        json=_data_response([_job(state_region="", location="Kuala Lumpur")]),
+    )
+    httpx_mock.add_response(url=_DATA_RE, json=_data_response([]),
+                            is_reusable=True)
+    jobs = HiredlyScraper("any").fetch()
+    assert jobs[0].location == "Kuala Lumpur"
+
+
+# --- pagination -------------------------------------------------------------
+
+
+def test_paginates_across_multiple_pages(httpx_mock) -> None:
+    httpx_mock.add_response(url=_LISTING_URL, text=_listing_html())
+    httpx_mock.add_response(
+        url="https://my.hiredly.com/_next/data/buildA/jobs.json?page=1",
+        json=_data_response([_job(id="a"), _job(id="b")]),
+    )
+    httpx_mock.add_response(
+        url="https://my.hiredly.com/_next/data/buildA/jobs.json?page=2",
+        json=_data_response([_job(id="c")]),
+    )
+    # Two consecutive empty pages stop the walk.
+    httpx_mock.add_response(
+        url="https://my.hiredly.com/_next/data/buildA/jobs.json?page=3",
+        json=_data_response([]),
+    )
+    httpx_mock.add_response(
+        url="https://my.hiredly.com/_next/data/buildA/jobs.json?page=4",
+        json=_data_response([]),
+    )
+    jobs = HiredlyScraper("any").fetch()
+    assert {j.ats_id for j in jobs} == {"a", "b", "c"}
+
+
+def test_max_pages_caps_walk(httpx_mock) -> None:
+    httpx_mock.add_response(url=_LISTING_URL, text=_listing_html())
+    # Stub a fresh job per page; only ``max_pages`` will stop us.
+    for p in (1, 2, 3):
+        httpx_mock.add_response(
+            url=f"https://my.hiredly.com/_next/data/buildA/jobs.json?page={p}",
+            json=_data_response([_job(id=f"id-{p}")]),
+        )
+    jobs = HiredlyScraper("any", max_pages=3).fetch()
+    assert {j.ats_id for j in jobs} == {"id-1", "id-2", "id-3"}
+
+
+# --- buildId rotation -------------------------------------------------------
+
+
+def test_re_discovers_build_id_on_404(httpx_mock) -> None:
+    """If the buildId rotates mid-walk, ``_next/data/{old}/...`` starts
+    returning 404. We refetch ``/jobs`` to get the new buildId and retry."""
+    # Initial discovery → buildA
+    httpx_mock.add_response(url=_LISTING_URL, text=_listing_html("buildA"))
+    httpx_mock.add_response(
+        url="https://my.hiredly.com/_next/data/buildA/jobs.json?page=1",
+        json=_data_response([_job(id="a")]),
+    )
+    # Page 2 with the old build → 404 (rotated mid-walk)
+    httpx_mock.add_response(
+        url="https://my.hiredly.com/_next/data/buildA/jobs.json?page=2",
+        status_code=404,
+    )
+    # Re-discovery → buildB
+    httpx_mock.add_response(url=_LISTING_URL, text=_listing_html("buildB"))
+    httpx_mock.add_response(
+        url="https://my.hiredly.com/_next/data/buildB/jobs.json?page=2",
+        json=_data_response([_job(id="b")]),
+    )
+    # Two empties end the walk.
+    httpx_mock.add_response(
+        url=re.compile(
+            r"^https://my\.hiredly\.com/_next/data/buildB/jobs\.json\?page=[3-9]$"
+        ),
+        json=_data_response([]),
+        is_reusable=True,
+    )
+    jobs = HiredlyScraper("any").fetch()
+    assert {j.ats_id for j in jobs} == {"a", "b"}
+
+
+def test_missing_build_id_raises(httpx_mock) -> None:
+    """The buildId regex must match; an HTML page without it is fatal."""
+    httpx_mock.add_response(
+        url=_LISTING_URL, text="<html>no nextjs here</html>",
+    )
+    with pytest.raises(ScraperError, match="buildId"):
+        HiredlyScraper("any").fetch()
+
+
+def test_500_on_data_endpoint_raises(httpx_mock) -> None:
+    httpx_mock.add_response(url=_LISTING_URL, text=_listing_html())
+    httpx_mock.add_response(url=_DATA_RE, status_code=500, is_reusable=True)
+    with pytest.raises(ScraperError):
+        HiredlyScraper("any").fetch()
+
+
+# --- pure helpers -----------------------------------------------------------
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("3000 - 4000", (3000.0, 4000.0)),
+    ("3000-4000", (3000.0, 4000.0)),
+    ("3,000 – 4,500", (3000.0, 4500.0)),
+    ("4500", (4500.0, 4500.0)),
+    ("", (None, None)),
+    (None, (None, None)),
+    ("Negotiable", (None, None)),
+])
+def test_parse_salary_range(raw, expected) -> None:
+    assert _parse_salary_range(raw) == expected
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("Full-Time", "FULL_TIME"),
+    ("Part Time", "PART_TIME"),
+    ("Contract", "CONTRACT"),
+    ("Internship", "INTERN"),
+    ("Temporary", "TEMPORARY"),
+    ("Volunteer", None),
+    ("", None),
+    (None, None),
+])
+def test_employment_type_normalization(raw, expected) -> None:
+    assert _employment_type(raw) == expected

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -30,6 +30,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
         "manfred", "thehub", "ycombinator", "wellfound",
+        "hiredly", "greenjapan",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",
         "recruitee", "taleo", "teamtailor",


### PR DESCRIPTION
## Summary

Two Next.js SSR scrapers added in one PR:

- **Hiredly MY** (`my.hiredly.com`) — Malaysia direct-employer board (~6k live jobs). Hits the underlying `_next/data/{buildId}/jobs.json?page=N` endpoint after a one-shot HTML fetch for the `buildId`. Re-discovers and resumes when the build rotates mid-walk (404 → re-grep `/jobs`).
- **Green Japan** (`green-japan.com`) — Japanese tech-focused board (~29.6k jobs / 4k companies). Same Next.js shape: HTML fetch seeds `buildId` + page-1 jobs + `totalJobOfferCount` in one round-trip; subsequent pages hit `_next/data/{buildId}/search.json?page=N`. Pagination capped by the total.

Both scrapers follow the single-source pattern (matches `bundesagentur` / `eures` / `wanted` / `getonbrd`): `company_slug` is informational and ignored.

Schema additions:
- `ATSType.HIREDLY = "hiredly"`
- `ATSType.GREENJAPAN = "greenjapan"`
- Hiredly jobs ship with `country_iso="MY"`, `language="en"`, `salary_currency="MYR"`, `salary_period="MONTH"`.
- Green Japan jobs ship with `country_iso="JP"`, `region="Asia"`, `language="ja"`, `salary_currency="JPY"`, `salary_period="YEAR"`, with the 万円 unit converted to absolute JPY.

## Test plan

- [x] `ruff check` passes on changed files
- [x] `pytest tests/test_hiredly.py tests/test_greenjapan.py tests/test_models.py` — 102 tests pass
- [x] Full suite (`pytest -q`) — 919 tests pass
- [x] Hiredly parser verified against a live page-1 JSON pull (`buildId=7tMJZGsk3kcLPYRcf2dz9`)
- [x] Green Japan parser verified against the live `/search_key` HTML and `_next/data/{buildId}/search.json?page=2`
- [ ] Live discovery run once the scraper lands on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add scrapers for Hiredly MY and Green Japan. Both use Next.js `_next/data` endpoints with buildId discovery and auto-recovery when builds rotate.

- **New Features**
  - Added `HiredlyScraper` (`my.hiredly.com`) and `GreenJapanScraper` (`green-japan.com`); registered in `ScraperRegistry`.
  - Next.js flow: discover `buildId` from HTML, fetch pages via `_next/data/{buildId}/...`, retry with re-discovery on 404; bounded concurrency and retries.
  - Green Japan seeds page 1 + `totalJobOfferCount` from `__NEXT_DATA__`, then paginates `search.json?page=N` up to the total (or `max_pages`).
  - Hiredly paginates `jobs.json?page=N` until two empty pages or `max_pages`.
  - Single-source pattern; `company_slug` is ignored.
  - Schema: added `ATSType.HIREDLY` and `ATSType.GREENJAPAN`. Defaults—Hiredly: `country_iso="MY"`, `language="en"`, `salary_currency="MYR"`, `salary_period="MONTH"`. Green Japan: `country_iso="JP"`, `region="Asia"`, `language="ja"`, `salary_currency="JPY"`, `salary_period="YEAR"`, with 万円 converted to JPY.

<sup>Written for commit a09e0bc2654075aa2078909da3793b327db2e4ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds two new single-source Next.js scrapers — Hiredly MY (`my.hiredly.com`) and Green Japan (`green-japan.com`) — following the established `bundesagentur`/`eures` pattern. Both discover the `buildId` from an initial HTML fetch, walk `_next/data/{buildId}/…` JSON pages with bounded concurrency, and handle mid-walk build rotation via re-discovery.

- **Hiredly** paginates `jobs.json?page=N` until two consecutive empty pages or `max_pages`, mapping MYR monthly salary ranges and normalising Malaysian state regions.
- **Green Japan** seeds page 1 + `totalJobOfferCount` from `__NEXT_DATA__` in a single HTML round-trip, then paginates `search.json?page=N` up to the total, converting 万円 ranges to absolute JPY.
- Both scrapers set `fetched_at=datetime.now()` (naive) while `posted_at` can be timezone-aware, creating a mixed-awareness `Job` object that will raise `TypeError` on any datetime comparison downstream.

<h3>Confidence Score: 3/5</h3>

Both new scrapers produce Job objects with a naive fetched_at alongside a potentially timezone-aware posted_at, which will raise TypeError wherever those fields are compared or subtracted.

Both scraper files mix naive datetime.now() for fetched_at with timezone-aware datetimes for posted_at. Any downstream code that compares or subtracts these two fields will raise TypeError at runtime. The fix is a one-character change per file, but until applied the scrapers ship inconsistent Job objects on every invocation.

Both src/jobhive/scrapers/greenjapan.py and src/jobhive/scrapers/hiredly.py need the fetched_at fix; the assert-based guards and the _parse_date fallback in hiredly.py are also worth a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/greenjapan.py | New Green Japan scraper with buildId discovery, paginated _next/data fetching, and 万円 salary parsing; has naive `fetched_at` datetime, assert-based guard, and re-discovery that discards fresh page-1 data. |
| src/jobhive/scrapers/hiredly.py | New Hiredly Malaysia scraper with same Next.js buildId pattern; naive `fetched_at`, assert guard, and `_parse_date` fallback that strips timezone offset need attention. |
| tests/test_greenjapan.py | Thorough test coverage: buildId discovery, multi-page walk, total-count capping, 404-triggered re-discovery, salary parsing, and error paths all tested. |
| tests/test_hiredly.py | Good coverage of buildId rotation, payload mapping, pagination termination, and salary/employment-type helpers; no test for fetched_at timezone awareness. |
| src/jobhive/models.py | Two new ATSType enum values added in the correct location; straightforward and safe. |
| src/jobhive/scrapers/__init__.py | Both scrapers imported and added to `__all__`; alphabetical ordering maintained correctly. |
| tests/test_models.py | Existing model test updated to include both new ATSType values in the exhaustive platform list. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 6 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 6
src/jobhive/scrapers/greenjapan.py:354
`fetched_at=datetime.now()` produces a naive (timezone-unaware) datetime, while `posted_at` is set to a timezone-aware UTC value via `_parse_unix_timestamp`. Mixing naive and aware datetimes raises `TypeError` on any comparison or arithmetic (`fetched_at - posted_at`). `UTC` is already imported in this file — the same fix applies to `hiredly.py` (where `UTC` needs to be added to the `from datetime import datetime` import as well).

```suggestion
            fetched_at=datetime.now(UTC),
```

### Issue 2 of 6
src/jobhive/scrapers/hiredly.py:326
`fetched_at=datetime.now()` is naive while `posted_at` can be timezone-aware (e.g. `datetime.fromisoformat("2026-04-30T18:46:00+08:00")` returns an aware datetime). Any comparison or subtraction between the two fields would raise `TypeError`. The fix requires also updating the import from `from datetime import datetime` to `from datetime import UTC, datetime`.

```suggestion
            fetched_at=datetime.now(UTC),
```

### Issue 3 of 6
src/jobhive/scrapers/greenjapan.py:227
Python `assert` statements are silently stripped when the interpreter runs with the `-O` (optimize) flag. If `_build_id` is `None` here in production, the code would proceed to build a malformed URL (`/_next/data/None/search.json`) rather than failing fast with a clear error. Same pattern exists at the same relative position in `hiredly.py`.

```suggestion
        if self._build_id is None:  # pragma: no cover
            raise ScraperError("Green Japan: _build_id not initialised before _fetch_data_page")
```

### Issue 4 of 6
src/jobhive/scrapers/hiredly.py:194-197
Same `assert` → silent no-op under `-O` concern as in `greenjapan.py`.

```suggestion
        if self._build_id is None:  # pragma: no cover
            raise ScraperError("Hiredly: _build_id not initialised before _fetch_data_page")
        url = (
            f"{API_ROOT}/_next/data/{self._build_id}/jobs.json?page={page}"
        )
```

### Issue 5 of 6
src/jobhive/scrapers/greenjapan.py:183-196
**Re-discovery silently discards updated total and page-1 jobs from new build**

`_rediscover_build_id` calls `_discover_and_first_page` and throws away both `_items` (the fresh page-1 job list) and `_total` (the updated total from the new build). The outer loop's `page_count` was computed from the original total and is never refreshed. If a deploy rotates the build mid-walk and the new build's total differs, the scraper will either under-fetch or wastefully over-page past the new ceiling. The same discard pattern exists in Hiredly's `_discover_build_id` re-call during rotation.

### Issue 6 of 6
src/jobhive/scrapers/hiredly.py:420-434
**Fallback path strips timezone offset, producing a naive `datetime`**

If `datetime.fromisoformat(text)` raises (e.g. on Python < 3.11, which doesn't support the `+HH:MM` offset in `fromisoformat`), the fallback `text.split("+")[0]` strips the timezone and returns a naive datetime while a successful primary-path parse returns an aware one. If this codebase targets Python < 3.11, every `+08:00` timestamp will silently lose its timezone. Confirm the minimum supported Python version; if it's 3.11+ the fallback is dead code and can be removed.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add Hiredly MY and Green Japan scrapers"](https://github.com/kalil0321/ats-scrapers/commit/a09e0bc2654075aa2078909da3793b327db2e4ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732461)</sub>

> Greptile also left **6 inline comments** on this PR.

<!-- /greptile_comment -->