### PR TITLE
Add JobKorea (잡코리아) scraper

### DIFF
--- a/ats-companies/jobkorea.csv
+++ b/ats-companies/jobkorea.csv
@@ -1,0 +1,2 @@
+name,slug,url
+JobKorea,jobkorea,https://www.jobkorea.co.kr

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -76,6 +76,7 @@ class ATSType(StrEnum):
     PROGRAMATHOR = "programathor"
     BUILTIN = "builtin"
     JOBSCH = "jobsch"
+    JOBKOREA = "jobkorea"
     MANFRED = "manfred"
     THEHUB = "thehub"
     YCOMBINATOR = "ycombinator"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -27,6 +27,7 @@ from jobhive.scrapers.google import GoogleScraper
 from jobhive.scrapers.greenhouse import GreenhouseScraper
 from jobhive.scrapers.icims import iCIMSScraper
 from jobhive.scrapers.jazzhr import JazzHRScraper
+from jobhive.scrapers.jobkorea import JobKoreaScraper
 from jobhive.scrapers.jobsch import JobsChScraper
 from jobhive.scrapers.join_com import JoinComScraper
 from jobhive.scrapers.lever import LeverScraper
@@ -78,6 +79,7 @@ __all__ = [
     "GoogleScraper",
     "GreenhouseScraper",
     "JazzHRScraper",
+    "JobKoreaScraper",
     "JobsChScraper",
     "JoinComScraper",
     "LeverScraper",

--- a/src/jobhive/scrapers/jobkorea.py
+++ b/src/jobhive/scrapers/jobkorea.py
@@ -33,7 +33,6 @@ from typing import TYPE_CHECKING
 from urllib.parse import quote_plus
 
 import httpx
-from bs4 import BeautifulSoup
 
 from jobhive.exceptions import ScraperError
 from jobhive.models import ATSType, Job
@@ -215,6 +214,14 @@ class JobKoreaScraper(BaseScraper):
     # --- parsing ------------------------------------------------------------
 
     def _parse_page(self, html_text: str) -> list[Job]:
+        try:
+            from bs4 import BeautifulSoup
+        except ImportError as exc:  # pragma: no cover
+            raise ScraperError(
+                "JobKorea scraper requires beautifulsoup4. Install with "
+                "`pip install jobhive[scrapers]` or `pip install beautifulsoup4`."
+            ) from exc
+
         soup = BeautifulSoup(html_text, "html.parser")
         # Cards are rendered by the ``CardJob`` Next.js component. The
         # outer ``<div data-sentry-component="CardJob">`` wraps every

--- a/src/jobhive/scrapers/jobkorea.py
+++ b/src/jobhive/scrapers/jobkorea.py
@@ -1,0 +1,416 @@
+"""JobKorea (https://www.jobkorea.co.kr) — Korea's top job board.
+
+JobKorea (잡코리아) is one of the two dominant direct-posting job
+platforms in Korea — competing head-to-head with Saramin, with
+hundreds of thousands of live postings across every industry.
+Companies post directly through JobKorea's recruiting product.
+
+The search page is a Next.js app whose server-rendered HTML embeds
+the listing cards inline (each as a ``data-sentry-component="CardJob"``
+block). We GET the integrated-search endpoint and pull listing cards
+out of the response body via BeautifulSoup. Pagination is offset-style
+through ``Page_No=N`` with ~25 cards per page; once the result set is
+exhausted JobKorea silently falls back to the same 5-card sponsored
+banner on every subsequent page (rather than returning a 4xx or an
+empty page), so the scraper terminates when two consecutive pages
+fail to introduce a new ``GI_No``.
+
+Single-source scraper: ``company_slug`` is reused as the *stext*
+(search term) so callers can scope a sweep to a vertical
+(``"developer"``, ``"디자이너"``, ``"마케팅"`` …). Passing ``"any"`` /
+empty falls back to the no-keyword landing — which JobKorea fills
+with sponsored TOP banner cards (~20 per page, low signal). For
+meaningful coverage, pick a keyword.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING
+from urllib.parse import quote_plus
+
+import httpx
+from bs4 import BeautifulSoup
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+API_ROOT = "https://www.jobkorea.co.kr"
+SEARCH_PATH = "/Search/"
+JOB_URL_TEMPLATE = "https://www.jobkorea.co.kr/Recruit/GI_Read/{gi_no}"
+# JobKorea's UI renders 20-25 cards per page; this is informational
+# (we don't actually pass it as a query param — the site doesn't
+# honour a page-size param on this endpoint).
+MAX_PAGES = 1000
+MAX_RETRIES = 4
+RETRY_BASE_DELAY = 1.5
+
+# Empty stext on JobKorea renders the no-keyword landing with sponsored
+# banner cards. Use the same sentinel set as wanted / saramin so
+# single-source scrapers stay swappable across the codebase.
+_EMPTY_SLUGS = {"", "any", "all", "jobkorea"}
+
+# Korean employment-type tokens — same vocabulary as Saramin, since the
+# two platforms compete for the same employer base and share label
+# conventions. Combo strings ("정규직·계약직") resolve to the most
+# permanent classification via ``_EMPLOYMENT_TYPE_PRIORITY``.
+#
+# - 정규직   : permanent / full-time
+# - 계약직   : fixed-term contract
+# - 인턴(직) : intern
+# - 파견직   : dispatched/agency worker → CONTRACT
+# - 프리랜서 : freelance → CONTRACT
+# - 아르바이트 : part-time / hourly → PART_TIME
+# - 파트타임 : part-time
+# - 위촉직   : commissioned (sales agent contract) → CONTRACT
+# - 일용직   : day-laborer / temporary → TEMPORARY
+_EMPLOYMENT_TYPE_MAP: dict[str, str] = {
+    "정규직": "FULL_TIME",
+    "계약직": "CONTRACT",
+    "인턴": "INTERN",
+    "인턴직": "INTERN",
+    "파견직": "CONTRACT",
+    "프리랜서": "CONTRACT",
+    "아르바이트": "PART_TIME",
+    "파트타임": "PART_TIME",
+    "위촉직": "CONTRACT",
+    "일용직": "TEMPORARY",
+}
+_EMPLOYMENT_TYPE_PRIORITY = (
+    "FULL_TIME", "INTERN", "CONTRACT", "PART_TIME", "TEMPORARY",
+)
+
+# JobKorea encodes the job id as a ``GI_No`` integer that also doubles
+# as the ``GI_Read/{id}`` slug. The site sometimes wraps the link in
+# ``?Oem_Code=...&listno=...`` tracking params; strip back to the bare
+# id so the row stays stable across re-scrapes.
+_GI_READ_RE = re.compile(r"/Recruit/GI_Read/(\d+)")
+
+
+@ScraperRegistry.register(ATSType.JOBKOREA)
+class JobKoreaScraper(BaseScraper):
+    """JobKorea (jobkorea.co.kr) — Korea's top direct-posting platform.
+
+    Single-source scraper: ``company_slug`` is used as the ``stext``
+    (search term) query param so callers can scope sweeps to a vertical
+    (e.g. ``JobKoreaScraper("개발자")`` for developer postings, or
+    ``JobKoreaScraper("디자이너")`` for designer roles). Pass ``"any"``
+    / ``""`` for an unscoped run (yields only the sponsored landing
+    cards — coverage is intentionally narrow for that path).
+    """
+
+    ats = ATSType.JOBKOREA
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        max_pages: int = MAX_PAGES,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.max_pages = max(1, min(max_pages, MAX_PAGES))
+        self._stext = (
+            "" if company_slug.strip().lower() in _EMPTY_SLUGS
+            else company_slug.strip()
+        )
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        # Detect end-of-results by tracking whether each page added a new
+        # ``GI_No`` to the seen-set. Once two pages in a row fail to add
+        # any new id we treat the sweep as exhausted — JobKorea silently
+        # returns the same ~5 sponsored cards on out-of-range pages so a
+        # pure HTTP-status / card-count check would loop forever.
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        consecutive_empty = 0
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True
+        ) as client:
+            for page in range(1, self.max_pages + 1):
+                page_html = await self._request_html(client, page)
+                page_jobs = self._parse_page(page_html)
+                added = 0
+                for job in page_jobs:
+                    if job.ats_id in seen:
+                        continue
+                    seen.add(job.ats_id)
+                    jobs.append(job)
+                    added += 1
+                if added == 0:
+                    consecutive_empty += 1
+                    if consecutive_empty >= 2:
+                        break
+                else:
+                    consecutive_empty = 0
+        return jobs
+
+    # --- HTTP layer ---------------------------------------------------------
+
+    def _build_url(self, page: int) -> str:
+        stext = quote_plus(self._stext)
+        return f"{API_ROOT}{SEARCH_PATH}?stext={stext}&Page_No={page}"
+
+    async def _request_html(
+        self,
+        client: httpx.AsyncClient,
+        page: int,
+    ) -> str:
+        url = self._build_url(page)
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                response = await client.get(
+                    url,
+                    headers={
+                        "User-Agent": (
+                            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                            "AppleWebKit/537.36 (KHTML, like Gecko) "
+                            "Chrome/124.0.0.0 Safari/537.36"
+                        ),
+                        "Accept": "text/html,application/xhtml+xml",
+                        "Accept-Language": "ko-KR,ko;q=0.9,en-US;q=0.8",
+                    },
+                )
+            except httpx.HTTPError as exc:
+                last_exc = exc
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"JobKorea fetch failed for {url}: {exc}"
+                    ) from exc
+                await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                continue
+            if response.status_code == 200:
+                return response.text
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"JobKorea returned {response.status_code} for "
+                        f"{url} after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"JobKorea returned {response.status_code} for {url}"
+            )
+        raise ScraperError(
+            f"JobKorea exhausted retries for {url}: {last_exc}"
+        )
+
+    # --- parsing ------------------------------------------------------------
+
+    def _parse_page(self, html_text: str) -> list[Job]:
+        soup = BeautifulSoup(html_text, "html.parser")
+        # Cards are rendered by the ``CardJob`` Next.js component. The
+        # outer ``<div data-sentry-component="CardJob">`` wraps every
+        # listing — including sponsored / banner cards on the no-keyword
+        # landing. We pick them by that attribute rather than a Tailwind
+        # class chain (which is auto-generated and unstable).
+        cards = soup.select('div[data-sentry-component="CardJob"]')
+        out: list[Job] = []
+        for card in cards:
+            job = self._parse_card(card)
+            if job is not None:
+                out.append(job)
+        return out
+
+    def _parse_card(self, card: Any) -> Job | None:
+        # ats_id lives inside ``/Recruit/GI_Read/{id}`` on any of the
+        # card's anchors (title, company-name, logo). Pick the first
+        # one we find — they all point at the same posting.
+        ats_id: str | None = None
+        for a in card.select("a[href*='/Recruit/GI_Read/']"):
+            m = _GI_READ_RE.search(a.get("href") or "")
+            if m:
+                ats_id = m.group(1)
+                break
+        if not ats_id:
+            return None
+
+        # JobKorea wraps the actual title in the ``Title`` link
+        # component; the visible span carries the human-readable string.
+        title_link = card.select_one(
+            'a[data-sentry-component="Title"] span'
+        )
+        title = (
+            title_link.get_text(strip=True) if title_link is not None
+            else ""
+        )
+        if not title:
+            return None
+        title = html.unescape(title)
+
+        # The bare ``GI_Read/{id}`` form is the canonical posting URL —
+        # strip the tracking querystring (``?Oem_Code=...&logpath=...``)
+        # the site adds for analytics so re-scrapes stay stable.
+        url = JOB_URL_TEMPLATE.format(gi_no=ats_id)
+
+        # Company name lives in a sibling ``<a>`` immediately after the
+        # title block — visually it's the smaller-typography line. We
+        # pick the first non-Title anchor that points at GI_Read
+        # (which on JobKorea also doubles as the company-link).
+        company = _extract_company(card)
+
+        # Each card has 1–3 ``GrayChip`` blocks beneath the title:
+        # location, job-category breadcrumb, optional salary. Classify
+        # by the embedded emoji icon class — the order is consistent
+        # but a card may omit any subset, so we look up by icon rather
+        # than positional index.
+        location, sector, salary_label = _parse_chips(card)
+
+        # The bottom row of the card shows experience requirement
+        # (``경력무관`` / ``신입`` / ``경력4년↑`` …) in a small
+        # ``text-typo-c1-13`` span. Employment-type may also surface
+        # in the title prefix (``[정규직] ...``) or as a separate badge.
+        experience_label = _extract_experience(card)
+
+        employment_type_label, employment_type = _detect_employment_type(
+            title
+        )
+
+        raw: dict[str, Any] = {}
+        if sector:
+            raw["sector"] = sector
+        if salary_label:
+            raw["salary_label"] = salary_label
+        if experience_label:
+            raw["experience"] = experience_label
+        if employment_type_label:
+            raw["employment_type_label"] = employment_type_label
+
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.JOBKOREA,
+            ats_id=ats_id,
+            location=location,
+            country_iso="KR",
+            language="ko",
+            employment_type=employment_type,  # type: ignore[arg-type]
+            description=sector or None,
+            posted_at=None,  # JobKorea cards don't expose a 'posted at' field
+            fetched_at=datetime.now(),
+            raw=raw or None,
+        )
+
+
+def _extract_company(card: Any) -> str:
+    """Pull the company name out of the card.
+
+    The company-name anchor sits just below the title block. It points
+    at the same ``GI_Read/{id}`` URL as the title link, but its inner
+    ``<span class="truncate text-gray700 text-typo-b2-16">`` carries
+    the company display name.
+    """
+    span = card.select_one("span.truncate.text-gray700.text-typo-b2-16")
+    if span is not None:
+        text = html.unescape(span.get_text(strip=True))
+        if text:
+            return text
+    # Fallback: image alt text on the logo (``"{company} 로고"``) — used
+    # when the company-name span is absent (rare; happens on a few
+    # sponsored placements).
+    logo = card.select_one("img[alt$=' 로고']")
+    if logo is not None:
+        alt = (logo.get("alt") or "").strip()
+        if alt.endswith(" 로고"):
+            return alt[:-3].strip() or "Unknown"
+    return "Unknown"
+
+
+def _parse_chips(
+    card: Any,
+) -> tuple[str | None, str | None, str | None]:
+    """Classify each ``GrayChip`` block on the card.
+
+    Three orthogonal chips may appear, in any subset:
+      * ``place2`` icon → location (``서울 송파구 외 5``)
+      * ``briefcase`` icon → job-category breadcrumb
+      * ``money_bill`` icon → salary label (``월급 400~500만원``)
+
+    Classify by the embedded emoji class so adding a new chip type
+    on JobKorea's side doesn't silently break the mapping.
+    """
+    location: str | None = None
+    sector: str | None = None
+    salary_label: str | None = None
+    for chip in card.select('div[data-sentry-component="GrayChip"]'):
+        emoji = chip.select_one("span[class*='emoji--basicemoji-']")
+        text_span = chip.select_one("span.truncate")
+        if text_span is None:
+            continue
+        text = html.unescape(text_span.get_text(strip=True))
+        if not text:
+            continue
+        emoji_classes = (emoji.get("class") if emoji is not None else []) or []
+        emoji_class = " ".join(emoji_classes)
+        if "place2" in emoji_class:
+            location = text
+        elif "briefcase" in emoji_class:
+            sector = text
+        elif "money_bill" in emoji_class:
+            salary_label = text
+    return location, sector, salary_label
+
+
+def _extract_experience(card: Any) -> str | None:
+    """Return the experience label (``경력무관`` / ``신입`` / ``경력4년↑``).
+
+    The label lives in a small ``text-typo-c1-13`` span in the
+    bottom-row of the card. JobKorea also reuses that class for the
+    'today's hot post' badge in the top-right, so we restrict the
+    search to spans whose text starts with an experience-related token.
+    """
+    for span in card.select("span.text-typo-c1-13"):
+        text = html.unescape(span.get_text(strip=True))
+        if not text:
+            continue
+        if any(
+            text.startswith(prefix)
+            for prefix in ("경력", "신입", "병역")
+        ):
+            return text
+    return None
+
+
+def _detect_employment_type(
+    title: str,
+) -> tuple[str | None, str | None]:
+    """Look for an employment-type token in the listing title.
+
+    JobKorea cards don't expose a structured employment-type field on
+    the listing card the way Saramin does; employers conventionally
+    prefix the title with the type in square brackets (``[정규직]``,
+    ``[계약직]``, ``[인턴]``) when it's notable. We surface both the
+    raw token and the normalized enum value.
+    """
+    if not title:
+        return None, None
+    matched: set[str] = set()
+    raw_tokens: list[str] = []
+    for token, normalized in _EMPLOYMENT_TYPE_MAP.items():
+        if token in title:
+            matched.add(normalized)
+            raw_tokens.append(token)
+    if not matched:
+        return None, None
+    for candidate in _EMPLOYMENT_TYPE_PRIORITY:
+        if candidate in matched:
+            return raw_tokens[0], candidate
+    return raw_tokens[0], next(iter(matched))

--- a/tests/test_jobkorea.py
+++ b/tests/test_jobkorea.py
@@ -1,0 +1,475 @@
+"""Tests for the JobKorea (잡코리아 — Korea's top job board) scraper.
+
+The JobKorea search page is a Next.js app whose server-rendered HTML
+embeds each listing inside a ``data-sentry-component="CardJob"``
+block. We pin the parsing contract for that markup, the offset-style
+pagination through ``Page_No=N``, and the end-of-results detection
+(sponsored cards repeat on out-of-range pages).
+
+Fixtures embed real HTML excerpts captured from
+``https://www.jobkorea.co.kr/Search/?stext=...&Page_No=1`` — keep them
+faithful to the live markup so a future site redesign is caught by
+the suite.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import JobKoreaScraper, ScraperRegistry
+
+_SEARCH_RE = re.compile(r"^https://www\.jobkorea\.co\.kr/Search/\?")
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.jobkorea as jk
+    monkeypatch.setattr(jk, "MAX_RETRIES", 1)
+    monkeypatch.setattr(jk, "RETRY_BASE_DELAY", 0.0)
+
+
+# --- HTML fixtures ----------------------------------------------------------
+
+
+def _card(
+    *,
+    gi_no: str = "49155209",
+    title: str = "백엔드 개발자 채용",
+    company: str = "㈜라웰드",
+    location: str | None = "서울 송파구 외 5",
+    sector: str | None = "솔루션·SI·CRM·ERP, 백엔드개발자",
+    salary_label: str | None = "월급 400~500만원",
+    experience: str | None = "경력4년↑",
+    include_company_span: bool = True,
+    company_alt: str | None = None,
+) -> str:
+    """Render a JobKorea ``CardJob`` block matching the live Next.js markup."""
+    href = (
+        f"https://www.jobkorea.co.kr/Recruit/GI_Read/{gi_no}"
+        f"?Oem_Code=C1&amp;logpath=1&amp;listno=1&amp;sc=630"
+    )
+
+    chips = []
+    if location is not None:
+        chips.append(
+            '<div data-sentry-component="GrayChip">'
+            '<div class="w-[16px] shrink-0">'
+            '<span class="emoji--basicemoji-place2 inline-block"></span>'
+            '</div>'
+            f'<span class="truncate text-gray900 text-typo-b4-14">{location}</span>'
+            '</div>'
+        )
+    if sector is not None:
+        chips.append(
+            '<div data-sentry-component="GrayChip">'
+            '<div class="w-[16px] shrink-0">'
+            '<span class="emoji--basicemoji-briefcase inline-block"></span>'
+            '</div>'
+            f'<span class="truncate text-gray900 text-typo-b4-14">{sector}</span>'
+            '</div>'
+        )
+    if salary_label is not None:
+        chips.append(
+            '<div data-sentry-component="GrayChip">'
+            '<div class="w-[16px] shrink-0">'
+            '<span class="emoji--basicemoji-money_bill inline-block"></span>'
+            '</div>'
+            f'<span class="truncate text-gray900 text-typo-b4-14">{salary_label}</span>'
+            '</div>'
+        )
+    chips_html = "".join(chips)
+
+    experience_html = (
+        f'<span class="flex-shrink-0 text-gray700 text-typo-c1-13">{experience}</span>'
+        if experience is not None else ""
+    )
+
+    company_span = (
+        f'<a href="{href}" data-sentry-element="BaseLink">'
+        f'<span class="truncate text-gray700 text-typo-b2-16">{company}</span>'
+        '</a>'
+        if include_company_span else ""
+    )
+    company_logo_alt = company_alt if company_alt is not None else f"{company} 로고"
+
+    return f"""
+    <div data-sentry-component="CardJob" class="w-full rounded-2xl shadow-list bg-white">
+      <div class="flex flex-col">
+        <div class="flex w-full gap-5 p-7">
+          <a href="{href}" data-sentry-component="CompanyLogo">
+            <img alt="{company_logo_alt}" />
+          </a>
+          <div class="w-full">
+            <div class="relative mb-[6px] flex items-center justify-between">
+              <div data-sentry-component="BadgeItem">
+                <span class="font-semibold text-typo-c1-13 text-brand-accent">오늘 뜬 따끈한 공고</span>
+              </div>
+            </div>
+            <div class="mb-0.5">
+              <a href="{href}" data-sentry-component="Title">
+                <span class="truncate font-semibold text-typo-b1-18 text-gray900">{title}</span>
+              </a>
+            </div>
+            <span class="mb-5 inline-flex items-center gap-[6px]">
+              {company_span}
+            </span>
+            <div class="flex flex-col gap-[10px]">
+              <div class="flex justify-between">
+                <div class="flex max-w-[643px] gap-2">{chips_html}</div>
+              </div>
+              <div class="flex items-center justify-between">
+                <div class="flex max-w-[565px] items-center gap-[2px]">
+                  {experience_html}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+
+
+def _page(cards_html: str = "", total: str = "총 21,429건") -> str:
+    return f"""
+    <!doctype html>
+    <html lang="ko">
+      <head><title>'개발자' 관련 채용공고 | {total}의 검색결과</title></head>
+      <body>
+        <div class="flex flex-col gap-4">
+          {cards_html}
+        </div>
+      </body>
+    </html>
+    """
+
+
+# --- registry / wiring ------------------------------------------------------
+
+
+def test_registry_resolves_jobkorea() -> None:
+    assert ScraperRegistry.get(ATSType.JOBKOREA) is JobKoreaScraper
+
+
+def test_ats_type_enum_value() -> None:
+    """The string value is part of the public schema — pin it."""
+    assert ATSType.JOBKOREA == "jobkorea"
+
+
+# --- happy path -------------------------------------------------------------
+
+
+def test_parses_full_card(httpx_mock) -> None:
+    """Single-page scrape; verify every populated Job field maps to the
+    right HTML region of a JobKorea card."""
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(_card()))
+    # Two consecutive empty pages → exhausts the sweep.
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""), is_reusable=True)
+
+    jobs = JobKoreaScraper("developer").fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.JOBKOREA
+    assert j.ats_id == "49155209"
+    assert j.title == "백엔드 개발자 채용"
+    assert j.company == "㈜라웰드"
+    assert str(j.url) == (
+        "https://www.jobkorea.co.kr/Recruit/GI_Read/49155209"
+    )
+    assert j.country_iso == "KR"
+    assert j.language == "ko"
+    assert j.location == "서울 송파구 외 5"
+    assert j.raw is not None
+    assert j.raw.get("sector") == "솔루션·SI·CRM·ERP, 백엔드개발자"
+    assert j.raw.get("salary_label") == "월급 400~500만원"
+    assert j.raw.get("experience") == "경력4년↑"
+
+
+def test_global_id_uses_jobkorea_prefix(httpx_mock) -> None:
+    """``global_id`` should be ``jobkorea:{gi_no}`` so cross-ATS dedup
+    works for postings that happen to be syndicated elsewhere."""
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(_card(gi_no="999")))
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""), is_reusable=True)
+
+    jobs = JobKoreaScraper("dev").fetch()
+    assert jobs[0].global_id == "jobkorea:999"
+
+
+def test_strips_tracking_querystring_from_url(httpx_mock) -> None:
+    """The card link carries ``?Oem_Code=&logpath=&listno=`` analytics
+    params — the emitted ``url`` should be the canonical bare form so
+    re-scrapes stay stable across days."""
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(_card(gi_no="42")))
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""), is_reusable=True)
+
+    jobs = JobKoreaScraper("dev").fetch()
+    assert str(jobs[0].url) == "https://www.jobkorea.co.kr/Recruit/GI_Read/42"
+
+
+# --- pagination -------------------------------------------------------------
+
+
+def test_paginates_until_two_empty_pages(httpx_mock) -> None:
+    """JobKorea doesn't expose a total-pages count — we walk until two
+    consecutive pages add no new ids (its end-of-result behavior is
+    repeating the same sponsored cards, not returning empty HTML)."""
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        text=_page(_card(gi_no="100")),
+    )
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        text=_page(_card(gi_no="200")),
+    )
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""))  # 1st no-new-id
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""))  # 2nd → stop
+
+    jobs = JobKoreaScraper("dev").fetch()
+    assert {j.ats_id for j in jobs} == {"100", "200"}
+
+
+def test_terminates_when_sponsored_cards_repeat(httpx_mock) -> None:
+    """Beyond the real result tail, JobKorea returns the same ~5
+    sponsored cards on every subsequent page (rather than an HTTP
+    error or an empty body). Two repeats in a row should terminate
+    the sweep — otherwise we'd loop forever."""
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        text=_page(_card(gi_no="1") + _card(gi_no="2")),
+    )
+    # Page 2: same two ids repeated — adds 0 new ids.
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        text=_page(_card(gi_no="1") + _card(gi_no="2")),
+    )
+    # Page 3: same again — 2nd consecutive no-new-id page → stop.
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        text=_page(_card(gi_no="1") + _card(gi_no="2")),
+    )
+
+    jobs = JobKoreaScraper("dev").fetch()
+    assert {j.ats_id for j in jobs} == {"1", "2"}
+
+
+def test_dedupes_repeated_cards_across_pages(httpx_mock) -> None:
+    """Sponsored cards repeat across pages; the scraper must collapse
+    them on ``ats_id`` so the row count is meaningful."""
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        text=_page(_card(gi_no="1") + _card(gi_no="2")),
+    )
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        # Page 2 repeats id=2 and adds id=3
+        text=_page(_card(gi_no="2") + _card(gi_no="3")),
+    )
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""), is_reusable=True)
+
+    jobs = JobKoreaScraper("dev").fetch()
+    assert {j.ats_id for j in jobs} == {"1", "2", "3"}
+
+
+def test_max_pages_clamps_to_safety_ceiling() -> None:
+    """``max_pages`` is internally clamped to ``MAX_PAGES`` (1000) so a
+    caller passing a huge number can't accidentally hammer the site."""
+    scraper = JobKoreaScraper("dev", max_pages=10_000)
+    assert scraper.max_pages == 1000
+
+
+def test_max_pages_honours_lower_caller_override(httpx_mock) -> None:
+    """A caller can set a tighter cap for a quick sample-pass."""
+    # Pad with cards on every page so the empty-tail logic doesn't stop
+    # the sweep before max_pages is reached.
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        text=_page(_card(gi_no="500")),
+        is_reusable=True,
+    )
+
+    jobs = JobKoreaScraper("dev", max_pages=2).fetch()
+    # De-dup on a single gi_no means at most one job is yielded —
+    # proving max_pages didn't allow an unbounded sweep.
+    assert len(jobs) == 1
+
+
+# --- empty-stext path -------------------------------------------------------
+
+
+def test_empty_slug_omits_search_term(httpx_mock) -> None:
+    """``JobKoreaScraper("any")`` falls back to no keyword. Verify the
+    URL omits a quoted keyword body so the server treats it as the
+    no-keyword landing."""
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""), is_reusable=True)
+
+    JobKoreaScraper("any", max_pages=1).fetch()
+    requests = httpx_mock.get_requests()
+    assert requests
+    url = str(requests[0].url)
+    assert "stext=&" in url or url.endswith("stext=")
+
+
+def test_explicit_keyword_is_url_encoded(httpx_mock) -> None:
+    """Korean keywords are common; they must be percent-encoded so the
+    GET line stays ASCII-safe."""
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""), is_reusable=True)
+
+    JobKoreaScraper("디자이너", max_pages=1).fetch()
+    requests = httpx_mock.get_requests()
+    assert requests
+    # ``디자이너`` URL-encoded as UTF-8:
+    assert "stext=%EB%94%94%EC%9E%90%EC%9D%B4%EB%84%88" in str(
+        requests[0].url
+    )
+
+
+# --- field handling ---------------------------------------------------------
+
+
+def test_skips_card_without_gi_no(httpx_mock) -> None:
+    """A malformed card with no ``GI_Read/{id}`` anchor should be
+    dropped, not emitted as a half-built row."""
+    bad_card = """
+    <div data-sentry-component="CardJob">
+      <a href="/some/other/path" data-sentry-component="Title">
+        <span>No id</span>
+      </a>
+    </div>
+    """
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        text=_page(_card(gi_no="42") + bad_card),
+    )
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""), is_reusable=True)
+
+    jobs = JobKoreaScraper("dev").fetch()
+    assert [j.ats_id for j in jobs] == ["42"]
+
+
+def test_falls_back_to_logo_alt_when_company_span_missing(httpx_mock) -> None:
+    """A few sponsored cards render without the company-name span; we
+    recover the company from the logo's ``alt`` attribute (``"{name} 로고"``)."""
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        text=_page(_card(
+            gi_no="77",
+            company="알트컴퍼니",
+            include_company_span=False,
+        )),
+    )
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""), is_reusable=True)
+
+    jobs = JobKoreaScraper("dev").fetch()
+    assert jobs[0].company == "알트컴퍼니"
+
+
+def test_company_unknown_when_no_span_and_no_logo_alt(httpx_mock) -> None:
+    """When neither the company span nor a usable logo alt is present,
+    fall back to a placeholder rather than crashing or emitting empty."""
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        text=_page(_card(
+            gi_no="78",
+            include_company_span=False,
+            company_alt="",
+        )),
+    )
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""), is_reusable=True)
+
+    jobs = JobKoreaScraper("dev").fetch()
+    assert jobs[0].company == "Unknown"
+
+
+@pytest.mark.parametrize(
+    ("title", "expected_norm", "expected_raw"),
+    [
+        ("[정규직] 백엔드 개발자", "FULL_TIME", "정규직"),
+        ("[계약직] 사무 보조", "CONTRACT", "계약직"),
+        ("2026 채용연계형 인턴 모집", "INTERN", "인턴"),
+        ("[프리랜서] Kubernetes 엔지니어", "CONTRACT", "프리랜서"),
+        ("[아르바이트] 매장 직원", "PART_TIME", "아르바이트"),
+        ("[파견직] 운영 보조", "CONTRACT", "파견직"),
+    ],
+)
+def test_employment_type_detected_from_title(
+    httpx_mock, title: str, expected_norm: str, expected_raw: str,
+) -> None:
+    """JobKorea doesn't carry a structured employment-type field on the
+    listing card; employers conventionally encode it in the title
+    prefix. We surface both the raw token and the normalized enum."""
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        text=_page(_card(title=title)),
+    )
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""), is_reusable=True)
+
+    jobs = JobKoreaScraper("dev").fetch()
+    assert jobs[0].employment_type == expected_norm
+    assert jobs[0].raw is not None
+    assert jobs[0].raw["employment_type_label"] == expected_raw
+
+
+def test_title_without_employment_token_leaves_field_none(httpx_mock) -> None:
+    """Most titles don't carry an explicit employment-type token —
+    ``employment_type`` should stay ``None`` rather than guess."""
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        text=_page(_card(title="백엔드 개발자")),
+    )
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""), is_reusable=True)
+
+    jobs = JobKoreaScraper("dev").fetch()
+    assert jobs[0].employment_type is None
+
+
+def test_chips_optional(httpx_mock) -> None:
+    """A card with no location / salary / sector chips should still
+    parse (those fields are simply ``None`` / absent from raw)."""
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        text=_page(_card(
+            location=None, sector=None, salary_label=None,
+        )),
+    )
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""), is_reusable=True)
+
+    jobs = JobKoreaScraper("dev").fetch()
+    j = jobs[0]
+    assert j.location is None
+    assert j.raw is None or "sector" not in j.raw
+    assert j.raw is None or "salary_label" not in j.raw
+
+
+def test_experience_label_optional(httpx_mock) -> None:
+    """Some cards omit the experience-requirement label. That should
+    not break parsing — ``raw['experience']`` is simply absent."""
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        text=_page(_card(experience=None)),
+    )
+    httpx_mock.add_response(url=_SEARCH_RE, text=_page(""), is_reusable=True)
+
+    jobs = JobKoreaScraper("dev").fetch()
+    assert jobs[0].raw is None or "experience" not in jobs[0].raw
+
+
+# --- error handling ---------------------------------------------------------
+
+
+def test_persistent_500_raises(httpx_mock) -> None:
+    """Real server failures should surface, not silently emit []."""
+    httpx_mock.add_response(url=_SEARCH_RE, status_code=500, is_reusable=True)
+    with pytest.raises(ScraperError):
+        JobKoreaScraper("dev").fetch()
+
+
+def test_403_raises_immediately(httpx_mock) -> None:
+    """A 4xx from JobKorea's WAF is not a retry-worthy error — surface
+    it to the caller so the operator rotates the UA / proxies."""
+    httpx_mock.add_response(url=_SEARCH_RE, status_code=403)
+    with pytest.raises(ScraperError):
+        JobKoreaScraper("dev").fetch()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,7 +29,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
-        "manfred", "thehub", "ycombinator", "wellfound",
+        "jobkorea", "manfred", "thehub", "ycombinator", "wellfound",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",
         "recruitee", "taleo", "teamtailor",


