### PR TITLE
jobthai: add Thailand's largest Thai-language job board

### DIFF
--- a/ats-companies/jobthai.csv
+++ b/ats-companies/jobthai.csv
@@ -1,0 +1,2 @@
+name,slug,url
+JobThai,jobthai,https://www.jobthai.com

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -76,6 +76,7 @@ class ATSType(StrEnum):
     PROGRAMATHOR = "programathor"
     BUILTIN = "builtin"
     JOBSCH = "jobsch"
+    JOBTHAI = "jobthai"
     MANFRED = "manfred"
     THEHUB = "thehub"
     YCOMBINATOR = "ycombinator"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -28,6 +28,7 @@ from jobhive.scrapers.greenhouse import GreenhouseScraper
 from jobhive.scrapers.icims import iCIMSScraper
 from jobhive.scrapers.jazzhr import JazzHRScraper
 from jobhive.scrapers.jobsch import JobsChScraper
+from jobhive.scrapers.jobthai import JobThaiScraper
 from jobhive.scrapers.join_com import JoinComScraper
 from jobhive.scrapers.lever import LeverScraper
 from jobhive.scrapers.manfred import ManfredScraper
@@ -78,6 +79,7 @@ __all__ = [
     "GoogleScraper",
     "GreenhouseScraper",
     "JazzHRScraper",
+    "JobThaiScraper",
     "JobsChScraper",
     "JoinComScraper",
     "LeverScraper",

--- a/src/jobhive/scrapers/jobthai.py
+++ b/src/jobhive/scrapers/jobthai.py
@@ -1,0 +1,461 @@
+"""JobThai (https://www.jobthai.com) — Thailand's largest Thai-language job board.
+
+JobThai is the dominant direct-posting job board in Thailand (separate
+from JobsDB TH, which is SEEK-owned). Coverage spans every sector, not
+just tech — at probe time (2026-05) the API reported ~48k active
+postings.
+
+GraphQL API at ``https://api.jobthai.com/v1/graphql`` — no auth, no
+key. The site is a Next.js SPA backed by Apollo; the same endpoint
+serves all reads. Introspection is disabled in production but the
+default Apollo error messages leak field/type suggestions ("Did you
+mean …") so the schema is recoverable by trial.
+
+Two quirks shape the fetch plan:
+
+  - Elasticsearch ``from + size <= 10000`` cap. The ``searchJobs``
+    query is backed by ES; the unfiltered listing tops out at 10 000
+    even though the API reports ``total ≈ 48k``. Sharding by
+    ``jobtype`` (43 distinct categories) keeps every per-bucket
+    sweep well under the cap — the busiest type at probe time was
+    "Sales" at ~7.2k. Results are deduped by job ``id`` across buckets
+    (a posting can be tagged with multiple types, though we observed
+    very little overlap in practice).
+
+  - Apollo CSRF guard. Bare POSTs are rejected unless either a
+    non-form ``Content-Type`` is set (we use ``application/json``)
+    or one of the preflight headers (``apollo-require-preflight`` /
+    ``x-apollo-operation-name``) is present. We set both for safety.
+
+Single-source scraper: ``company_slug`` is informational and ignored
+(matches the bundesagentur / eures / wanted / jobsch pattern). Output
+rows carry the publishing employer's Thai-language name as ``company``.
+The dataset is overwhelmingly Thai-language; ``language="th"`` is set
+on every row and ``country_iso="TH"`` on every row.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+log = logging.getLogger(__name__)
+
+GRAPHQL_URL = "https://api.jobthai.com/v1/graphql"
+JOB_URL_TEMPLATE = "https://www.jobthai.com/en/job/{id}"
+PER_PAGE = 100  # ES ``from+size<=10000`` cap → 100 pages × 100 rows.
+MAX_USABLE_PAGES = 100  # 100 × 100 = 10 000 = ES window cap.
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 4
+RETRY_BASE_DELAY = 1.5
+
+# ``searchJobs`` query — keep the selection set conservative since the
+# schema is reconstructed by probing; new fields can be added once
+# verified. ``$jobtype`` is a String (the API rejects [Int!]).
+_SEARCH_JOBS_QUERY = (
+    "query searchJobs($page:Int,$size:Int,$jobtype:String){"
+    "searchJobs(filter:{page:$page,size:$size,jobtype:$jobtype}){"
+    "data{"
+    "total "
+    "data{"
+    "id jobTitle companyName companyID workLocation salary "
+    "jobDescription updatedAt tags "
+    "urgent{id name} "
+    "jobType{id name} "
+    "province{id name} "
+    "district{id name}"
+    "}}}}"
+)
+
+# Job-type IDs surfaced by ``getJobTypeList(version:1)`` at probe time
+# (2026-05-12). Sharding ``searchJobs`` by this list keeps every
+# per-bucket sweep under the ES ``from+size<=10000`` cap (largest type
+# observed was ``4`` at 7.2k entries). The IDs match the ``jobType.id``
+# field returned on each row so a "jobs not in any of these buckets"
+# regression would be visible as a drop in total. New IDs added by
+# JobThai will be missed until this list is refreshed.
+_DEFAULT_JOB_TYPE_IDS: tuple[str, ...] = (
+    "1", "2", "3", "4", "5", "6", "7", "8", "9", "10",
+    "11", "12", "13", "14", "15", "16", "17", "18", "19", "20",
+    "21", "22", "23", "25", "26", "27", "28", "29", "30",
+    "31", "32", "33", "34", "36", "37", "38", "39", "40",
+    "41", "42", "43", "44", "45", "50",
+)
+
+# Salary string → currency hints. JobThai salaries are nearly always
+# in Thai baht (THB); the API surfaces them as free text mixing Thai
+# digits / Arabic digits and a trailing "บาท" (baht) marker. Anything
+# else falls through and ``salary_currency`` stays None.
+_THAI_BAHT_RE = re.compile(r"บาท|THB|baht", re.IGNORECASE)
+_NEGOTIABLE_RE = re.compile(r"ตามตกลง|ตามโครงสร้าง|ตามประสบการณ์|ตามตำแหน่ง|negotiable", re.IGNORECASE)
+# Salary range pattern: numbers, optional commas/dots, separator
+# (hyphen, en-dash, "to", "ถึง"), more numbers. Captures min/max.
+_RANGE_RE = re.compile(
+    r"(?P<min>\d[\d,\.]*)\s*[-–~]\s*(?P<max>\d[\d,\.]*)"
+)
+# Single-value salary pattern (no range), trailing baht / THB.
+_SINGLE_RE = re.compile(r"(?P<val>\d[\d,\.]*)")
+
+# Thai-script detection: U+0E00..U+0E7F covers the Thai block. If any
+# character in a title falls in this range we tag the listing as
+# ``language="th"``; otherwise ``language="en"`` (rare — most postings
+# are Thai even when the title is partly English).
+_THAI_SCRIPT_RE = re.compile(r"[฀-๿]")
+
+
+@ScraperRegistry.register(ATSType.JOBTHAI)
+class JobThaiScraper(BaseScraper):
+    """JobThai (jobthai.com) — Thailand's largest direct-posting board.
+
+    Single-source scraper: ``company_slug`` is ignored. Pass anything
+    (``"any"``, ``""``) — the scraper enumerates the entire site by
+    sharding across the ``jobtype`` filter to defeat the 10 000-row
+    Elasticsearch window cap on a single query.
+
+    To restrict to a subset of categories (smoke tests, partial
+    refreshes), instantiate with
+    ``JobThaiScraper("any", job_type_ids=("4",))``.
+    """
+
+    ats = ATSType.JOBTHAI
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        job_type_ids: tuple[str, ...] | list[str] = _DEFAULT_JOB_TYPE_IDS,
+        max_pages_per_type: int = MAX_USABLE_PAGES,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.job_type_ids = tuple(job_type_ids)
+        self.max_pages_per_type = max_pages_per_type
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        lock = asyncio.Lock()
+
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+
+            async def per_type(jt: str) -> None:
+                for page in range(1, self.max_pages_per_type + 1):
+                    payload = await self._search_page(client, sem, jt, page)
+                    data_envelope = (payload.get("searchJobs") or {}).get("data") or {}
+                    items = data_envelope.get("data") or []
+                    if not items:
+                        return
+                    async with lock:
+                        for item in items:
+                            job = self._parse_job(item)
+                            if job is None or job.ats_id in seen:
+                                continue
+                            seen.add(job.ats_id)
+                            jobs.append(job)
+                    # Short-circuit when the current page returned less
+                    # than a full page — the next page is guaranteed
+                    # empty.
+                    if len(items) < PER_PAGE:
+                        return
+
+            await asyncio.gather(*(per_type(jt) for jt in self.job_type_ids))
+        return jobs
+
+    # --- HTTP layer ---------------------------------------------------------
+
+    async def _search_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        jobtype: str,
+        page: int,
+    ) -> dict[str, Any]:
+        body = {
+            "operationName": "searchJobs",
+            "query": _SEARCH_JOBS_QUERY,
+            "variables": {"page": page, "size": PER_PAGE, "jobtype": jobtype},
+        }
+        headers = {
+            "User-Agent": "Mozilla/5.0",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            # Apollo CSRF guard requires either a non-form Content-Type
+            # OR one of these preflight headers. Set both so a future
+            # tightening on either side doesn't break us.
+            "apollo-require-preflight": "true",
+            "x-apollo-operation-name": "searchJobs",
+        }
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.post(
+                        GRAPHQL_URL, json=body, headers=headers,
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"JobThai fetch failed (jobtype={jobtype}, "
+                            f"page={page}): {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                try:
+                    payload = response.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"JobThai returned non-JSON for jobtype={jobtype} "
+                        f"page={page}: {exc}"
+                    ) from exc
+                if payload.get("errors"):
+                    # Treat GraphQL errors as fatal — they signal a
+                    # schema drift, not a transient failure.
+                    raise ScraperError(
+                        f"JobThai GraphQL errors (jobtype={jobtype}, "
+                        f"page={page}): {payload['errors']}"
+                    )
+                return payload.get("data") or {}
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"JobThai returned {response.status_code} for "
+                        f"jobtype={jobtype} page={page} after "
+                        f"{MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"JobThai returned {response.status_code} for "
+                f"jobtype={jobtype} page={page}"
+            )
+        raise ScraperError(
+            f"JobThai exhausted retries for jobtype={jobtype} "
+            f"page={page}: {last_exc}"
+        )
+
+    # --- parsing ------------------------------------------------------------
+
+    def _parse_job(self, item: dict[str, Any]) -> Job | None:
+        raw_id = item.get("id")
+        if raw_id is None:
+            return None
+        ats_id = str(raw_id)
+        title = (item.get("jobTitle") or "").strip()
+        if not ats_id or not title:
+            return None
+
+        company_name = (item.get("companyName") or "").strip() or "Unknown"
+        company_id = item.get("companyID")
+
+        location = _format_location(item)
+        description = _format_description(item.get("jobDescription"))
+        posted_at = _parse_iso(item.get("updatedAt"))
+
+        salary_summary, salary_currency, salary_min, salary_max = _parse_salary(
+            item.get("salary")
+        )
+
+        # Heuristic language detection: any Thai-script char in the
+        # title → ``th``. Otherwise ``en``. Most postings are Thai;
+        # the few all-English titles are usually for international
+        # firms posting in English.
+        language = "th" if _THAI_SCRIPT_RE.search(title) else "en"
+
+        # Provider-specific overflow — keep only IDs and labels we
+        # parsed off the listing. JobThai's category / industry /
+        # level fields are not on JobSearch (only on the per-job
+        # detail), so the task-spec ``category``/``industry``/``level``
+        # are best-effort: ``category`` is the ``jobType.id``.
+        raw: dict[str, Any] = {}
+        job_type = item.get("jobType") or {}
+        if job_type.get("id") is not None:
+            raw["category"] = job_type.get("id")
+        if job_type.get("name"):
+            raw["category_name"] = job_type.get("name")
+        province = item.get("province") or {}
+        if province.get("id") is not None:
+            raw["province_id"] = province.get("id")
+        if province.get("name"):
+            raw["province_name"] = province.get("name")
+        district = item.get("district") or {}
+        if district.get("id") is not None:
+            raw["district_id"] = district.get("id")
+        if district.get("name"):
+            raw["district_name"] = district.get("name")
+        urgent = item.get("urgent") or {}
+        urgent_id = urgent.get("id")
+        if isinstance(urgent_id, int) and urgent_id > 0:
+            raw["is_urgent"] = True
+        tags = item.get("tags")
+        if isinstance(tags, list) and tags:
+            raw["tags"] = [t for t in tags if isinstance(t, str)]
+        if company_id is not None:
+            raw["company_id"] = company_id
+
+        return Job(
+            url=JOB_URL_TEMPLATE.format(id=ats_id),
+            title=title,
+            company=company_name,
+            ats_type=ATSType.JOBTHAI,
+            ats_id=ats_id,
+            location=location,
+            country_iso="TH",
+            region="Asia",
+            language=language,
+            description=description,
+            posted_at=posted_at,
+            salary_currency=salary_currency,
+            salary_summary=salary_summary,
+            salary_min=salary_min,
+            salary_max=salary_max,
+            salary_period="MONTH" if salary_currency == "THB" else None,
+            fetched_at=datetime.now(),
+            raw=raw or None,
+        )
+
+
+# --- helpers ---------------------------------------------------------------
+
+
+def _format_location(item: dict[str, Any]) -> str | None:
+    """Build a comma-separated location from district + province +
+    free-text ``workLocation``. JobThai stores the province name in
+    Thai script (e.g. ``กรุงเทพมหานคร``); we keep it verbatim — the
+    downstream LLM enrichment knows how to handle multilingual
+    location strings."""
+    parts: list[str] = []
+    district = item.get("district") or {}
+    if isinstance(district, dict) and district.get("name"):
+        parts.append(str(district["name"]).strip())
+    province = item.get("province") or {}
+    if isinstance(province, dict) and province.get("name"):
+        name = str(province["name"]).strip()
+        if name and name not in parts:
+            parts.append(name)
+    work_loc = (item.get("workLocation") or "").strip()
+    # The free-text ``workLocation`` is often a paragraph (address,
+    # transport directions, emoji-heavy benefits blurb). Skip it for
+    # the structured ``location`` field — it would blow past the
+    # ~120-char expectation downstream consumers have. The full text
+    # is preserved in ``description`` via _format_description below.
+    if not parts and work_loc:
+        # Fall back to the first line of the free-text field when no
+        # structured parts are present.
+        first_line = work_loc.split("\n", 1)[0].strip()
+        if first_line:
+            return first_line
+    return ", ".join(parts) if parts else None
+
+
+def _format_description(value: object) -> str | None:
+    """JobThai's ``jobDescription`` is a list of bullet-style strings.
+    Join with newlines to produce a plain-text description; cap at
+    ~10 kB to match the canonical schema's truncation policy."""
+    if isinstance(value, list):
+        lines = [str(v).strip() for v in value if str(v).strip()]
+        if not lines:
+            return None
+        joined = "\n".join(lines)
+        return joined[:10_000]
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped[:10_000] if stripped else None
+    return None
+
+
+def _parse_iso(value: object) -> datetime | None:
+    """JobThai timestamps come in ISO 8601 with a trailing ``Z``
+    (e.g. ``2026-05-12T04:09:54.000Z``). ``fromisoformat`` accepts
+    ``+00:00`` but not ``Z`` until 3.11; we normalize unconditionally."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    txt = value.strip().replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(txt)
+    except ValueError:
+        log.debug("JobThai: failed to parse timestamp %r", value)
+        return None
+
+
+def _parse_salary(
+    value: object,
+) -> tuple[str | None, str | None, float | None, float | None]:
+    """Parse JobThai's free-text salary field.
+
+    Returns ``(summary, currency, min, max)``. JobThai salaries are
+    almost universally in Thai baht; the field text mixes Thai script
+    ("บาท"), Arabic digits, hyphens / en-dashes, and free-form
+    fallback phrases like ``ตามตกลง`` (negotiable).
+
+    Examples observed in production:
+
+      - ``"15,000 - 20,000 บาท"`` → THB, 15000, 20000
+      - ``"35,000 - 50,000 บาท"`` → THB, 35000, 50000
+      - ``"ตามตกลง"`` → currency None, min/max None, summary preserved
+      - ``"ตามโครงสร้างบริษัทฯ"`` → currency None, min/max None
+    """
+    if not isinstance(value, str):
+        return None, None, None, None
+    summary = value.strip()
+    if not summary:
+        return None, None, None, None
+
+    has_baht = bool(_THAI_BAHT_RE.search(summary))
+    is_negotiable = bool(_NEGOTIABLE_RE.search(summary))
+
+    if is_negotiable and not has_baht:
+        # Pure free-text "negotiable" — keep the original phrase but
+        # don't invent a currency.
+        return summary, None, None, None
+
+    range_match = _RANGE_RE.search(summary)
+    if range_match:
+        min_v = _to_float(range_match.group("min"))
+        max_v = _to_float(range_match.group("max"))
+        currency = "THB" if has_baht else None
+        return summary, currency, min_v, max_v
+
+    single_match = _SINGLE_RE.search(summary)
+    if single_match and has_baht:
+        val = _to_float(single_match.group("val"))
+        return summary, "THB", val, val
+
+    # Anything else: keep the summary verbatim, no currency claim.
+    return summary, None, None, None
+
+
+def _to_float(text: str) -> float | None:
+    if not isinstance(text, str):
+        return None
+    cleaned = text.replace(",", "").replace(" ", "")
+    if not cleaned:
+        return None
+    try:
+        return float(cleaned)
+    except ValueError:
+        return None

--- a/tests/test_jobthai.py
+++ b/tests/test_jobthai.py
@@ -1,0 +1,319 @@
+"""Tests for the JobThai (jobthai.com) scraper.
+
+Pin the parsing contract (GraphQL ``searchJobs`` payload → Job
+fields), the ``jobtype`` sharding plan that defeats the
+Elasticsearch ``from+size<=10000`` cap, and the salary-text parser
+for the common Thai-baht / ``ตามตกลง`` (negotiable) patterns.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import JobThaiScraper, ScraperRegistry
+
+_API_URL = "https://api.jobthai.com/v1/graphql"
+_API_RE = re.compile(r"^https://api\.jobthai\.com/v1/graphql$")
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.jobthai as jt
+    monkeypatch.setattr(jt, "MAX_RETRIES", 1)
+    monkeypatch.setattr(jt, "RETRY_BASE_DELAY", 0.0)
+
+
+def _row(
+    *,
+    job_id: int = 1900404,
+    job_title: str = "เจ้าหน้าที่ฝ่ายผลิต",
+    company_name: str = "บริษัท ฟงซาน อินเตอร์เนชั่นแนล (ไทยแลนด์) จำกัด",
+    company_id: int = 221463,
+    work_location: str = "",
+    salary: str = "15,000 - 20,000 บาท",
+    job_description: list[str] | None = None,
+    updated_at: str = "2026-05-12T04:06:46.000Z",
+    tags: list[str] | None = None,
+    urgent_id: int = 0,
+    job_type_id: int = 17,
+    job_type_name: str = "งานผลิต/ควบคุมคุณภาพ/โรงงาน",
+    province_id: str = "01",
+    province_name: str = "กรุงเทพมหานคร",
+    district_id: str = "0141",
+    district_name: str = "วัฒนา",
+) -> dict[str, Any]:
+    return {
+        "id": job_id,
+        "jobTitle": job_title,
+        "companyName": company_name,
+        "companyID": company_id,
+        "workLocation": work_location,
+        "salary": salary,
+        "jobDescription": job_description if job_description is not None else [
+            "ติดตามเร่งรัดหนี้สิน",
+            "จัดทำรายงานประจำเดือน",
+        ],
+        "updatedAt": updated_at,
+        "tags": tags if tags is not None else [],
+        "urgent": {"id": urgent_id, "name": ""},
+        "jobType": {"id": job_type_id, "name": job_type_name},
+        "province": {"id": province_id, "name": province_name},
+        "district": {"id": district_id, "name": district_name},
+    }
+
+
+def _envelope(rows: list[dict[str, Any]], *, total: int | None = None) -> dict[str, Any]:
+    """Wrap rows in the same shape the GraphQL endpoint returns."""
+    return {
+        "data": {
+            "searchJobs": {
+                "data": {
+                    "total": total if total is not None else len(rows),
+                    "data": rows,
+                },
+            },
+        },
+    }
+
+
+# --- registry / wiring ------------------------------------------------------
+
+
+def test_registry_resolves_jobthai() -> None:
+    assert ScraperRegistry.get(ATSType.JOBTHAI) is JobThaiScraper
+
+
+def test_ats_type_value() -> None:
+    """Pin the enum value — downstream CSV columns key off this string."""
+    assert ATSType.JOBTHAI.value == "jobthai"
+
+
+# --- happy path -------------------------------------------------------------
+
+
+def test_parses_full_search_payload(httpx_mock) -> None:
+    """Single-bucket scrape; verify every populated Job field maps to
+    the right ``searchJobs`` field."""
+    httpx_mock.add_response(
+        url=_API_URL,
+        json=_envelope([_row()]),
+    )
+
+    jobs = JobThaiScraper("any", job_type_ids=("17",)).fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.JOBTHAI
+    assert j.ats_id == "1900404"
+    assert j.title == "เจ้าหน้าที่ฝ่ายผลิต"
+    assert j.company.startswith("บริษัท ฟงซาน")
+    assert j.country_iso == "TH"
+    assert j.region == "Asia"
+    # Title contains Thai script → language is "th"
+    assert j.language == "th"
+    # Location is district-first, then province (both in Thai)
+    assert j.location == "วัฒนา, กรุงเทพมหานคร"
+    # Salary parses to THB / MONTH and pulls min/max from the range
+    assert j.salary_currency == "THB"
+    assert j.salary_period == "MONTH"
+    assert j.salary_min == 15000
+    assert j.salary_max == 20000
+    assert j.salary_summary == "15,000 - 20,000 บาท"
+    # Posted-at parses the trailing-Z ISO format
+    assert j.posted_at is not None
+    assert j.posted_at.year == 2026
+    # Description joins the bullet list with newlines
+    assert j.description is not None
+    assert "ติดตามเร่งรัดหนี้สิน" in j.description
+    assert "\n" in j.description
+    # URL template uses the English locale
+    assert str(j.url) == "https://www.jobthai.com/en/job/1900404"
+    # Raw stores the structured taxonomy ids
+    assert j.raw is not None
+    assert j.raw["category"] == 17
+    assert j.raw["province_id"] == "01"
+    assert j.raw["district_id"] == "0141"
+    assert j.raw["company_id"] == 221463
+
+
+def test_english_only_title_sets_language_en(httpx_mock) -> None:
+    """Postings with no Thai-script characters in the title should
+    be tagged ``language="en"`` — rare but real (multinationals
+    posting English-only titles)."""
+    httpx_mock.add_response(
+        url=_API_URL,
+        json=_envelope([_row(job_title="Investor Relations Officer")]),
+    )
+    jobs = JobThaiScraper("any", job_type_ids=("17",)).fetch()
+    assert jobs[0].language == "en"
+
+
+# --- pagination -------------------------------------------------------------
+
+
+def test_paginates_until_short_page(httpx_mock) -> None:
+    """``searchJobs`` uses offset pagination (``page``,``size``).
+    Stop when a page returns < size rows."""
+    import jobhive.scrapers.jobthai as jt
+    # Page 1: full page (PER_PAGE rows). Page 2: short page → stop.
+    page_one = [_row(job_id=i) for i in range(jt.PER_PAGE)]
+    page_two = [_row(job_id=i) for i in range(jt.PER_PAGE, jt.PER_PAGE + 5)]
+    httpx_mock.add_response(url=_API_URL, json=_envelope(page_one))
+    httpx_mock.add_response(url=_API_URL, json=_envelope(page_two))
+
+    jobs = JobThaiScraper("any", job_type_ids=("4",)).fetch()
+    assert len(jobs) == jt.PER_PAGE + 5
+
+
+def test_dedupes_overlapping_buckets(httpx_mock) -> None:
+    """A job tagged with multiple ``jobType`` IDs will be returned
+    once per bucket sweep. Dedup must collapse them on ``ats_id``."""
+    # Two buckets, both returning the same job.
+    httpx_mock.add_response(url=_API_URL, json=_envelope([_row(job_id=1)]))
+    httpx_mock.add_response(url=_API_URL, json=_envelope([_row(job_id=1)]))
+
+    jobs = JobThaiScraper("any", job_type_ids=("4", "11")).fetch()
+    assert len(jobs) == 1
+    assert jobs[0].ats_id == "1"
+
+
+def test_empty_first_page_short_circuits(httpx_mock) -> None:
+    """If a jobtype has zero postings the first page returns an empty
+    ``data`` array — don't make a second request."""
+    httpx_mock.add_response(url=_API_URL, json=_envelope([]))
+    jobs = JobThaiScraper("any", job_type_ids=("99",)).fetch()
+    assert jobs == []
+    # Exactly one HTTP request was made (the empty first page).
+    assert len(httpx_mock.get_requests()) == 1
+
+
+# --- salary parsing ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "salary_text,expected_min,expected_max,expected_currency",
+    [
+        ("15,000 - 20,000 บาท", 15000, 20000, "THB"),
+        ("35,000 - 50,000 บาท", 35000, 50000, "THB"),
+        # En-dash separator also seen on the API.
+        ("18,000 – 22,000 บาท", 18000, 22000, "THB"),
+        # Single value with trailing baht marker → min == max.
+        ("25,000 บาท", 25000, 25000, "THB"),
+        # "Negotiable" phrases — currency stays None.
+        ("ตามตกลง", None, None, None),
+        ("ตามโครงสร้างบริษัทฯ", None, None, None),
+    ],
+)
+def test_salary_parser(
+    httpx_mock,
+    salary_text: str,
+    expected_min: float | None,
+    expected_max: float | None,
+    expected_currency: str | None,
+) -> None:
+    httpx_mock.add_response(
+        url=_API_URL,
+        json=_envelope([_row(salary=salary_text)]),
+    )
+    jobs = JobThaiScraper("any", job_type_ids=("17",)).fetch()
+    assert jobs[0].salary_summary == salary_text
+    assert jobs[0].salary_min == expected_min
+    assert jobs[0].salary_max == expected_max
+    assert jobs[0].salary_currency == expected_currency
+
+
+# --- location handling ------------------------------------------------------
+
+
+def test_location_falls_back_to_work_location_first_line(httpx_mock) -> None:
+    """When the structured ``province``/``district`` are missing,
+    fall back to the first line of the free-text ``workLocation``."""
+    row = _row()
+    row["province"] = {"id": None, "name": ""}
+    row["district"] = {"id": None, "name": ""}
+    row["workLocation"] = "อ.เมือง จ.ชลบุรี\nรายละเอียดเพิ่มเติม..."
+    httpx_mock.add_response(url=_API_URL, json=_envelope([row]))
+    jobs = JobThaiScraper("any", job_type_ids=("17",)).fetch()
+    assert jobs[0].location == "อ.เมือง จ.ชลบุรี"
+
+
+def test_location_none_when_all_empty(httpx_mock) -> None:
+    """No province, no district, no workLocation → ``location`` is
+    None (not an empty string), matching the canonical schema."""
+    row = _row()
+    row["province"] = {"id": None, "name": ""}
+    row["district"] = {"id": None, "name": ""}
+    row["workLocation"] = ""
+    httpx_mock.add_response(url=_API_URL, json=_envelope([row]))
+    jobs = JobThaiScraper("any", job_type_ids=("17",)).fetch()
+    assert jobs[0].location is None
+
+
+# --- field handling ---------------------------------------------------------
+
+
+def test_skips_rows_missing_id_or_title(httpx_mock) -> None:
+    """Defensive: drop malformed rows rather than emit half-built Job
+    instances."""
+    httpx_mock.add_response(
+        url=_API_URL,
+        json=_envelope([
+            _row(job_id=1, job_title="Good"),
+            {**_row(job_id=2, job_title=""), },  # blank title
+            {**_row(job_title="No id"), "id": None},
+        ]),
+    )
+    jobs = JobThaiScraper("any", job_type_ids=("4",)).fetch()
+    assert [j.ats_id for j in jobs] == ["1"]
+
+
+def test_urgent_flag_lifts_to_raw(httpx_mock) -> None:
+    """``urgent.id`` > 0 → ``raw.is_urgent`` = True. Zero → omitted."""
+    httpx_mock.add_response(
+        url=_API_URL,
+        json=_envelope([_row(job_id=1, urgent_id=2), _row(job_id=2, urgent_id=0)]),
+    )
+    jobs = JobThaiScraper("any", job_type_ids=("4",)).fetch()
+    raw_by_id = {j.ats_id: (j.raw or {}) for j in jobs}
+    assert raw_by_id["1"].get("is_urgent") is True
+    assert "is_urgent" not in raw_by_id["2"]
+
+
+def test_tags_lift_to_raw(httpx_mock) -> None:
+    """Non-empty tags array → ``raw.tags``. Empty array stays out of raw."""
+    httpx_mock.add_response(
+        url=_API_URL,
+        json=_envelope([
+            _row(job_id=1, tags=["สัมภาษณ์งานออนไลน์", "Online Interview"]),
+            _row(job_id=2, tags=[]),
+        ]),
+    )
+    jobs = JobThaiScraper("any", job_type_ids=("4",)).fetch()
+    raw_by_id = {j.ats_id: (j.raw or {}) for j in jobs}
+    assert raw_by_id["1"]["tags"] == ["สัมภาษณ์งานออนไลน์", "Online Interview"]
+    assert "tags" not in raw_by_id["2"]
+
+
+# --- error handling ---------------------------------------------------------
+
+
+def test_graphql_errors_raise(httpx_mock) -> None:
+    """Schema drift → GraphQL ``errors`` array → fatal. Don't silently
+    emit []."""
+    httpx_mock.add_response(
+        url=_API_URL,
+        json={"errors": [{"message": "Cannot query field 'xyz'"}]},
+    )
+    with pytest.raises(ScraperError, match="GraphQL errors"):
+        JobThaiScraper("any", job_type_ids=("4",)).fetch()
+
+
+def test_persistent_500_raises(httpx_mock) -> None:
+    """Server errors should surface, not silently emit []."""
+    httpx_mock.add_response(url=_API_URL, status_code=500, is_reusable=True)
+    with pytest.raises(ScraperError):
+        JobThaiScraper("any", job_type_ids=("4",)).fetch()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,6 +29,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
+        "jobthai",
         "manfred", "thehub", "ycombinator", "wellfound",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",


