### PR TITLE
Add InfoJobs Brasil scraper

### DIFF
--- a/ats-companies/infojobs_br.csv
+++ b/ats-companies/infojobs_br.csv
@@ -1,0 +1,2 @@
+name,slug,url
+InfoJobs Brasil,infojobs_br,https://www.infojobs.com.br

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -80,6 +80,7 @@ class ATSType(StrEnum):
     THEHUB = "thehub"
     YCOMBINATOR = "ycombinator"
     WELLFOUND = "wellfound"
+    INFOJOBSBR = "infojobs_br"
     # Additional multi-tenant ATSes (post-0.1)
     BAMBOOHR = "bamboohr"
     BREEZY = "breezy"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -26,6 +26,7 @@ from jobhive.scrapers.getonbrd import GetOnBrdScraper
 from jobhive.scrapers.google import GoogleScraper
 from jobhive.scrapers.greenhouse import GreenhouseScraper
 from jobhive.scrapers.icims import iCIMSScraper
+from jobhive.scrapers.infojobs_br import InfoJobsBrasilScraper
 from jobhive.scrapers.jazzhr import JazzHRScraper
 from jobhive.scrapers.jobsch import JobsChScraper
 from jobhive.scrapers.join_com import JoinComScraper
@@ -77,6 +78,7 @@ __all__ = [
     "GetOnBrdScraper",
     "GoogleScraper",
     "GreenhouseScraper",
+    "InfoJobsBrasilScraper",
     "JazzHRScraper",
     "JobsChScraper",
     "JoinComScraper",

--- a/src/jobhive/scrapers/infojobs_br.py
+++ b/src/jobhive/scrapers/infojobs_br.py
@@ -1,0 +1,513 @@
+"""InfoJobs Brasil (https://www.infojobs.com.br) — Brazilian job board scraper.
+
+InfoJobs Brasil is one of the largest general-purpose job boards in
+Brazil (60k+ active postings at any given time). Companies post
+directly to InfoJobs; the site is not aggregated from LinkedIn or
+Indeed. The listing pages are ASP.NET server-rendered HTML with
+stable ``data-id`` attributes on each card. Detail URLs are slugged
+with the numeric id in a trailing ``__{id}.aspx`` suffix:
+
+    /vaga-de-promotor-vendas-em-sao-paulo__11608342.aspx
+
+Pagination uses an AJAX JSON endpoint behind an infinite-scroll
+mechanic — the browser hits
+
+    /mf-publicarea/VacancyList/GetVacancyListFragment?url={encoded}
+
+with ``{encoded}`` being a URL-encoded listing URL that carries a
+``page=N`` query parameter. The response is JSON with an ``eof``
+boolean and a ``listFragmentHTML`` string containing the same card
+markup as the SSR page. We use this endpoint exclusively (rather
+than the SSR variant) because:
+
+  - The SSR page is heavy (~245kB, full chrome each page) and the
+    fragment is ~95kB (just the cards).
+  - The SSR page geo-defaults to São Paulo when called from a
+    non-Brazilian IP, while the fragment URL we pass is honored
+    verbatim.
+
+Each card carries enough fields that we don't need per-job detail
+fetches:
+
+  - data-id="11608342"            → ats_id
+  - data-href="/vaga-de-X__N.aspx" → url
+  - <h2 class="...js_vacancyTitle"> → title
+  - <a href="https://.../company"> → company
+  - "São Paulo - SP" (free text)    → location
+  - js_date data-value="YYYY/MM/DD HH:MM:SS" → posted_at
+  - icon-money + "R$ X,XX a R$ Y,YY" → salary
+  - icon-buildings / icon-house-and-building → modality
+  - text-medium block at bottom → description teaser
+
+Single-source scraper: ``company_slug`` is informational and ignored.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import re
+import urllib.parse
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+API_ROOT = "https://www.infojobs.com.br"
+FRAGMENT_PATH = "/mf-publicarea/VacancyList/GetVacancyListFragment"
+# Default listing URL — country-wide, no filters. The fragment endpoint
+# honors the ``page=N`` query string verbatim, unlike the SSR page which
+# geolocates the request.
+DEFAULT_LISTING_URL = f"{API_ROOT}/vagas-de-emprego.aspx"
+DEFAULT_MAX_PAGES = 200  # ~20 cards/page → ~4,000 most-recent jobs
+# InfoJobs is friendly but we keep concurrency low to be a polite citizen.
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 4
+RETRY_BASE_DELAY = 2.0
+
+# Card delimiter — every result card opens with this exact attribute set.
+_CARD_START_RE = re.compile(
+    r'<div data-typesimilar="" class="card[^"]*">\s*'
+    r'<div id="vacancy(?P<id>\d+)"[^>]*data-id="(?P=id)"[^>]*'
+    r'data-href="(?P<href>/vaga[^"]+)"',
+)
+# Card body extractors (run scoped per card).
+_TITLE_RE = re.compile(
+    r'<h2[^>]*js_vacancyTitle[^>]*>\s*(?P<t>.*?)\s*</h2>', re.DOTALL,
+)
+_DATE_RE = re.compile(r'class="js_date" data-value="(?P<v>[^"]+)"')
+_COMPANY_LINK_RE = re.compile(
+    r'<a class="text-body[^"]*"\s+href="(?P<href>https://www\.infojobs\.com\.br/[^"]+)"[^>]*>'
+    r'(?P<name>.*?)</a>',
+    re.DOTALL,
+)
+_LOCATION_RE = re.compile(
+    r'<div class="mb-8">\s*(?P<loc>[^<]+?)\s*(?:<|$)',
+    re.DOTALL,
+)
+# Per-icon metadata blocks: <svg class="icon icon-NAME ..."><use .../></svg> TEXT
+_ICON_BLOCK_RE = re.compile(
+    r'icon icon-(?P<icon>[a-z-]+)\s[^"]*"\s*>\s*<use[^/]+/>\s*</svg>'
+    r'\s*(?P<v>[^<]*)',
+)
+# Description teaser — the last <div class="text-medium"> in the card.
+_DESCRIPTION_RE = re.compile(
+    r'<div class="text-medium">\s*(?P<v>.*?)\s*</div>', re.DOTALL,
+)
+
+# Modality (working method) → ``is_remote`` + raw label.
+_MODALITY_LABELS = {
+    "buildings": "Presencial",
+    "house-and-building": "Híbrido",
+    "house": "Home Office",
+}
+
+# Brazilian employment-type label → canonical EmploymentType enum. These
+# labels appear on detail pages and occasionally in the card teaser; we
+# keep the map module-level so future detail-page scraping can reuse it.
+_EMPLOYMENT_MAP: dict[str, str] = {
+    "efetivo": "FULL_TIME",
+    "clt": "FULL_TIME",
+    "temporário": "TEMPORARY",
+    "temporario": "TEMPORARY",
+    "estagiário": "INTERN",
+    "estagiario": "INTERN",
+    "estágio": "INTERN",
+    "estagio": "INTERN",
+    "trainee": "FULL_TIME",
+    "aprendiz": "INTERN",
+    "freelancer": "CONTRACT",
+    "freelance": "CONTRACT",
+    "autônomo": "CONTRACT",
+    "autonomo": "CONTRACT",
+    "pj": "CONTRACT",
+    "cooperado": "CONTRACT",
+}
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"\s+")
+_BRL_AMOUNT_RE = re.compile(r"R\$\s*([\d.,]+)")
+
+
+@ScraperRegistry.register(ATSType.INFOJOBSBR)
+class InfoJobsBrasilScraper(BaseScraper):
+    """InfoJobs Brasil (infojobs.com.br) — Brazilian general-purpose jobs.
+
+    Single-source: ``company_slug`` is ignored. Pass anything (``"any"``,
+    ``""``, ``"brasil"``) — the scraper paginates the entire jobs board.
+
+    Knobs:
+
+    - ``max_pages`` — pagination cap (default 200 → ~4,000 jobs).
+    - ``listing_url`` — override the base listing URL when you want to
+      restrict to a city / category. The page=N parameter is appended
+      by the scraper; don't include it in the override.
+    """
+
+    ats = ATSType.INFOJOBSBR
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        max_pages: int = DEFAULT_MAX_PAGES,
+        listing_url: str = DEFAULT_LISTING_URL,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.max_pages = max_pages
+        self.listing_url = listing_url
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        seen_ids: set[str] = set()
+        jobs: list[Job] = []
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True,
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+            page = 1
+            consecutive_empty = 0
+            while page <= self.max_pages and consecutive_empty < 3:
+                payload = await self._fetch_page(client, sem, page)
+                fragment = payload.get("listFragmentHTML") or ""
+                eof = bool(payload.get("eof"))
+                new_count = 0
+                for job in self._parse_listing(fragment):
+                    if job.ats_id in seen_ids:
+                        continue
+                    seen_ids.add(job.ats_id)
+                    jobs.append(job)
+                    new_count += 1
+                if eof:
+                    break
+                if new_count == 0:
+                    consecutive_empty += 1
+                else:
+                    consecutive_empty = 0
+                page += 1
+        return jobs
+
+    async def _fetch_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        page: int,
+    ) -> dict[str, Any]:
+        # Append/overwrite ``page=N`` on the base listing URL. The
+        # backend reads the param from the URL we pass in, not from the
+        # request URL itself.
+        listing = _set_query_param(self.listing_url, "page", str(page))
+        encoded = urllib.parse.quote(listing, safe="")
+        url = f"{API_ROOT}{FRAGMENT_PATH}?url={encoded}"
+        return await self._request_json(client, sem, url)
+
+    async def _request_json(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        url: str,
+    ) -> dict[str, Any]:
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(
+                        url, headers={
+                            "User-Agent": (
+                                "Mozilla/5.0 (X11; Linux x86_64) "
+                                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                                "Chrome/124.0.0.0 Safari/537.36"
+                            ),
+                            "Accept": "application/json, text/html;q=0.9",
+                            "Accept-Language": "pt-BR,pt;q=0.9,en;q=0.8",
+                        },
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"InfoJobs Brasil fetch failed for {url}: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                try:
+                    return response.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"InfoJobs Brasil returned non-JSON for {url}: {exc}"
+                    ) from exc
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"InfoJobs Brasil returned {response.status_code} for "
+                        f"{url} after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"InfoJobs Brasil returned {response.status_code} for {url}"
+            )
+        raise ScraperError(
+            f"InfoJobs Brasil exhausted retries for {url}: {last_exc}"
+        )
+
+    def _parse_listing(self, fragment: str):
+        # Split per card on the start marker — every card is bounded by
+        # the next ``<div data-typesimilar=""`` or end of fragment.
+        starts = list(_CARD_START_RE.finditer(fragment))
+        for i, m in enumerate(starts):
+            start = m.start()
+            end = starts[i + 1].start() if i + 1 < len(starts) else len(fragment)
+            body = fragment[start:end]
+            job = self._parse_card(
+                ats_id=m.group("id"), href=m.group("href"), body=body,
+            )
+            if job is not None:
+                yield job
+
+    def _parse_card(self, *, ats_id: str, href: str, body: str) -> Job | None:
+        title_match = _TITLE_RE.search(body)
+        if not title_match:
+            return None
+        title = _strip_html(title_match.group("t"))
+        if not title:
+            return None
+
+        # Company: linked employer name, else "Empresa confidencial".
+        company = "Empresa confidencial"
+        link_match = _COMPANY_LINK_RE.search(body)
+        if link_match:
+            cand = _strip_html(link_match.group("name"))
+            # Strip trailing "verified" tooltip text the link sometimes
+            # wraps inline (e.g. "SODEXO Este selo indica…"). The badge
+            # tooltip leaks through entity decoding; keep only the first
+            # line / cap to a sane length.
+            cand = cand.split("Este selo indica")[0].strip()
+            if cand:
+                company = cand
+
+        # Location lives in <div class="mb-8">Cidade - UF<…> when present.
+        # "Home office" sometimes leaks in here too — keep it; downstream
+        # ``_infer_remote`` reads the value to decide ``is_remote``.
+        location = None
+        loc_match = _LOCATION_RE.search(body)
+        if loc_match:
+            raw_loc = _strip_html(loc_match.group("loc"))
+            if raw_loc:
+                location = raw_loc
+
+        # Metadata icons: money / suitcase / graduate-hat / buildings /
+        # house-and-building. We only key on the ones that map to schema
+        # fields; the rest go into ``raw``.
+        icon_values: dict[str, str] = {}
+        for m in _ICON_BLOCK_RE.finditer(body):
+            v = _strip_html(m.group("v"))
+            if v and m.group("icon") not in icon_values:
+                icon_values[m.group("icon")] = v
+
+        salary_raw = icon_values.get("money")
+        salary_min, salary_max, salary_currency, salary_summary = _parse_salary(
+            salary_raw
+        )
+
+        # Modality / remote inference. icon-house-and-building =
+        # Híbrido, icon-buildings = Presencial. "Remoto" / "Home
+        # office" can appear on either the buildings text or the
+        # location string.
+        modality_raw = None
+        for icon, label in _MODALITY_LABELS.items():
+            if icon in icon_values:
+                modality_raw = icon_values[icon] or label
+                break
+        is_remote = _infer_remote(modality_raw, location)
+
+        # Employment type: rarely surfaced on the card (lives on
+        # the detail page) but mapped defensively when it is.
+        commitment_raw = None
+        for k in ("file", "file-alt", "document", "suitcase"):
+            if k in icon_values and any(
+                t in icon_values[k].lower() for t in _EMPLOYMENT_MAP
+            ):
+                commitment_raw = icon_values[k]
+                break
+        employment_type = (
+            _EMPLOYMENT_MAP.get(commitment_raw.lower()) if commitment_raw else None
+        )
+
+        # Description teaser — the last text-medium block in the card.
+        # Multiple may match; take the longest, which is always the
+        # description rather than the date/rating snippets.
+        description = None
+        desc_candidates = [
+            _strip_html(m.group("v"))
+            for m in _DESCRIPTION_RE.finditer(body)
+        ]
+        desc_candidates = [d for d in desc_candidates if d]
+        if desc_candidates:
+            description = max(desc_candidates, key=len)
+
+        # posted_at: structured datetime in the hidden js_date block.
+        posted_at = None
+        date_match = _DATE_RE.search(body)
+        if date_match:
+            posted_at = _parse_brazilian_date(date_match.group("v"))
+
+        raw: dict[str, Any] = {}
+        if "graduate-hat" in icon_values:
+            raw["education"] = icon_values["graduate-hat"]
+        if "suitcase" in icon_values:
+            raw["experience_label"] = icon_values["suitcase"]
+        if modality_raw:
+            raw["modality"] = modality_raw
+        if salary_raw and salary_raw != salary_summary:
+            raw["salary_raw"] = salary_raw
+
+        url = href if href.startswith("http") else f"{API_ROOT}{href}"
+
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.INFOJOBSBR,
+            ats_id=ats_id,
+            location=location,
+            country_iso="BR",
+            is_remote=is_remote,
+            salary_currency=salary_currency,
+            salary_period="MONTH" if salary_currency else None,
+            salary_summary=salary_summary,
+            salary_min=salary_min,
+            salary_max=salary_max,
+            employment_type=employment_type,  # type: ignore[arg-type]
+            commitment=commitment_raw,
+            description=description,
+            posted_at=posted_at,
+            fetched_at=datetime.now(),
+            language="pt",
+            raw=raw or None,
+        )
+
+
+# --- module-level helpers ---------------------------------------------------
+
+
+def _strip_html(text: str) -> str:
+    if not text:
+        return ""
+    cleaned = _TAG_RE.sub(" ", text)
+    cleaned = html.unescape(cleaned)
+    return _WS_RE.sub(" ", cleaned).strip()
+
+
+def _set_query_param(url: str, key: str, value: str) -> str:
+    """Return ``url`` with ``key=value`` set in the query string,
+    overwriting any existing value. Preserves order of other params."""
+    parsed = urllib.parse.urlparse(url)
+    params = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+    params = [(k, v) for k, v in params if k != key]
+    params.append((key, value))
+    return urllib.parse.urlunparse(parsed._replace(query=urllib.parse.urlencode(params)))
+
+
+def _parse_brl_amount(raw: str) -> float | None:
+    """``R$ 3.000`` → 3000.0; ``R$ 3.500,50`` → 3500.50.
+
+    Brazilian currency uses ``.`` as the thousand separator and ``,``
+    as the decimal point, opposite to en-US conventions.
+    """
+    if not raw:
+        return None
+    cleaned = raw.replace(".", "").replace(",", ".")
+    try:
+        value = float(cleaned)
+    except ValueError:
+        return None
+    return value if value > 0 else None
+
+
+def _parse_salary(
+    raw: str | None,
+) -> tuple[float | None, float | None, str | None, str | None]:
+    """InfoJobs salary strings:
+
+    - ``"A combinar"``                       → no signal
+    - ``"R$ 1.700,00 a R$ 2.000,00"``        → min=1700, max=2000, BRL
+    - ``"Até R$ 5.000,00"``                  → max only
+    - ``"A partir de R$ 8.000,00"``          → min only
+    - empty / None                            → no signal
+
+    Returns ``(min, max, currency, summary)``. ``summary`` is the
+    original string with whitespace normalized so the public schema
+    has a verbatim form of what users see; it's ``None`` when no
+    numeric amount was extractable (e.g. "A combinar").
+    """
+    if not raw:
+        return None, None, None, None
+    normalized = _WS_RE.sub(" ", raw).strip()
+    nums = _BRL_AMOUNT_RE.findall(normalized)
+    if not nums:
+        return None, None, None, None
+    parsed = [_parse_brl_amount(n) for n in nums]
+    parsed = [p for p in parsed if p is not None]
+    if not parsed:
+        return None, None, None, None
+    lower = normalized.lower()
+    if len(parsed) == 1:
+        if "até" in lower or "ate" in lower:
+            return None, parsed[0], "BRL", normalized
+        if "partir" in lower or "a partir" in lower:
+            return parsed[0], None, "BRL", normalized
+        return None, parsed[0], "BRL", normalized
+    return parsed[0], parsed[-1], "BRL", normalized
+
+
+def _infer_remote(modality_raw: str | None, location: str | None) -> bool | None:
+    """Combine the modality label and location text to infer remote.
+
+    Returns ``True`` when either signal explicitly states remote; the
+    canonical ``is_remote`` field accepts both ``True`` and ``False``
+    here because the modality icon is structured (i.e. absence really
+    is evidence of on-site, unlike the title-only heuristic).
+    """
+    sources = [s.lower() for s in (modality_raw, location) if s]
+    if not sources:
+        return None
+    blob = " ".join(sources)
+    if "home office" in blob or "remoto" in blob or "remote" in blob:
+        return True
+    if "híbrido" in blob or "hibrido" in blob or "hybrid" in blob:
+        return False
+    if "presencial" in blob or "on-site" in blob:
+        return False
+    return None
+
+
+def _parse_brazilian_date(raw: str) -> datetime | None:
+    """``js_date`` carries an exact ``YYYY/MM/DD HH:MM:SS`` value —
+    the human-readable "Hoje" / "Ontem" / "Há 3 dias" labels are
+    derived from this so we just parse the structured form."""
+    if not raw:
+        return None
+    raw = raw.strip()
+    for fmt in ("%Y/%m/%d %H:%M:%S", "%Y/%m/%d %H:%M", "%Y/%m/%d", "%d/%m/%Y"):
+        try:
+            return datetime.strptime(raw, fmt)
+        except ValueError:
+            continue
+    return None

--- a/src/jobhive/scrapers/infojobs_br.py
+++ b/src/jobhive/scrapers/infojobs_br.py
@@ -238,8 +238,12 @@ class InfoJobsBrasilScraper(BaseScraper):
                         raise ScraperError(
                             f"InfoJobs Brasil fetch failed for {url}: {exc}"
                         ) from exc
-                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
-                    continue
+                    response = None
+            if response is None:
+                # Transport error — back off outside the semaphore so we
+                # don't hold a concurrency slot while sleeping.
+                await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                continue
             if response.status_code == 200:
                 try:
                     return response.json()
@@ -347,7 +351,7 @@ class InfoJobsBrasilScraper(BaseScraper):
                 commitment_raw = icon_values[k]
                 break
         employment_type = (
-            _EMPLOYMENT_MAP.get(commitment_raw.lower()) if commitment_raw else None
+            _match_employment_type(commitment_raw) if commitment_raw else None
         )
 
         # Description teaser — the last text-medium block in the card.
@@ -413,6 +417,19 @@ def _strip_html(text: str) -> str:
     cleaned = _TAG_RE.sub(" ", text)
     cleaned = html.unescape(cleaned)
     return _WS_RE.sub(" ", cleaned).strip()
+
+
+def _match_employment_type(raw: str) -> str | None:
+    """Map a (possibly composite) Brazilian employment label to a
+    canonical ``EmploymentType``. Labels are frequently composite
+    (e.g. ``"Efetivo CLT"``, ``"Estágio / Trainee"``) so we match the
+    map keys as tokens/substrings rather than requiring an exact hit.
+    The first matching key (in map insertion order) wins."""
+    lowered = raw.lower()
+    for key, value in _EMPLOYMENT_MAP.items():
+        if key in lowered:
+            return value
+    return None
 
 
 def _set_query_param(url: str, key: str, value: str) -> str:

--- a/tests/test_infojobs_br.py
+++ b/tests/test_infojobs_br.py
@@ -1,0 +1,463 @@
+"""Tests for the InfoJobs Brasil scraper.
+
+InfoJobs Brasil is a server-rendered ASP.NET site whose infinite-scroll
+behavior is backed by a JSON fragment endpoint
+(``/mf-publicarea/VacancyList/GetVacancyListFragment``). The fragment
+payload carries the same card markup the SSR page does. These tests
+exercise:
+
+- Card parsing for every Job slot the scraper populates
+- Brazilian salary parsing (``R$ 1.700,00 a R$ 2.000,00``, "Até",
+  "A partir de", "A combinar")
+- Modality → remote inference (Presencial / Híbrido / Home office)
+- Date parsing (``YYYY/MM/DD HH:MM:SS`` exact form)
+- Pagination termination (``eof: true`` or three consecutive
+  duplicate-only pages)
+- The ``url`` query param is set on the listing URL, not the
+  fragment-endpoint URL (the backend reads ``page`` from the
+  encoded value, not from its own request URL)
+- ``page`` cap honors ``max_pages``
+"""
+
+from __future__ import annotations
+
+import re
+import urllib.parse
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import InfoJobsBrasilScraper, ScraperRegistry
+from jobhive.scrapers.infojobs_br import (
+    _infer_remote,
+    _parse_brazilian_date,
+    _parse_brl_amount,
+    _parse_salary,
+    _set_query_param,
+)
+
+_FRAGMENT_RE = re.compile(
+    r"^https://www\.infojobs\.com\.br/mf-publicarea/VacancyList/GetVacancyListFragment\?url="
+)
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.infojobs_br as ij
+    monkeypatch.setattr(ij, "MAX_RETRIES", 1)
+    monkeypatch.setattr(ij, "RETRY_BASE_DELAY", 0.0)
+
+
+def _card(
+    *,
+    job_id: str,
+    title: str = "Engenheiro de Software",
+    company: str | None = "Acme Tech",
+    company_href: str | None = "https://www.infojobs.com.br/acme-tech",
+    location: str = "São Paulo - SP",
+    posted_at: str = "2026/05/12 12:03:00",
+    salary: str = "A combinar",
+    modality_icon: str = "buildings",
+    modality_label: str = "Presencial",
+    education: str = "Ensino Médio (2º Grau)",
+    experience: str = "Sem experiência",
+    description: str = "Vaga incrível em uma empresa em crescimento.",
+) -> str:
+    """Build a realistic card matching the live HTML structure."""
+    if company is None:
+        company_block = (
+            '<div class="text-body">\n'
+            '    Empresa\n'
+            '    <span class="text-nowrap">confidencial</span>\n'
+            '</div>'
+        )
+    else:
+        company_block = (
+            '<div class="text-body">\n'
+            f'    <a class="text-body text-decoration-none" href="{company_href}">\n'
+            f'        {company}\n'
+            '    </a>\n'
+            '</div>'
+        )
+    slug = re.sub(r"[^a-z0-9-]", "-", title.lower().replace(" ", "-"))
+    href = f"/vaga-de-{slug}__{job_id}.aspx"
+    return (
+        f'<div data-typesimilar="" class="card card-shadow js_rowCard active">'
+        f'<div id="vacancy{job_id}" data-modelversion="" data-id="{job_id}" '
+        f'class="js_vacancyLoad js_cardLink" data-href="{href}" '
+        f'data-testabbutton="false">'
+        f'<div class="d-flex flex-wrap gap-8">'
+        f'<div hidden class="js_date" data-value="{posted_at}">'
+        f'<div class="tag mb-2 tag-outline-premium tag-sm"><span>NOVA</span></div>'
+        f'</div></div>'
+        f'<div class="d-flex gap-8 justify-content-between">'
+        f'<a class="text-decoration-none" href="{href}">'
+        f'<h2 class="h3 font-weight-bold text-body mb-2 js_vacancyTitle">{title}</h2>'
+        f'</a>'
+        f'<div class="text-medium small text-nowrap">Hoje</div>'
+        f'</div>'
+        f'<div class="d-flex align-items-baseline">{company_block}</div>'
+        f'<div class="mb-8">{location}</div>'
+        f'<div class="d-inline-flex flex-wrap mb-8 text-medium">'
+        f'<div><svg class="icon icon-money   icon-size-16"><use xlink:href="#money" /></svg> {salary}</div>'
+        f'<div><svg class="icon icon-suitcase   icon-size-16"><use xlink:href="#suitcase" /></svg> {experience}</div>'
+        f'<div><svg class="icon icon-graduate-hat   icon-size-16"><use xlink:href="#graduate-hat" /></svg> {education}</div>'
+        f'<div><svg class="icon icon-{modality_icon}   icon-size-16"><use xlink:href="#{modality_icon}" /></svg> {modality_label}</div>'
+        f'</div>'
+        f'<div class="text-medium">{description}</div>'
+        f'</div></div>'
+    )
+
+
+def _fragment(cards: list[str], *, eof: bool = False) -> dict:
+    """Wrap card HTML the way the live API does."""
+    body = (
+        '<div class="js_vacanciesGridFragment mb-16">'
+        + "".join(cards)
+        + '</div>'
+    )
+    return {"eof": eof, "listFragmentHTML": body}
+
+
+def _empty_fragment(*, eof: bool = False) -> dict:
+    return {"eof": eof, "listFragmentHTML": '<div class="js_vacanciesGridFragment mb-16"></div>'}
+
+
+# --- registry ---------------------------------------------------------------
+
+
+def test_registry_resolves_infojobs_br() -> None:
+    assert ScraperRegistry.get(ATSType.INFOJOBSBR) is InfoJobsBrasilScraper
+
+
+def test_ats_type_value_is_infojobs_br() -> None:
+    """The enum value drives every downstream CSV column name and
+    storage path — pin it explicitly."""
+    assert ATSType.INFOJOBSBR.value == "infojobs_br"
+
+
+# --- happy path -------------------------------------------------------------
+
+
+def test_parses_full_card(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE.pattern + r".*page%3D1"),
+        json=_fragment([_card(
+            job_id="11608342",
+            title="Promotor de Vendas",
+            company="Gi Group",
+            location="São Paulo - SP",
+            posted_at="2026/05/12 12:03:00",
+            salary="R$ 1.700,00 a R$ 2.000,00",
+            modality_icon="buildings",
+            modality_label="Presencial",
+            description="Vaga de promotor para grande rede.",
+        )], eof=True),
+    )
+    jobs = InfoJobsBrasilScraper("any", max_pages=1).fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.INFOJOBSBR
+    assert j.ats_id == "11608342"
+    assert j.title == "Promotor de Vendas"
+    assert j.company == "Gi Group"
+    assert j.location == "São Paulo - SP"
+    assert j.country_iso == "BR"
+    assert j.language == "pt"
+    assert j.is_remote is False
+    assert j.salary_currency == "BRL"
+    assert j.salary_period == "MONTH"
+    assert j.salary_min == 1700.0
+    assert j.salary_max == 2000.0
+    assert j.salary_summary == "R$ 1.700,00 a R$ 2.000,00"
+    assert j.description == "Vaga de promotor para grande rede."
+    assert j.posted_at is not None
+    assert j.posted_at.year == 2026 and j.posted_at.month == 5 and j.posted_at.day == 12
+    assert str(j.url).endswith(
+        "/vaga-de-promotor-de-vendas__11608342.aspx"
+    )
+    assert j.raw is not None
+    assert j.raw["education"] == "Ensino Médio (2º Grau)"
+    assert j.raw["modality"] == "Presencial"
+
+
+def test_company_falls_back_to_empresa_confidencial(httpx_mock) -> None:
+    """When there's no anchor to a company page the card displays
+    'Empresa confidencial' and the scraper should propagate that
+    verbatim instead of inventing a name."""
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE.pattern + r".*page%3D1"),
+        json=_fragment([_card(job_id="1", company=None)], eof=True),
+    )
+    jobs = InfoJobsBrasilScraper("any", max_pages=1).fetch()
+    assert jobs[0].company == "Empresa confidencial"
+
+
+def test_hibrido_modality_sets_is_remote_false(httpx_mock) -> None:
+    """Híbrido (icon-house-and-building) → not fully remote."""
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE.pattern + r".*page%3D1"),
+        json=_fragment([_card(
+            job_id="1",
+            modality_icon="house-and-building",
+            modality_label="Híbrido",
+        )], eof=True),
+    )
+    jobs = InfoJobsBrasilScraper("any", max_pages=1).fetch()
+    assert jobs[0].is_remote is False
+    assert jobs[0].raw is not None
+    assert jobs[0].raw["modality"] == "Híbrido"
+
+
+def test_home_office_modality_sets_is_remote_true(httpx_mock) -> None:
+    """Remote roles appear with Home Office / Remoto labels."""
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE.pattern + r".*page%3D1"),
+        json=_fragment([_card(
+            job_id="1",
+            modality_icon="buildings",
+            modality_label="Home Office",
+            location="Remoto",
+        )], eof=True),
+    )
+    jobs = InfoJobsBrasilScraper("any", max_pages=1).fetch()
+    assert jobs[0].is_remote is True
+
+
+def test_salary_a_combinar_yields_no_signal(httpx_mock) -> None:
+    """``A combinar`` (negotiable) is the most common label on
+    InfoJobs cards — no numeric extraction should fire."""
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE.pattern + r".*page%3D1"),
+        json=_fragment([_card(job_id="1", salary="A combinar")], eof=True),
+    )
+    jobs = InfoJobsBrasilScraper("any", max_pages=1).fetch()
+    j = jobs[0]
+    assert j.salary_currency is None
+    assert j.salary_min is None and j.salary_max is None
+    assert j.salary_summary is None
+
+
+# --- salary parsing ---------------------------------------------------------
+
+
+def test_parse_brl_amount_handles_brazilian_thousand_separator() -> None:
+    """Brazilian formatting uses ``.`` as thousands, ``,`` as decimal —
+    opposite to en-US. Mishandling collapses ``R$ 1.700,00`` into
+    1.7 instead of 1700.0."""
+    assert _parse_brl_amount("1.700,00") == 1700.0
+    assert _parse_brl_amount("8.000,00") == 8000.0
+    assert _parse_brl_amount("99.000,00") == 99000.0
+    assert _parse_brl_amount("3.500,50") == 3500.50
+    assert _parse_brl_amount("0") is None
+    assert _parse_brl_amount("") is None
+
+
+@pytest.mark.parametrize("raw, expected", [
+    ("A combinar", (None, None, None, None)),
+    ("", (None, None, None, None)),
+    (None, (None, None, None, None)),
+    (
+        "R$ 1.700,00 a R$ 2.000,00",
+        (1700.0, 2000.0, "BRL", "R$ 1.700,00 a R$ 2.000,00"),
+    ),
+    (
+        "Até R$ 5.000,00",
+        (None, 5000.0, "BRL", "Até R$ 5.000,00"),
+    ),
+    (
+        "A partir de R$ 8.000,00",
+        (8000.0, None, "BRL", "A partir de R$ 8.000,00"),
+    ),
+])
+def test_parse_salary_shapes(raw, expected) -> None:
+    assert _parse_salary(raw) == expected
+
+
+def test_parse_salary_normalizes_whitespace_in_summary() -> None:
+    """The real DOM ships values like ``R$ 1.700,00\\n  a\\n  R$ 2.000,00``
+    with embedded line breaks. The summary should collapse those so
+    consumers see a clean single-line string."""
+    raw = "R$ 1.700,00\r\n                a\r\n                R$ 2.000,00"
+    min_, max_, cur, summary = _parse_salary(raw)
+    assert min_ == 1700.0 and max_ == 2000.0 and cur == "BRL"
+    assert summary == "R$ 1.700,00 a R$ 2.000,00"
+
+
+# --- date parsing ------------------------------------------------------------
+
+
+def test_parse_brazilian_date_full_timestamp() -> None:
+    """The hidden ``js_date`` block carries a structured timestamp —
+    parse it directly, don't try to derive from 'Hoje' / 'Ontem'."""
+    dt = _parse_brazilian_date("2026/05/12 12:03:00")
+    assert dt is not None
+    assert (dt.year, dt.month, dt.day, dt.hour) == (2026, 5, 12, 12)
+
+
+def test_parse_brazilian_date_dd_mm_yyyy() -> None:
+    """Some legacy detail pages use DD/MM/YYYY only — also accept that
+    form so we don't crash if the listing emits it."""
+    dt = _parse_brazilian_date("12/05/2026")
+    assert dt is not None
+    assert (dt.year, dt.month, dt.day) == (2026, 5, 12)
+
+
+def test_parse_brazilian_date_invalid_returns_none() -> None:
+    assert _parse_brazilian_date("") is None
+    assert _parse_brazilian_date("never") is None
+
+
+# --- remote inference --------------------------------------------------------
+
+
+@pytest.mark.parametrize("modality, location, expected", [
+    ("Home Office", "Brasil", True),
+    ("Remoto", "São Paulo - SP", True),
+    ("Presencial", "Belo Horizonte - MG", False),
+    ("Híbrido", "Curitiba - PR", False),
+    (None, "Home Office", True),
+    (None, None, None),
+])
+def test_infer_remote(modality, location, expected) -> None:
+    assert _infer_remote(modality, location) is expected
+
+
+# --- URL helper --------------------------------------------------------------
+
+
+def test_set_query_param_appends_when_missing() -> None:
+    out = _set_query_param("https://example.com/x.aspx", "page", "2")
+    assert out == "https://example.com/x.aspx?page=2"
+
+
+def test_set_query_param_overwrites_existing() -> None:
+    """``?page=1&foo=bar`` updated with page=3 should become
+    ``?foo=bar&page=3`` — the foo param stays, the old page= is
+    dropped, the new one appended. parse_qsl preserves order minus
+    the removed key."""
+    out = _set_query_param(
+        "https://example.com/x.aspx?page=1&foo=bar", "page", "3",
+    )
+    parsed = urllib.parse.urlparse(out)
+    params = dict(urllib.parse.parse_qsl(parsed.query))
+    assert params == {"page": "3", "foo": "bar"}
+
+
+# --- pagination termination --------------------------------------------------
+
+
+def test_stops_when_eof_true(httpx_mock) -> None:
+    """The fragment payload carries an ``eof`` boolean; honor it as
+    the cheapest stop signal rather than walking to max_pages."""
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE),
+        json=_fragment([_card(job_id="100"), _card(job_id="101")], eof=True),
+    )
+    jobs = InfoJobsBrasilScraper("any", max_pages=50).fetch()
+    assert {j.ats_id for j in jobs} == {"100", "101"}
+
+
+def test_stops_after_three_consecutive_duplicate_pages(httpx_mock) -> None:
+    """If ``eof`` stays False but the page returns 0 new ids three
+    times in a row we stop. Real InfoJobs pagination occasionally
+    re-emits the last page when you walk past the live tail."""
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE.pattern + r".*page%3D1"),
+        json=_fragment([_card(job_id="100"), _card(job_id="101")]),
+    )
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE),
+        json=_fragment([_card(job_id="100"), _card(job_id="101")]),
+        is_reusable=True,
+    )
+    jobs = InfoJobsBrasilScraper("any", max_pages=20).fetch()
+    assert {j.ats_id for j in jobs} == {"100", "101"}
+
+
+def test_paginates_until_eof(httpx_mock) -> None:
+    """Distinct ids per page → walk through until ``eof: True``."""
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE.pattern + r".*page%3D1"),
+        json=_fragment([_card(job_id="1"), _card(job_id="2")]),
+    )
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE.pattern + r".*page%3D2"),
+        json=_fragment([_card(job_id="3"), _card(job_id="4")]),
+    )
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE.pattern + r".*page%3D3"),
+        json=_fragment([_card(job_id="5")], eof=True),
+    )
+    jobs = InfoJobsBrasilScraper("any", max_pages=10).fetch()
+    assert {j.ats_id for j in jobs} == {"1", "2", "3", "4", "5"}
+
+
+def test_max_pages_caps_pagination(httpx_mock) -> None:
+    """Even if every page is fresh and ``eof`` never fires, the cap
+    is hard. Prevents a buggy site from looping forever."""
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE),
+        json=_fragment([_card(job_id="42")]),  # same id every page
+        is_reusable=True,
+    )
+    # Three consecutive dupes would stop us at page 4; the cap should
+    # bite before that. Set max_pages=2 and check we got exactly 1 job
+    # (deduped across pages 1+2).
+    jobs = InfoJobsBrasilScraper("any", max_pages=2).fetch()
+    assert {j.ats_id for j in jobs} == {"42"}
+
+
+# --- error paths ------------------------------------------------------------
+
+
+def test_non_json_response_raises_scraper_error(httpx_mock) -> None:
+    """The API endpoint sometimes returns 200 with an HTML interstitial
+    when CDN caching misbehaves — surface that as a typed ScraperError."""
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE),
+        text="<html>error page</html>",
+        is_reusable=True,
+    )
+    with pytest.raises(ScraperError, match="non-JSON"):
+        InfoJobsBrasilScraper("any", max_pages=1).fetch()
+
+
+def test_persistent_500_raises(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE),
+        status_code=500, is_reusable=True,
+    )
+    with pytest.raises(ScraperError):
+        InfoJobsBrasilScraper("any", max_pages=1).fetch()
+
+
+# --- listing-URL passthrough -------------------------------------------------
+
+
+def test_fragment_url_carries_listing_with_page_param(httpx_mock) -> None:
+    """The backend reads ``page`` from the encoded listing URL, not
+    from the request URL. We verify the captured request URL contains
+    the listing URL with ``page=1`` percent-encoded inside.
+
+    Also pins the listing-URL override knob — a per-city listing URL
+    passes through verbatim with only ``page=N`` appended.
+    """
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE),
+        json={"eof": True, "listFragmentHTML": ""},
+        is_reusable=True,
+    )
+    InfoJobsBrasilScraper(
+        "any", max_pages=1,
+        listing_url="https://www.infojobs.com.br/empregos-em-rio-de-janeiro.aspx",
+    ).fetch()
+    requests = httpx_mock.get_requests()
+    assert requests, "expected at least one fragment request"
+    qs = urllib.parse.urlparse(str(requests[0].url)).query
+    inner = urllib.parse.parse_qs(qs)["url"][0]
+    inner_parsed = urllib.parse.urlparse(inner)
+    inner_params = urllib.parse.parse_qs(inner_parsed.query)
+    assert inner_parsed.path == "/empregos-em-rio-de-janeiro.aspx"
+    assert inner_params["page"] == ["1"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -30,6 +30,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
         "manfred", "thehub", "ycombinator", "wellfound",
+        "infojobs_br",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",
         "recruitee", "taleo", "teamtailor",


### PR DESCRIPTION
## Summary

- Adds `InfoJobsBrasilScraper` for [InfoJobs Brasil](https://www.infojobs.com.br), one of the largest general-purpose Brazilian job boards.
- Single-source scraper following the existing hybrid-jobboard pattern (Programathor, Get on Board, Welcome to the Jungle). `company_slug` is ignored.
- Pagination uses InfoJobs's own infinite-scroll fragment endpoint (`/mf-publicarea/VacancyList/GetVacancyListFragment?url={listing-url}`) which returns JSON with `eof` + `listFragmentHTML`. We hit that directly so we don't have to scrape the heavier SSR shell every page.
- Cards are HTML-only (no JSON-LD) but carry stable `data-id`, `data-href`, structured `js_date`, salary, modality, education and experience metadata. The scraper extracts what maps cleanly to the canonical `Job` schema and stashes the rest in `raw`.
- Brazilian-Portuguese specifics handled module-locally: `R$ 1.700,00` style numbers, `Até` / `A partir de` ranges, `Híbrido` / `Home Office` / `Presencial` → `is_remote`, `Efetivo` / `Estágio` / `PJ` etc. → canonical `EmploymentType`, `pt` locale, `BR` country.
- `ATSType.INFOJOBSBR = "infojobs_br"` added under the "Hybrid jobboards" group, with the corresponding test-suite pin in `tests/test_models.py` and re-export in `jobhive.scrapers.__init__`.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run pytest tests/test_infojobs_br.py` — 33 passed
- [x] `uv run pytest` — 912 passed (no regressions across the existing suite)
- [ ] Live spot check from a BR IP (manual; not part of CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `InfoJobsBrasilScraper` to ingest InfoJobs Brasil listings via the lightweight fragment API and map pt-BR fields to our canonical `Job` schema. Also adds `ATSType.INFOJOBSBR`, exports the scraper, seeds `ats-companies/infojobs_br.csv`, and fixes two review-found issues.

- **New Features**
  - New `InfoJobsBrasilScraper` (single-source; ignores `company_slug`) with pagination via `/mf-publicarea/VacancyList/GetVacancyListFragment?url=...&page=N`; stops on `eof` or 3 duplicate pages.
  - Extracts title, company, location, `posted_at` from `js_date`, BRL salaries (`R$`, “Até”, “A partir de”), modality → `is_remote`, and stores extras in `raw`.
  - Adds `ATSType.INFOJOBSBR = "infojobs_br"`, re-exports in `jobhive.scrapers.__init__`, and seeds `ats-companies/infojobs_br.csv`; tests cover parsing, salary/date handling, and pagination.

- **Bug Fixes**
  - Correct employment-type mapping for composite labels (e.g., “Efetivo CLT”) using substring matching.
  - Move network-error backoff sleep outside the concurrency semaphore to avoid blocking concurrent requests.

<sup>Written for commit 2fd3fc4cdee2a5b48c5a38c9028e2e2bf16621b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `InfoJobsBrasilScraper`, a new single-source scraper for the InfoJobs Brasil job board that paginates via a lightweight JSON fragment endpoint and maps Portuguese-language card fields to the canonical `Job` schema.

- Introduces `InfoJobsBrasilScraper` with BRL salary parsing, pt-BR modality → `is_remote` inference, structured date extraction, and exponential backoff retry logic.
- Adds `ATSType.INFOJOBSBR = \"infojobs_br\"`, re-exports the scraper from `jobhive.scrapers`, seeds `ats-companies/infojobs_br.csv`, and adds 33 targeted tests.

<h3>Confidence Score: 3/5</h3>

The scraper is safe to land for the common case, but the employment_type field will silently return None for any compound label (e.g. "Efetivo CLT") due to a mismatch between the substring-based detection guard and the exact-key map lookup.

Employment type detection uses `any(t in value.lower() for t in map)` to decide a match exists, but then calls `map.get(full_value.lower())` for the actual lookup — if the card label contains more than one keyword or has parenthetical text, detection succeeds but the lookup returns None every time. No test exercises an employment-type card value so the gap has gone unnoticed.

src/jobhive/scrapers/infojobs_br.py — specifically the employment_type detection/lookup block in `_parse_card` and the semaphore-held sleep in `_request_json`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/infojobs_br.py | New scraper with well-structured pagination, retry, and BRL parsing logic; has a logic bug where employment_type is always None for any compound card label because substring detection and exact-key lookup are mismatched. |
| tests/test_infojobs_br.py | Good coverage of salary parsing, remote inference, pagination termination, and error paths; the employment_type code path is not exercised by any test, leaving the P1 bug undetected. |
| src/jobhive/models.py | Adds INFOJOBSBR = "infojobs_br" to ATSType in the hybrid-jobboard group; straightforward and correct. |
| src/jobhive/scrapers/__init__.py | Adds import and __all__ export for InfoJobsBrasilScraper in alphabetical order; no issues. |
| tests/test_models.py | Adds "infojobs_br" to the ATSType exhaustiveness check; correct. |
| ats-companies/infojobs_br.csv | Seeds the board with a single InfoJobs Brasil entry; correct format. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/jobhive/scrapers/infojobs_br.py:342-351
The employment-type detection and lookup are logically mismatched. `any(t in icon_values[k].lower() for t in _EMPLOYMENT_MAP)` uses substring matching, but `_EMPLOYMENT_MAP.get(commitment_raw.lower())` does an exact-key lookup. Whenever the card shows a compound label like `"Efetivo CLT"` or `"Estágio (Sem Remuneração)"`, the `any()` succeeds (finding `"efetivo"` or `"estágio"` as a substring), `commitment_raw` is set to the full string, and the exact `get()` then silently returns `None` — so `employment_type` is never populated for those cases.

```suggestion
        commitment_raw = None
        employment_type = None
        for k in ("file", "file-alt", "document", "suitcase"):
            if k in icon_values:
                val_lower = icon_values[k].lower()
                for t in _EMPLOYMENT_MAP:
                    if t in val_lower:
                        commitment_raw = icon_values[k]
                        employment_type = _EMPLOYMENT_MAP[t]
                        break
            if commitment_raw:
                break
```

### Issue 2 of 2
src/jobhive/scrapers/infojobs_br.py:235-242
The `asyncio.sleep` in the `httpx.HTTPError` handler is executed while holding the semaphore (it's inside the `async with sem:` block). Any concurrent caller waiting to acquire a slot is blocked for the full backoff duration. The 429/5xx retry path correctly sleeps *outside* the semaphore; the network-error path should do the same.

```suggestion
                except httpx.HTTPError as exc:
                    last_exc = exc
                    if attempt == MAX_RETRIES:
                        raise ScraperError(
                            f"InfoJobs Brasil fetch failed for {url}: {exc}"
                        ) from exc
                    needs_retry = True
                else:
                    needs_retry = False
            if needs_retry:
                await asyncio.sleep(RETRY_BASE_DELAY * attempt)
                continue
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: infojobs\_br...."](https://github.com/kalil0321/ats-scrapers/commit/b271943ce325cd905968fbaeb5585a7bab455544) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732483)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->