### PR TITLE
worknet_kr: add Korean Ministry of Employment job board scraper

### DIFF
--- a/ats-companies/worknet_kr.csv
+++ b/ats-companies/worknet_kr.csv
@@ -1,0 +1,2 @@
+name,slug,url
+WorkNet Korea,worknet_kr,https://www.work24.go.kr

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -67,6 +67,7 @@ class ATSType(StrEnum):
     BUNDESAGENTUR = "bundesagentur"
     ARBETSFORMEDLINGEN = "arbetsformedlingen"
     EURES = "eures"
+    WORKNETKR = "worknetkr"
     # Hybrid jobboards (companies post directly, not aggregated)
     WELCOMETOTHEJUNGLE = "welcometothejungle"
     GETONBRD = "getonbrd"

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -67,7 +67,7 @@ class ATSType(StrEnum):
     BUNDESAGENTUR = "bundesagentur"
     ARBETSFORMEDLINGEN = "arbetsformedlingen"
     EURES = "eures"
-    WORKNETKR = "worknetkr"
+    WORKNETKR = "worknet_kr"
     # Hybrid jobboards (companies post directly, not aggregated)
     WELCOMETOTHEJUNGLE = "welcometothejungle"
     GETONBRD = "getonbrd"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -57,6 +57,7 @@ from jobhive.scrapers.wellfound import WellfoundScraper
 from jobhive.scrapers.weworkremotely import WeWorkRemotelyScraper
 from jobhive.scrapers.workable import WorkableScraper
 from jobhive.scrapers.workday import WorkdayScraper