### PR DESCRIPTION
## Summary

- Adds `JobThaiScraper` (`ATSType.JOBTHAI`) for jobthai.com — Thailand's largest direct-posting job board (~48k active postings at probe time). Separate from JobsDB TH (SEEK-owned, covered elsewhere).
- Backend is an Apollo GraphQL endpoint at `api.jobthai.com/v1/graphql`. Schema reconstructed via "Did you mean ...?" error suggestions (introspection is disabled in prod). Fields used: `searchJobs(filter:{page,size,jobtype}){data{total data{id jobTitle companyName companyID workLocation salary jobDescription updatedAt tags urgent jobType province district}}}`.
- The unfiltered listing hits an Elasticsearch `from+size<=10000` cap. We shard by 43 `jobtype` IDs (largest bucket ~7.2k) and dedup by job id, recovering the full ~48k.
- Sets `country_iso=TH`, `region=Asia`, `language=th|en` (Thai-script presence in title), parses Thai-baht salary text (`"15,000 - 20,000 บาท"` → THB/MONTH/min/max), surfaces taxonomy ids in `raw` (`category`, `province_id`, `district_id`, `is_urgent`, `company_id`, `tags`).
- Apollo CSRF guard handled by setting `Content-Type: application/json` plus `apollo-require-preflight` / `x-apollo-operation-name` headers.

