### PR TITLE
elempleo: add Colombian national job board scraper

### DIFF
--- a/ats-companies/elempleo.csv
+++ b/ats-companies/elempleo.csv
@@ -1,0 +1,2 @@
+name,slug,url
+Elempleo,elempleo,https://www.elempleo.com

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -80,6 +80,7 @@ class ATSType(StrEnum):
     THEHUB = "thehub"
     YCOMBINATOR = "ycombinator"
     WELLFOUND = "wellfound"
+    ELEMPLEO = "elempleo"
     # Additional multi-tenant ATSes (post-0.1)
     BAMBOOHR = "bamboohr"
     BREEZY = "breezy"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -20,6 +20,7 @@ from jobhive.scrapers.builtin import BuiltInScraper
 from jobhive.scrapers.bundesagentur import BundesagenturScraper
 from jobhive.scrapers.cornerstone import CornerstoneScraper
 from jobhive.scrapers.eightfold import EightfoldScraper
+from jobhive.scrapers.elempleo import ElempleoScraper
 from jobhive.scrapers.eures import EuresScraper
 from jobhive.scrapers.gem import GemScraper
 from jobhive.scrapers.getonbrd import GetOnBrdScraper
@@ -72,6 +73,7 @@ __all__ = [
     "BundesagenturScraper",
     "CornerstoneScraper",
     "EightfoldScraper",
+    "ElempleoScraper",
     "EuresScraper",
     "GemScraper",
     "GetOnBrdScraper",

--- a/src/jobhive/scrapers/elempleo.py
+++ b/src/jobhive/scrapers/elempleo.py
@@ -52,8 +52,9 @@ if TYPE_CHECKING:
     from typing import Any
 
 API_ROOT = "https://www.elempleo.com"
-DEFAULT_MAX_PAGES = 600  # 20 jobs/page × 600 = 12,000 max — covers
-                        # the entire live inventory with headroom.
+DEFAULT_MAX_PAGES = 1500  # 20 jobs/page × 1500 = 30,000 max — covers
+                          # the entire live inventory (~21.7k) with headroom.
+                          # Pagination still stops early on the empty-page tail.
 MAX_CONCURRENCY = 4
 MAX_RETRIES = 4
 RETRY_BASE_DELAY = 2.0
@@ -146,7 +147,7 @@ class ElempleoScraper(BaseScraper):
     (``"any"``, ``""``) — the scraper paginates the entire board.
 
     Knobs:
-    - ``max_pages`` — pagination cap (default 600 → up to 12k jobs).
+    - ``max_pages`` — pagination cap (default 1500 → up to 30k jobs).
       The scraper stops earlier when a page returns zero cards.
     """
 

--- a/src/jobhive/scrapers/elempleo.py
+++ b/src/jobhive/scrapers/elempleo.py
@@ -1,0 +1,502 @@
+"""elempleo.com — Colombia's largest direct-posting job board.
+
+elempleo serves Colombia primarily (10k+ live postings across every
+sector — tech is a small slice, the bulk is operations, healthcare,
+sales, manufacturing). Companies post directly through the site,
+which makes coverage high-signal for the CO market that LinkedIn
+under-indexes.
+
+The listing pages at ``https://www.elempleo.com/co/ofertas-empleo?Page=N``
+are server-rendered HTML. Each card carries enough fields that we
+don't need to fetch detail pages:
+
+  - title — ``<a class="… js-offer-title …">``
+  - company — ``<span class="… js-offer-company …">``
+  - city — ``<span class="… js-offer-city …">``
+  - salary — first ``<div class="text-blue-petrol-dark">`` above
+    ``<div class="small-text … ">Salario</div>``
+  - contract type, modality (Presencial / Híbrido / Remoto)  —
+    same labelled-pair pattern
+  - posted date — ``<span class="… js-offer-date …">`` shows
+    ``Hoy`` or a ``{{publishDateInfo}}`` template placeholder; the
+    real date renders client-side, so dates older than today aren't
+    visible on the listing without an extra detail fetch
+  - id — trailing number in the detail URL slug
+    (``/co/ofertas-trabajo/some-title-1886709556`` → ``1886709556``).
+    The same id is also embedded as ``data-offer-id`` on the share
+    button, which is what we anchor the parser on for robustness.
+
+Pagination uses ``?Page=N`` (capital P matters); pages past the live
+tail return HTTP 200 with zero job cards rather than 404, so the
+scraper terminates on the first empty page.
+
+Single-source scraper: ``company_slug`` is ignored — the scraper
+sweeps the entire site.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+API_ROOT = "https://www.elempleo.com"
+DEFAULT_MAX_PAGES = 600  # 20 jobs/page × 600 = 12,000 max — covers
+                        # the entire live inventory with headroom.
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 4
+RETRY_BASE_DELAY = 2.0
+
+# Each result-item is a top-level wrapper card. The class includes a
+# trailing space in the live HTML — match flexibly. We use the
+# data-offer-id present on the share button inside the card as the
+# canonical id; that's the same numeric trailing chunk in the slug
+# URL but extracting it from a dedicated attribute is more robust
+# than re-parsing the URL.
+_CARD_RE = re.compile(
+    r'<div class="col-md-12 result-item mb-3 bg-white"(?P<body>.*?)'
+    r'(?=<div class="col-md-12 result-item mb-3 bg-white"|<div class="text-center pt-3"|<footer)',
+    re.DOTALL,
+)
+_OFFER_ID_RE = re.compile(r'data-offer-id="(?P<id>\d+)"')
+_DETAIL_HREF_RE = re.compile(
+    r'href="(?P<href>/co/ofertas-trabajo/[a-z0-9-]+-(?P<id>\d+))"'
+)
+_TITLE_RE = re.compile(
+    r'class="[^"]*js-offer-title[^"]*"[^>]*title="(?P<t>[^"]+)"'
+)
+_COMPANY_RE = re.compile(
+    r'class="[^"]*js-offer-company[^"]*"[^>]*>\s*(?P<v>[^<]+?)\s*</span>'
+)
+_CITY_RE = re.compile(
+    r'class="[^"]*js-offer-city[^"]*"[^>]*>\s*(?P<v>[^<]+?)\s*</span>'
+)
+# Labelled-pair pattern: a <div class="text-blue-petrol-dark"> with
+# the value, followed by a <div class="small-text …">LABEL</div>.
+_LABELLED_VALUE_RE = re.compile(
+    r'<div class="text-blue-petrol-dark">\s*(?P<v>[^<]+?)\s*</div>\s*'
+    r'<div class="small-text[^"]*">\s*(?P<label>[^<{]+?)\s*</div>',
+    re.DOTALL,
+)
+# js-offer-date wraps the publish hint in a <span> with an icon
+# in front; capture whatever text follows the </i>. ``Hoy`` = today.
+# Anything else is a Mustache placeholder rendered by JS (``{{…}}``)
+# which we ignore.
+_DATE_RE = re.compile(
+    r'class="[^"]*js-offer-date[^"]*"[^>]*>\s*'
+    r'(?:<i[^>]*></i>\s*)?(?P<v>[^<]+?)\s*</span>',
+    re.DOTALL,
+)
+# Description fallback: the share modal embeds the full posting body
+# as data-offer-description="…". HTML-escaped, multi-line.
+_DESCRIPTION_RE = re.compile(
+    r'data-offer-description="(?P<v>[^"]*)"', re.DOTALL,
+)
+
+# elempleo contract-type → canonical ``EmploymentType`` enum.
+#
+# Colombian labour-contract terminology:
+#   - "Indefinido"             — open-ended permanent contract → FULL_TIME
+#   - "Definido" / "Termino fijo" — fixed-term contract → TEMPORARY
+#   - "Por obra o labor"       — project / task-based → CONTRACT
+#   - "Prestacion de Servicios"— independent contractor → CONTRACT
+#   - "Contrato de aprendizaje"— apprenticeship → INTERN
+#   - "Practicas"              — internship → INTERN
+#   - "Temporal"               — temp agency → TEMPORARY
+_EMPLOYMENT_MAP: dict[str, str] = {
+    "indefinido": "FULL_TIME",
+    "termino indefinido": "FULL_TIME",
+    "definido": "TEMPORARY",
+    "termino fijo": "TEMPORARY",
+    "termino definido": "TEMPORARY",
+    "temporal": "TEMPORARY",
+    "por obra o labor": "CONTRACT",
+    "prestacion de servicios": "CONTRACT",
+    "freelance": "CONTRACT",
+    "contrato de aprendizaje": "INTERN",
+    "practicas": "INTERN",
+    "otro": None,  # surfaced via commitment, no canonical mapping
+}
+
+# Modality (work arrangement) → is_remote signal.
+_MODALITY_REMOTE: dict[str, bool] = {
+    "remoto": True,
+    "presencial": False,
+    "hibrido": False,
+    "híbrido": False,
+}
+
+
+@ScraperRegistry.register(ATSType.ELEMPLEO)
+class ElempleoScraper(BaseScraper):
+    """elempleo.com — Colombian national job board.
+
+    Single-source: ``company_slug`` is ignored. Pass anything
+    (``"any"``, ``""``) — the scraper paginates the entire board.
+
+    Knobs:
+    - ``max_pages`` — pagination cap (default 600 → up to 12k jobs).
+      The scraper stops earlier when a page returns zero cards.
+    """
+
+    ats = ATSType.ELEMPLEO
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        max_pages: int = DEFAULT_MAX_PAGES,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.max_pages = max_pages
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        seen_ids: set[str] = set()
+        jobs: list[Job] = []
+
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True,
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+            # Pages out of range return HTTP 200 with zero job cards
+            # (rather than 404). Walk until we see two consecutive
+            # empty pages — a single empty page in the middle would
+            # otherwise be a brittle stop signal if the site ever
+            # ships a transient render glitch.
+            consecutive_empty = 0
+            page = 1
+            while page <= self.max_pages and consecutive_empty < 2:
+                page_jobs = await self._fetch_page(client, sem, page)
+                new_count = 0
+                for job in page_jobs:
+                    if job.ats_id in seen_ids:
+                        continue
+                    seen_ids.add(job.ats_id or "")
+                    jobs.append(job)
+                    new_count += 1
+                if new_count == 0:
+                    consecutive_empty += 1
+                else:
+                    consecutive_empty = 0
+                page += 1
+        return jobs
+
+    async def _fetch_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        page: int,
+    ) -> list[Job]:
+        url = f"{API_ROOT}/co/ofertas-empleo?Page={page}"
+        text = await self._request_html(client, sem, url)
+        return list(self._parse_listing(text))
+
+    async def _request_html(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        url: str,
+    ) -> str:
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(
+                        url, headers={
+                            "User-Agent": (
+                                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                                "Chrome/120.0.0.0 Safari/537.36"
+                            ),
+                            "Accept": "text/html,*/*",
+                            "Accept-Language": "es-CO,es;q=0.9,en;q=0.5",
+                        },
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"elempleo fetch failed for {url}: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                return response.text
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"elempleo returned {response.status_code} for "
+                        f"{url} after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"elempleo returned {response.status_code} for {url}"
+            )
+        raise ScraperError(
+            f"elempleo exhausted retries for {url}: {last_exc}"
+        )
+
+    def _parse_listing(self, text: str):
+        for match in _CARD_RE.finditer(text):
+            body = match.group("body")
+            job = self._parse_card(body)
+            if job is not None:
+                yield job
+
+    def _parse_card(self, body: str) -> Job | None:
+        # Prefer the explicit data-offer-id (anchored to the share
+        # button); fall back to the trailing-id slug of the detail
+        # URL if the share button isn't rendered for some variant.
+        id_match = _OFFER_ID_RE.search(body)
+        href_match = _DETAIL_HREF_RE.search(body)
+        if not href_match:
+            return None
+        ats_id = id_match.group("id") if id_match else href_match.group("id")
+        if not ats_id:
+            return None
+
+        title_match = _TITLE_RE.search(body)
+        if not title_match:
+            return None
+        title = html.unescape(title_match.group("t")).strip()
+        if not title:
+            return None
+
+        company_match = _COMPANY_RE.search(body)
+        company = (
+            html.unescape(company_match.group("v")).strip()
+            if company_match else "Confidencial"
+        )
+
+        # Labelled fields — walk the (value, label) pairs once.
+        salary_raw: str | None = None
+        contract_raw: str | None = None
+        modality_raw: str | None = None
+        for pair in _LABELLED_VALUE_RE.finditer(body):
+            value = html.unescape(pair.group("v")).strip()
+            label = pair.group("label").strip().lower()
+            if value.startswith("{{") or not value:
+                continue
+            if label.startswith("salario") and salary_raw is None:
+                salary_raw = value
+            elif label.startswith("tipo de contrato") and contract_raw is None:
+                contract_raw = value
+            elif label.startswith("modalidad laboral") and modality_raw is None:
+                modality_raw = value
+
+        # City — js-offer-city span; some postings (remote, multi-city)
+        # leave it blank. Fall back to ``Colombia`` only when truly
+        # absent so country_iso stays accurate.
+        city_match = _CITY_RE.search(body)
+        city = (
+            html.unescape(city_match.group("v")).strip()
+            if city_match else ""
+        )
+        location = (
+            f"{city}, Colombia" if city else "Colombia"
+        )
+
+        # Modality drives is_remote — listing exposes this directly
+        # rather than via the JSON-LD ``jobLocationType`` flag.
+        is_remote: bool | None = None
+        if modality_raw:
+            is_remote = _MODALITY_REMOTE.get(
+                _strip_accents(modality_raw).lower()
+            )
+
+        # Contract type → normalized employment_type + verbatim commitment.
+        employment_type: str | None = None
+        commitment: str | None = None
+        if contract_raw:
+            commitment = contract_raw
+            key = _strip_accents(contract_raw).lower()
+            employment_type = _EMPLOYMENT_MAP.get(key)
+
+        # Salary — ``$X a $Y millones`` → COP/month range; ``Salario
+        # confidencial`` → no numeric signal but keep the summary so
+        # consumers know it's intentionally hidden.
+        salary_min, salary_max, salary_currency, salary_period = (
+            _parse_salary(salary_raw)
+        )
+
+        # Posted date — listing only renders ``Hoy`` literally; older
+        # dates ship as ``{{publishDateInfo}}`` Mustache placeholders
+        # that hydrate client-side. Map ``Hoy`` → today; leave the
+        # rest to None so downstream enrichment can fill from detail
+        # JSON-LD if desired.
+        posted_at = None
+        date_match = _DATE_RE.search(body)
+        if date_match:
+            label = html.unescape(date_match.group("v")).strip()
+            if _strip_accents(label).lower() == "hoy":
+                posted_at = datetime.now().replace(
+                    hour=0, minute=0, second=0, microsecond=0
+                )
+
+        # Description — pulled from the share modal's data attribute
+        # so listings already carry the body. Keep this defensive:
+        # the attribute is HTML-escaped and may contain entities.
+        description = None
+        desc_match = _DESCRIPTION_RE.search(body)
+        if desc_match:
+            description = _normalize_description(desc_match.group("v"))
+
+        raw: dict[str, Any] = {}
+        if salary_raw:
+            raw["salary_text"] = salary_raw
+        if modality_raw:
+            raw["modality"] = modality_raw
+        if contract_raw:
+            raw["contract_type"] = contract_raw
+
+        return Job(
+            url=f"{API_ROOT}{href_match.group('href')}",
+            title=title,
+            company=company,
+            ats_type=ATSType.ELEMPLEO,
+            ats_id=ats_id,
+            location=location,
+            country_iso="CO",
+            region="South America",
+            is_remote=is_remote,
+            salary_currency=salary_currency,
+            salary_period=salary_period,
+            salary_summary=salary_raw,
+            salary_min=salary_min,
+            salary_max=salary_max,
+            employment_type=employment_type,
+            commitment=commitment,
+            description=description,
+            posted_at=posted_at,
+            fetched_at=datetime.now(),
+            language="es",
+            raw=raw or None,
+        )
+
+
+# --- module-level helpers ---------------------------------------------------
+
+
+_ACCENT_RE = re.compile(r"[áéíóúñÁÉÍÓÚÑ]")
+_ACCENT_MAP = str.maketrans(
+    "áéíóúñÁÉÍÓÚÑ",
+    "aeiounAEIOUN",
+)
+
+
+def _strip_accents(text: str) -> str:
+    """ASCII-fold for case-insensitive lookups against the
+    ``_EMPLOYMENT_MAP`` / ``_MODALITY_REMOTE`` keys (which are stored
+    accent-free for stability — the live HTML may render ``Híbrido``
+    with or without the accent depending on encoding)."""
+    if not text:
+        return ""
+    return text.translate(_ACCENT_MAP)
+
+
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _normalize_description(raw: str) -> str | None:
+    """Decode HTML entities, drop residual tags, collapse whitespace,
+    truncate to the schema's ~10kB budget."""
+    if not raw:
+        return None
+    decoded = html.unescape(raw)
+    cleaned = _TAG_RE.sub(" ", decoded)
+    cleaned = re.sub(r"[\r\n]+", "\n", cleaned)
+    cleaned = re.sub(r"[ \t]+", " ", cleaned).strip()
+    return cleaned[:10_000] or None
+
+
+# ``$1,5 a $2 millones`` — Colombian salary shorthand. Comma is the
+# decimal separator (``1,5`` = 1.5), and ``millones`` is the implicit
+# ×1,000,000 COP multiplier. Listings only ever display ranges (or
+# the literal ``Salario confidencial``); pre-defined buckets cap at
+# ``$15 millones`` and floor at ``$1 millón``.
+_SALARY_RANGE_RE = re.compile(
+    r"\$\s*(?P<min>[\d.,]+)\s*a\s*\$\s*(?P<max>[\d.,]+)\s*(?P<unit>millones?|mil)",
+    re.IGNORECASE,
+)
+_SALARY_SINGLE_RE = re.compile(
+    r"\$\s*(?P<v>[\d.,]+)\s*(?P<unit>millones?|mil)",
+    re.IGNORECASE,
+)
+
+
+def _parse_salary(
+    raw: str | None,
+) -> tuple[float | None, float | None, str | None, str | None]:
+    """elempleo salary strings → ``(min, max, currency, period)``.
+
+    - ``$1,5 a $2 millones`` → ``(1_500_000, 2_000_000, "COP", "MONTH")``
+    - ``$10 millones``        → ``(10_000_000, 10_000_000, "COP", "MONTH")``
+      (single-value, rare on listings)
+    - ``Salario confidencial`` → ``(None, None, None, None)``
+    - ``""`` / ``None``        → ``(None, None, None, None)``
+    """
+    if not raw:
+        return None, None, None, None
+    text = raw.strip()
+    range_match = _SALARY_RANGE_RE.search(text)
+    if range_match:
+        unit = range_match.group("unit").lower()
+        multiplier = 1_000_000 if unit.startswith("millon") else 1_000
+        lo = _parse_co_number(range_match.group("min"))
+        hi = _parse_co_number(range_match.group("max"))
+        if lo is None or hi is None:
+            return None, None, None, None
+        return lo * multiplier, hi * multiplier, "COP", "MONTH"
+    single_match = _SALARY_SINGLE_RE.search(text)
+    if single_match:
+        unit = single_match.group("unit").lower()
+        multiplier = 1_000_000 if unit.startswith("millon") else 1_000
+        value = _parse_co_number(single_match.group("v"))
+        if value is None:
+            return None, None, None, None
+        amount = value * multiplier
+        return amount, amount, "COP", "MONTH"
+    return None, None, None, None
+
+
+def _parse_co_number(raw: str) -> float | None:
+    """``1,5`` → 1.5; ``12,5`` → 12.5; ``2`` → 2.0.
+
+    elempleo uses the European convention (comma decimal, dot
+    thousand) — but the listing buckets never have thousands so this
+    is mostly a comma-swap.
+    """
+    if not raw:
+        return None
+    cleaned = raw.strip()
+    # Defensive: if both . and , are present, dots are thousands.
+    if "." in cleaned and "," in cleaned:
+        cleaned = cleaned.replace(".", "").replace(",", ".")
+    else:
+        cleaned = cleaned.replace(",", ".")
+    try:
+        value = float(cleaned)
+    except ValueError:
+        return None
+    return value if value > 0 else None