+from jobhive.scrapers.worknet_kr import WorkNetKoreaScraper
 from jobhive.scrapers.ycombinator import YCombinatorScraper
 
 __all__ = [
@@ -107,6 +108,7 @@ __all__ = [
     "WantedScraper",
     "WeWorkRemotelyScraper",
     "WellfoundScraper",
+    "WorkNetKoreaScraper",
     "WorkableScraper",
     "WorkdayScraper",
     "YCombinatorScraper",

--- a/src/jobhive/scrapers/worknet_kr.py
+++ b/src/jobhive/scrapers/worknet_kr.py
@@ -1,0 +1,384 @@
+"""WorkNet (work24.go.kr / work.go.kr) — Korean Ministry of Employment
+job board scraper.
+
+WorkNet is operated by the Korean Ministry of Employment & Labor and is
+the country's official public-sector job listings service. It exposes a
+documented open API ("채용정보 API") via Korea's data portal
+(data.go.kr) at:
+
+    GET https://openapi.work.go.kr/opi/opi/opia/wantedApi.do
+        ?authKey={WORKNET_API_KEY}
+        &callTp=L              # L = list, D = detail
+        &returnType=XML        # only XML works; JSON triggers msgCd=004
+        &startPage={1..N}
+        &display={1..100}
+
+Authentication is by free API key. Apply at https://www.data.go.kr/ or
+the WorkNet open-API portal, then store it as ``WORKNET_API_KEY``. When
+the env var is missing, :meth:`fetch` raises :class:`ScraperError` with
+a clear pointer to the docs — the scraper gracefully degrades rather
+than crashing the cron with an opaque traceback.
+
+Typical run: 100-400k active postings spread across public-sector
+employers, mid-size Korean SMEs that publish through the government
+service, and rotating regional-government job programmes. The
+single-source pattern follows Bundesagentur / USAJOBS: ``company_slug``
+is informational (used for logging only) and we always pull the full
+active dataset.
+
+Field mapping (XML element → Job field):
+
+* ``wantedAuthNo`` → ``ats_id`` (composite ID of the form
+  ``K1622...``, stable per posting).
+* ``empWantedTitle`` → ``title``
+* ``coNm`` → ``company`` (employer name).
+* ``workRegion`` → ``location``.
+* ``empWantedHomepgDetail`` / detail URL → ``url``.
+* ``regDt``, ``regDtEnd`` → ``posted_at`` and ``raw.expires_at``.
+* ``salTpNm`` / ``sal`` → ``salary_summary`` (free text; structured
+  min/max derivation happens downstream).
+* ``empWantedTypeNm`` → ``commitment`` (raw Korean label).
+* ``jobsCd`` / ``industry`` / ``career`` / ``salTpCd`` → ``raw`` dict.
+
+``country_iso="KR"`` and ``language="ko"`` are set unconditionally —
+WorkNet is single-country, Korean-only by definition.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING
+from xml.etree import ElementTree as ET
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+API_URL = "https://openapi.work.go.kr/opi/opi/opia/wantedApi.do"
+DETAIL_URL_TEMPLATE = (
+    "https://www.work24.go.kr/wk/a/b/1500/empDetailAuthView.do?wantedAuthNo={ats_id}"
+)
+DEFAULT_PAGE_SIZE = 100  # API hard-caps at 100 (display=100).
+DEFAULT_MAX_PAGES = 200  # 20k postings/run safety bound; bump for full crawls.
+MAX_CONCURRENCY = 2  # Korean gov APIs throttle aggressively above this.
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1.5
+ENV_API_KEY = "WORKNET_API_KEY"
+
+# API responses describe terminal application errors via ``<messageCd>``.
+# 000 / 200 indicate success; any other value is a contract break
+# (invalid key, malformed params, etc.) and we surface it as a hard
+# ``ScraperError``. The text label is in Korean.
+_APP_ERROR_CODES = {
+    "002": "Invalid authentication key",
+    "003": "Daily quota exceeded",
+    "004": "Invalid returnType (only XML is supported)",
+    "018": "Missing required parameter for detail view",
+}
+
+# WorkNet's Korean employment-type labels → canonical EmploymentType.
+# The API exposes ``empWantedTypeNm`` as a free-text Korean label; the
+# code-form ``empWantedTypeCd`` is taxonomy-stable but Korean labels
+# carry more nuance, so we map both.
+_TYPE_LABEL_MAP = {
+    "정규직": "FULL_TIME",
+    "계약직": "CONTRACT",
+    "기간제": "CONTRACT",
+    "파견직": "TEMPORARY",
+    "일용직": "TEMPORARY",
+    "인턴": "INTERN",
+    "아르바이트": "PART_TIME",
+}
+
+HTML_TAG_RE = re.compile(r"<[^>]+>")
+WHITESPACE_RE = re.compile(r"\s+")
+MAX_DESCRIPTION_LEN = 10_000
+
+
+@ScraperRegistry.register(ATSType.WORKNETKR)
+class WorkNetKoreaScraper(BaseScraper):
+    """WorkNet (Korea, work24.go.kr) scraper. Single-source —
+    ``company_slug`` is unused.
+
+    Reads ``WORKNET_API_KEY`` from the environment; raises
+    :class:`ScraperError` when missing. Free API keys are issued at
+    https://www.data.go.kr/ or the WorkNet Open-API portal.
+    """
+
+    ats = ATSType.WORKNETKR
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        page_size: int = DEFAULT_PAGE_SIZE,
+        max_pages: int = DEFAULT_MAX_PAGES,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.page_size = page_size
+        self.max_pages = max_pages
+
+    def fetch(self) -> list[Job]:
+        api_key = os.environ.get(ENV_API_KEY, "").strip()
+        if not api_key:
+            raise ScraperError(
+                f"{ENV_API_KEY} env var is required. Register at "
+                "https://www.data.go.kr/ (search '워크넷 채용정보') or "
+                "https://www.work24.go.kr/cm/e/a/0110/selectOpenApiIntro.do "
+                "for a free key."
+            )
+        return asyncio.run(self._fetch_async(api_key))
+
+    async def _fetch_async(self, api_key: str) -> list[Job]:
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+            page = 1
+            while page <= self.max_pages:
+                items = await self._fetch_page(client, sem, api_key, page)
+                if not items:
+                    break
+                new_count = 0
+                for item in items:
+                    job = self._parse_item(item)
+                    if job is None or job.ats_id in seen:
+                        continue
+                    seen.add(job.ats_id)
+                    jobs.append(job)
+                    new_count += 1
+                # The API returns fewer than display=page_size when the
+                # last page is reached — that's the termination signal.
+                if len(items) < self.page_size or new_count == 0:
+                    break
+                page += 1
+        return jobs
+
+    async def _fetch_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        api_key: str,
+        page: int,
+    ) -> list[dict[str, Any]]:
+        params: dict[str, Any] = {
+            "authKey": api_key,
+            "callTp": "L",
+            "returnType": "XML",
+            "startPage": page,
+            "display": self.page_size,
+        }
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(
+                        API_URL,
+                        params=params,
+                        headers={
+                            "User-Agent": "Mozilla/5.0 (stapply-ai jobhive)",
+                            "Accept": "application/xml,text/xml,*/*",
+                            "Accept-Language": "ko-KR,ko;q=0.9,en;q=0.5",
+                        },
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"WorkNet fetch failed at page={page}: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                return self._parse_list_xml(response.text, page=page)
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"WorkNet returned {response.status_code} at "
+                        f"page={page} after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2**attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"WorkNet returned {response.status_code} at page={page}"
+            )
+        raise ScraperError(
+            f"WorkNet exhausted retries at page={page}: {last_exc}"
+        )
+
+    def _parse_list_xml(self, body: str, *, page: int) -> list[dict[str, Any]]:
+        """Parse the ``<wantedRoot>`` XML list response into row dicts.
+
+        Surfaces ``<messageCd>`` errors as :class:`ScraperError` — those
+        are contract breaks (bad key, quota exhausted) and must not be
+        swallowed as ``[]``. Empty result sets come back as a
+        well-formed root with zero ``<wanted>`` children, which is
+        different from an error response and returns ``[]`` cleanly.
+        """
+        try:
+            root = ET.fromstring(body)
+        except ET.ParseError as exc:
+            raise ScraperError(
+                f"WorkNet returned malformed XML at page={page}: {exc}"
+            ) from exc
+
+        message_cd = root.findtext("messageCd")
+        if message_cd and message_cd not in ("", "000", "200"):
+            label = _APP_ERROR_CODES.get(
+                message_cd, root.findtext("message") or "unknown error"
+            )
+            raise ScraperError(
+                f"WorkNet API error msgCd={message_cd} at page={page}: {label}"
+            )
+
+        items: list[dict[str, Any]] = []
+        # The API wraps each posting in ``<wanted>`` under
+        # ``<wantedRoot>`` — there are no namespaces or attributes to
+        # juggle, just direct child text.
+        for posting in root.findall("wanted"):
+            row: dict[str, Any] = {}
+            for child in posting:
+                if child.text is None:
+                    continue
+                value = child.text.strip()
+                if value:
+                    row[child.tag] = value
+            if row:
+                items.append(row)
+        return items
+
+    def _parse_item(self, item: dict[str, Any]) -> Job | None:
+        ats_id = (item.get("wantedAuthNo") or "").strip()
+        title = (item.get("empWantedTitle") or item.get("title") or "").strip()
+        if not ats_id or not title:
+            return None
+
+        company = (item.get("coNm") or "WorkNet").strip() or "WorkNet"
+
+        # Prefer the API-provided detail URL when present; fall back to
+        # the canonical work24 detail page built from wantedAuthNo.
+        url_field = (
+            item.get("empWantedHomepgDetail")
+            or item.get("empWantedHomepg")
+            or item.get("empWantedInfoUrl")
+        )
+        if isinstance(url_field, str) and url_field.startswith("http"):
+            url = url_field.strip()
+        else:
+            url = DETAIL_URL_TEMPLATE.format(ats_id=ats_id)
+
+        location = _first_nonempty(
+            item.get("workRegion"),
+            item.get("workPlcNm"),
+            item.get("region"),
+        )
+
+        type_label = (item.get("empWantedTypeNm") or "").strip() or None
+        employment_type = _TYPE_LABEL_MAP.get(type_label) if type_label else None
+
+        salary_summary = _first_nonempty(
+            item.get("sal"),
+            item.get("salTpNm"),
+        )
+        # Only attach a currency when there is a salary signal to
+        # describe — empty salary_summary + KRW currency would lie about
+        # the row having compensation data.
+        salary_currency = "KRW" if salary_summary else None
+
+        posted_at = _parse_date(item.get("regDt") or item.get("regDate"))
+
+        # Free-text job description varies across endpoints; the list
+        # call doesn't return the full HTML body, but it does include a
+        # short "preview" / required-condition field on most rows.
+        description = _html_to_text(
+            item.get("empWantedContents")
+            or item.get("empBassRequdCont")
+            or item.get("jobCont")
+        )
+
+        raw: dict[str, Any] = {}
+        for source, dest in (
+            ("jobsCd", "job_type_code"),
+            ("salTpCd", "wage_code"),
+            ("indCd", "industry_code"),
+            ("career", "career_level"),
+            ("careerCd", "career_code"),
+            ("empWantedTypeCd", "employment_type_code"),
+            ("regDtEnd", "expires_at"),
+            ("eduNm", "education_label"),
+            ("eduCd", "education_code"),
+            ("collectPsncnt", "headcount"),
+        ):
+            value = item.get(source)
+            if value not in (None, ""):
+                raw[dest] = value
+
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.WORKNETKR,
+            ats_id=ats_id,
+            location=location,
+            country_iso="KR",
+            language="ko",
+            employment_type=employment_type,
+            commitment=type_label,
+            description=description,
+            salary_summary=salary_summary,
+            salary_currency=salary_currency,
+            posted_at=posted_at,
+            fetched_at=datetime.now(),
+            raw=raw or None,
+        )
+
+
+def _first_nonempty(*values: object) -> str | None:
+    for v in values:
+        if isinstance(v, str) and v.strip():
+            return v.strip()
+    return None
+
+
+def _html_to_text(value: object) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    text = HTML_TAG_RE.sub(" ", value)
+    text = WHITESPACE_RE.sub(" ", text).strip()
+    if not text:
+        return None
+    return text[:MAX_DESCRIPTION_LEN]
+
+
+def _parse_date(value: object) -> datetime | None:
+    """Parse WorkNet date strings.
+
+    The list endpoint emits ``YYYYMMDD`` (eight-digit, no separators) or
+    occasionally ``YYYY-MM-DD``. Both are surface-formats over the same
+    underlying date — try both before giving up.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip()
+    for fmt in ("%Y%m%d", "%Y-%m-%d", "%Y/%m/%d"):
+        try:
+            return datetime.strptime(raw, fmt)
+        except ValueError:
+            continue
+    return None

--- a/src/jobhive/scrapers/worknet_kr.py
+++ b/src/jobhive/scrapers/worknet_kr.py
@@ -67,7 +67,7 @@ DETAIL_URL_TEMPLATE = (
     "https://www.work24.go.kr/wk/a/b/1500/empDetailAuthView.do?wantedAuthNo={ats_id}"
 )
 DEFAULT_PAGE_SIZE = 100  # API hard-caps at 100 (display=100).
-DEFAULT_MAX_PAGES = 200  # 20k postings/run safety bound; bump for full crawls.
+DEFAULT_MAX_PAGES = 5000  # 500k postings/run ceiling; board runs 100-400k active.
 MAX_CONCURRENCY = 2  # Korean gov APIs throttle aggressively above this.
 MAX_RETRIES = 3
 RETRY_BASE_DELAY = 1.5

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -25,7 +25,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "amazon", "apple", "google", "meta",
         "tesla", "tiktok", "uber", "usajobs",
         # National / supranational public-sector aggregators
-        "bundesagentur", "arbetsformedlingen", "eures", "worknetkr",
+        "bundesagentur", "arbetsformedlingen", "eures", "worknet_kr",
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -25,7 +25,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "amazon", "apple", "google", "meta",
         "tesla", "tiktok", "uber", "usajobs",
         # National / supranational public-sector aggregators
-        "bundesagentur", "arbetsformedlingen", "eures",
+        "bundesagentur", "arbetsformedlingen", "eures", "worknetkr",
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",

--- a/tests/test_worknet_kr.py
+++ b/tests/test_worknet_kr.py
@@ -86,7 +86,7 @@ def test_registry_resolves_worknet() -> None:
 
 def test_ats_type_enum_value() -> None:
     """The enum value travels into the public dataset; pin it."""
-    assert ATSType.WORKNETKR.value == "worknetkr"
+    assert ATSType.WORKNETKR.value == "worknet_kr"
 
 
 # --- env-var gate -----------------------------------------------------------

--- a/tests/test_worknet_kr.py
+++ b/tests/test_worknet_kr.py
@@ -1,0 +1,311 @@
+"""Tests for the WorkNet (Korea, work24.go.kr) scraper.
+
+The open API is XML-only and key-gated; these tests pin the parsing
+contract, the env-var gate, and the error-code handling that
+distinguishes a clean empty result from a contract break (invalid key,
+exhausted quota) that must crash rather than silently return ``[]``.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import ScraperRegistry, WorkNetKoreaScraper
+
+_API_RE = re.compile(r"^https://openapi\.work\.go\.kr/opi/opi/opia/wantedApi\.do")
+
+
+@pytest.fixture(autouse=True)
+def _api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default to a non-empty key so tests don't all have to set it.
+
+    Tests that exercise the missing-key path explicitly ``delenv`` first.
+    """
+    monkeypatch.setenv("WORKNET_API_KEY", "TEST_KEY")
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.worknet_kr as wn
+    monkeypatch.setattr(wn, "MAX_RETRIES", 1)
+    monkeypatch.setattr(wn, "RETRY_BASE_DELAY", 0.0)
+
+
+def _wanted_xml(rows: list[dict[str, str]]) -> str:
+    """Build a ``<wantedRoot>`` body the way the open API emits it."""
+    elements = []
+    for row in rows:
+        children = "".join(
+            f"<{k}>{v}</{k}>" for k, v in row.items()
+        )
+        elements.append(f"<wanted>{children}</wanted>")
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        f"<wantedRoot>{''.join(elements)}</wantedRoot>"
+    )
+
+
+_DEFAULT_ROW: dict[str, str] = {
+    "wantedAuthNo": "K162825302008",
+    "empWantedTitle": "데이터 엔지니어",
+    "coNm": "한국전자통신연구원",
+    "workRegion": "서울특별시 강남구",
+    "regDt": "20260501",
+    "empWantedTypeNm": "정규직",
+    "sal": "연 4,500만원 이상",
+    "salTpNm": "연봉",
+    "jobsCd": "133100",
+    "salTpCd": "Y",
+    "indCd": "62010",
+    "career": "신입",
+}
+
+
+def _row(**overrides: str) -> dict[str, str]:
+    """Build one ``<wanted>`` row by overlaying overrides on the
+    default Korean-public-sector posting fixture.
+
+    Pass field names exactly as the WorkNet API emits them (camelCase
+    Korean) — they propagate verbatim into the XML body.
+    """
+    base = dict(_DEFAULT_ROW)
+    base.update(overrides)
+    return base
+
+
+# --- registry / wiring ------------------------------------------------------
+
+
+def test_registry_resolves_worknet() -> None:
+    assert ScraperRegistry.get(ATSType.WORKNETKR) is WorkNetKoreaScraper
+
+
+def test_ats_type_enum_value() -> None:
+    """The enum value travels into the public dataset; pin it."""
+    assert ATSType.WORKNETKR.value == "worknetkr"
+
+
+# --- env-var gate -----------------------------------------------------------
+
+
+def test_missing_api_key_raises_clear_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("WORKNET_API_KEY", raising=False)
+    with pytest.raises(ScraperError) as excinfo:
+        WorkNetKoreaScraper("any").fetch()
+    assert "WORKNET_API_KEY" in str(excinfo.value)
+
+
+def test_empty_api_key_raises_clear_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Whitespace-only key counts as missing."""
+    monkeypatch.setenv("WORKNET_API_KEY", "   ")
+    with pytest.raises(ScraperError) as excinfo:
+        WorkNetKoreaScraper("any").fetch()
+    assert "WORKNET_API_KEY" in str(excinfo.value)
+
+
+# --- parsing happy path ----------------------------------------------------
+
+
+def test_parses_full_xml_row(httpx_mock) -> None:
+    """Single-page scrape; verify every populated Job field maps to the
+    right WorkNet XML element."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        content=_wanted_xml([_row()]).encode("utf-8"),
+        headers={"Content-Type": "application/xml"},
+        is_reusable=True,
+    )
+    jobs = WorkNetKoreaScraper("any").fetch()
+    assert len(jobs) == 1
+    job = jobs[0]
+    assert job.ats_id == "K162825302008"
+    assert job.ats_type is ATSType.WORKNETKR
+    assert job.title == "데이터 엔지니어"
+    assert job.company == "한국전자통신연구원"
+    assert job.location == "서울특별시 강남구"
+    assert job.country_iso == "KR"
+    assert job.language == "ko"
+    assert job.employment_type == "FULL_TIME"
+    assert job.commitment == "정규직"
+    assert job.salary_currency == "KRW"
+    assert job.salary_summary == "연 4,500만원 이상"
+    assert job.posted_at is not None
+    assert job.posted_at.year == 2026
+    assert job.posted_at.month == 5
+    assert job.posted_at.day == 1
+    # Detail URL falls back to work24.go.kr when the API doesn't
+    # expose a direct link.
+    assert "K162825302008" in str(job.url)
+    assert "work24.go.kr" in str(job.url)
+    assert job.raw == {
+        "job_type_code": "133100",
+        "wage_code": "Y",
+        "industry_code": "62010",
+        "career_level": "신입",
+    }
+
+
+def test_detail_url_prefers_api_provided_link(httpx_mock) -> None:
+    """When the API returns a fully qualified detail URL, use it
+    verbatim instead of the work24 fallback."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        content=_wanted_xml([
+            _row(empWantedHomepgDetail="https://example.com/jobs/abc"),
+        ]).encode("utf-8"),
+    )
+    jobs = WorkNetKoreaScraper("any").fetch()
+    assert str(jobs[0].url).rstrip("/") == "https://example.com/jobs/abc"
+
+
+def test_employment_type_label_mapping(httpx_mock) -> None:
+    """Korean employment-type labels map to the canonical enum;
+    commitment keeps the original Korean text."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        content=_wanted_xml([
+            _row(wantedAuthNo="A1", empWantedTypeNm="정규직"),
+            _row(wantedAuthNo="A2", empWantedTypeNm="계약직"),
+            _row(wantedAuthNo="A3", empWantedTypeNm="인턴"),
+            _row(wantedAuthNo="A4", empWantedTypeNm="아르바이트"),
+            _row(wantedAuthNo="A5", empWantedTypeNm="파견직"),
+        ]).encode("utf-8"),
+    )
+    jobs = WorkNetKoreaScraper("any").fetch()
+    by_id = {j.ats_id: j for j in jobs}
+    assert by_id["A1"].employment_type == "FULL_TIME"
+    assert by_id["A2"].employment_type == "CONTRACT"
+    assert by_id["A3"].employment_type == "INTERN"
+    assert by_id["A4"].employment_type == "PART_TIME"
+    assert by_id["A5"].employment_type == "TEMPORARY"
+    assert by_id["A1"].commitment == "정규직"
+
+
+def test_missing_required_fields_drops_row(httpx_mock) -> None:
+    """A row without ``wantedAuthNo`` or ``empWantedTitle`` is unusable
+    and must be skipped silently."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        content=_wanted_xml([
+            {"empWantedTitle": "No ID"},  # missing wantedAuthNo
+            {"wantedAuthNo": "K9"},  # missing title
+            _row(wantedAuthNo="K10", empWantedTitle="Valid"),
+        ]).encode("utf-8"),
+    )
+    jobs = WorkNetKoreaScraper("any").fetch()
+    assert {j.ats_id for j in jobs} == {"K10"}
+
+
+def test_no_salary_no_currency(httpx_mock) -> None:
+    """When the row has no salary text, we don't attach a phantom KRW
+    currency — that would lie about the row having compensation data."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        content=_wanted_xml([
+            {
+                "wantedAuthNo": "K1",
+                "empWantedTitle": "Engineer",
+                "coNm": "Acme",
+            },
+        ]).encode("utf-8"),
+    )
+    jobs = WorkNetKoreaScraper("any").fetch()
+    assert jobs[0].salary_currency is None
+    assert jobs[0].salary_summary is None
+
+
+# --- pagination -------------------------------------------------------------
+
+
+def test_pagination_terminates_on_short_page(httpx_mock) -> None:
+    """The API has no explicit ``last`` flag — pagination stops when a
+    page returns fewer rows than ``display``."""
+    page1 = _wanted_xml([_row(wantedAuthNo=f"P1-{i}") for i in range(100)])
+    page2 = _wanted_xml([_row(wantedAuthNo=f"P2-{i}") for i in range(3)])
+    httpx_mock.add_response(url=_API_RE, content=page1.encode("utf-8"))
+    httpx_mock.add_response(url=_API_RE, content=page2.encode("utf-8"))
+    jobs = WorkNetKoreaScraper("any").fetch()
+    assert len(jobs) == 103
+
+
+def test_pagination_terminates_on_empty_page(httpx_mock) -> None:
+    """An empty ``<wantedRoot></wantedRoot>`` response (zero <wanted>
+    children) is the natural end-of-stream — return what we've got."""
+    page1 = _wanted_xml([_row(wantedAuthNo="K-1")])
+    page2 = '<?xml version="1.0" encoding="UTF-8"?><wantedRoot></wantedRoot>'
+    httpx_mock.add_response(url=_API_RE, content=page1.encode("utf-8"))
+    httpx_mock.add_response(url=_API_RE, content=page2.encode("utf-8"))
+
+    scraper = WorkNetKoreaScraper("any", page_size=1)
+    jobs = scraper.fetch()
+    assert {j.ats_id for j in jobs} == {"K-1"}
+
+
+def test_dedup_across_pages(httpx_mock) -> None:
+    """If the API returns the same row twice across pages, ats_id-based
+    dedup drops the repeat."""
+    repeated = _row(wantedAuthNo="K-DUP")
+    page1 = _wanted_xml([repeated, _row(wantedAuthNo="K-A")])
+    # Page 2 sends only the duplicate (short page → terminates).
+    page2 = _wanted_xml([repeated])
+    httpx_mock.add_response(url=_API_RE, content=page1.encode("utf-8"))
+    httpx_mock.add_response(url=_API_RE, content=page2.encode("utf-8"))
+
+    scraper = WorkNetKoreaScraper("any", page_size=2)
+    jobs = scraper.fetch()
+    assert sorted(j.ats_id for j in jobs) == ["K-A", "K-DUP"]
+
+
+# --- contract-break failures: must crash, not soft-fail --------------------
+
+
+def test_invalid_key_application_error_crashes(httpx_mock) -> None:
+    """API error code 002 (invalid key) is a contract break — the
+    scraper must raise, not silently return ``[]``. A silent zero-result
+    response would publish a wholesale undercount as a successful run."""
+    body = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        "<wantedRoot>"
+        "<message>유효하지 않은 인증키 입니다.</message>"
+        "<messageCd>002</messageCd>"
+        "</wantedRoot>"
+    )
+    httpx_mock.add_response(url=_API_RE, content=body.encode("utf-8"))
+    with pytest.raises(ScraperError) as excinfo:
+        WorkNetKoreaScraper("any").fetch()
+    assert "002" in str(excinfo.value)
+
+
+def test_quota_exceeded_application_error_crashes(httpx_mock) -> None:
+    """Quota exhaustion (msgCd=003) is loud-fail too — operator should
+    see it, not have it papered over as a successful empty run."""
+    body = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        "<wantedRoot>"
+        "<message>일일 트래픽 한도를 초과했습니다.</message>"
+        "<messageCd>003</messageCd>"
+        "</wantedRoot>"
+    )
+    httpx_mock.add_response(url=_API_RE, content=body.encode("utf-8"))
+    with pytest.raises(ScraperError) as excinfo:
+        WorkNetKoreaScraper("any").fetch()
+    assert "003" in str(excinfo.value)
+
+
+def test_malformed_xml_crashes(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_API_RE,
+        content=b"<html>Maintenance</html><<not-xml>>",
+    )
+    with pytest.raises(ScraperError):
+        WorkNetKoreaScraper("any").fetch()
+
+
+def test_http_500_crashes_after_retries(httpx_mock) -> None:
+    httpx_mock.add_response(url=_API_RE, status_code=500, is_reusable=True)
+    with pytest.raises(ScraperError):
+        WorkNetKoreaScraper("any").fetch()


