### PR TITLE
profession_hu: add Hungary's #1 job board scraper (~18k live)

### DIFF
--- a/ats-companies/profession_hu.csv
+++ b/ats-companies/profession_hu.csv
@@ -1,0 +1,2 @@
+name,slug,url
+Profession.hu,profession_hu,https://www.profession.hu

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -77,6 +77,7 @@ class ATSType(StrEnum):
     BUILTIN = "builtin"
     JOBSCH = "jobsch"
     MANFRED = "manfred"
+    PROFESSIONHU = "profession_hu"
     THEHUB = "thehub"
     YCOMBINATOR = "ycombinator"
     WELLFOUND = "wellfound"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -37,6 +37,7 @@ from jobhive.scrapers.oracle import OracleScraper
 from jobhive.scrapers.personio import PersonioScraper
 from jobhive.scrapers.phenom import PhenomScraper
 from jobhive.scrapers.pinpoint import PinpointScraper
+from jobhive.scrapers.profession_hu import ProfessionHuScraper
 from jobhive.scrapers.programathor import ProgramathorScraper
 from jobhive.scrapers.recruitee import RecruiteeScraper
 from jobhive.scrapers.recruiterbox import RecruiterboxScraper
@@ -88,6 +89,7 @@ __all__ = [
     "PersonioScraper",
     "PhenomScraper",
     "PinpointScraper",
+    "ProfessionHuScraper",
     "ProgramathorScraper",
     "RecruiteeScraper",
     "RecruiterboxScraper",

--- a/src/jobhive/scrapers/profession_hu.py
+++ b/src/jobhive/scrapers/profession_hu.py
@@ -1,0 +1,422 @@
+"""Profession.hu — Hungary's dominant direct-posting job board (~50k live).
+
+Profession.hu hosts ~18-50k active postings at any given time and is by
+far the largest Hungarian-language job platform; companies post directly
+(it's not a LinkedIn / Indeed aggregator). May 2026 audit had Hungary at
+near-zero share of the dataset — this single source unlocks the country.
+
+Scraping surface: the public listing pages at
+``https://www.profession.hu/allasok/{page}`` serve a complete
+``dataLayer.push({"event": "view_item_list", ...})`` block on every
+response. That block carries every field we need (title, employer,
+category, sub-category, employment-type normalized to English, salary
+visibility flag, experience bucket, location-id) — no per-job detail
+fetch is required for the canonical schema. The matching
+``<li class="advertisement-result-list-item" data-prof-id="…" data-link="…">``
+tag pairs each item with its detail-page URL. Pagination is a plain
+trailing path segment (``/allasok/2``, ``/allasok/3`` …) with 20 rows
+per page; the listing header advertises a total (e.g.
+``18750 db``) we parse to size the pagination plan.
+
+Notes / quirks:
+
+  - The ``?page=N`` query-string variant returns page 1 regardless of
+    ``N`` — only the ``/allasok/{N}`` path form actually advances.
+
+  - ``location_id`` is a normalised Hungarian slug, e.g.
+    ``Heves_megye,_Gyöngyös`` (county + city). The scraper turns the
+    underscores into spaces but leaves the comma layout intact;
+    downstream LLM enrichment normalises further.
+
+  - The dataLayer's ``item_category3`` is pre-normalised to English
+    (``"full time"``, ``"part time"``, ``"contract"``, ``"internship"``,
+    ``"temporary"``). We map straight off that English string — no need
+    to translate ``Teljes munkaidős`` / ``Részmunkaidős`` ourselves.
+
+  - ``item_variant`` is the salary-visibility flag
+    (``salary publicised`` / ``salary confidential``). The structured
+    HUF range only appears on the detail page; with no per-job fetch we
+    leave ``salary_currency`` / ``salary_min`` / ``salary_max`` null on
+    the listing surface. The visibility flag is preserved in ``raw``.
+
+  - Hungarian listings are in Hungarian, so ``language="hu"`` and
+    ``country_iso="HU"`` are populated unconditionally.
+
+Single-source scraper: ``company_slug`` is informational and ignored.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+log = logging.getLogger(__name__)
+
+LISTING_URL_TEMPLATE = "https://www.profession.hu/allasok/{page}"
+DETAIL_URL_TEMPLATE = "https://www.profession.hu/allas/{job_id}"
+PER_PAGE = 20  # Hard-coded by the listing renderer.
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1.5
+# Profession.hu currently exposes ~18-25k jobs; 1 500 pages × 20 rows
+# = 30k is well above the live ceiling. Lower via ``max_pages`` for
+# smoke runs.
+DEFAULT_MAX_PAGES = 1500
+
+# The dataLayer push we rely on. Anchored to ``event":"view_item_list"``
+# (with optional whitespace around the colon to tolerate the live
+# minified shape and pretty-printed test fixtures alike) to avoid
+# matching the unrelated ``view_item`` push on the detail page. The
+# capture is everything up to the matching ``});`` — the JSON payload
+# nests dicts so a naive ``\}`` match would stop at the first inner
+# brace; we anchor on the closing ``);`` sequence instead and let the
+# JSON parser deal with the contents.
+_DATALAYER_RE = re.compile(
+    r"dataLayer\.push\(\s*(\{\s*\"event\"\s*:\s*\"view_item_list\".*?\})\s*\)\s*;",
+    re.DOTALL,
+)
+# Listing rows ship a ``data-prof-id`` + ``data-link`` pair on each
+# ``<li class="advertisement-result-list-item">`` tag. We use the
+# id→href map to turn dataLayer rows into absolute URLs.
+_ROW_LINK_RE = re.compile(
+    r'data-prof-id="(\d+)"\s+data-link="([^"]+)"'
+)
+# Total-postings counter in the listing header
+# (``item_list_name`` field or visible header — both share the
+# ``- {N} db -`` pattern; we read the dataLayer field which is more
+# robust than the rendered DOM).
+_TOTAL_RE = re.compile(r"-\s*(\d[\d\s ]*)\s*db\s*-")
+
+# item_category3 → canonical EmploymentType. Source uses English
+# strings even on the Hungarian-language site (verified live
+# 2026-05-12 across pages 1, 5, 50, 200, 500).
+_EMPLOYMENT_TYPE_MAP: dict[str, str] = {
+    "full time": "FULL_TIME",
+    "part time": "PART_TIME",
+    "contract": "CONTRACT",
+    "internship": "INTERN",
+    "temporary": "TEMPORARY",
+    # Defensive: cover the Hungarian originals as well in case
+    # Profession.hu ever stops normalising. ``Teljes munkaidős`` etc.
+    # come from the rendered detail-page chip; not currently in the
+    # dataLayer surface but cheap to support.
+    "teljes munkaidős": "FULL_TIME",
+    "részmunkaidős": "PART_TIME",
+    "alkalmi munka": "TEMPORARY",
+    "gyakornoki": "INTERN",
+    "bedolgozói": "CONTRACT",
+}
+
+
+@ScraperRegistry.register(ATSType.PROFESSIONHU)
+class ProfessionHuScraper(BaseScraper):
+    """Profession.hu (Hungary) — direct-posting board.
+
+    Single-source: ``company_slug`` is ignored. Pass anything
+    (``"any"``, ``""``).
+
+    Knobs:
+    - ``max_pages`` — pagination cap (default 1 500, comfortably above
+      the ~1k pages × 20 rows the live board currently exposes).
+    """
+
+    ats = ATSType.PROFESSIONHU
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        max_pages: int = DEFAULT_MAX_PAGES,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.max_pages = max_pages
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        lock = asyncio.Lock()
+
+        async def absorb(items: list[Job]) -> None:
+            async with lock:
+                for job in items:
+                    if job.ats_id in seen:
+                        continue
+                    seen.add(job.ats_id)  # type: ignore[arg-type]
+                    jobs.append(job)
+
+        async with httpx.AsyncClient(
+            timeout=self.timeout,
+            follow_redirects=True,
+            headers={
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/124.0.0.0 Safari/537.36"
+                ),
+                "Accept-Language": "hu-HU,hu;q=0.9,en;q=0.8",
+            },
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+
+            # Probe page 1 to learn the total job count.
+            first_html = await self._fetch_page(client, sem, page=1)
+            first_items, total = self._parse_listing(first_html)
+            await absorb(first_items)
+
+            if total <= PER_PAGE:
+                return jobs
+
+            page_count = min(
+                (total + PER_PAGE - 1) // PER_PAGE, self.max_pages
+            )
+            if page_count <= 1:
+                return jobs
+
+            async def one(page: int) -> None:
+                try:
+                    body = await self._fetch_page(client, sem, page=page)
+                except ScraperError as exc:
+                    log.warning(
+                        "profession.hu: page=%d failed: %s — skipping.",
+                        page,
+                        exc,
+                    )
+                    return
+                items, _ = self._parse_listing(body)
+                await absorb(items)
+
+            await asyncio.gather(
+                *(one(p) for p in range(2, page_count + 1))
+            )
+        return jobs
+
+    async def _fetch_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        *,
+        page: int,
+    ) -> str:
+        url = LISTING_URL_TEMPLATE.format(page=page)
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(url)
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"profession.hu fetch failed at page={page}: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                return response.text
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"profession.hu returned {response.status_code} at "
+                        f"page={page} after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after)
+                    if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"profession.hu returned {response.status_code} at page={page}"
+            )
+        raise ScraperError(
+            f"profession.hu exhausted retries at page={page}: {last_exc}"
+        )
+
+    def _parse_listing(self, html_body: str) -> tuple[list[Job], int]:
+        """Extract jobs + total-row count from a listing-page HTML body.
+
+        Returns ``([], 0)`` (rather than raising) when the dataLayer
+        block is missing — that happens on empty / 404-style pages past
+        the real pagination cap, and we'd rather drop a stray page than
+        crash the whole scrape.
+        """
+        match = _DATALAYER_RE.search(html_body)
+        if match is None:
+            return [], 0
+        try:
+            payload = json.loads(match.group(1))
+        except json.JSONDecodeError as exc:
+            log.warning(
+                "profession.hu: malformed view_item_list dataLayer: %s",
+                exc,
+            )
+            return [], 0
+
+        items = (
+            (payload.get("ecommerce") or {}).get("items") or []
+            if isinstance(payload.get("ecommerce"), dict)
+            else []
+        )
+
+        # Build id → detail-URL map from the matching <li> tags. The
+        # dataLayer row carries the integer ``item_id``, the <li> ships
+        # the absolute URL; we join on stringified id.
+        link_map = dict(_ROW_LINK_RE.findall(html_body))
+
+        # Total job count for the active filter set — published in
+        # ``item_list_name`` ("Állások, munkák ... - 18750 db - …").
+        # Falls back to the raw item count if the header changes shape.
+        total = 0
+        list_name = ""
+        for it in items:
+            if isinstance(it, dict) and it.get("item_list_name"):
+                list_name = str(it["item_list_name"])
+                break
+        m_total = _TOTAL_RE.search(list_name)
+        if m_total:
+            raw = re.sub(r"[\s ]", "", m_total.group(1))
+            try:
+                total = int(raw)
+            except ValueError:
+                total = 0
+
+        jobs: list[Job] = []
+        for raw_item in items:
+            if not isinstance(raw_item, dict):
+                continue
+            job = self._parse_item(raw_item, link_map)
+            if job is not None:
+                jobs.append(job)
+
+        # Defensive: when the header's total is unparseable, at least
+        # return the visible row count so single-page scraping still
+        # works.
+        if not total:
+            total = len(jobs)
+        return jobs, total
+
+    def _parse_item(
+        self, item: dict[str, Any], link_map: dict[str, str]
+    ) -> Job | None:
+        raw_id = item.get("item_id")
+        if raw_id is None:
+            return None
+        ats_id = str(raw_id).strip()
+        if not ats_id:
+            return None
+
+        title = (item.get("item_name") or "").strip()
+        if not title:
+            return None
+
+        # ``affiliation`` is the hiring employer's display name;
+        # ``item_brand`` is always "classified listing" (the product
+        # tier), not the company — don't confuse the two.
+        company = (item.get("affiliation") or "").strip() or "Unknown"
+
+        # Prefer the canonical detail URL we scraped off the <li>; if
+        # that's missing (rare — happens when a row is rendered without
+        # the standard advertisement wrapper) fall back to the slug-less
+        # ``/allas/{id}`` form, which Profession.hu 301-redirects to the
+        # full slug.
+        url = link_map.get(ats_id) or DETAIL_URL_TEMPLATE.format(
+            job_id=ats_id
+        )
+
+        location_id = (item.get("location_id") or "").strip()
+        location = _format_location(location_id)
+
+        category3 = (item.get("item_category3") or "").strip().lower()
+        employment_type = _EMPLOYMENT_TYPE_MAP.get(category3)
+
+        salary_summary, salary_currency = _parse_salary_flag(
+            (item.get("item_variant") or "").strip().lower()
+        )
+
+        raw: dict[str, object] = {}
+        if item.get("item_category"):
+            raw["category"] = item["item_category"]
+        if item.get("item_category2"):
+            raw["industry"] = item["item_category2"]
+        if item.get("item_category4"):
+            raw["experience_bucket"] = item["item_category4"]
+        if item.get("item_variant"):
+            raw["salary_visibility"] = item["item_variant"]
+        if item.get("application_type"):
+            raw["application_type"] = item["application_type"]
+        if item.get("prof_product_name"):
+            raw["modality"] = item["prof_product_name"]
+
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.PROFESSIONHU,
+            ats_id=ats_id,
+            location=location,
+            country_iso="HU",
+            region="Europe",
+            language="hu",
+            employment_type=employment_type,  # type: ignore[arg-type]
+            salary_currency=salary_currency,
+            salary_summary=salary_summary,
+            fetched_at=datetime.now(),
+            raw=raw or None,
+        )
+
+
+def _format_location(location_id: str) -> str | None:
+    """Profession.hu encodes ``location_id`` as
+    ``County_megye,_City`` with underscore-spaces (e.g.
+    ``Heves_megye,_Gyöngyös``). Empty strings show up for remote /
+    country-wide postings — return None so downstream enrichment can
+    apply its own heuristics.
+
+    We swap underscores for spaces but leave the comma + ``megye``
+    suffix intact; that's the canonical Hungarian county notation and
+    matches how downstream geocoders / LLM enrichment expect to see
+    Hungarian addresses.
+    """
+    if not location_id:
+        return None
+    return location_id.replace("_", " ").strip() or None
+
+
+def _parse_salary_flag(variant: str) -> tuple[str | None, str | None]:
+    """The listing dataLayer's ``item_variant`` is a salary-visibility
+    flag, not a numeric range. We surface the human-readable label as
+    ``salary_summary`` and pin the currency to HUF when the salary is
+    publicly visible — the actual numeric range only appears on the
+    detail page, and the scraper deliberately stays at listing level.
+
+    Returns ``(summary, currency)``:
+      - ``("Sávos bérezés", "HUF")`` when the listing says
+        ``salary publicised``.
+      - ``(None, None)`` for ``salary confidential`` and unknown
+        flags — leave the field blank rather than misleading consumers
+        with "confidential" as the salary.
+    """
+    if variant == "salary publicised":
+        # Hungarian: "Sávos bérezés" = banded/range salary. Mirrors how
+        # the rendered chip on the live site labels it.
+        return "Sávos bérezés", "HUF"
+    return None, None

--- a/src/jobhive/scrapers/profession_hu.py
+++ b/src/jobhive/scrapers/profession_hu.py
@@ -82,10 +82,22 @@ DEFAULT_MAX_PAGES = 1500
 # matching the unrelated ``view_item`` push on the detail page. The
 # capture is everything up to the matching ``});`` — the JSON payload
 # nests dicts so a naive ``\}`` match would stop at the first inner
-# brace; we anchor on the closing ``);`` sequence instead and let the
-# JSON parser deal with the contents.
+# brace. A non-greedy ``.*?`` would stop at the *first* ``});`` and
+# silently truncate the payload whenever a string value happens to
+# contain that sequence (dropping the whole page). We instead grab
+# everything *greedily* up to the last ``});`` on the page and let
+# ``json.loads`` validate the contents — listing pages carry a single
+# ``view_item_list`` push so the greedy span is the full block.
 _DATALAYER_RE = re.compile(
-    r"dataLayer\.push\(\s*(\{\s*\"event\"\s*:\s*\"view_item_list\".*?\})\s*\)\s*;",
+    r"dataLayer\.push\(\s*"
+    r"(\{\s*\"event\"\s*:\s*\"view_item_list\""
+    # Tempered-greedy body: consume everything up to the block's own
+    # ``});`` *without* crossing into a subsequent ``dataLayer.push(``.
+    # Plain greedy ``.*`` would over-match to the last ``});`` on the
+    # page (swallowing later pushes); plain non-greedy ``.*?`` would
+    # stop at the first ``});`` even when it sits inside a string value
+    # — both silently break ``json.loads`` and drop the whole page.
+    r"(?:(?!dataLayer\.push\().)*\})\s*\)\s*;",
     re.DOTALL,
 )
 # Listing rows ship a ``data-prof-id`` + ``data-link`` pair on each
@@ -175,21 +187,7 @@ class ProfessionHuScraper(BaseScraper):
         ) as client:
             sem = asyncio.Semaphore(MAX_CONCURRENCY)
 
-            # Probe page 1 to learn the total job count.
-            first_html = await self._fetch_page(client, sem, page=1)
-            first_items, total = self._parse_listing(first_html)
-            await absorb(first_items)
-
-            if total <= PER_PAGE:
-                return jobs
-
-            page_count = min(
-                (total + PER_PAGE - 1) // PER_PAGE, self.max_pages
-            )
-            if page_count <= 1:
-                return jobs
-
-            async def one(page: int) -> None:
+            async def one(page: int) -> list[Job]:
                 try:
                     body = await self._fetch_page(client, sem, page=page)
                 except ScraperError as exc:
@@ -198,13 +196,36 @@ class ProfessionHuScraper(BaseScraper):
                         page,
                         exc,
                     )
-                    return
+                    return []
                 items, _ = self._parse_listing(body)
                 await absorb(items)
+                return items
 
-            await asyncio.gather(
-                *(one(p) for p in range(2, page_count + 1))
-            )
+            # Probe page 1 to learn the total job count.
+            first_html = await self._fetch_page(client, sem, page=1)
+            first_items, total = self._parse_listing(first_html)
+            await absorb(first_items)
+            if not first_items:
+                return jobs
+
+            if total > 0:
+                # Known total → size the pagination plan and fan out.
+                page_count = min(
+                    (total + PER_PAGE - 1) // PER_PAGE, self.max_pages
+                )
+                if page_count <= 1:
+                    return jobs
+                await asyncio.gather(
+                    *(one(p) for p in range(2, page_count + 1))
+                )
+            else:
+                # Unknown total (header counter unparseable) → walk pages
+                # sequentially until one comes back empty, capped at
+                # ``max_pages`` so a missing terminator can't loop forever.
+                for page in range(2, self.max_pages + 1):
+                    items = await one(page)
+                    if not items:
+                        break
         return jobs
 
     async def _fetch_page(
@@ -307,11 +328,12 @@ class ProfessionHuScraper(BaseScraper):
             if job is not None:
                 jobs.append(job)
 
-        # Defensive: when the header's total is unparseable, at least
-        # return the visible row count so single-page scraping still
-        # works.
-        if not total:
-            total = len(jobs)
+        # When the header's total is unparseable we leave ``total`` at 0
+        # rather than falling back to the visible row count: a full page
+        # (20 rows == PER_PAGE) would otherwise look like a single-page
+        # result and stop pagination after page 1, dropping ~18k jobs.
+        # The caller treats total==0 as "unknown" and paginates until an
+        # empty page instead.
         return jobs, total
 
     def _parse_item(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,7 +29,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
-        "manfred", "thehub", "ycombinator", "wellfound",
+        "manfred", "profession_hu", "thehub", "ycombinator", "wellfound",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",
         "recruitee", "taleo", "teamtailor",

--- a/tests/test_profession_hu.py
+++ b/tests/test_profession_hu.py
@@ -1,0 +1,454 @@
+"""Tests for the Profession.hu (Hungary) scraper.
+
+Profession.hu's listing pages embed a ``dataLayer.push({"event":
+"view_item_list", ...})`` block that carries every field the canonical
+schema needs (title, employer, employment-type, category, sub-category,
+location, salary-visibility, experience bucket). The scraper parses
+that block plus the matching ``<li data-prof-id … data-link …>`` tags
+to recover absolute detail URLs — no per-job detail fetches required.
+
+These tests pin:
+  - registry wiring
+  - dataLayer + data-link extraction (id → absolute URL)
+  - location-id underscore handling and ``country_iso="HU"``
+  - employment_type map for both English (live) and Hungarian
+    (defensive) labels
+  - salary visibility flag → ``salary_summary`` / ``salary_currency``
+  - pagination by total-rows count and ``max_pages`` cap
+  - HTTP retry / failure behaviour
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import ProfessionHuScraper, ScraperRegistry
+
+_LISTING_URL_RE = re.compile(r"^https://www\.profession\.hu/allasok/\d+$")
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.profession_hu as p
+    monkeypatch.setattr(p, "MAX_RETRIES", 1)
+    monkeypatch.setattr(p, "RETRY_BASE_DELAY", 0.0)
+
+
+# --- fixture builders -------------------------------------------------------
+
+
+def _item(
+    *,
+    item_id: int = 2898489,
+    item_name: str = "BPO Projekt koordinátor",
+    affiliation: str = "Trenkwalder",
+    category: str = "Gyártás, Termelés",
+    category2: str = "Projektmenedzsment",
+    category3: str = "full time",
+    category4: str = "3-5 years experience",
+    item_variant: str = "salary confidential",
+    location_id: str = "Heves_megye,_Gyöngyös",
+    application_type: str = "karrierlink",
+    prof_product_name: str = "normal",
+) -> dict[str, Any]:
+    return {
+        "item_name": item_name,
+        "item_id": item_id,
+        "item_brand": "classified listing",
+        "item_category": category,
+        "item_category2": category2,
+        "item_category3": category3,
+        "item_category4": category4,
+        "item_list_name": (
+            "Állások, munkák és állásajánlatok - 18750 db - "
+            "2026 Május | Profession.hu"
+        ),
+        "item_list_id": "classified_search_results",
+        "item_variant": item_variant,
+        "location_id": location_id,
+        "index": 1,
+        "affiliation": affiliation,
+        "quantity": 1,
+        "price": None,
+        "application_type": application_type,
+        "prof_product_name": prof_product_name,
+        "ai_search_list": "0",
+    }
+
+
+def _build_listing_html(
+    items: list[dict[str, Any]],
+    *,
+    total_label: str | None = None,
+) -> str:
+    """Mirror the live listing-page shape closely enough that the
+    scraper's regexes match: a ``dataLayer.push`` with the
+    ``view_item_list`` payload, plus ``<li data-prof-id data-link>``
+    rows for each item."""
+    # Patch the total count into every item's item_list_name so the
+    # ``-{N} db-`` regex sees the value the test wants. Default to a
+    # total that exactly matches the visible row count, so single-page
+    # tests don't trigger pagination unless they ask for it.
+    real_total = total_label or f"{len(items)} db"
+    for it in items:
+        if isinstance(it, dict):
+            it["item_list_name"] = (
+                f"Állások, munkák és állásajánlatok - {real_total} - "
+                "2026 Május | Profession.hu"
+            )
+    payload = {
+        "event": "view_item_list",
+        "subProperty": "Application",
+        "ecommerce": {"currency": "HUF", "items": items},
+    }
+    blob = json.dumps(payload, ensure_ascii=False)
+    li_rows = "\n".join(
+        f'<li class="advertisement-result-list-item" '
+        f'data-prof-id="{it["item_id"]}" '
+        f'data-link="https://www.profession.hu/allas/job-{it["item_id"]}'
+        f'?sessionId=abc">'
+        for it in items
+        if "item_id" in it
+    )
+    return (
+        "<html><body>"
+        + li_rows
+        + "<script>dataLayer.push("
+        + blob
+        + ");</script>"
+        + "</body></html>"
+    )
+
+
+# --- registry / wiring ------------------------------------------------------
+
+
+def test_registry_resolves_profession_hu() -> None:
+    assert ScraperRegistry.get(ATSType.PROFESSIONHU) is ProfessionHuScraper
+
+
+def test_ats_type_value() -> None:
+    assert ATSType.PROFESSIONHU == "profession_hu"
+
+
+# --- happy path -------------------------------------------------------------
+
+
+def test_parses_listing_item_with_full_payload(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://www.profession.hu/allasok/1",
+        text=_build_listing_html([_item()]),
+    )
+    jobs = ProfessionHuScraper("any").fetch()
+    assert len(jobs) == 1
+    job = jobs[0]
+    assert job.ats_type is ATSType.PROFESSIONHU
+    assert job.ats_id == "2898489"
+    assert job.global_id == "profession_hu:2898489"
+    assert job.title == "BPO Projekt koordinátor"
+    assert job.company == "Trenkwalder"
+    assert job.country_iso == "HU"
+    assert job.region == "Europe"
+    assert job.language == "hu"
+    assert job.employment_type == "FULL_TIME"
+    # location_id 'Heves_megye,_Gyöngyös' → 'Heves megye, Gyöngyös'
+    assert job.location == "Heves megye, Gyöngyös"
+    # data-link survives — including the sessionId query string
+    assert str(job.url).startswith(
+        "https://www.profession.hu/allas/job-2898489"
+    )
+    assert "sessionId=abc" in str(job.url)
+    # Confidential salary → don't synthesise a numeric range or label.
+    assert job.salary_currency is None
+    assert job.salary_summary is None
+    assert job.raw is not None
+    assert job.raw["category"] == "Gyártás, Termelés"
+    assert job.raw["industry"] == "Projektmenedzsment"
+    assert job.raw["modality"] == "normal"
+    assert job.raw["salary_visibility"] == "salary confidential"
+
+
+# --- employment type map ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "category3,expected",
+    [
+        ("full time", "FULL_TIME"),
+        ("part time", "PART_TIME"),
+        ("contract", "CONTRACT"),
+        ("internship", "INTERN"),
+        ("temporary", "TEMPORARY"),
+        # Defensive: Hungarian originals also map.
+        ("Teljes munkaidős", "FULL_TIME"),
+        ("Részmunkaidős", "PART_TIME"),
+        ("Gyakornoki", "INTERN"),
+    ],
+)
+def test_employment_type_map(
+    httpx_mock, category3: str, expected: str
+) -> None:
+    httpx_mock.add_response(
+        url="https://www.profession.hu/allasok/1",
+        text=_build_listing_html(
+            [_item(item_id=1, category3=category3)]
+        ),
+    )
+    jobs = ProfessionHuScraper("any").fetch()
+    assert jobs[0].employment_type == expected
+
+
+def test_unknown_employment_type_is_none(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://www.profession.hu/allasok/1",
+        text=_build_listing_html(
+            [_item(item_id=1, category3="weekends only")]
+        ),
+    )
+    assert ProfessionHuScraper("any").fetch()[0].employment_type is None
+
+
+# --- salary visibility -----------------------------------------------------
+
+
+def test_salary_publicised_sets_summary_and_huf_currency(httpx_mock) -> None:
+    """The listing's ``item_variant`` only flags visibility, not a
+    numeric range. When publicised we surface ``HUF`` + a Hungarian
+    'banded salary' label so consumers can filter for paid postings;
+    the actual min/max only ships on the detail page."""
+    httpx_mock.add_response(
+        url="https://www.profession.hu/allasok/1",
+        text=_build_listing_html(
+            [_item(item_id=1, item_variant="salary publicised")]
+        ),
+    )
+    job = ProfessionHuScraper("any").fetch()[0]
+    assert job.salary_currency == "HUF"
+    assert job.salary_summary == "Sávos bérezés"
+
+
+def test_salary_confidential_leaves_fields_blank(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://www.profession.hu/allasok/1",
+        text=_build_listing_html(
+            [_item(item_id=1, item_variant="salary confidential")]
+        ),
+    )
+    job = ProfessionHuScraper("any").fetch()[0]
+    assert job.salary_currency is None
+    assert job.salary_summary is None
+
+
+# --- location handling -----------------------------------------------------
+
+
+def test_empty_location_id_falls_back_to_none(httpx_mock) -> None:
+    """Country-wide / remote postings ship location_id="". The scraper
+    leaves ``location`` null so downstream LLM enrichment can apply its
+    own heuristics rather than misclassify the row."""
+    httpx_mock.add_response(
+        url="https://www.profession.hu/allasok/1",
+        text=_build_listing_html([_item(item_id=1, location_id="")]),
+    )
+    job = ProfessionHuScraper("any").fetch()[0]
+    assert job.location is None
+    assert job.country_iso == "HU"  # Country still pinned.
+
+
+def test_location_id_underscore_to_space(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://www.profession.hu/allasok/1",
+        text=_build_listing_html(
+            [_item(item_id=1, location_id="Pest_megye,_Budapest")]
+        ),
+    )
+    assert ProfessionHuScraper("any").fetch()[0].location == (
+        "Pest megye, Budapest"
+    )
+
+
+# --- URL fallback ----------------------------------------------------------
+
+
+def test_url_falls_back_to_slugless_when_data_link_absent(
+    httpx_mock,
+) -> None:
+    """When a listing row is rendered without the standard <li> wrapper
+    (rare — has happened on highlighted ads) the scraper still emits a
+    job, using the slug-less ``/allas/{id}`` URL form which the site
+    301-redirects to the full slug page."""
+    # Hand-craft a listing body with the dataLayer but no <li> rows.
+    item = _item(item_id=42)
+    item["item_list_name"] = (
+        "Állások, munkák és állásajánlatok - 1 db - 2026 | Profession.hu"
+    )
+    payload = {
+        "event": "view_item_list",
+        "ecommerce": {"items": [item]},
+    }
+    html = (
+        "<html><body><script>dataLayer.push("
+        + json.dumps(payload, ensure_ascii=False)
+        + ");</script></body></html>"
+    )
+    httpx_mock.add_response(
+        url="https://www.profession.hu/allasok/1", text=html
+    )
+    job = ProfessionHuScraper("any").fetch()[0]
+    assert str(job.url) == "https://www.profession.hu/allas/42"
+
+
+# --- pagination ------------------------------------------------------------
+
+
+def test_paginates_until_total_count(httpx_mock) -> None:
+    """Page 1's dataLayer header advertises the total (``- 50 db -``).
+    With 20 rows per page that's 3 pages — the scraper fans out the
+    remaining 2 in parallel."""
+    page1_items = [_item(item_id=i) for i in range(1, 21)]
+    page2_items = [_item(item_id=i) for i in range(21, 41)]
+    page3_items = [_item(item_id=i) for i in range(41, 51)]
+    httpx_mock.add_response(
+        url="https://www.profession.hu/allasok/1",
+        text=_build_listing_html(page1_items, total_label="50 db"),
+    )
+    httpx_mock.add_response(
+        url="https://www.profession.hu/allasok/2",
+        text=_build_listing_html(page2_items, total_label="50 db"),
+    )
+    httpx_mock.add_response(
+        url="https://www.profession.hu/allasok/3",
+        text=_build_listing_html(page3_items, total_label="50 db"),
+    )
+    jobs = ProfessionHuScraper("any").fetch()
+    assert len(jobs) == 50
+
+
+def test_no_fanout_when_total_fits_one_page(httpx_mock) -> None:
+    items = [_item(item_id=i) for i in range(1, 11)]
+    httpx_mock.add_response(
+        url="https://www.profession.hu/allasok/1",
+        text=_build_listing_html(items, total_label="10 db"),
+    )
+    # No page 2 — if requested, httpx_mock would error.
+    assert len(ProfessionHuScraper("any").fetch()) == 10
+
+
+def test_max_pages_caps_pagination(httpx_mock) -> None:
+    """Even if the header says 10 000 rows (500 pages), ``max_pages=2``
+    must stop after the probe + 1 fan-out."""
+    items = [_item(item_id=i) for i in range(1, 21)]
+    httpx_mock.add_response(
+        url="https://www.profession.hu/allasok/1",
+        text=_build_listing_html(items, total_label="10000 db"),
+    )
+    httpx_mock.add_response(
+        url="https://www.profession.hu/allasok/2",
+        text=_build_listing_html(
+            [_item(item_id=i) for i in range(21, 41)],
+            total_label="10000 db",
+        ),
+    )
+    # Page 3 must NOT be requested.
+    jobs = ProfessionHuScraper("any", max_pages=2).fetch()
+    assert len(jobs) == 40
+
+
+def test_dedupes_across_pages(httpx_mock) -> None:
+    """If two pages happen to surface the same ``item_id`` (race
+    conditions on the ranking re-sort) the row should appear once."""
+    httpx_mock.add_response(
+        url="https://www.profession.hu/allasok/1",
+        text=_build_listing_html(
+            [_item(item_id=1), _item(item_id=2)],
+            total_label="40 db",
+        ),
+    )
+    httpx_mock.add_response(
+        url="https://www.profession.hu/allasok/2",
+        text=_build_listing_html(
+            [_item(item_id=2), _item(item_id=3)],
+            total_label="40 db",
+        ),
+    )
+    jobs = ProfessionHuScraper("any").fetch()
+    assert sorted(j.ats_id for j in jobs) == ["1", "2", "3"]
+
+
+# --- defensive -------------------------------------------------------------
+
+
+def test_missing_datalayer_yields_empty_page(httpx_mock) -> None:
+    """Pages past the real pagination cap render an empty results
+    section without a ``view_item_list`` push. Returning an empty list
+    (rather than crashing) lets the scraper survive flaky upper-bound
+    estimates."""
+    httpx_mock.add_response(
+        url=_LISTING_URL_RE,
+        text="<html><body><p>Nincs találat</p></body></html>",
+        is_reusable=True,
+    )
+    # max_pages=1 so we only hit page 1.
+    assert ProfessionHuScraper("any", max_pages=1).fetch() == []
+
+
+def test_drops_item_with_no_id_or_title(httpx_mock) -> None:
+    items = [
+        _item(item_id=1),
+        # Missing item_id entirely
+        {"item_name": "ghost", "affiliation": "x"},
+        # Empty title
+        _item(item_id=3, item_name=""),
+    ]
+    httpx_mock.add_response(
+        url="https://www.profession.hu/allasok/1",
+        text=_build_listing_html(items, total_label="3 db"),
+    )
+    jobs = ProfessionHuScraper("any").fetch()
+    assert [j.ats_id for j in jobs] == ["1"]
+
+
+def test_missing_affiliation_falls_back_to_unknown(httpx_mock) -> None:
+    items = [_item(item_id=1, affiliation="")]
+    httpx_mock.add_response(
+        url="https://www.profession.hu/allasok/1",
+        text=_build_listing_html(items),
+    )
+    assert ProfessionHuScraper("any").fetch()[0].company == "Unknown"
+
+
+def test_persistent_500_raises(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_LISTING_URL_RE, status_code=500, is_reusable=True
+    )
+    with pytest.raises(ScraperError):
+        ProfessionHuScraper("any").fetch()
+
+
+def test_one_page_failure_does_not_abort_whole_scrape(
+    httpx_mock,
+) -> None:
+    """A 5xx on a fan-out page is logged and skipped — the probe page's
+    rows still come back."""
+    httpx_mock.add_response(
+        url="https://www.profession.hu/allasok/1",
+        text=_build_listing_html(
+            [_item(item_id=i) for i in range(1, 21)],
+            total_label="40 db",
+        ),
+    )
+    # Page 2 fails persistently
+    httpx_mock.add_response(
+        url="https://www.profession.hu/allasok/2",
+        status_code=500,
+        is_reusable=True,
+    )
+    jobs = ProfessionHuScraper("any").fetch()
+    # 20 rows from page 1 survived.
+    assert len(jobs) == 20


