### PR TITLE
nofluffjobs: add Europe-focused IT/tech jobboard scraper

### DIFF
--- a/ats-companies/nofluffjobs.csv
+++ b/ats-companies/nofluffjobs.csv
@@ -1,0 +1,2 @@
+name,slug,url
+No Fluff Jobs,nofluffjobs,https://nofluffjobs.com

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -77,6 +77,7 @@ class ATSType(StrEnum):
     BUILTIN = "builtin"
     JOBSCH = "jobsch"
     MANFRED = "manfred"
+    NOFLUFFJOBS = "nofluffjobs"
     THEHUB = "thehub"
     YCOMBINATOR = "ycombinator"
     WELLFOUND = "wellfound"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -33,6 +33,7 @@ from jobhive.scrapers.lever import LeverScraper
 from jobhive.scrapers.manfred import ManfredScraper
 from jobhive.scrapers.mercor import MercorScraper
 from jobhive.scrapers.meta import MetaScraper
+from jobhive.scrapers.nofluffjobs import NoFluffJobsScraper
 from jobhive.scrapers.oracle import OracleScraper
 from jobhive.scrapers.personio import PersonioScraper
 from jobhive.scrapers.phenom import PhenomScraper
@@ -84,6 +85,7 @@ __all__ = [
     "ManfredScraper",
     "MercorScraper",
     "MetaScraper",
+    "NoFluffJobsScraper",
     "OracleScraper",
     "PersonioScraper",
     "PhenomScraper",

--- a/src/jobhive/scrapers/nofluffjobs.py
+++ b/src/jobhive/scrapers/nofluffjobs.py
@@ -1,0 +1,402 @@
+"""NoFluffJobs (https://nofluffjobs.com) — Europe-focused IT/tech jobboard.
+
+NoFluffJobs is a direct-posting tech-jobs board with deep coverage in
+Poland and adjacent Central/Eastern European markets (Czech, Germany,
+Netherlands), all in English. Listings are tech-heavy with structured
+metadata: salary range + currency + period, seniority levels,
+technology stack, must-have / nice-to-have requirements, and a
+``fullyRemote`` flag — no LinkedIn / Indeed syndication noise.
+
+Public JSON at ``POST https://nofluffjobs.com/api/search/posting``.
+The endpoint requires two query parameters, ``salaryCurrency`` and
+``salaryPeriod``, which control the *display currency* the response
+converts ranges into — it does not narrow the result set. The request
+body holds an (often-empty) ``criteriaSearch`` filter object.
+
+Pagination is via ``page`` (1-indexed) + ``pageSize``; ``totalPages``
+in the response is the loop bound. The platform caps individual
+responses at ~136 entries regardless of requested ``pageSize``.
+
+Single-source scraper: ``company_slug`` is informational and ignored
+(matches the bundesagentur / eures / remoteok / manfred pattern).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+API_URL = "https://nofluffjobs.com/api/search/posting"
+JOB_URL_TEMPLATE = "https://nofluffjobs.com/job/{slug}"
+DEFAULT_CURRENCY = "PLN"
+DEFAULT_PERIOD = "month"
+DEFAULT_PAGE_SIZE = 200
+MAX_PAGES_HARD_CAP = 500
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1.5
+
+# NoFluffJobs returns country as ISO 3166-1 alpha-3 (``POL``, ``DEU``,
+# ``CZE``…); our Job schema wants alpha-2. Map the common European
+# codes that show up on the board; anything else falls back to
+# ``None`` so the LLM enrichment pass can take a crack at the
+# free-form location string.
+_ALPHA3_TO_ALPHA2: dict[str, str] = {
+    "POL": "PL", "DEU": "DE", "NLD": "NL", "CZE": "CZ", "SVK": "SK",
+    "AUT": "AT", "CHE": "CH", "GBR": "GB", "IRL": "IE", "FRA": "FR",
+    "ESP": "ES", "PRT": "PT", "ITA": "IT", "BEL": "BE", "LUX": "LU",
+    "DNK": "DK", "SWE": "SE", "NOR": "NO", "FIN": "FI", "EST": "EE",
+    "LVA": "LV", "LTU": "LT", "HUN": "HU", "ROU": "RO", "BGR": "BG",
+    "HRV": "HR", "SVN": "SI", "GRC": "GR", "UKR": "UA", "BLR": "BY",
+    "USA": "US", "CAN": "CA", "ISR": "IL", "ARE": "AE", "TUR": "TR",
+    "IND": "IN", "AUS": "AU", "NZL": "NZ", "JPN": "JP", "SGP": "SG",
+}
+
+# NoFluffJobs' ``salary.type`` is the contract flavor. Map to the
+# normalized ``employment_type`` enum the schema documents:
+#   - ``permanent`` (Polish UoP — employee contract) → FULL_TIME
+#   - ``b2b`` (Polish B2B — invoiced contractor) → CONTRACT
+#   - ``mandate`` / ``zlecenie`` (Polish UZ — civil contract) → CONTRACT
+#   - ``freelance`` → CONTRACT
+#   - ``internship`` / ``trainee`` → INTERN
+_EMPLOYMENT_TYPE_MAP: dict[str, str] = {
+    "permanent": "FULL_TIME",
+    "b2b": "CONTRACT",
+    "mandate": "CONTRACT",
+    "zlecenie": "CONTRACT",
+    "freelance": "CONTRACT",
+    "internship": "INTERN",
+    "trainee": "INTERN",
+}
+
+# NoFluffJobs' ``salary.period`` is lower-case ('month', 'hour',
+# 'year'); our schema's ``SalaryPeriod`` literal is upper-case.
+_SALARY_PERIOD_MAP: dict[str, str] = {
+    "hour": "HOUR",
+    "day": "DAY",
+    "week": "WEEK",
+    "month": "MONTH",
+    "year": "YEAR",
+}
+
+
+@ScraperRegistry.register(ATSType.NOFLUFFJOBS)
+class NoFluffJobsScraper(BaseScraper):
+    """NoFluffJobs (nofluffjobs.com) — Europe-focused IT job board.
+
+    Single-source: ``company_slug`` is ignored. Pass anything
+    (``"any"``, ``""``).
+
+    Knobs:
+    - ``salary_currency`` — display currency the API converts ranges
+      into. Must be one of the API's supported codes (``PLN``,
+      ``EUR``, ``USD``, ``GBP``, ``CHF``). Does not filter results;
+      affects only the numeric range surfaced on ``salary_min`` /
+      ``salary_max``. Default ``PLN`` matches the board's native
+      currency for the bulk of the listings.
+    - ``salary_period`` — display period (``month`` / ``year`` /
+      ``hour``). Same display-only semantics as ``salary_currency``.
+    - ``page_size`` — pagination batch size. The server caps at ~136
+      per response so larger values are quietly clamped; a generous
+      default keeps the retry budget low.
+    """
+
+    ats = ATSType.NOFLUFFJOBS
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 60.0,
+        salary_currency: str = DEFAULT_CURRENCY,
+        salary_period: str = DEFAULT_PERIOD,
+        page_size: int = DEFAULT_PAGE_SIZE,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.salary_currency = salary_currency.upper()
+        self.salary_period = salary_period.lower()
+        self.page_size = max(1, int(page_size))
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True,
+        ) as client:
+            page = 1
+            total_pages = 1
+            while page <= total_pages and page <= MAX_PAGES_HARD_CAP:
+                payload = await self._fetch_page(client, page)
+                postings = payload.get("postings") or []
+                if not isinstance(postings, list):
+                    raise ScraperError(
+                        "NoFluffJobs API shape changed — 'postings' is "
+                        f"{type(postings).__name__}, expected list"
+                    )
+                for item in postings:
+                    if not isinstance(item, dict):
+                        continue
+                    job = self._parse(item)
+                    if job is None or job.ats_id in seen:
+                        continue
+                    seen.add(job.ats_id)
+                    jobs.append(job)
+                total_pages = _to_int(payload.get("totalPages")) or 1
+                # If the server returns no postings on a page that
+                # should exist, bail rather than spin — guards against
+                # off-by-one server bugs / changes to pagination.
+                if not postings:
+                    break
+                page += 1
+        return jobs
+
+    async def _fetch_page(
+        self, client: httpx.AsyncClient, page: int
+    ) -> dict[str, Any]:
+        params = {
+            "salaryCurrency": self.salary_currency,
+            "salaryPeriod": self.salary_period,
+            "page": str(page),
+            "pageSize": str(self.page_size),
+        }
+        body = {"criteriaSearch": {}}
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                response = await client.post(
+                    API_URL,
+                    params=params,
+                    json=body,
+                    headers={
+                        "User-Agent": "Mozilla/5.0",
+                        "Accept": "application/json",
+                        "Content-Type": "application/json",
+                    },
+                )
+            except httpx.HTTPError as exc:
+                last_exc = exc
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"NoFluffJobs fetch failed: {exc}"
+                    ) from exc
+                await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                continue
+            if response.status_code == 200:
+                try:
+                    payload = response.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"NoFluffJobs returned non-JSON: {exc}"
+                    ) from exc
+                if not isinstance(payload, dict):
+                    raise ScraperError(
+                        "NoFluffJobs API shape changed — expected an "
+                        f"object, got {type(payload).__name__}"
+                    )
+                return payload
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"NoFluffJobs returned {response.status_code} "
+                        f"after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after)
+                    if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"NoFluffJobs returned {response.status_code}"
+            )
+        raise ScraperError(f"NoFluffJobs exhausted retries: {last_exc}")
+
+    def _parse(self, item: dict[str, Any]) -> Job | None:
+        ats_id = (item.get("id") or "").strip()
+        title = (item.get("title") or "").strip()
+        # ``name`` on a NoFluffJobs posting is the *company display name*
+        # (their schema is confusingly named: ``title`` = job title,
+        # ``name`` = company). Slug-based ``url`` is the routable form.
+        company = (item.get("name") or "").strip() or "Unknown"
+        slug = (item.get("url") or "").strip()
+        if not ats_id or not title or not slug:
+            return None
+
+        location_info = item.get("location") or {}
+        if not isinstance(location_info, dict):
+            location_info = {}
+        location, country_iso = _parse_location(location_info)
+        is_remote = bool(
+            location_info.get("fullyRemote") or item.get("fullyRemote")
+        )
+
+        salary = item.get("salary") or {}
+        if not isinstance(salary, dict):
+            salary = {}
+        salary_min = _to_pos_float(salary.get("from"))
+        salary_max = _to_pos_float(salary.get("to"))
+        salary_currency = (
+            salary.get("currency") if (salary_min or salary_max) else None
+        )
+        salary_period = _SALARY_PERIOD_MAP.get(
+            (salary.get("period") or self.salary_period).lower()
+        ) if (salary_min or salary_max) else None
+        contract_type = (salary.get("type") or "").lower()
+        employment_type = _EMPLOYMENT_TYPE_MAP.get(contract_type)
+
+        posted_at = _epoch_ms_to_dt(item.get("posted"))
+
+        raw: dict[str, Any] = {}
+        if item.get("category"):
+            raw["category"] = item["category"]
+        seniority = item.get("seniority")
+        if isinstance(seniority, list) and seniority:
+            raw["seniority"] = [s for s in seniority if isinstance(s, str)]
+        elif isinstance(seniority, str) and seniority:
+            raw["seniority"] = [seniority]
+        if item.get("technology"):
+            raw["technology"] = item["technology"]
+        # ``tiles.values`` holds the prominent stack labels surfaced on
+        # the card — surface them under ``must_haves`` for consistency
+        # with the public spec (the field name maps cleanly onto the
+        # detail-page concept).
+        tiles = (item.get("tiles") or {}).get("values") if isinstance(
+            item.get("tiles"), dict
+        ) else None
+        if isinstance(tiles, list):
+            requirements = [
+                t.get("value")
+                for t in tiles
+                if isinstance(t, dict)
+                and t.get("type") == "requirement"
+                and isinstance(t.get("value"), str)
+            ]
+            if requirements:
+                raw["must_haves"] = requirements[:20]
+        regions = item.get("regions")
+        if isinstance(regions, list) and regions:
+            raw["regions"] = [r for r in regions if isinstance(r, str)]
+        if contract_type:
+            raw["contract_type"] = contract_type
+        reference = item.get("reference")
+        if isinstance(reference, str) and reference:
+            raw["reference"] = reference
+
+        return Job(
+            url=JOB_URL_TEMPLATE.format(slug=slug),
+            title=title,
+            company=company,
+            ats_type=ATSType.NOFLUFFJOBS,
+            ats_id=ats_id,
+            location=location,
+            country_iso=country_iso,
+            language="en",  # NoFluffJobs is English-primary.
+            is_remote=is_remote or None,
+            salary_currency=salary_currency,
+            salary_period=salary_period,  # type: ignore[arg-type]
+            salary_min=salary_min,
+            salary_max=salary_max,
+            employment_type=employment_type,  # type: ignore[arg-type]
+            commitment=contract_type or None,
+            requisition_id=reference if isinstance(reference, str) else None,
+            posted_at=posted_at,
+            fetched_at=datetime.now(),
+            raw=raw or None,
+        )
+
+
+def _parse_location(
+    info: dict[str, Any],
+) -> tuple[str | None, str | None]:
+    """Render NoFluffJobs' multi-place location to a single string plus
+    a single ISO 3166-1 alpha-2 country code.
+
+    The API exposes a ``places`` list — each entry is one of (a) a city
+    with structured ``country`` object, (b) a freeform city like
+    ``"Remote"`` with no country, or (c) a country-only entry. Multiple
+    places get pipe-joined; the country code is taken from the first
+    place that exposes one. We don't try to derive a country from
+    "Remote" labels — that's enrichment territory.
+    """
+    places = info.get("places")
+    if not isinstance(places, list) or not places:
+        return None, None
+    labels: list[str] = []
+    country_iso: str | None = None
+    for pl in places:
+        if not isinstance(pl, dict):
+            continue
+        city = (pl.get("city") or "").strip()
+        country = pl.get("country") or {}
+        country_name = ""
+        if isinstance(country, dict):
+            code3 = (country.get("code") or "").upper()
+            if not country_iso and code3 in _ALPHA3_TO_ALPHA2:
+                country_iso = _ALPHA3_TO_ALPHA2[code3]
+            country_name = (country.get("name") or "").strip()
+        if city and country_name and city.lower() != country_name.lower():
+            labels.append(f"{city}, {country_name}")
+        elif city:
+            labels.append(city)
+        elif country_name:
+            labels.append(country_name)
+    # Dedupe preserving order — multi-place postings frequently repeat
+    # the same city under multiple regional flavors.
+    seen: set[str] = set()
+    unique: list[str] = []
+    for lbl in labels:
+        if lbl not in seen:
+            seen.add(lbl)
+            unique.append(lbl)
+    location = " | ".join(unique[:5]) if unique else None
+    return location, country_iso
+
+
+def _to_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return None
+
+
+def _to_pos_float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)) and value > 0:
+        return float(value)
+    return None
+
+
+def _epoch_ms_to_dt(value: object) -> datetime | None:
+    """NoFluffJobs' ``posted`` is unix-milliseconds (e.g.
+    ``1777521835788``). Convert to a naive UTC datetime so the
+    schema's ``datetime | None`` field accepts it across consumers
+    that compare against naive values."""
+    if isinstance(value, bool):
+        return None
+    try:
+        ms = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    if ms <= 0:
+        return None
+    return datetime.fromtimestamp(ms / 1000.0, tz=UTC).replace(tzinfo=None)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,7 +29,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
-        "manfred", "thehub", "ycombinator", "wellfound",
+        "manfred", "nofluffjobs", "thehub", "ycombinator", "wellfound",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",
         "recruitee", "taleo", "teamtailor",

--- a/tests/test_nofluffjobs.py
+++ b/tests/test_nofluffjobs.py
@@ -1,0 +1,494 @@
+"""Tests for the NoFluffJobs scraper.
+
+NoFluffJobs ships a POST search endpoint that returns one page at a
+time. Pin parsing of the rich payload (places + country → alpha-2,
+salary range w/ currency + period + contract type, posted epoch-ms,
+seniority / category / requirement tiles → raw) plus the pagination
+loop driven by ``totalPages``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import NoFluffJobsScraper, ScraperRegistry
+
+API_URL = "https://nofluffjobs.com/api/search/posting"
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.nofluffjobs as nfj
+    monkeypatch.setattr(nfj, "MAX_RETRIES", 1)
+    monkeypatch.setattr(nfj, "RETRY_BASE_DELAY", 0.0)
+
+
+def _posting(
+    *,
+    job_id: str = "senior-angular-developer-acme-Kraków-1",
+    title: str = "Senior Angular Developer",
+    company: str = "Acme",
+    url_slug: str = "senior-angular-developer-acme-krakow",
+    places: list[dict[str, Any]] | None = None,
+    fully_remote: bool = False,
+    salary_from: float | None = 21840.0,
+    salary_to: float | None = 28560.0,
+    salary_currency: str | None = "PLN",
+    salary_type: str = "b2b",
+    seniority: list[str] | None = None,
+    category: str = "frontend",
+    technology: str = "Angular",
+    posted: int = 1777521835788,
+    reference: str = "S6VTM4BA",
+    tiles: list[dict[str, str]] | None = None,
+) -> dict[str, Any]:
+    if places is None:
+        places = [
+            {
+                "country": {"code": "POL", "name": "Poland"},
+                "city": "Kraków",
+            }
+        ]
+    if seniority is None:
+        seniority = ["Senior"]
+    if tiles is None:
+        tiles = [
+            {"value": "frontend", "type": "category"},
+            {"value": "Angular", "type": "requirement"},
+            {"value": "TypeScript", "type": "requirement"},
+        ]
+    salary: dict[str, Any] = {"type": salary_type}
+    if salary_from is not None:
+        salary["from"] = salary_from
+    if salary_to is not None:
+        salary["to"] = salary_to
+    if salary_currency is not None:
+        salary["currency"] = salary_currency
+    return {
+        "id": job_id,
+        "name": company,
+        "title": title,
+        "url": url_slug,
+        "location": {
+            "places": places,
+            "fullyRemote": fully_remote,
+        },
+        "fullyRemote": fully_remote,
+        "salary": salary,
+        "seniority": seniority,
+        "category": category,
+        "technology": technology,
+        "posted": posted,
+        "regions": ["pl"],
+        "reference": reference,
+        "tiles": {"values": tiles},
+    }
+
+
+def _response(
+    postings: list[dict[str, Any]],
+    *,
+    total_pages: int = 1,
+    total_count: int | None = None,
+) -> dict[str, Any]:
+    return {
+        "criteriaSearch": {},
+        "postings": postings,
+        "totalCount": total_count if total_count is not None else len(postings),
+        "totalPages": total_pages,
+    }
+
+
+# --- registry / wiring ------------------------------------------------------
+
+
+def test_registry_resolves_nofluffjobs() -> None:
+    assert ScraperRegistry.get(ATSType.NOFLUFFJOBS) is NoFluffJobsScraper
+
+
+def test_ats_type_value() -> None:
+    assert ATSType.NOFLUFFJOBS.value == "nofluffjobs"
+
+
+# --- happy path -------------------------------------------------------------
+
+
+def test_parses_full_posting(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=httpx.URL(API_URL).copy_merge_params({
+            "salaryCurrency": "PLN", "salaryPeriod": "month",
+            "page": "1", "pageSize": "200",
+        }),
+        method="POST",
+        json=_response([_posting()]),
+    )
+    j = NoFluffJobsScraper("any").fetch()[0]
+    assert j.ats_type is ATSType.NOFLUFFJOBS
+    assert j.ats_id == "senior-angular-developer-acme-Kraków-1"
+    assert j.title == "Senior Angular Developer"
+    assert j.company == "Acme"
+    assert str(j.url) == (
+        "https://nofluffjobs.com/job/senior-angular-developer-acme-krakow"
+    )
+    assert j.location == "Kraków, Poland"
+    assert j.country_iso == "PL"
+    assert j.language == "en"
+    assert j.salary_currency == "PLN"
+    assert j.salary_period == "MONTH"
+    assert j.salary_min == 21840.0
+    assert j.salary_max == 28560.0
+    assert j.employment_type == "CONTRACT"
+    assert j.commitment == "b2b"
+    assert j.requisition_id == "S6VTM4BA"
+    assert j.posted_at == datetime.fromtimestamp(
+        1777521835788 / 1000.0, tz=UTC
+    ).replace(tzinfo=None)
+    assert j.raw is not None
+    assert j.raw["category"] == "frontend"
+    assert j.raw["seniority"] == ["Senior"]
+    assert j.raw["must_haves"] == ["Angular", "TypeScript"]
+    assert j.raw["regions"] == ["pl"]
+    assert j.raw["contract_type"] == "b2b"
+
+
+def test_global_id_format() -> None:
+    """``global_id`` follows ``nofluffjobs:{id}`` so consumers can
+    split on the first colon."""
+    from jobhive.models import Job
+
+    job = Job(
+        url="https://nofluffjobs.com/job/x",
+        title="x",
+        company="x",
+        ats_type=ATSType.NOFLUFFJOBS,
+        ats_id="senior-angular-acme-krakow-1",
+    )
+    assert job.global_id == "nofluffjobs:senior-angular-acme-krakow-1"
+
+
+# --- employment-type mapping ------------------------------------------------
+
+
+@pytest.mark.parametrize("contract, expected_emp", [
+    ("permanent", "FULL_TIME"),
+    ("b2b", "CONTRACT"),
+    ("mandate", "CONTRACT"),
+    ("freelance", "CONTRACT"),
+    ("internship", "INTERN"),
+    ("trainee", "INTERN"),
+])
+def test_employment_type_mapping(
+    contract: str, expected_emp: str, httpx_mock
+) -> None:
+    httpx_mock.add_response(
+        url=httpx.URL(API_URL).copy_merge_params({
+            "salaryCurrency": "PLN", "salaryPeriod": "month",
+            "page": "1", "pageSize": "200",
+        }),
+        method="POST",
+        json=_response([_posting(job_id=f"x-{contract}", salary_type=contract)]),
+    )
+    j = NoFluffJobsScraper("any").fetch()[0]
+    assert j.employment_type == expected_emp
+    assert j.commitment == contract
+
+
+def test_unknown_contract_type_leaves_employment_type_none(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=httpx.URL(API_URL).copy_merge_params({
+            "salaryCurrency": "PLN", "salaryPeriod": "month",
+            "page": "1", "pageSize": "200",
+        }),
+        method="POST",
+        json=_response([_posting(job_id="x", salary_type="weird-contract")]),
+    )
+    j = NoFluffJobsScraper("any").fetch()[0]
+    assert j.employment_type is None
+    assert j.commitment == "weird-contract"
+
+
+# --- location + country -----------------------------------------------------
+
+
+def test_remote_only_posting(httpx_mock) -> None:
+    """Some postings have a single ``Remote`` place with no country
+    object — set ``is_remote=True``, location='Remote', country_iso=None."""
+    httpx_mock.add_response(
+        url=httpx.URL(API_URL).copy_merge_params({
+            "salaryCurrency": "PLN", "salaryPeriod": "month",
+            "page": "1", "pageSize": "200",
+        }),
+        method="POST",
+        json=_response([_posting(
+            job_id="remote-1",
+            places=[{"city": "Remote"}],
+            fully_remote=True,
+        )]),
+    )
+    j = NoFluffJobsScraper("any").fetch()[0]
+    assert j.location == "Remote"
+    assert j.country_iso is None
+    assert j.is_remote is True
+
+
+def test_multi_place_pipe_joined_and_first_country_wins(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=httpx.URL(API_URL).copy_merge_params({
+            "salaryCurrency": "PLN", "salaryPeriod": "month",
+            "page": "1", "pageSize": "200",
+        }),
+        method="POST",
+        json=_response([_posting(
+            job_id="multi",
+            places=[
+                {"city": "Remote"},
+                {
+                    "country": {"code": "POL", "name": "Poland"},
+                    "city": "Katowice",
+                },
+                {
+                    "country": {"code": "DEU", "name": "Germany"},
+                    "city": "Berlin",
+                },
+            ],
+        )]),
+    )
+    j = NoFluffJobsScraper("any").fetch()[0]
+    assert j.location == "Remote | Katowice, Poland | Berlin, Germany"
+    assert j.country_iso == "PL"  # first place w/ country code wins
+
+
+@pytest.mark.parametrize("code3, code2", [
+    ("POL", "PL"), ("DEU", "DE"), ("NLD", "NL"),
+    ("CZE", "CZ"), ("GBR", "GB"), ("USA", "US"),
+])
+def test_alpha3_to_alpha2_country_mapping(
+    code3: str, code2: str, httpx_mock
+) -> None:
+    httpx_mock.add_response(
+        url=httpx.URL(API_URL).copy_merge_params({
+            "salaryCurrency": "PLN", "salaryPeriod": "month",
+            "page": "1", "pageSize": "200",
+        }),
+        method="POST",
+        json=_response([_posting(
+            job_id=f"x-{code3}",
+            places=[{
+                "country": {"code": code3, "name": "X"}, "city": "Y",
+            }],
+        )]),
+    )
+    j = NoFluffJobsScraper("any").fetch()[0]
+    assert j.country_iso == code2
+
+
+def test_unknown_country_code_yields_none(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=httpx.URL(API_URL).copy_merge_params({
+            "salaryCurrency": "PLN", "salaryPeriod": "month",
+            "page": "1", "pageSize": "200",
+        }),
+        method="POST",
+        json=_response([_posting(
+            job_id="x",
+            places=[{"country": {"code": "XYZ", "name": "Atlantis"},
+                     "city": "Sub"}],
+        )]),
+    )
+    j = NoFluffJobsScraper("any").fetch()[0]
+    assert j.country_iso is None
+    assert j.location == "Sub, Atlantis"
+
+
+# --- salary -----------------------------------------------------------------
+
+
+def test_no_salary_when_amounts_missing(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=httpx.URL(API_URL).copy_merge_params({
+            "salaryCurrency": "PLN", "salaryPeriod": "month",
+            "page": "1", "pageSize": "200",
+        }),
+        method="POST",
+        json=_response([_posting(
+            job_id="x", salary_from=None, salary_to=None, salary_currency=None,
+        )]),
+    )
+    j = NoFluffJobsScraper("any").fetch()[0]
+    assert j.salary_currency is None
+    assert j.salary_period is None
+    assert j.salary_min is None
+    assert j.salary_max is None
+
+
+def test_salary_period_from_payload_wins_over_query_default(
+    httpx_mock,
+) -> None:
+    """When the posting's salary explicitly carries a ``period``, use
+    it; fall back to the query-default only when missing."""
+    httpx_mock.add_response(
+        url=httpx.URL(API_URL).copy_merge_params({
+            "salaryCurrency": "EUR", "salaryPeriod": "year",
+            "page": "1", "pageSize": "200",
+        }),
+        method="POST",
+        json=_response([{
+            **_posting(job_id="hourly", salary_from=50, salary_to=80),
+            "salary": {
+                "from": 50, "to": 80, "type": "b2b",
+                "currency": "EUR", "period": "hour",
+            },
+        }]),
+    )
+    j = NoFluffJobsScraper(
+        "any", salary_currency="EUR", salary_period="year"
+    ).fetch()[0]
+    assert j.salary_period == "HOUR"
+
+
+# --- pagination -------------------------------------------------------------
+
+
+def test_paginates_until_total_pages(httpx_mock) -> None:
+    """``totalPages=3`` should drive three POSTs, with page=1..3."""
+    httpx_mock.add_response(
+        url=httpx.URL(API_URL).copy_merge_params({
+            "salaryCurrency": "PLN", "salaryPeriod": "month",
+            "page": "1", "pageSize": "200",
+        }),
+        method="POST",
+        json=_response([_posting(job_id="p1")], total_pages=3),
+    )
+    httpx_mock.add_response(
+        url=httpx.URL(API_URL).copy_merge_params({
+            "salaryCurrency": "PLN", "salaryPeriod": "month",
+            "page": "2", "pageSize": "200",
+        }),
+        method="POST",
+        json=_response([_posting(job_id="p2")], total_pages=3),
+    )
+    httpx_mock.add_response(
+        url=httpx.URL(API_URL).copy_merge_params({
+            "salaryCurrency": "PLN", "salaryPeriod": "month",
+            "page": "3", "pageSize": "200",
+        }),
+        method="POST",
+        json=_response([_posting(job_id="p3")], total_pages=3),
+    )
+    jobs = NoFluffJobsScraper("any").fetch()
+    assert sorted(j.ats_id for j in jobs) == ["p1", "p2", "p3"]
+
+
+def test_pagination_dedupes_repeated_ids_across_pages(httpx_mock) -> None:
+    """If the server returns the same id on two adjacent pages
+    (race / re-sort), the second appearance is dropped."""
+    httpx_mock.add_response(
+        url=httpx.URL(API_URL).copy_merge_params({
+            "salaryCurrency": "PLN", "salaryPeriod": "month",
+            "page": "1", "pageSize": "200",
+        }),
+        method="POST",
+        json=_response(
+            [_posting(job_id="a"), _posting(job_id="b")], total_pages=2,
+        ),
+    )
+    httpx_mock.add_response(
+        url=httpx.URL(API_URL).copy_merge_params({
+            "salaryCurrency": "PLN", "salaryPeriod": "month",
+            "page": "2", "pageSize": "200",
+        }),
+        method="POST",
+        json=_response(
+            [_posting(job_id="b"), _posting(job_id="c")], total_pages=2,
+        ),
+    )
+    jobs = NoFluffJobsScraper("any").fetch()
+    assert sorted(j.ats_id for j in jobs) == ["a", "b", "c"]
+
+
+def test_pagination_short_circuits_on_empty_page(httpx_mock) -> None:
+    """If a page comes back empty before totalPages, bail (don't spin)."""
+    httpx_mock.add_response(
+        url=httpx.URL(API_URL).copy_merge_params({
+            "salaryCurrency": "PLN", "salaryPeriod": "month",
+            "page": "1", "pageSize": "200",
+        }),
+        method="POST",
+        json=_response([_posting(job_id="a")], total_pages=10),
+    )
+    httpx_mock.add_response(
+        url=httpx.URL(API_URL).copy_merge_params({
+            "salaryCurrency": "PLN", "salaryPeriod": "month",
+            "page": "2", "pageSize": "200",
+        }),
+        method="POST",
+        json=_response([], total_pages=10),
+    )
+    jobs = NoFluffJobsScraper("any").fetch()
+    assert [j.ats_id for j in jobs] == ["a"]
+
+
+# --- defensive --------------------------------------------------------------
+
+
+def test_skips_posting_missing_required_fields(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=httpx.URL(API_URL).copy_merge_params({
+            "salaryCurrency": "PLN", "salaryPeriod": "month",
+            "page": "1", "pageSize": "200",
+        }),
+        method="POST",
+        json=_response([
+            _posting(),
+            {"id": "no-title", "name": "x", "url": "slug"},  # no title
+            {"title": "x", "name": "y"},  # no id, no url
+        ]),
+    )
+    jobs = NoFluffJobsScraper("any").fetch()
+    assert len(jobs) == 1
+
+
+def test_non_dict_response_raises(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=httpx.URL(API_URL).copy_merge_params({
+            "salaryCurrency": "PLN", "salaryPeriod": "month",
+            "page": "1", "pageSize": "200",
+        }),
+        method="POST",
+        json=[1, 2, 3],
+    )
+    with pytest.raises(ScraperError, match="API shape changed"):
+        NoFluffJobsScraper("any").fetch()
+
+
+def test_postings_not_a_list_raises(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=httpx.URL(API_URL).copy_merge_params({
+            "salaryCurrency": "PLN", "salaryPeriod": "month",
+            "page": "1", "pageSize": "200",
+        }),
+        method="POST",
+        json={"postings": "nope", "totalPages": 1},
+    )
+    with pytest.raises(ScraperError, match="'postings' is"):
+        NoFluffJobsScraper("any").fetch()
+
+
+def test_persistent_500_raises(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=httpx.URL(API_URL).copy_merge_params({
+            "salaryCurrency": "PLN", "salaryPeriod": "month",
+            "page": "1", "pageSize": "200",
+        }),
+        method="POST",
+        status_code=500,
+        is_reusable=True,
+    )
+    with pytest.raises(ScraperError):
+        NoFluffJobsScraper("any").fetch()