### PR DESCRIPTION
## Summary

- New `JobKoreaScraper` for [jobkorea.co.kr](https://www.jobkorea.co.kr/), one of Korea's two dominant direct-posting job platforms (alongside Saramin). Server-rendered Next.js HTML; hundreds of thousands of live postings.
- Single-source scraper: `company_slug` is reused as the search term (`stext`) so callers can scope a sweep to a vertical. Pagination is offset-style via `Page_No=N` with ~25 cards per page.
- End-of-results detection: JobKorea silently repeats ~5 sponsored cards on out-of-range pages instead of returning empty/4xx, so the sweep terminates when two consecutive pages introduce no new `GI_No`.
- Adds `ATSType.JOBKOREA = "jobkorea"` (Hybrid jobboards group) and 26 fixture-driven tests covering the card-parsing contract, pagination behaviour, empty-stext fallback, deduplication, employment-type detection from title prefixes (`[정규직]`, `[인턴]`, …), and error surfaces.

## Test plan

- [x] `uv run pytest tests/test_jobkorea.py tests/test_models.py` — 88 passing
- [x] `uv run pytest` — full suite, 905 passing
- [x] `uv run ruff check` — clean
- [ ] One-off smoke probe against the live site for a Korean keyword (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `JobKoreaScraper` to ingest listings from jobkorea.co.kr with keyword search, robust pagination, and deduplication; also seeds `ats-companies/jobkorea.csv`. Expands KR coverage.

- New Features
  - New `JobKoreaScraper` parsing `CardJob` blocks from server-rendered HTML.
  - Keyword-driven: uses `company_slug` as `stext`; `{"", "any", "all", "jobkorea"}` → empty keyword.
  - Offset pagination via `Page_No`; stop after two pages with no new `GI_No` to avoid sponsored repeats.
  - Canonicalize URLs to `GI_Read/{id}`; emit `global_id=jobkorea:{id}`.
  - Detect employment type from title tokens (e.g., `[정규직]`, `[인턴]`); set `country_iso=KR`, `language=ko`.
  - Wiring and tests: add `ATSType.JOBKOREA`, export `JobKoreaScraper`; fixtures cover parsing, pagination, dedup, empty-keyword, encoding, and errors.
  - Seed `ats-companies/jobkorea.csv` with `name,slug,url`.

- Bug Fixes
  - Defer `bs4` import to runtime and raise a clear error if missing, avoiding base-install breakage; document `pip install beautifulsoup4` (or `jobhive[scrapers]`).

<sup>Written for commit ebc5fcade69d7f552bf7c179d7a676ab261849bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `JobKoreaScraper` for jobkorea.co.kr, Korea's top direct-posting job board. It parses server-rendered Next.js HTML via BeautifulSoup, uses `company_slug` as the search keyword, and detects end-of-results by tracking two consecutive pages with no new `GI_No` IDs.

- **New `JobKoreaScraper`**: full offset-pagination loop, exponential-backoff retry on 429/5xx, stable canonical URLs, and `global_id=jobkorea:{id}` for cross-ATS dedup.
- **Employment-type detection**: infers type from bracket-prefixed title tokens using a priority table; has a raw-label/normalized-type mismatch when a title contains multiple matching tokens.
- **Wiring + fixtures**: `ATSType.JOBKOREA` enum, `__init__` export, `jobkorea.csv` seed, and 26 tests — none exercise the combo-token employment case.

<h3>Confidence Score: 3/5</h3>

Safe to merge after fixing the employment-type label mismatch; the bug produces wrong data in the raw field for combo-token titles but does not crash.

The `_detect_employment_type` function returns `raw_tokens[0]` — whichever token was iterated first in `_EMPLOYMENT_TYPE_MAP` — regardless of which token the priority table actually selected. For combo-token titles the `raw["employment_type_label"]` ends up describing a different classification than `employment_type`, silently emitting wrong data. No existing test exercises this path.

src/jobhive/scrapers/jobkorea.py — specifically `_detect_employment_type`; tests/test_jobkorea.py needs a parametrized combo-token test case.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/jobkorea.py | New JobKorea scraper with HTML parsing, pagination, and retry logic; `_detect_employment_type` returns the wrong raw token when multiple employment-type tokens are present in a single title. |
| tests/test_jobkorea.py | 26 fixture-driven tests covering card parsing, pagination, deduplication, and error surfaces; no test covers the combo-token employment-type case, leaving the raw-token mismatch bug undetected. |
| src/jobhive/models.py | Adds `ATSType.JOBKOREA = "jobkorea"` enum member in the correct alphabetical position within the Hybrid jobboards group. |
| src/jobhive/scrapers/__init__.py | Adds `JobKoreaScraper` import and `__all__` export; correctly placed in alphabetical order alongside existing scrapers. |
| tests/test_models.py | Adds `"jobkorea"` to the expected ATSType set; minimal and correct change. |
| ats-companies/jobkorea.csv | Seeds the jobkorea.csv company file with a single row; format matches the existing CSV convention. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/jobhive/scrapers/jobkorea.py`, line 459-462 ([link](https://github.com/kalil0321/ats-scrapers/blob/198d9ad8cd37cca598fb1e1e1dd0d4e8f5398d11/src/jobhive/scrapers/jobkorea.py#L459-L462)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Raw token mismatch when multiple employment-type tokens are present**

   `raw_tokens[0]` is the first token matched in `_EMPLOYMENT_TYPE_MAP` iteration order, which is *not* guaranteed to be the token that maps to the priority-selected `candidate`. For a title like `"[계약직·인턴] 개발자"`, iteration adds `"계약직"` to `raw_tokens` before `"인턴"`, so `raw_tokens[0]` is `"계약직"`. But the priority table prefers `INTERN` over `CONTRACT`, so `candidate` becomes `"INTERN"` — yielding `("계약직", "INTERN")`. The raw label and normalized type then refer to different things.

   Fix: look up the raw token that actually maps to the chosen candidate: `raw_token = next(t for t in raw_tokens if _EMPLOYMENT_TYPE_MAP[t] == candidate)`

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/jobhive/scrapers/jobkorea.py
   Line: 459-462

   Comment:
   **Raw token mismatch when multiple employment-type tokens are present**

   `raw_tokens[0]` is the first token matched in `_EMPLOYMENT_TYPE_MAP` iteration order, which is *not* guaranteed to be the token that maps to the priority-selected `candidate`. For a title like `"[계약직·인턴] 개발자"`, iteration adds `"계약직"` to `raw_tokens` before `"인턴"`, so `raw_tokens[0]` is `"계약직"`. But the priority table prefers `INTERN` over `CONTRACT`, so `candidate` becomes `"INTERN"` — yielding `("계약직", "INTERN")`. The raw label and normalized type then refer to different things.

   Fix: look up the raw token that actually maps to the chosen candidate: `raw_token = next(t for t in raw_tokens if _EMPLOYMENT_TYPE_MAP[t] == candidate)`

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/jobhive/scrapers/jobkorea.py:459-462
**Raw token mismatch when multiple employment-type tokens are present**

`raw_tokens[0]` is the first token matched in `_EMPLOYMENT_TYPE_MAP` iteration order, which is *not* guaranteed to be the token that maps to the priority-selected `candidate`. For a title like `"[계약직·인턴] 개발자"`, iteration adds `"계약직"` to `raw_tokens` before `"인턴"`, so `raw_tokens[0]` is `"계약직"`. But the priority table prefers `INTERN` over `CONTRACT`, so `candidate` becomes `"INTERN"` — yielding `("계약직", "INTERN")`. The raw label and normalized type then refer to different things.

Fix: look up the raw token that actually maps to the chosen candidate: `raw_token = next(t for t in raw_tokens if _EMPLOYMENT_TYPE_MAP[t] == candidate)`


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: jobkorea.csv"](https://github.com/kalil0321/ats-scrapers/commit/198d9ad8cd37cca598fb1e1e1dd0d4e8f5398d11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732463)</sub>

<!-- /greptile_comment -->