### PR DESCRIPTION
## Summary

- New single-source scraper `WorkNetKoreaScraper` (`ATSType.WORKNETKR`) for **work24.go.kr / work.go.kr** — Korea's official public-sector job board operated by the Ministry of Employment & Labor. Hundreds of thousands of postings spanning public-sector employers, mid-size Korean SMEs that publish via the government service, and rotating regional-government programmes.
- Uses the documented open API at `https://openapi.work.go.kr/opi/opi/opia/wantedApi.do` (XML-only — JSON returns `messageCd=004`). Authentication is by free API key from data.go.kr; the scraper reads `WORKNET_API_KEY` from the env and raises `ScraperError` with a clear pointer when missing.
- Application-error contract: codes other than `000/200` (invalid key `002`, quota exhausted `003`, etc.) propagate as `ScraperError` — silent zero-result responses are explicitly disallowed since they would publish a wholesale undercount as a successful run. Same contract pattern as Bundesagentur.

## Field mapping

| WorkNet XML element        | `Job` field                       |
| -------------------------- | --------------------------------- |
| `wantedAuthNo`             | `ats_id`                          |
| `empWantedTitle`           | `title`                           |
| `coNm`                     | `company`                         |
| `workRegion`               | `location` (always `country_iso="KR"`, `language="ko"`) |
| `empWantedHomepgDetail`    | `url` (fallback → work24 detail URL) |
| `regDt` (YYYYMMDD)         | `posted_at`                       |
| `sal` / `salTpNm`          | `salary_summary` (currency `KRW` only when present) |
| `empWantedTypeNm`          | `commitment` + canonical `employment_type` |
| `jobsCd`, `salTpCd`, `indCd`, `career` | `raw.{job_type_code, wage_code, industry_code, career_level}` |