## Test plan

- [x] `ruff check src/ tests/` — clean.
- [x] `pytest tests/test_jobthai.py tests/test_models.py` — 82 passing (20 new for jobthai, including registry wiring, payload parsing, language detection, pagination short-circuit, cross-bucket dedup, salary parser parametrised across 6 forms, location fallback, urgent/tag lifting to raw, GraphQL-error → ScraperError, 500 → ScraperError).
- [x] Full suite (`pytest --ignore=tests/test_publisher.py …`) — 789 passing, no regressions.
- [x] Live smoke test against `api.jobthai.com` — fetched 5 real Sales-bucket rows, parsed cleanly (Thai + English titles, THB salary ranges, structured location, urgent flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `JobThaiScraper` for `jobthai.com`, bringing nationwide Thai job postings into our feed with language detection and THB salary parsing. The scraper shards by job type to bypass the API’s 10k window and fetches the full set reliably.

- New Features
  - New `JobThaiScraper` (`ATSType.JOBTHAI`) using Apollo GraphQL at `api.jobthai.com/v1/graphql`.
  - Recovers the full dataset by sharding across 43 `jobType` buckets and de-duplicating by job `id` (works around ES `from+size<=10000`).
  - Parses Thai salary text into THB/month min/max; sets `language` (`th` if Thai script in title), `country_iso=TH`, `region=Asia`.
  - Builds `location` from district/province with `workLocation` first-line fallback; adds `raw` fields (`category`/`category_name`, province/district ids/names, `is_urgent`, `company_id`, `tags`).
  - Sends Apollo preflight headers and retries on 5xx/429; adds tests for parsing, pagination, dedup, salary, location, and error handling.
  - Adds seed entry `ats-companies/jobthai.csv`.

<sup>Written for commit 0247e56c6d5d64f012fe4aa39c9daf9543155578. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `JobThaiScraper` (`ATSType.JOBTHAI`) targeting the Apollo GraphQL endpoint at `api.jobthai.com/v1/graphql`. The scraper shards across 43 `jobtype` buckets to bypass Elasticsearch's 10 000-row window cap, deduplicates by job ID, parses Thai-baht salary text into structured min/max fields, and detects language from Thai-script presence in the job title.

- The new `jobthai.py` module handles Apollo CSRF headers, exponential-backoff retries with a semaphore for concurrency control, and maps GraphQL fields to the canonical `Job` model.
- `models.py` and `scrapers/__init__.py` receive the minimal registry wiring; `ats-companies/jobthai.csv` adds the seed entry.
- The test suite covers registry wiring, payload parsing, pagination, cross-bucket dedup, salary parsing across 6 forms, location fallback, urgent/tag lifting, and error propagation.

<h3>Confidence Score: 3/5</h3>

Two defects in the core scraping path need fixing before merge.

The retry path for httpx.HTTPError sleeps while holding the semaphore, stalling other concurrent coroutines during backoff. A comment in _format_location also incorrectly claims workLocation text is preserved in the description when it is actually silently dropped. Everything else — parsing, dedup, language detection, tests — looks correct.

src/jobhive/scrapers/jobthai.py — the retry/sleep block in _search_page and workLocation handling in _format_location.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/jobthai.py | New scraper for jobthai.com via Apollo GraphQL; two issues found: retry sleep for HTTPError holds the semaphore, and workLocation text is silently dropped despite a comment claiming otherwise. |
| tests/test_jobthai.py | Comprehensive test suite covering happy path, pagination, dedup, salary parametrization, location fallback, urgent/tag lifting, and error cases. |
| src/jobhive/models.py | Adds ATSType.JOBTHAI = 'jobthai' to the StrEnum; consistent with existing entries. |
| src/jobhive/scrapers/__init__.py | Adds import and __all__ entry for JobThaiScraper following the alphabetical convention. |
| ats-companies/jobthai.csv | New seed CSV with a single jobthai.com entry in the correct format. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/jobhive/scrapers/jobthai.py:213-221
**`asyncio.sleep` holds the semaphore during HTTPError retry**

`await asyncio.sleep(RETRY_BASE_DELAY * attempt)` is called inside `async with sem:`, so the semaphore slot remains occupied for the entire back-off duration (1.5 s on attempt 1, 3 s on attempt 2, etc.). During that wait, no other `per_type` coroutine can acquire the slot — effectively dropping concurrency to `MAX_CONCURRENCY - 1` per retry. The 429/5xx path (outside the `sem` block, line 250) correctly releases the slot before sleeping; the HTTPError path should do the same.

### Issue 2 of 3
src/jobhive/scrapers/jobthai.py:361-366
**`workLocation` text silently dropped despite comment claiming it's in `description`**

The comment says the free-text `workLocation` is "preserved in ``description`` via `_format_description`", but `_format_description` is called with `item.get("jobDescription")`, not `workLocation`. When structured `province`/`district` parts are found, `workLocation` is read, discarded, and never surfaced anywhere in the output `Job`. Either append it to the description or correct the comment to reflect the intentional drop.

### Issue 3 of 3
src/jobhive/scrapers/jobthai.py:33-34
The module docstring says `language="th"` is set on every row, but the code performs per-job language detection (Thai script in title → `"th"`, otherwise `"en"`). The docstring should reflect the actual heuristic.

```suggestion
The dataset is overwhelmingly Thai-language; ``language="th"`` is set
on rows whose title contains Thai-script characters, ``"en"`` otherwise,
and ``country_iso="TH"`` on every row.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: jobthai.csv"](https://github.com/kalil0321/ats-scrapers/commit/0247e56c6d5d64f012fe4aa39c9daf9543155578) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732490)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->