### PR TITLE
timesjobs: add scraper for India's TimesJobs hybrid jobboard

### DIFF
--- a/ats-companies/timesjobs.csv
+++ b/ats-companies/timesjobs.csv
@@ -1,0 +1,2 @@
+name,slug,url
+TimesJobs,timesjobs,https://www.timesjobs.com

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -78,6 +78,7 @@ class ATSType(StrEnum):
     JOBSCH = "jobsch"
     MANFRED = "manfred"
     THEHUB = "thehub"
+    TIMESJOBS = "timesjobs"
     YCOMBINATOR = "ycombinator"
     WELLFOUND = "wellfound"
     # Additional multi-tenant ATSes (post-0.1)

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -49,6 +49,7 @@ from jobhive.scrapers.teamtailor import TeamtailorScraper
 from jobhive.scrapers.tesla import TeslaScraper
 from jobhive.scrapers.thehub import TheHubScraper
 from jobhive.scrapers.tiktok import TikTokScraper
+from jobhive.scrapers.timesjobs import TimesJobsScraper
 from jobhive.scrapers.uber import UberScraper
 from jobhive.scrapers.usajobs import USAJobsScraper
 from jobhive.scrapers.wanted import WantedScraper
@@ -101,6 +102,7 @@ __all__ = [
     "TeslaScraper",
     "TheHubScraper",
     "TikTokScraper",
+    "TimesJobsScraper",
     "USAJobsScraper",
     "UberScraper",
     "WTTJScraper",

--- a/src/jobhive/scrapers/timesjobs.py
+++ b/src/jobhive/scrapers/timesjobs.py
@@ -1,0 +1,447 @@
+"""TimesJobs (https://www.timesjobs.com) — Indian hybrid jobboard scraper.
+
+TimesJobs (a Times Internet property) is one of India's largest job
+boards, alongside Naukri and Foundit/Monster. The site recently
+migrated to a Next.js SPA backed by a public JSON API at
+``tjapi.timesjobs.com`` which the frontend calls via:
+
+    POST https://tjapi.timesjobs.com/search/api/v1/search/jobs/list
+
+The endpoint is unauthenticated and accepts page-based pagination via
+``{"keyword": " ", "location": "", "page": "1", "size": "100"}``. An
+empty ``keyword`` returns HTTP 400 ("Invalid JSON format"); a single
+space matches every active listing (~200 k jobs at any given time).
+
+Page size limit appears generous (we successfully request ``size=1000``
+in probes), but we stay at 100/page to keep individual responses small
+and the server polite.
+
+The list response carries enough fields per row that we don't need to
+fetch the per-job detail endpoint
+(``/job-api/api/jobs/public/{jobId}``) — title, company, location,
+truncated description, skills, experience range, posted date, and a
+public ``jobDetailUrl`` are all present on the list payload.
+
+Single-source scraper: ``company_slug`` is informational and ignored.
+Output rows carry the publishing employer's name as ``company`` so
+cross-ATS dedup against the same role on Workday/Greenhouse still works.
+
+Although TimesJobs is an Indian board, the inventory mixes India-based
+roles with global postings (Google in Taiwan, Hilton in the US, …) —
+so ``country_iso`` is left ``None`` and the downstream LLM enrichment
+derives it from the ``location`` string instead of hard-coding ``IN``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import logging
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Awaitable, Callable
+    from typing import Any
+
+log = logging.getLogger(__name__)
+
+API_URL = "https://tjapi.timesjobs.com/search/api/v1/search/jobs/list"
+# A single space matches every active listing. An empty keyword returns
+# HTTP 400 from the API.
+WILDCARD_KEYWORD = " "
+PAGE_SIZE = 100
+MAX_PAGES = 2000  # Safety belt — at 100/page that's 200 k jobs.
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1.5
+
+_HEADERS = {
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+    "Origin": "https://www.timesjobs.com",
+    "Referer": "https://www.timesjobs.com/",
+    "User-Agent": "Mozilla/5.0",
+}
+
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+@ScraperRegistry.register(ATSType.TIMESJOBS)
+class TimesJobsScraper(BaseScraper):
+    """TimesJobs (timesjobs.com) — Indian hybrid job board.
+
+    Single-source scraper: ``company_slug`` is ignored. Pass anything
+    (``"any"``, ``""``, ``"india"``) — the scraper enumerates the entire
+    active board.
+    """
+
+    ats = ATSType.TIMESJOBS
+
+    def fetch(self) -> list[Job]:
+        """Legacy in-memory fetch — accumulates the full corpus into a
+        list. At ~200 k jobs that's a few hundred MB; for cron contexts
+        that write straight to disk prefer :meth:`fetch_stream`."""
+        return asyncio.run(self._fetch_async())
+
+    async def fetch_stream(self) -> AsyncGenerator[Job, None]:
+        """Stream jobs as they're parsed.
+
+        Same producer-queue-consumer pattern as
+        :meth:`jobhive.scrapers.eures.EuresScraper.fetch_stream` — keeps
+        memory bounded regardless of corpus size."""
+        queue: asyncio.Queue[Job] = asyncio.Queue(maxsize=2000)
+        producer_done = asyncio.Event()
+
+        async def on_job(job: Job) -> None:
+            await queue.put(job)
+
+        async def producer() -> None:
+            try:
+                await self._fetch_async(on_job=on_job)
+            finally:
+                producer_done.set()
+
+        task = asyncio.create_task(producer())
+        try:
+            while True:
+                if producer_done.is_set() and queue.empty():
+                    await task  # propagate any producer exception
+                    break
+                try:
+                    item = await asyncio.wait_for(queue.get(), timeout=0.5)
+                except TimeoutError:
+                    continue
+                yield item
+        except BaseException:
+            task.cancel()
+            raise
+
+    async def _fetch_async(
+        self,
+        *,
+        on_job: Callable[[Job], Awaitable[None]] | None = None,
+    ) -> list[Job]:
+        seen: set[str] = set()
+        all_jobs: list[Job] = []
+        lock = asyncio.Lock()
+
+        async def absorb(items: list[dict[str, Any]]) -> None:
+            new_jobs: list[Job] = []
+            async with lock:
+                for it in items:
+                    job = self._parse(it)
+                    if job is None or job.ats_id in seen:
+                        continue
+                    seen.add(job.ats_id)
+                    new_jobs.append(job)
+            if on_job is not None:
+                for job in new_jobs:
+                    await on_job(job)
+            else:
+                all_jobs.extend(new_jobs)
+
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True
+        ) as client:
+            # Fetch page 1 synchronously so we know the total count and
+            # can fan-out the remaining pages concurrently. The API
+            # returns ``totalPages`` as a float, so coerce to int.
+            first = await self._search(client, page=1)
+            await absorb(first.get("jobs") or [])
+
+            total_pages_raw = first.get("totalPages") or 0
+            try:
+                total_pages = int(total_pages_raw)
+            except (TypeError, ValueError):
+                total_pages = 0
+            total_pages = min(total_pages, MAX_PAGES)
+            if total_pages <= 1:
+                return all_jobs
+
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+
+            async def one(page: int) -> None:
+                async with sem:
+                    payload = await self._search(client, page=page)
+                await absorb(payload.get("jobs") or [])
+
+            results = await asyncio.gather(
+                *(one(p) for p in range(2, total_pages + 1)),
+                return_exceptions=True,
+            )
+            for r in results:
+                if isinstance(r, BaseException):
+                    log.warning("TimesJobs page fetch failed: %s", r)
+
+        return all_jobs
+
+    async def _search(
+        self, client: httpx.AsyncClient, *, page: int
+    ) -> dict[str, Any]:
+        body = {
+            "keyword": WILDCARD_KEYWORD,
+            "location": "",
+            "page": str(page),
+            "size": str(PAGE_SIZE),
+        }
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                r = await client.post(API_URL, json=body, headers=_HEADERS)
+            except httpx.HTTPError as exc:
+                last_exc = exc
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"TimesJobs fetch failed (page={page}): {exc}"
+                    ) from exc
+                await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                continue
+
+            if r.status_code == 200:
+                try:
+                    data = r.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"TimesJobs returned non-JSON for page={page}: {exc}"
+                    ) from exc
+                if not isinstance(data, dict):
+                    raise ScraperError(
+                        f"TimesJobs API shape changed — expected a dict, "
+                        f"got {type(data).__name__}"
+                    )
+                return data
+
+            if r.status_code == 400:
+                # Past the last page or filter rejected — treat as exhausted.
+                return {"jobs": [], "totalPages": 0, "total": 0}
+
+            if r.status_code in (429,) or 500 <= r.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"TimesJobs returned {r.status_code} after "
+                        f"{MAX_RETRIES} retries (page={page})"
+                    )
+                retry_after = r.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+
+            raise ScraperError(
+                f"TimesJobs returned {r.status_code} (page={page}): "
+                f"{r.text[:120]}"
+            )
+
+        raise ScraperError(
+            f"TimesJobs exhausted retries (page={page}): {last_exc}"
+        )
+
+    def _parse(self, item: dict[str, Any]) -> Job | None:
+        ats_id = str(item.get("jobId") or "").strip()
+        title = (item.get("title") or "").strip()
+        url = (item.get("jobDetailUrl") or "").strip()
+        if not (ats_id and title and url):
+            return None
+
+        company = (item.get("company") or item.get("hfCompany") or "").strip() or "Unknown"
+        location = _clean_location(item.get("location"))
+
+        # Salary: TimesJobs uses -1 to indicate "not disclosed", and the
+        # currency is always present (mostly INR). Only emit salary
+        # fields when a real range is provided.
+        salary_min, salary_max = _clean_salary_range(
+            item.get("lowSalary"), item.get("highSalary"),
+        )
+        salary_currency = item.get("currency") if (salary_min or salary_max) else None
+        if isinstance(salary_currency, str):
+            salary_currency = salary_currency.strip().upper() or None
+            # The API uses "RS" / "RR" in a few rows; normalize the most
+            # common alternates to the canonical ISO code.
+            if salary_currency in {"RS", "RUPEES", "INR."}:
+                salary_currency = "INR"
+            if len(salary_currency) != 3:
+                salary_currency = None
+
+        description = _clean_description(item.get("description"))
+        posted_at = _date_to_dt(item.get("postDate"))
+
+        # Job type "On-site" / "Remote" / "Hybrid" is surfaced by the
+        # API — promote "Remote" to ``is_remote=True``. We don't set
+        # ``is_remote=False`` for on-site since the canonical model
+        # only ever asserts True (the absence of a remote marker is
+        # not evidence of on-site).
+        job_type = item.get("jobType")
+        is_remote = (
+            True if isinstance(job_type, str) and "remote" in job_type.lower()
+            else None
+        )
+
+        # Skills is a comma-joined string on the list endpoint. Split,
+        # trim, drop empties.
+        skills_raw = item.get("skills")
+        skills: list[str] = []
+        if isinstance(skills_raw, str):
+            skills = [s.strip() for s in skills_raw.split(",") if s.strip()]
+
+        # Experience is a (from, to) range — surface the lower bound
+        # as ``experience`` for canonical filtering, keep the raw range
+        # in ``raw`` so consumers can render "5-8 years".
+        exp_from = _safe_int(item.get("experienceFrom"))
+        exp_to = _safe_int(item.get("experienceTo"))
+        experience = exp_from if exp_from is not None and exp_from >= 0 else None
+
+        raw: dict[str, Any] = {}
+        if exp_from is not None and exp_from >= 0:
+            raw["experience_from"] = exp_from
+        if exp_to is not None and exp_to >= 0:
+            raw["experience_to"] = exp_to
+        if exp_from is not None and exp_to is not None and exp_from >= 0 and exp_to >= 0:
+            raw["experience_label"] = (
+                f"{exp_from}-{exp_to} years" if exp_from != exp_to
+                else f"{exp_from} years"
+            )
+        if skills:
+            raw["skills"] = skills[:30]
+        if isinstance(job_type, str) and job_type.strip():
+            raw["job_type"] = job_type.strip()
+        job_function = item.get("jobFunction")
+        if isinstance(job_function, str) and job_function.strip():
+            raw["job_function"] = job_function.strip()
+        expiry = item.get("expiryDate")
+        if isinstance(expiry, str) and expiry.strip():
+            raw["expiry_date"] = expiry.strip()
+
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.TIMESJOBS,
+            ats_id=ats_id,
+            location=location,
+            country_iso=_infer_in_country_iso(location),
+            language="en",
+            is_remote=is_remote,
+            salary_currency=salary_currency,
+            salary_min=salary_min,
+            salary_max=salary_max,
+            experience=experience,
+            department=raw.get("job_function"),
+            commitment=raw.get("job_type"),
+            description=description,
+            posted_at=posted_at,
+            fetched_at=datetime.now(),
+            raw=raw or None,
+        )
+
+
+# A non-exhaustive set of major Indian metros + state names that
+# unambiguously imply ``country_iso='IN'`` when they appear as the
+# whole or majority of a TimesJobs ``location`` string. The list is
+# deliberately conservative — for ambiguous / mixed locations
+# ("Other City(s) in New York, Bengaluru") we leave ``country_iso``
+# unset and the downstream LLM enrichment decides.
+_INDIAN_CITIES = frozenset(
+    {
+        "ahmedabad", "bengaluru", "bangalore", "bhubaneswar", "chandigarh",
+        "chennai", "coimbatore", "delhi", "new delhi", "faridabad",
+        "ghaziabad", "gurgaon", "gurugram", "guwahati", "hubli",
+        "hyderabad", "hyderabad/secunderabad", "indore", "jaipur",
+        "jamshedpur", "kanpur", "kochi", "kolkata", "kozhikode",
+        "lucknow", "ludhiana", "madurai", "mangalore", "mumbai",
+        "mysore", "nagpur", "nashik", "navi mumbai", "noida",
+        "patna", "pune", "raipur", "ranchi", "secunderabad",
+        "surat", "thane", "thiruvananthapuram", "tiruchirapalli",
+        "trichy", "trivandrum", "vadodara", "varanasi", "vijayawada",
+        "visakhapatnam", "vizag",
+    }
+)
+
+
+def _infer_in_country_iso(location: str | None) -> str | None:
+    """Return ``"IN"`` when the location string is unambiguously
+    Indian, otherwise ``None`` so LLM enrichment can derive it.
+
+    TimesJobs is an Indian board but indexes global postings too —
+    blindly stamping every row with ``IN`` would corrupt the country
+    field for the ~30% non-IN inventory.
+    """
+    if not isinstance(location, str) or not location.strip():
+        return None
+    parts = [p.strip().lower() for p in location.split(",") if p.strip()]
+    if not parts:
+        return None
+    if all(p in _INDIAN_CITIES for p in parts):
+        return "IN"
+    return None
+
+
+def _clean_location(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = re.sub(r"\s+", " ", value).strip()
+    return cleaned or None
+
+
+def _clean_salary_range(
+    low: object, high: object
+) -> tuple[float | None, float | None]:
+    lo = _to_positive_float(low)
+    hi = _to_positive_float(high)
+    return lo, hi
+
+
+def _to_positive_float(value: object) -> float | None:
+    if isinstance(value, bool):  # bool subclass of int — exclude explicitly
+        return None
+    if isinstance(value, (int, float)) and value > 0:
+        return float(value)
+    return None
+
+
+def _safe_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            return int(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def _date_to_dt(value: object) -> datetime | None:
+    """``postDate`` is an ISO date string (``YYYY-MM-DD``)."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    s = value.strip()
+    # Support both ``YYYY-MM-DD`` and the occasional full ISO timestamp.
+    try:
+        if "T" in s:
+            return datetime.fromisoformat(s.replace("Z", "+00:00"))
+        return datetime.strptime(s, "%Y-%m-%d")
+    except ValueError:
+        return None
+
+
+def _clean_description(value: object) -> str | None:
+    """Strip HTML, collapse whitespace, truncate to ~10kB."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = html.unescape(value)
+    text = _TAG_RE.sub(" ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text[:10_000] or None

--- a/src/jobhive/scrapers/timesjobs.py
+++ b/src/jobhive/scrapers/timesjobs.py
@@ -58,7 +58,7 @@ API_URL = "https://tjapi.timesjobs.com/search/api/v1/search/jobs/list"
 # HTTP 400 from the API.
 WILDCARD_KEYWORD = " "
 PAGE_SIZE = 100
-MAX_PAGES = 2000  # Safety belt — at 100/page that's 200 k jobs.
+MAX_PAGES = 5000  # Safety belt — live board is ~2 k pages at 100/page.
 MAX_CONCURRENCY = 4
 MAX_RETRIES = 3
 RETRY_BASE_DELAY = 1.5
@@ -269,7 +269,7 @@ class TimesJobsScraper(BaseScraper):
             # common alternates to the canonical ISO code.
             if salary_currency in {"RS", "RUPEES", "INR."}:
                 salary_currency = "INR"
-            if len(salary_currency) != 3:
+            if not (isinstance(salary_currency, str) and len(salary_currency) == 3):
                 salary_currency = None
 
         description = _clean_description(item.get("description"))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,7 +29,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
-        "manfred", "thehub", "ycombinator", "wellfound",
+        "manfred", "thehub", "timesjobs", "ycombinator", "wellfound",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",
         "recruitee", "taleo", "teamtailor",

--- a/tests/test_timesjobs.py
+++ b/tests/test_timesjobs.py
@@ -1,0 +1,381 @@
+"""Tests for the TimesJobs scraper.
+
+The API is a page-based JSON POST endpoint at
+``tjapi.timesjobs.com/search/api/v1/search/jobs/list`` keyed by a
+single-space wildcard keyword. We pin: registry wiring, pagination via
+``totalPages``, the salary ``-1`` sentinel, India-specific country
+inference, skill/experience extraction into ``raw``, and the standard
+retry / shape-changed defensive paths.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import ScraperRegistry, TimesJobsScraper
+
+API_URL = "https://tjapi.timesjobs.com/search/api/v1/search/jobs/list"
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tighten retry timings so test runs stay snappy."""
+    import jobhive.scrapers.timesjobs as tj
+
+    monkeypatch.setattr(tj, "MAX_RETRIES", 1)
+    monkeypatch.setattr(tj, "RETRY_BASE_DELAY", 0.0)
+
+
+def _job(
+    job_id: str = "80497778",
+    *,
+    title: str = "QA Automation Engineer",
+    company: str = "Acme",
+    location: str = "Bengaluru",
+    description: str = "Build automated tests.",
+    low_salary: int = -1,
+    high_salary: int = -1,
+    currency: str = "INR",
+    skills: str = "Selenium, Java, Pytest",
+    experience_from: int = 3,
+    experience_to: int = 6,
+    job_type: str = "On-site",
+    job_function: str = "IT Software : QA & Testing",
+    post_date: str = "2026-05-11",
+    job_detail_url: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "jobId": job_id,
+        "title": title,
+        "company": company,
+        "hfCompany": company,
+        "location": location,
+        "description": description,
+        "lowSalary": low_salary,
+        "highSalary": high_salary,
+        "currency": currency,
+        "skills": skills,
+        "experienceFrom": experience_from,
+        "experienceTo": experience_to,
+        "jobType": job_type,
+        "jobFunction": job_function,
+        "postDate": post_date,
+        "expiryDate": "2026-07-09",
+        "jobDetailUrl": (
+            job_detail_url
+            or f"https://www.timesjobs.com/job-detail/job-{job_id}"
+        ),
+    }
+
+
+def _response(
+    jobs: list[dict[str, Any]],
+    *,
+    page: int = 1,
+    total_pages: float | int = 1,
+    total: int | None = None,
+) -> dict[str, Any]:
+    return {
+        "total": total if total is not None else len(jobs),
+        "page": page,
+        "size": len(jobs),
+        # The real API returns totalPages as a float (e.g. 1978.0).
+        "totalPages": total_pages,
+        "jobs": jobs,
+    }
+
+
+# --- registry / wiring ------------------------------------------------------
+
+
+def test_registry_resolves_timesjobs() -> None:
+    assert ScraperRegistry.get(ATSType.TIMESJOBS) is TimesJobsScraper
+
+
+def test_ats_type_value() -> None:
+    assert ATSType.TIMESJOBS.value == "timesjobs"
+
+
+# --- happy path -------------------------------------------------------------
+
+
+def test_parses_minimal_job(httpx_mock) -> None:
+    httpx_mock.add_response(url=API_URL, json=_response([_job()]))
+    jobs = TimesJobsScraper("any").fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.TIMESJOBS
+    assert j.ats_id == "80497778"
+    assert j.global_id == "timesjobs:80497778"
+    assert j.title == "QA Automation Engineer"
+    assert j.company == "Acme"
+    assert j.location == "Bengaluru"
+    assert j.country_iso == "IN"
+    assert j.language == "en"
+    assert j.description == "Build automated tests."
+    assert str(j.url).startswith("https://www.timesjobs.com/job-detail/")
+
+
+def test_paginates_via_total_pages(httpx_mock) -> None:
+    """Page 1 is fetched synchronously to learn the page count, then
+    remaining pages fan out concurrently."""
+    httpx_mock.add_response(
+        url=API_URL,
+        match_json={
+            "keyword": " ", "location": "", "page": "1", "size": "100",
+        },
+        json=_response(
+            [_job(job_id="1"), _job(job_id="2")],
+            page=1,
+            total_pages=3.0,
+            total=6,
+        ),
+    )
+    httpx_mock.add_response(
+        url=API_URL,
+        match_json={
+            "keyword": " ", "location": "", "page": "2", "size": "100",
+        },
+        json=_response([_job(job_id="3")], page=2, total_pages=3.0, total=6),
+    )
+    httpx_mock.add_response(
+        url=API_URL,
+        match_json={
+            "keyword": " ", "location": "", "page": "3", "size": "100",
+        },
+        json=_response([_job(job_id="4")], page=3, total_pages=3.0, total=6),
+    )
+    jobs = TimesJobsScraper("any").fetch()
+    assert sorted(j.ats_id for j in jobs) == ["1", "2", "3", "4"]
+
+
+def test_dedupes_repeated_job_ids(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response(
+            [_job(job_id="1"), _job(job_id="1"), _job(job_id="2")],
+        ),
+    )
+    jobs = TimesJobsScraper("any").fetch()
+    assert sorted(j.ats_id for j in jobs) == ["1", "2"]
+
+
+# --- field extraction -------------------------------------------------------
+
+
+def test_salary_minus_one_is_treated_as_missing(httpx_mock) -> None:
+    """TimesJobs encodes 'salary not disclosed' as low/high = -1. Make
+    sure we don't emit a -1 salary range."""
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([_job(low_salary=-1, high_salary=-1)]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.salary_min is None
+    assert j.salary_max is None
+    assert j.salary_currency is None
+
+
+def test_real_salary_range_is_preserved(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([
+            _job(low_salary=800_000, high_salary=1_500_000, currency="INR"),
+        ]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.salary_min == 800_000
+    assert j.salary_max == 1_500_000
+    assert j.salary_currency == "INR"
+
+
+def test_currency_alias_rs_is_normalized_to_inr(httpx_mock) -> None:
+    """A handful of rows use 'RS' instead of the ISO 'INR' code."""
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([
+            _job(low_salary=500_000, high_salary=900_000, currency="RS"),
+        ]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.salary_currency == "INR"
+
+
+def test_skills_split_into_raw_list(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([
+            _job(skills="Selenium Automation, Java Programming, Test Frameworks"),
+        ]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.raw is not None
+    assert j.raw["skills"] == [
+        "Selenium Automation", "Java Programming", "Test Frameworks",
+    ]
+
+
+def test_experience_label_in_raw(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([
+            _job(experience_from=5, experience_to=8),
+        ]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.experience == 5
+    assert j.raw is not None
+    assert j.raw["experience_from"] == 5
+    assert j.raw["experience_to"] == 8
+    assert j.raw["experience_label"] == "5-8 years"
+
+
+def test_experience_label_collapses_when_from_equals_to(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([_job(experience_from=4, experience_to=4)]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.raw is not None
+    assert j.raw["experience_label"] == "4 years"
+
+
+def test_remote_job_type_sets_is_remote(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([_job(job_type="Remote")]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.is_remote is True
+    assert j.commitment == "Remote"
+
+
+def test_onsite_job_type_leaves_is_remote_none(httpx_mock) -> None:
+    """Per the model contract is_remote only ever asserts True — absence
+    of a remote marker should not be encoded as False."""
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([_job(job_type="On-site")]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.is_remote is None
+    assert j.commitment == "On-site"
+
+
+def test_post_date_parsed_to_datetime(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([_job(post_date="2026-05-11")]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.posted_at is not None
+    assert j.posted_at.year == 2026
+    assert j.posted_at.month == 5
+    assert j.posted_at.day == 11
+
+
+def test_html_is_stripped_from_description(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([
+            _job(description="<p>Lead the <b>QA</b> team.</p>"),
+        ]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.description is not None
+    assert "<" not in j.description
+    assert "QA" in j.description
+
+
+# --- country_iso inference --------------------------------------------------
+
+
+def test_country_iso_in_for_clearly_indian_location(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([_job(location="Bengaluru")]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.country_iso == "IN"
+
+
+def test_country_iso_none_for_global_location(httpx_mock) -> None:
+    """TimesJobs indexes global postings too — stamping every row with
+    IN would corrupt the country field. Leave it unset for non-Indian
+    locations and let downstream LLM enrichment derive it."""
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([_job(location="Taiwan")]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.country_iso is None
+
+
+def test_country_iso_none_for_mixed_location(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([_job(location="Bengaluru, New York")]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.country_iso is None
+
+
+# --- defensive --------------------------------------------------------------
+
+
+def test_skips_rows_missing_required_fields(httpx_mock) -> None:
+    """Rows without jobId/title/jobDetailUrl are skipped rather than
+    failing the whole page."""
+    bad_no_id = _job()
+    bad_no_id.pop("jobId")
+    bad_no_title = _job(job_id="2")
+    bad_no_title.pop("title")
+    bad_no_url = _job(job_id="3")
+    bad_no_url.pop("jobDetailUrl")
+    good = _job(job_id="4")
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([bad_no_id, bad_no_title, bad_no_url, good]),
+    )
+    jobs = TimesJobsScraper("any").fetch()
+    assert [j.ats_id for j in jobs] == ["4"]
+
+
+def test_non_dict_response_raises(httpx_mock) -> None:
+    httpx_mock.add_response(url=API_URL, json=["not", "a", "dict"])
+    with pytest.raises(ScraperError, match="API shape changed"):
+        TimesJobsScraper("any").fetch()
+
+
+def test_persistent_500_raises(httpx_mock) -> None:
+    httpx_mock.add_response(url=API_URL, status_code=500, is_reusable=True)
+    with pytest.raises(ScraperError):
+        TimesJobsScraper("any").fetch()
+
+
+def test_400_on_subsequent_page_terminates_cleanly(httpx_mock) -> None:
+    """A 400 past the last page is the API's way of saying 'no more
+    rows' — treat as exhausted, not as an error."""
+    httpx_mock.add_response(
+        url=API_URL,
+        match_json={
+            "keyword": " ", "location": "", "page": "1", "size": "100",
+        },
+        json=_response(
+            [_job(job_id="1")], page=1, total_pages=2.0, total=2,
+        ),
+    )
+    httpx_mock.add_response(
+        url=API_URL,
+        match_json={
+            "keyword": " ", "location": "", "page": "2", "size": "100",
+        },
+        status_code=400,
+        json={"error": "Invalid JSON format"},
+    )
+    jobs = TimesJobsScraper("any").fetch()
+    assert [j.ats_id for j in jobs] == ["1"]


### PR DESCRIPTION
## Summary

- New `TimesJobsScraper` (`ATSType.TIMESJOBS`) — single-source scraper for India's TimesJobs board (~200k active postings, top 3 alongside Naukri and Foundit/Monster).
- Uses the unauthenticated SPA backend at `POST https://tjapi.timesjobs.com/search/api/v1/search/jobs/list`. Page 1 is fetched synchronously to learn `totalPages`, then pages 2..N fan out under a 4-way semaphore.
- Includes a `fetch_stream` async generator (same producer-queue-consumer pattern as `EuresScraper`) so cron contexts can write 200k rows straight to disk with bounded memory.
- Salary `-1` sentinel maps to "not disclosed" (no salary fields emitted), `RS`/`RUPEES`/`INR.` currency aliases normalize to `INR`, `Remote` job type sets `is_remote=True`.
- `country_iso` is conservatively inferred via a 50-city Indian metro list — left `None` for unambiguous non-Indian or mixed locations (the board indexes global postings too, ~30% of inventory).
- Skills, experience range (`experienceFrom`/`experienceTo`), `jobFunction`, `jobType`, and `expiryDate` are surfaced via `raw`.
- Wired into `ATSType` ("Hybrid jobboards" tier), `scrapers/__init__.py`, and `test_models.py`.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest tests/test_timesjobs.py tests/test_models.py` — 84 passed
- [x] Full suite: `pytest` — 901 passed
- [x] Live API smoke test — page 1 returns 200 jobs, `total=200836`, `totalPages=2009.0`; sample rows parse with correct `country_iso` (`IN` for Bengaluru, `None` for Taiwan/USA/Ireland)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new scraper for India’s TimesJobs hybrid job board using their public search API. Supports concurrent pagination and a streaming fetch to handle ~200k postings efficiently, and fixes a currency edge case.

- **New Features**
  - New `TimesJobsScraper` (`ATSType.TIMESJOBS`) calling `POST https://tjapi.timesjobs.com/search/api/v1/search/jobs/list`, plus a `fetch_stream` async generator; wired into `scrapers/__init__.py`, `ATSType`, tests, and `ats-companies/timesjobs.csv`.
  - Concurrent pagination: learn `totalPages` from page 1, then fan out with a 4-way semaphore; `MAX_PAGES` cap set to 5000.
  - Field normalization: ignore salary `-1`, map `RS`/`RUPEES`/`INR.` to `INR`, strip HTML, parse dates, split skills, set `is_remote`, and surface experience range in `raw`.
  - Location handling: infer `country_iso="IN"` from a conservative metro list; leave `None` for non-Indian or mixed locations.

- **Bug Fixes**
  - Fixed crash when `currency` is blank alongside a real salary by type-checking before length validation; invalid/short codes are now dropped safely.

<sup>Written for commit a5deff5d841472a1e8151cb4abad750c7f0b1572. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `TimesJobsScraper` for India's TimesJobs hybrid job board, hitting their unauthenticated SPA API with concurrent pagination (4-way semaphore), deduplication, and a streaming `fetch_stream` generator for bounded-memory full-corpus dumps.

- Core scraper fans out pages 2..N concurrently after learning `totalPages` from page 1, with retry logic for 429/5xx and graceful 400 handling.
- Field normalization covers salary `-1` sentinel, `RS`/`RUPEES`/`INR.` currency aliases, HTML stripping, experience range → `raw`, and conservative Indian-city `country_iso` inference.
- One bug: an empty-string `currency` field alongside a real salary amount causes `len(None)` → `TypeError` because the `or None` assignment is not re-checked before the length guard.

<h3>Confidence Score: 3/5</h3>

The scraper is production-ready for typical API responses, but a single-line oversight in currency normalization will crash `_parse` for any job row that carries a real salary value but an empty `currency` string from the API.

The currency-length guard calls `len(salary_currency)` without first confirming the variable is still a `str` — it is set to `None` earlier in the same block when the raw value is blank. Any API row with a positive salary and a blank currency field will raise `TypeError` during parsing, which is not caught by `absorb` and will surface as an unhandled exception.

The `_parse` method in `src/jobhive/scrapers/timesjobs.py` around the currency normalization block (lines 266-273) needs the one-line fix before merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/timesjobs.py | New scraper with well-structured pagination, retry logic, and dedup — but has a TypeError crash when the API returns an empty currency string alongside a real salary (`len(None)` on line 272), and a stale module docstring contradicting the actual country_iso inference behavior. |
| tests/test_timesjobs.py | Comprehensive test coverage for pagination, dedup, salary sentinel, currency normalization, experience range, HTML stripping, country inference, and error paths; no test for the empty-string currency edge case that triggers the TypeError. |
| src/jobhive/models.py | Adds `TIMESJOBS = "timesjobs"` to `ATSType` enum in the correct alphabetical position within the hybrid jobboards tier. |
| src/jobhive/scrapers/__init__.py | Wires `TimesJobsScraper` into the public import namespace and `__all__` list; alphabetically ordered correctly. |
| tests/test_models.py | Adds `"timesjobs"` to the platform enumeration test in the correct position; straightforward update. |
| ats-companies/timesjobs.csv | Seed CSV with a single TimesJobs entry; correct format matching the rest of the directory. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/jobhive/scrapers/timesjobs.py:270-273
If the API returns an empty or whitespace-only string for `currency` alongside a real salary, `salary_currency` is set to `None` on line 267 (`"".strip().upper() or None`), then `None in {"RS", "RUPEES", "INR."}` is silently `False`, and `len(None)` on the next line raises `TypeError`. The `len()` guard needs to confirm `salary_currency` is still a `str` before calling `len`.

```suggestion
            if salary_currency in {"RS", "RUPEES", "INR."}:
                salary_currency = "INR"
            if not isinstance(salary_currency, str) or len(salary_currency) != 3:
                salary_currency = None
```

### Issue 2 of 3
src/jobhive/scrapers/timesjobs.py:29-32
The module-level docstring says `country_iso` is always left `None` so LLM enrichment can derive it, but the implementation calls `_infer_in_country_iso` which does return `"IN"` for known Indian metros. The docstring is stale and will mislead callers about the actual field semantics.

```suggestion
Although TimesJobs is an Indian board, the inventory mixes India-based
roles with global postings (Google in Taiwan, Hilton in the US, …) —
so ``country_iso`` is conservatively inferred from a known-Indian-city
list and left ``None`` for ambiguous or non-Indian locations, with
downstream LLM enrichment filling the remainder.
```

### Issue 3 of 3
src/jobhive/scrapers/timesjobs.py:268-271
The inline comment lists `"RR"` as a known API variant (`# The API uses "RS" / "RR" in a few rows`), but the normalization set only covers `{"RS", "RUPEES", "INR."}`. A `"RR"` value would fall through to the `len()` check (length 2 ≠ 3) and be silently dropped to `None`. Either add `"RR"` to the normalization set or remove it from the comment to avoid confusion.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: timesjobs.cs..."](https://github.com/kalil0321/ats-scrapers/commit/a85ae3dff4f5b8291d4d96ead2b8aa562b4b9ee9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732503)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->