## Test plan

- [x] `tests/test_worknet_kr.py` — 16 tests covering: registry wiring, env-var gate (missing + whitespace-only), full XML row parsing, detail-URL fallback, Korean employment-type label mapping, missing-required-fields drop, no-salary path, pagination termination on short / empty pages, dedup across pages, and four contract-break failure modes (invalid key, quota, malformed XML, persistent HTTP 500).
- [x] `tests/test_models.py` — `ATSType.WORKNETKR = "worknetkr"` pinned in the enum-value contract test.
- [x] `ruff check` clean across the project.
- [x] `pytest` — full suite passes (895 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new scraper for Korea’s official job board (work24.go.kr / work.go.kr) using the XML API. Raises the default page cap to 5,000 to avoid undercounting and aligns the enum slug to `worknet_kr`.

- **New Features**
  - Added `WorkNetKoreaScraper` using `https://openapi.work.go.kr/opi/opi/opia/wantedApi.do` (XML only).
  - Reads `WORKNET_API_KEY`; missing key or API `messageCd` errors raise `ScraperError`.
  - Field mapping: `wantedAuthNo`→`ats_id`, `empWantedTitle`→`title`, `coNm`→`company`, `workRegion`→`location` (`KR`, `ko`), detail URL with work24 fallback, `regDt`→`posted_at`, salary→`salary_summary` (`KRW` only if present), Korean employment-type labels→canonical type.
  - Pagination with dedup, low concurrency, and retries for 429/5xx; default `max_pages=5000`. Wired into registry and enum `ATSType.WORKNETKR` with value `worknet_kr`; tests cover parsing, pagination, and failure modes.
  - Seeded `ats-companies/worknet_kr.csv`.

- **Migration**
  - Set `WORKNET_API_KEY` with a valid key from data.go.kr/work24.

<sup>Written for commit de30775c7bab9f6f505ea920026dff7040cb67d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `WorkNetKoreaScraper` (`ATSType.WORKNETKR`) — a single-source XML scraper for Korea's official government job board (`work24.go.kr`), authenticated via a free `WORKNET_API_KEY` from data.go.kr. The scraper is well-structured with proper error-code detection, `ats_id`-based dedup, and a solid test suite.

- Field mapping covers all key WorkNet XML elements to the canonical `Job` model, with Korean employment-type labels mapped to `EmploymentType` constants.
- `messageCd` errors surface as hard `ScraperError` rather than silent empty returns.
- `DEFAULT_MAX_PAGES = 200` caps every run at 20 000 jobs from a board holding 100–400 k active postings, making the default config a systematic undercount.

<h3>Confidence Score: 3/5</h3>

Safe to merge for wiring and parsing correctness, but the default page cap will silently deliver a small fraction of the board postings on every production run.

The scraper XML parsing, error-code handling, dedup logic, and test coverage are all solid. The default max_pages=200 means a production scrape of a 400k-posting board returns at most 20k jobs and reports success — the same class of silent undercount the PR design explicitly prohibits.

src/jobhive/scrapers/worknet_kr.py — specifically the DEFAULT_MAX_PAGES constant and the retry-sleep placement inside the semaphore.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/worknet_kr.py | New WorkNet scraper with solid XML parsing and error-code handling, but DEFAULT_MAX_PAGES=200 caps output at 20k jobs on a 100-400k posting board, silently undercounting every run. |
| src/jobhive/models.py | Adds WORKNETKR = "worknetkr" to ATSType enum in the correct position. |
| src/jobhive/scrapers/__init__.py | Adds import and __all__ entry for WorkNetKoreaScraper in alphabetical order; no issues. |
| tests/test_worknet_kr.py | 16 tests covering registry wiring, env-var gate, XML parsing, pagination termination, dedup, and all four error-code paths. |
| tests/test_models.py | Adds worknetkr to the enum-value contract test. |
| ats-companies/worknet_kr.csv | Two-line seed CSV with correct fields; no issues. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/jobhive/scrapers/worknet_kr.py:70
The default cap of 200 pages × 100 items = 20 000 jobs per run silently underreports a board that the module docstring says holds 100–400 k active postings. Every production run would publish ≤ 5–20 % of the board as a "successful" scrape — the exact silent-undercount pattern the PR's own design philosophy states must be prevented. Consider raising the default to a value that comfortably covers the largest realistic dataset, or — following the Bundesagentur approach — add a date-range / category subdivision to stay within any per-query API cap.

```suggestion
DEFAULT_MAX_PAGES = 5000  # 500k postings safety bound (board has 100-400k active).
```

### Issue 2 of 2
src/jobhive/scrapers/worknet_kr.py:195-202
The retry `asyncio.sleep` for network errors is called **inside** the `async with sem:` block, so the semaphore slot is held for the full back-off duration. While the current sequential pagination means only one `_fetch_page` call is in-flight at a time (making this harmless today), the slot-while-sleeping pattern would fully serialize concurrency if page fetching is ever parallelised. The 429/5xx sleep path (outside the semaphore) correctly avoids this.

```suggestion
                except httpx.HTTPError as exc:
                    last_exc = exc
                    if attempt == MAX_RETRIES:
                        raise ScraperError(
                            f"WorkNet fetch failed at page={page}: {exc}"
                        ) from exc
            if last_exc is not None:
                await asyncio.sleep(RETRY_BASE_DELAY * attempt)
                last_exc = None
                continue
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: worknet\_kr.c..."](https://github.com/kalil0321/ats-scrapers/commit/26bc7a9b9437ce3e8894e7e7bbbe588806d6c1a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732487)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->