### PR DESCRIPTION
## Summary
- New `ProfessionHuScraper` for [Profession.hu](https://www.profession.hu/), Hungary's dominant direct-posting job board (~18-50k active rows; May 2026 audit had Hungary near 0% of the dataset, so this is the country's primary lift).
- Single-source scraper: parses the `dataLayer.push({"event":"view_item_list",...})` block embedded on every `/allasok/{page}` listing page. That block carries every canonical-schema field (title, employer, category, sub-category, employment-type normalised to English, location-id, salary visibility, experience bucket) plus, paired with the matching `<li data-prof-id data-link>` rows, the absolute detail URLs. No per-job detail fetch, no CF gate (verified 2026-05-12).
- Pins `country_iso="HU"`, `region="Europe"`, `language="hu"`, and `salary_currency="HUF"` when the listing surfaces a publicised salary (the numeric range only appears on the detail page, so we leave `min`/`max` for a future detail-enrichment pass).
- Adds `ATSType.PROFESSIONHU = "profession_hu"` to the Hybrid jobboards group; registers in the scraper `__init__` and updates `test_models` enum pin.

## Test plan
- [x] `uv run pytest tests/test_profession_hu.py` — 26 tests cover registry wiring, dataLayer + data-link extraction, employment-type map (English live + Hungarian defensive), location handling, salary-visibility flag, pagination by total-rows count, `max_pages` cap, dedup across pages, missing-dataLayer fallback, per-page 5xx isolation, and persistent-5xx escalation.
- [x] `uv run pytest` — full suite (905 passed).
- [x] `uv run ruff check` — clean.
- [x] Live smoke against `https://www.profession.hu/allasok/` with `max_pages=2` returns 40 well-formed `Job` rows (titles, employer, FULL_TIME, HUF currency on publicised rows, valid HU locations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `ProfessionHuScraper` to pull jobs from Profession.hu via listing pages only, expanding Hungary coverage with no per‑job requests. Also fixes pagination stopping early on unknown totals and hardens the dataLayer regex to avoid truncated pages.

- **New Features**
  - New `ProfessionHuScraper` parses `dataLayer.push({"event":"view_item_list"})` on `/allasok/{page}` and pairs items with `<li data-prof-id data-link>` for absolute URLs.
  - Adds `ATSType.PROFESSIONHU = "profession_hu"` and registers in `scrapers.__init__`.
  - Sets `country_iso="HU"`, `region="Europe"`, `language="hu"`. When salary is public, sets `salary_currency="HUF"` and a summary label; leaves min/max blank.
  - Maps employment type from `item_category3` with Hungarian fallbacks.
  - Paginates by advertised total (or walks until an empty page when total is unknown), honors `max_pages`, de‑dupes, and skips failing pages.
  - Seeds `ats-companies/profession_hu.csv` with board metadata.

- **Bug Fixes**
  - Data extraction: replace non‑greedy dataLayer regex with a tempered‑greedy pattern anchored to `view_item_list` to prevent early termination on `});` inside strings.
  - Pagination: avoid treating an unparseable total as single‑page; continue until the first empty page, capped by `max_pages`.

<sup>Written for commit ab2c2d37215836e55e174698e3393b20b79fc46d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `ProfessionHuScraper`, a new single-source scraper for Hungary's dominant job board (Profession.hu), parsing the `dataLayer.push({"event":"view_item_list",...})` block on listing pages without any per-job detail fetches. It pins `country_iso="HU"`, `language="hu"`, maps employment types from English `item_category3` values, surfaces salary visibility via `item_variant`, and paginates by the total advertised in `item_list_name`.

- **New scraper** (`src/jobhive/scrapers/profession_hu.py`): async, semaphore-limited fanout across listing pages with retry logic, deduplication via a lock-protected `seen` set, and graceful per-page failure isolation.
- **Registry wiring**: `ATSType.PROFESSIONHU = "profession_hu"` added to models, import and `__all__` entry added to `scrapers/__init__.py`, and the enum-pin test updated.
- **Test coverage** (`tests/test_profession_hu.py`): 26 tests cover the full scraper lifecycle including employment-type mapping, salary visibility, location handling, pagination, dedup, and HTTP failure modes.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the scraper is well-structured and thoroughly tested. Two issues in the retry path of `_fetch_page` are worth fixing before a high-volume run but won't cause incorrect data.

The scraper logic, deduplication, and pagination are correct. The two findings are both in `_fetch_page`: the semaphore is held during the HTTPError retry sleep (which could stall all four concurrent slots during flaky-network periods), and the dataLayer regex uses a non-greedy pattern that would silently drop a page if a JSON string value ever contained `});`. Neither causes wrong job data or data loss under normal conditions, but the semaphore issue could seriously slow a full 1 500-page run against an unreliable network.

src/jobhive/scrapers/profession_hu.py — specifically the `_fetch_page` retry block and the `_DATALAYER_RE` regex definition.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/profession_hu.py | New scraper; logic is solid overall but the semaphore is held during HTTPError retry sleeps (blocking other concurrent fetches) and the dataLayer regex could silently drop a page if a JSON string value contains `});`. |
| tests/test_profession_hu.py | Comprehensive test suite covering happy path, employment-type map, salary visibility, location handling, pagination, dedup, and failure modes. No issues found. |
| src/jobhive/models.py | Adds `ATSType.PROFESSIONHU = "profession_hu"` alphabetically in the Hybrid jobboards group; clean change. |
| src/jobhive/scrapers/__init__.py | Registers `ProfessionHuScraper` import and `__all__` entry in alphabetical order; no issues. |
| tests/test_models.py | Adds `"profession_hu"` to the enum pin test in the correct position; no issues. |
| ats-companies/profession_hu.csv | Seeds board metadata CSV with correct name, slug, and URL; no issues. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/jobhive/scrapers/profession_hu.py:223-230
The retry sleep for `httpx.HTTPError` is called while the semaphore is still held. With `MAX_CONCURRENCY=4`, if all four slots are sleeping through network retries simultaneously, no other concurrent page fetch can proceed until the sleep expires — effectively serialising the scraper during flaky-network periods. The 5xx/429 path correctly releases the semaphore before sleeping; the `HTTPError` path should do the same.

```suggestion
                except httpx.HTTPError as exc:
                    last_exc = exc
                    if attempt == MAX_RETRIES:
                        raise ScraperError(
                            f"profession.hu fetch failed at page={page}: {exc}"
                        ) from exc
                    sleep_delay = RETRY_BASE_DELAY * attempt
            if last_exc is not None and sleep_delay is not None:
                await asyncio.sleep(sleep_delay)
                last_exc = None
                sleep_delay = None
                continue
```

### Issue 2 of 2
src/jobhive/scrapers/profession_hu.py:133-136
**Non-greedy regex may terminate early on `});` in string values**

`_DATALAYER_RE` uses `.*?` (non-greedy) to capture the JSON object. If any string field in the payload contains the literal sequence `});` (e.g., in a job title or `item_list_name` suffix), the regex will stop there, yield truncated JSON, and the `json.loads` will fail, silently returning `([], 0)` for that page. The graceful fallback prevents a crash, but an entire page of jobs would be silently dropped. Anchoring on the outermost `});` instead of the first one — e.g., using a possessive/atomic approach or a proper HTML parser — would eliminate the risk.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: profession\_h..."](https://github.com/kalil0321/ats-scrapers/commit/1a27130fa8d255388e3599cc9e76ad15185b215e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732494)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->