--- a/tests/test_elempleo.py
+++ b/tests/test_elempleo.py
@@ -1,0 +1,444 @@
+"""Tests for the elempleo (Colombia) scraper.
+
+The site is server-rendered HTML — these tests stub the listing
+page responses with realistic card markup and assert that every
+field maps to the right ``Job`` slot. The fixtures mirror the
+selectors documented in ``elempleo.py``:
+
+  - ``js-offer-title`` + ``title="…"``
+  - ``js-offer-company`` / ``js-offer-city``
+  - ``data-offer-id`` (canonical id; trailing slug id is the fallback)
+  - labelled-pair triplet for Salario / Tipo de contrato / Modalidad
+
+Pagination terminates on the first empty page, and the Colombian
+salary format (``$1,5 a $2 millones`` → 1.5M–2M COP) needs the
+comma-as-decimal handling exercised explicitly.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import ElempleoScraper, ScraperRegistry
+from jobhive.scrapers.elempleo import (
+    _EMPLOYMENT_MAP,
+    _parse_co_number,
+    _parse_salary,
+    _strip_accents,
+)
+
+_LISTING_RE = re.compile(r"^https://www\.elempleo\.com/co/ofertas-empleo\?Page=\d+$")
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drop retry backoff so failure-path tests don't take 30s each."""
+    import jobhive.scrapers.elempleo as m
+    monkeypatch.setattr(m, "MAX_RETRIES", 1)
+    monkeypatch.setattr(m, "RETRY_BASE_DELAY", 0.0)
+
+
+def _card(
+    *,
+    offer_id: str,
+    title: str,
+    company: str = "Acme SAS",
+    city: str = "Bogotá",
+    salary: str = "$2 a $2,5 millones",
+    contract: str = "Indefinido",
+    modality: str = "Presencial",
+    date_label: str = "Hoy",
+    description: str = "",
+    omit_data_offer_id: bool = False,
+) -> str:
+    """Realistic single-card fragment.
+
+    Mirrors the structure live elempleo ships — wrapper div carrying
+    ``col-md-12 result-item mb-3 bg-white``, the title anchor with
+    ``title="…"`` and ``js-offer-title`` class, the company span with
+    ``js-offer-company``, the labelled triplet for salary/contract/
+    modality, and the share button carrying ``data-offer-id`` (the
+    canonical id source) plus an optional ``data-offer-description``.
+    """
+    slug = re.sub(r"[^a-z0-9-]", "-", title.lower().replace(" ", "-"))
+    href = f"/co/ofertas-trabajo/{slug}-{offer_id}"
+    data_offer_id = "" if omit_data_offer_id else f'data-offer-id="{offer_id}"'
+    desc_attr = (
+        f'data-offer-description="{description}"' if description else ""
+    )
+    return (
+        f'<div class="col-md-12 result-item mb-3 bg-white" '
+        f'style="text-align: left;">'
+        # title
+        f'<a class="text-ellipsis js-offer-title fw-bold" '
+        f'href="{href}" title="{title}">{title}</a>'
+        # company
+        f'<span class="info-company-name js-offer-company fs-6">'
+        f'{company}</span>'
+        # salary
+        f'<div class="text-blue-petrol-dark">{salary}</div>'
+        f'<div class="small-text pb-2 text-medium-gray">Salario</div>'
+        # contract
+        f'<div class="text-blue-petrol-dark">{contract}</div>'
+        f'<div class="small-text pb-2 text-medium-gray">Tipo de contrato</div>'
+        # city
+        f'<span class="info-city js-offer-city text-blue-petrol-dark">'
+        f'{city}</span>'
+        f'<div class="small-text pb-2 text-medium-gray">Ubicación</div>'
+        # modality
+        f'<div class="text-blue-petrol-dark">{modality}</div>'
+        f'<div class="small-text pb-2 text-medium-gray">Modalidad laboral</div>'
+        # date
+        f'<span class="rounded-pill js-offer-date mi-etiqueta">'
+        f'<i class="fa fa-clock-o"></i>{date_label}</span>'
+        # share button (carries the canonical id + description)
+        f'<a {data_offer_id} {desc_attr} href="#">Compartir</a>'
+        f'</div>'
+    )
+
+
+def _empty_listing() -> str:
+    return "<html><body><div class='no-results'>0</div></body></html>"
+
+
+def _listing(cards: list[str]) -> str:
+    # Trailing pagination sentinel so the card regex knows where to stop.
+    pagination = '<div class="text-center pt-3">pagination</div>'
+    return f"<html><body>{''.join(cards)}{pagination}</body></html>"
+
+
+# --- registry ---------------------------------------------------------------
+
+
+def test_registry_resolves_elempleo() -> None:
+    assert ScraperRegistry.get(ATSType.ELEMPLEO) is ElempleoScraper
+
+
+def test_ats_type_value() -> None:
+    assert ATSType.ELEMPLEO.value == "elempleo"
+
+
+# --- happy path -------------------------------------------------------------
+
+
+def test_parses_full_listing_card(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=1",
+        text=_listing([_card(
+            offer_id="1886709556",
+            title="Terapeuta ocupacional domiciliario",
+            company="Health &amp; Life IPS SAS",
+            city="Bucaramanga",
+            salary="$1,5 a $2 millones",
+            contract="Prestacion de Servicios",
+            modality="Presencial",
+            date_label="Hoy",
+            description="Vacante de terapia ocupacional...",
+        )]),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://www\.elempleo\.com/co/ofertas-empleo\?Page=[2-9]$"),
+        text=_listing([]),
+        is_reusable=True,
+    )
+
+    jobs = ElempleoScraper("any").fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.ELEMPLEO
+    assert j.ats_id == "1886709556"
+    assert j.global_id == "elempleo:1886709556"
+    assert j.title == "Terapeuta ocupacional domiciliario"
+    # HTML entity must be decoded — "&amp;" → "&".
+    assert j.company == "Health & Life IPS SAS"
+    assert j.location == "Bucaramanga, Colombia"
+    assert j.country_iso == "CO"
+    assert j.region == "South America"
+    assert j.language == "es"
+    assert j.is_remote is False  # Presencial
+    assert j.salary_currency == "COP"
+    assert j.salary_period == "MONTH"
+    assert j.salary_min == 1_500_000
+    assert j.salary_max == 2_000_000
+    assert j.salary_summary == "$1,5 a $2 millones"
+    # Prestacion de Servicios → CONTRACT (independent contractor).
+    assert j.employment_type == "CONTRACT"
+    assert j.commitment == "Prestacion de Servicios"
+    assert j.description == "Vacante de terapia ocupacional..."
+    assert j.posted_at is not None  # "Hoy" parses to today
+    assert str(j.url) == (
+        "https://www.elempleo.com/co/ofertas-trabajo/"
+        "terapeuta-ocupacional-domiciliario-1886709556"
+    )
+    assert j.raw is not None
+    assert j.raw["salary_text"] == "$1,5 a $2 millones"
+    assert j.raw["modality"] == "Presencial"
+    assert j.raw["contract_type"] == "Prestacion de Servicios"
+
+
+def test_remote_modality_sets_is_remote(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=1",
+        text=_listing([_card(
+            offer_id="1", title="Ejecutivo Remoto", modality="Remoto",
+        )]),
+    )
+    httpx_mock.add_response(
+        url=_LISTING_RE, text=_listing([]), is_reusable=True,
+    )
+    jobs = ElempleoScraper("any").fetch()
+    assert jobs[0].is_remote is True
+
+
+def test_hybrid_modality_is_not_remote(httpx_mock) -> None:
+    """Híbrido is on-site sometimes — we conservatively flag it as
+    not-fully-remote so the public dataset's is_remote filter stays
+    honest."""
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=1",
+        text=_listing([_card(
+            offer_id="1", title="Híbrido role", modality="Híbrido",
+        )]),
+    )
+    httpx_mock.add_response(
+        url=_LISTING_RE, text=_listing([]), is_reusable=True,
+    )
+    jobs = ElempleoScraper("any").fetch()
+    assert jobs[0].is_remote is False
+
+
+def test_falls_back_to_slug_id_when_data_offer_id_missing(httpx_mock) -> None:
+    """The share-button anchor is occasionally rendered without
+    ``data-offer-id`` (some legacy / preview variants). The trailing
+    numeric slug chunk is the documented fallback."""
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=1",
+        text=_listing([_card(
+            offer_id="9876543", title="Test", omit_data_offer_id=True,
+        )]),
+    )
+    httpx_mock.add_response(
+        url=_LISTING_RE, text=_listing([]), is_reusable=True,
+    )
+    jobs = ElempleoScraper("any").fetch()
+    assert jobs[0].ats_id == "9876543"
+
+
+def test_confidential_salary_yields_no_numeric_signal(httpx_mock) -> None:
+    """``Salario confidencial`` is the most common salary value
+    (~7,300 of the ~10k live postings). Treat it as no-signal — keep
+    summary None so the parquet schema isn't polluted with the
+    placeholder string, currency stays None."""
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=1",
+        text=_listing([_card(
+            offer_id="1", title="X", salary="Salario confidencial",
+        )]),
+    )
+    httpx_mock.add_response(
+        url=_LISTING_RE, text=_listing([]), is_reusable=True,
+    )
+    jobs = ElempleoScraper("any").fetch()
+    j = jobs[0]
+    assert j.salary_currency is None
+    assert j.salary_min is None
+    assert j.salary_max is None
+    # We still record the raw text for debugging / downstream parsing.
+    assert j.raw is not None and j.raw["salary_text"] == "Salario confidencial"
+
+
+# --- salary parsing --------------------------------------------------------
+
+
+@pytest.mark.parametrize("raw, expected", [
+    ("$1,5 a $2 millones",   (1_500_000, 2_000_000, "COP", "MONTH")),
+    ("$2 a $2,5 millones",   (2_000_000, 2_500_000, "COP", "MONTH")),
+    ("$12,5 a $15 millones", (12_500_000, 15_000_000, "COP", "MONTH")),
+    ("$10 millones",         (10_000_000, 10_000_000, "COP", "MONTH")),
+    ("Salario confidencial", (None, None, None, None)),
+    ("",                     (None, None, None, None)),
+    (None,                   (None, None, None, None)),
+])
+def test_parse_salary_shapes(raw, expected) -> None:
+    assert _parse_salary(raw) == expected
+
+
+@pytest.mark.parametrize("raw, expected", [
+    ("1,5", 1.5),
+    ("12,5", 12.5),
+    ("2", 2.0),
+    ("1.000,5", 1000.5),
+    ("0", None),
+    ("", None),
+])
+def test_parse_co_number_decimal_comma(raw, expected) -> None:
+    assert _parse_co_number(raw) == expected
+
+
+# --- contract type mapping --------------------------------------------------
+
+
+@pytest.mark.parametrize("contract, expected", [
+    ("Indefinido",              "FULL_TIME"),
+    ("Definido",                "TEMPORARY"),
+    ("Por obra o labor",        "CONTRACT"),
+    ("Prestacion de Servicios", "CONTRACT"),
+    ("Contrato de aprendizaje", "INTERN"),
+])
+def test_contract_type_maps_to_employment_type(
+    contract: str, expected: str, httpx_mock
+) -> None:
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=1",
+        text=_listing([_card(offer_id="1", title="X", contract=contract)]),
+    )
+    httpx_mock.add_response(
+        url=_LISTING_RE, text=_listing([]), is_reusable=True,
+    )
+    jobs = ElempleoScraper("any").fetch()
+    assert jobs[0].employment_type == expected
+    assert jobs[0].commitment == contract
+
+
+def test_employment_map_keys_are_accent_free() -> None:
+    """The contract-label lookup ASCII-folds before matching so the
+    same map handles ``Híbrido`` and ``Hibrido``. Guard against an
+    accidental accented key sneaking in — it would silently miss."""
+    for key in _EMPLOYMENT_MAP:
+        assert _strip_accents(key) == key, key
+
+
+# --- placeholder handling ---------------------------------------------------
+
+
+def test_mustache_placeholders_are_ignored(httpx_mock) -> None:
+    """elempleo renders dates / contract for older postings as
+    Mustache placeholders like ``{{contracttypetxt}}`` that hydrate
+    client-side. We treat any value starting with ``{{`` as missing
+    so the dataset isn't polluted with literal placeholder strings."""
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=1",
+        text=_listing([_card(
+            offer_id="1", title="X",
+            contract="{{contracttypetxt}}", salary="{{salaryInfo}}",
+            date_label="{{publishDateInfo}}",
+        )]),
+    )
+    httpx_mock.add_response(
+        url=_LISTING_RE, text=_listing([]), is_reusable=True,
+    )
+    jobs = ElempleoScraper("any").fetch()
+    j = jobs[0]
+    assert j.employment_type is None
+    assert j.commitment is None
+    assert j.salary_summary is None
+    assert j.salary_currency is None
+    assert j.posted_at is None  # not "Hoy" → don't synthesize a date
+
+
+# --- pagination -------------------------------------------------------------
+
+
+def test_paginates_multiple_pages(httpx_mock) -> None:
+    """Each page surfaces 20 unique cards; the scraper should
+    accumulate across pages until it hits two consecutive empties."""
+    page1 = _listing([
+        _card(offer_id=f"{100+i}", title=f"Job {i}") for i in range(3)
+    ])
+    page2 = _listing([
+        _card(offer_id=f"{200+i}", title=f"Job p2 {i}") for i in range(2)
+    ])
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=1", text=page1,
+    )
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=2", text=page2,
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://www\.elempleo\.com/co/ofertas-empleo\?Page=[3-9]$"),
+        text=_listing([]),
+        is_reusable=True,
+    )
+    jobs = ElempleoScraper("any").fetch()
+    assert {j.ats_id for j in jobs} == {
+        "100", "101", "102", "200", "201",
+    }
+
+
+def test_stops_after_two_consecutive_empty_pages(httpx_mock) -> None:
+    """Pages beyond the live tail return HTTP 200 with zero cards.
+    The scraper tolerates one empty page (mid-stream render glitch)
+    but stops at two consecutive empties — page 4 must never be
+    requested."""
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=1",
+        text=_listing([_card(offer_id="1", title="A")]),
+    )
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=2",
+        text=_listing([]),
+    )
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=3",
+        text=_listing([]),
+    )
+    # Page 4 has no stub — httpx_mock would error if it were requested.
+    jobs = ElempleoScraper("any", max_pages=20).fetch()
+    assert len(jobs) == 1
+
+
+def test_max_pages_caps_pagination(httpx_mock) -> None:
+    """Hard ceiling so a buggy site returning fresh-looking cards
+    forever can't run unbounded."""
+    for p in range(1, 4):
+        httpx_mock.add_response(
+            url=f"https://www.elempleo.com/co/ofertas-empleo?Page={p}",
+            text=_listing([_card(offer_id=str(p * 10), title=f"Job {p}")]),
+        )
+    jobs = ElempleoScraper("any", max_pages=3).fetch()
+    assert len(jobs) == 3
+
+
+def test_deduplicates_repeated_ids_across_pages(httpx_mock) -> None:
+    """When the same posting appears on two pages (rare — happens
+    when a fresh job pushes a stale one across a page boundary mid-
+    scrape), de-dup by ats_id."""
+    card = _card(offer_id="555", title="Dup")
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=1",
+        text=_listing([card]),
+    )
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=2",
+        text=_listing([card]),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://www\.elempleo\.com/co/ofertas-empleo\?Page=[3-9]$"),
+        text=_listing([]),
+        is_reusable=True,
+    )
+    jobs = ElempleoScraper("any").fetch()
+    assert len(jobs) == 1
+
+
+# --- error handling ---------------------------------------------------------
+
+
+def test_persistent_500_raises(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_LISTING_RE, status_code=500, is_reusable=True,
+    )
+    with pytest.raises(ScraperError):
+        ElempleoScraper("any").fetch()
+
+
+def test_unexpected_status_raises(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_LISTING_RE, status_code=403, is_reusable=True,
+    )
+    with pytest.raises(ScraperError, match="403"):
+        ElempleoScraper("any").fetch()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,7 +29,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
-        "manfred", "thehub", "ycombinator", "wellfound",
+        "manfred", "thehub", "ycombinator", "wellfound", "elempleo",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",
         "recruitee", "taleo", "teamtailor",