### PR DESCRIPTION
## Summary
- Adds `NoFluffJobsScraper` (single-source, hybrid jobboard). Talks the public `POST /api/search/posting` endpoint, walks `totalPages` with a 200-item page size, and produces ~19k `Job` rows against the live API.
- Registers `ATSType.NOFLUFFJOBS = "nofluffjobs"` and wires it through `__init__.py` + `test_models.py`.
- Rich field mapping: ISO 3166-1 alpha-3 → alpha-2 country code, `salary` (currency / period / range), `salary.type` → normalized `employment_type` (`permanent` → FULL_TIME, `b2b` / `mandate` / `freelance` → CONTRACT, `internship` → INTERN). Stashes `category`, `seniority`, `technology`, must-have requirement tiles, `regions`, and the public reference code in `raw`. `posted` (unix-ms) decoded to naive-UTC.

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run pytest` — 908 passed (29 new tests in `test_nofluffjobs.py`, model-set assertion updated).
- [x] Live smoke against `https://nofluffjobs.com/api/search/posting` (page_size=10) returned 19k+ jobs across paginated requests with the expected shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `NoFluffJobsScraper` to ingest Europe-focused IT/tech listings from No Fluff Jobs. It paginates the public search API and maps salary, location, and contract details into our `Job` schema; also seeds board metadata in `ats-companies/nofluffjobs.csv`.