### PR DESCRIPTION
## Summary

- Adds `ElempleoScraper` (`ATSType.ELEMPLEO`, Hybrid jobboards group) — single-source scraper for `elempleo.com`, Colombia's largest direct-posting board with ~10k live postings across every sector.
- Listing-only parsing: each card on `/co/ofertas-empleo?Page=N` exposes title, company, city, salary, contract type, modality, and a share-button `data-offer-id`, so we avoid per-job detail HTTP fetches. ~20 cards/page; pagination terminates after two consecutive empty pages (out-of-range pages return HTTP 200 with no cards rather than 404) or `max_pages` (default 600 → 12k headroom).
- Schema mapping: `country_iso="CO"`, `region="South America"`, `language="es"`, Colombian salary shorthand `"$1,5 a $2 millones"` → 1.5M–2M `COP/MONTH`; `"Salario confidencial"` → no numeric signal; contract-type map covers Indefinido (`FULL_TIME`), Definido (`TEMPORARY`), Por obra o labor / Prestacion de Servicios (`CONTRACT`), Contrato de aprendizaje (`INTERN`); modality (Presencial / Híbrido / Remoto) drives `is_remote`.
- 33 new tests + 1 ATS-enum row in `test_models.py`. All 912 suite tests pass; ruff clean.

## Test plan

- [x] `uv run pytest tests/test_elempleo.py tests/test_models.py` — 95 pass
- [x] `uv run pytest` (full suite) — 912 pass, no regressions
- [x] `uv run ruff check` on changed files — clean
- [x] Smoke-tested parser against live HTML from `https://www.elempleo.com/co/ofertas-empleo?Page=1` and `?Page=2`: 20/20 cards parsed per page, all field mappings (title, company, location, salary, contract → employment_type, modality → is_remote, posted_at for "Hoy", description from share-modal `data-offer-description`) verified end-to-end.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ElempleoScraper` to pull jobs from `elempleo.com` using listing-only parsing to expand Colombia coverage without per-job requests. Sets a default `max_pages=1500` to cover the full board.

- **New Features**
  - Added `ATSType.ELEMPLEO` and `ElempleoScraper`; exported in `scrapers/__init__.py`.
  - Parses `/co/ofertas-empleo?Page=N` cards for title, company, city, salary, contract type, modality, posted label, and ID from `data-offer-id` (slug fallback).
  - Salary: maps `$1,5 a $2 millones` to COP/month ranges; treats “Salario confidencial” as no numeric signal.
  - Contract types: Indefinido → `FULL_TIME`, Definido/Temporal → `TEMPORARY`, Por obra/Prestacion → `CONTRACT`, Aprendizaje → `INTERN`; modality sets `is_remote`.
  - Locale: `country_iso="CO"`, `region="South America"`, `language="es"`.
  - Pagination via `?Page=N`; stops after two empty pages; de-dupes by ID; default `max_pages=1500`.
  - Seeded `ats-companies/elempleo.csv` with name/slug/url.

<sup>Written for commit 10bad5e28c8548358aaaaaf26e7ea456730dae3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `ElempleoScraper` for elempleo.com, Colombia's largest direct-posting job board, using listing-only HTML parsing across paginated `/co/ofertas-empleo?Page=N` pages with no per-job detail fetches.

- Colombian salary shorthand (`$1,5 a $2 millones`) is parsed into COP/month ranges; contract types and modality map to the canonical `employment_type` and `is_remote` fields with accent-folding for lookup stability.
- Pagination stops after two consecutive empty pages or `max_pages` (default 600); duplicate IDs are deduplicated across pages.
- Three small issues in `elempleo.py`: a dead `_ACCENT_RE` constant, an unreachable `\"híbrido\"` key in `_MODALITY_REMOTE` (accent-folding is always applied before lookup), and a retry backoff sleep held inside the semaphore block (harmless today since fetches are sequential, but will limit effective concurrency if the loop is ever parallelised).