- New Features
  - New `NoFluffJobsScraper` using `POST /api/search/posting`; walks `totalPages`, dedupes IDs, and retries on 429/5xx.
  - Field mapping: ISO alpha‑3→alpha‑2 country, `salary` (currency/period/range), `salary.type`→employment type, `posted` epoch‑ms→naive UTC, `fullyRemote`→`is_remote`.
  - Extras in `raw`: `category`, `seniority`, `technology`, must‑have tiles, `regions`, `reference`; job URL built from slug.
  - Registered `ATSType.NOFLUFFJOBS`, exported in `scrapers/__init__.py`, and added seed CSV `ats-companies/nofluffjobs.csv`.
  - Added tests for parsing, pagination, and error handling; updated model set assertion.

<sup>Written for commit aa575c31ad23689d5f603a57cda45b0f5223eb0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `NoFluffJobsScraper`, a new single-source scraper for the Europe-focused No Fluff Jobs board. It paginates a public `POST /api/search/posting` endpoint, maps ISO alpha-3 country codes, salary metadata, and contract flavours into the shared `Job` schema, and registers the new `ATSType.NOFLUFFJOBS` enum value.

- The pagination loop, deduplication, retry logic, and rich field mapping (employment type, salary period, location joining) are well-structured and backed by 29 new tests.
- `_epoch_ms_to_dt` wraps `int()` in a try/except but leaves the subsequent `datetime.fromtimestamp()` call unguarded; an out-of-range timestamp from the API would raise an unhandled `OSError`/`OverflowError` and abort the entire scrape run rather than skipping the bad row.
- Minor: `Retry-After` delay parsing uses `str.isdigit()`, which silently ignores decimal values like `\"1.5\"`, falling back to exponential back-off instead.