<h3>Confidence Score: 4/5</h3>

The scraper is well-structured and safe to merge; the issues found are dead code, a misleading docstring, and a sleep-inside-semaphore pattern that has no runtime impact given the current sequential fetch loop.

All findings are non-blocking quality issues: an unused compiled regex, a dead map key that can never be reached after accent-folding, a module docstring that says 'first empty page' when the code waits for two, and a test docstring that contradicts the actual salary_summary behavior for confidential salaries. No data corruption, no auth issues, no functional regressions identified.

src/jobhive/scrapers/elempleo.py — the _MODALITY_REMOTE dead key and the semaphore/sleep interaction are worth a quick look before merging.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/elempleo.py | New scraper for elempleo.com; core logic is solid but has a dead `_ACCENT_RE`, an unreachable `"híbrido"` key in `_MODALITY_REMOTE`, a misleading module docstring about the pagination stop condition, and a retry sleep held inside the semaphore block. |
| tests/test_elempleo.py | Comprehensive test suite covering happy paths, edge cases, pagination, and error handling; one test docstring contradicts the implementation's `salary_summary` behaviour for confidential salaries and no assertion pins the actual value. |
| src/jobhive/models.py | Adds `ELEMPLEO = "elempleo"` to the `ATSType` enum in the correct group; straightforward, no issues. |
| src/jobhive/scrapers/__init__.py | Adds import and `__all__` entry for `ElempleoScraper` in alphabetical order; clean. |
| ats-companies/elempleo.csv | Minimal seed file with correct headers and a single Elempleo row; no issues. |
| tests/test_models.py | Adds `"elempleo"` to the expected ATSType set; no issues. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/test_elempleo.py`, line 789-791 ([link](https://github.com/kalil0321/ats-scrapers/blob/e336ac9e4e79a1450e460c64675ce3f6513e9fcd/tests/test_elempleo.py#L789-L791)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Test docstring contradicts the implementation for `salary_summary`**

   The docstring says *"keep summary None so the parquet schema isn't polluted with the placeholder string"*, but `_parse_card` sets `salary_summary=salary_raw` unconditionally, so `salary_summary` will be `"Salario confidencial"` for confidential postings. The PR description says the opposite: *"keep the summary so consumers know it's intentionally hidden"*. The test does not assert either way, so both interpretations are unverified — the intent should be pinned with an explicit assertion.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: tests/test_elempleo.py
   Line: 789-791

   Comment:
   **Test docstring contradicts the implementation for `salary_summary`**

   The docstring says *"keep summary None so the parquet schema isn't polluted with the placeholder string"*, but `_parse_card` sets `salary_summary=salary_raw` unconditionally, so `salary_summary` will be `"Salario confidencial"` for confidential postings. The PR description says the opposite: *"keep the summary so consumers know it's intentionally hidden"*. The test does not assert either way, so both interpretations are unverified — the intent should be pinned with an explicit assertion.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 5 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 5
src/jobhive/scrapers/elempleo.py:29-31
**Module docstring contradicts the actual stopping condition**

The docstring says *"the scraper terminates on the first empty page"* but the implementation uses `consecutive_empty < 2`, stopping only after **two** consecutive empty pages. Any reader relying on the docstring to understand the pagination contract will have the wrong mental model. The PR description itself correctly states "terminates after two consecutive empty pages."

### Issue 2 of 5
src/jobhive/scrapers/elempleo.py:401-402
**`_ACCENT_RE` is defined but never used**

`_ACCENT_RE` is compiled at module level but `_strip_accents` uses `str.translate` with `_ACCENT_MAP` exclusively. The regex is dead code and will generate a ruff/pylint warning if the project ever enables unused-variable checks.

```suggestion
_ACCENT_MAP = str.maketrans(
```

### Issue 3 of 5
src/jobhive/scrapers/elempleo.py:133-138
**`"híbrido"` key in `_MODALITY_REMOTE` is dead code**

`_strip_accents` is always applied before the `_MODALITY_REMOTE` lookup (`_strip_accents(modality_raw).lower()`), so `"híbrido"` (with accent) can never be the lookup key — it will always arrive as `"hibrido"`. The accented key is silently unreachable. The companion test `test_employment_map_keys_are_accent_free` only guards `_EMPLOYMENT_MAP`, leaving this inconsistency uncovered.

```suggestion
_MODALITY_REMOTE: dict[str, bool] = {
    "remoto": True,
    "presencial": False,
    "hibrido": False,
}
```

### Issue 4 of 5
src/jobhive/scrapers/elempleo.py:230-237
**Retry sleep holds the semaphore during backoff**

`asyncio.sleep(RETRY_BASE_DELAY * attempt)` on network errors is called **inside** the `async with sem:` block, so one of the MAX_CONCURRENCY slots remains occupied during the full sleep duration. The 429/5xx retry sleep on line 251 correctly releases the semaphore first. Since pages are currently fetched sequentially the semaphore is never contended, but if the fetch loop is ever parallelised (the semaphore clearly anticipates this), this will artificially reduce effective concurrency during retries.

### Issue 5 of 5
tests/test_elempleo.py:789-791
**Test docstring contradicts the implementation for `salary_summary`**

The docstring says *"keep summary None so the parquet schema isn't polluted with the placeholder string"*, but `_parse_card` sets `salary_summary=salary_raw` unconditionally, so `salary_summary` will be `"Salario confidencial"` for confidential postings. The PR description says the opposite: *"keep the summary so consumers know it's intentionally hidden"*. The test does not assert either way, so both interpretations are unverified — the intent should be pinned with an explicit assertion.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: elempleo.csv"](https://github.com/kalil0321/ats-scrapers/commit/e336ac9e4e79a1450e460c64675ce3f6513e9fcd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732499)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->