<h3>Confidence Score: 3/5</h3>

Safe to merge after fixing the unguarded `datetime.fromtimestamp` call in `_epoch_ms_to_dt`; a malformed timestamp from the live API would silently kill an entire scrape run.

The implementation is thorough and the test suite is strong, but `_epoch_ms_to_dt` leaves `datetime.fromtimestamp` unguarded — any out-of-range `posted` value in a live 19k-posting run propagates as an unhandled `OSError` or `OverflowError` all the way through `_fetch_async`, returning no jobs instead of skipping the bad row. That is a present defect on the live-API path that the tests do not exercise.

src/jobhive/scrapers/nofluffjobs.py — specifically `_epoch_ms_to_dt` and the `Retry-After` parsing in `_fetch_page`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/nofluffjobs.py | New 402-line scraper; core pagination and field mapping look correct. `_epoch_ms_to_dt` is missing `OSError`/`OverflowError` handling, which could crash an entire run on a single out-of-range timestamp. Minor issues: `Retry-After` isdigit() ignores decimal delays; unreachable statement after the retry loop. |
| tests/test_nofluffjobs.py | 29 new tests covering pagination, deduplication, employment-type mapping, location/country extraction, salary parsing, and error paths. Coverage is thorough; no issues found. |
| src/jobhive/models.py | Adds `ATSType.NOFLUFFJOBS = "nofluffjobs"` in alphabetical order. Straightforward, no issues. |
| src/jobhive/scrapers/__init__.py | Exports `NoFluffJobsScraper` in alphabetical order in both the import list and `__all__`. Clean. |
| tests/test_models.py | Updates the model-set assertion to include `"nofluffjobs"`. Correct. |
| ats-companies/nofluffjobs.csv | Seed CSV with a single row for No Fluff Jobs. No issues. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/jobhive/scrapers/nofluffjobs.py:396-402
`_epoch_ms_to_dt` only catches `TypeError` and `ValueError`, but `datetime.fromtimestamp` can raise `OSError` (on POSIX, for values > 32536799999) or `OverflowError` (for very large floats that don't fit the C `time_t`). Because `_parse` calls this with no surrounding try/except, a single out-of-range `posted` value in a 19k-posting scrape run will crash the entire `_fetch_async` coroutine and surface no jobs at all — rather than just skipping the bad row.

```suggestion
    try:
        ms = int(value)  # type: ignore[arg-type]
    except (TypeError, ValueError):
        return None
    if ms <= 0:
        return None
    try:
        return datetime.fromtimestamp(ms / 1000.0, tz=UTC).replace(tzinfo=None)
    except (OSError, OverflowError, ValueError):
        return None
```

### Issue 2 of 3
src/jobhive/scrapers/nofluffjobs.py:215-220
`str.isdigit()` returns `False` for decimal strings like `"1.5"`, so a server-sent `Retry-After: 1.5` silently falls back to the exponential back-off instead of honouring the server's hint. Replacing with a `float()` conversion inside a try/except handles both integer and decimal values correctly.

```suggestion
                retry_after = response.headers.get("Retry-After")
                try:
                    delay = float(retry_after) if retry_after else None
                except ValueError:
                    delay = None
                delay = delay if delay and delay > 0 else RETRY_BASE_DELAY * (2 ** attempt)
```

### Issue 3 of 3
src/jobhive/scrapers/nofluffjobs.py:272
**Unreachable statement after retry loop**

Every branch inside the `for attempt in range(1, MAX_RETRIES + 1)` loop either `return`s, `raise`s, or `continue`s. On the final attempt both the `httpx.HTTPError` path and the 429/5xx path always `raise`. For any other status code the inner `raise ScraperError(...)` fires unconditionally. The loop therefore cannot exit normally, making this `raise` dead code. It won't cause a runtime bug but it misleads readers into thinking there is an additional escape path.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: nofluffjobs...."](https://github.com/kalil0321/ats-scrapers/commit/aa575c31ad23689d5f603a57cda45b0f5223eb0e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732491)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->