### PR TITLE
myjobmag: add pan-African multi-country jobs scraper

### DIFF
--- a/ats-companies/myjobmag.csv
+++ b/ats-companies/myjobmag.csv
@@ -1,0 +1,6 @@
+name,slug,url
+MyJobMag Ghana,gh,https://www.myjobmagghana.com
+MyJobMag Kenya,ke,https://www.myjobmag.co.ke
+MyJobMag Nigeria,ng,https://www.myjobmag.com
+MyJobMag South Africa,za,https://www.myjobmag.co.za
+MyJobMag Uganda,ug,https://www.myjobmag.co.ug

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -77,6 +77,7 @@ class ATSType(StrEnum):
     BUILTIN = "builtin"
     JOBSCH = "jobsch"
     MANFRED = "manfred"
+    MYJOBMAG = "myjobmag"
     THEHUB = "thehub"
     YCOMBINATOR = "ycombinator"
     WELLFOUND = "wellfound"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -33,6 +33,7 @@ from jobhive.scrapers.lever import LeverScraper
 from jobhive.scrapers.manfred import ManfredScraper
 from jobhive.scrapers.mercor import MercorScraper
 from jobhive.scrapers.meta import MetaScraper
+from jobhive.scrapers.myjobmag import MyJobMagScraper
 from jobhive.scrapers.oracle import OracleScraper
 from jobhive.scrapers.personio import PersonioScraper
 from jobhive.scrapers.phenom import PhenomScraper
@@ -84,6 +85,7 @@ __all__ = [
     "ManfredScraper",
     "MercorScraper",
     "MetaScraper",
+    "MyJobMagScraper",
     "OracleScraper",
     "PersonioScraper",
     "PhenomScraper",

--- a/src/jobhive/scrapers/myjobmag.py
+++ b/src/jobhive/scrapers/myjobmag.py
@@ -1,0 +1,512 @@
+"""MyJobMag (https://www.myjobmag.com) — pan-African jobs scraper.
+
+MyJobMag is a multi-country direct-posting job board covering Nigeria,
+Ghana, Kenya, Uganda, and South Africa, with a shared HTML engine
+across regional subdomains. Each region runs the same listing
+template (``<li class="job-list-li">`` cards on ``/jobs/page/N``) so
+one parser handles all five.
+
+Country selection is via ``company_slug``:
+
+- ``"ng"`` → ``https://www.myjobmag.com`` (Nigeria, default)
+- ``"gh"`` → ``https://www.myjobmagghana.com``
+- ``"ke"`` → ``https://www.myjobmag.co.ke``
+- ``"ug"`` → ``https://www.myjobmag.co.ug``
+- ``"za"`` → ``https://www.myjobmag.co.za``
+
+Aliases (``""``, ``"any"``, ``"nigeria"``, full country names) resolve
+to the Nigeria default, so the scraper is registry-friendly even when
+the slug isn't a region code.
+
+The listing page surfaces a handful of structured fields per card
+(title, company, posted date, ~200-char summary, slug-based ats_id).
+Job-detail pages on the ``.com`` / ``.co.ke`` / ``.co.za`` properties
+also embed a JSON-LD ``JobPosting`` block with employmentType,
+addressCountry, occupationalCategory, and the full description. The
+scraper deliberately stays at the listing level for the default sweep
+so one full pass is N requests instead of N×~30 — downstream
+enrichment can fetch detail pages where richer data is required.
+
+Pagination follows ``/jobs/page/N``. The site never returns an empty
+results page (page 9999 still renders 20+ cards), so we dedup on
+``ats_id`` and stop when a fetched page introduces zero new IDs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+# slug → (base_url, ISO 3166-1 alpha-2, ISO 639-1 language, ISO 4217 currency)
+REGIONS: dict[str, tuple[str, str, str, str]] = {
+    "ng": ("https://www.myjobmag.com", "NG", "en", "NGN"),
+    "gh": ("https://www.myjobmagghana.com", "GH", "en", "GHS"),
+    "ke": ("https://www.myjobmag.co.ke", "KE", "en", "KES"),
+    "ug": ("https://www.myjobmag.co.ug", "UG", "en", "UGX"),
+    "za": ("https://www.myjobmag.co.za", "ZA", "en", "ZAR"),
+}
+
+# Aliases mapped to the canonical 2-letter region code. The
+# ScraperRegistry instantiates with the company-CSV slug — being
+# tolerant of free-form values keeps live runs from crashing when
+# a discovery pass writes ``nigeria`` instead of ``ng``.
+_REGION_ALIASES: dict[str, str] = {
+    "": "ng", "any": "ng",
+    "nigeria": "ng", "ng": "ng",
+    "ghana": "gh", "gh": "gh",
+    "kenya": "ke", "ke": "ke",
+    "uganda": "ug", "ug": "ug",
+    "south africa": "za", "south-africa": "za",
+    "southafrica": "za", "za": "za",
+}
+
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1.5
+# Cap pagination so misbehaving sites can't run away — the live boards
+# carry ~10k active rows at most (≈250 pages of 40), so 400 is a comfy
+# ceiling that's still well below an accidental infinite loop.
+DEFAULT_MAX_PAGES = 400
+
+# ``<li class="job-list-li">`` is the per-card wrapper. The list also
+# contains AdSense placeholder ``<li class="job-list-li">`` rows with
+# no ``job-info`` child — those are filtered out downstream.
+_CARD_START_RE = re.compile(r'<li class="job-list-li"', re.IGNORECASE)
+
+# Inside a card: the main posting title sits in
+# ``<li class="mag-b"><h2><a href="/job/...">Title at Company</a></h2></li>``.
+# Rollup entries link to ``/jobs/...`` (e.g. "Latest Jobs at X") and are
+# skipped — those expand into sub-job entries we capture separately.
+_MAIN_LINK_RE = re.compile(
+    r'<h2>\s*<a[^>]*\bhref="(/job/[^"]+)"[^>]*>(.*?)</a>\s*</h2>',
+    re.IGNORECASE | re.DOTALL,
+)
+_JOBS_AT_RE = re.compile(
+    r'<a[^>]*\bhref="/jobs-at/[^"]+"[^>]*>\s*<img[^>]*\balt="([^"]*)"',
+    re.IGNORECASE,
+)
+_DESC_RE = re.compile(
+    r'<li class="job-desc">\s*(.*?)\s*</li>',
+    re.IGNORECASE | re.DOTALL,
+)
+_DATE_RE = re.compile(
+    r'id="job-date">\s*([^<]+?)\s*</li>',
+    re.IGNORECASE,
+)
+# Sub-job-section contains a flat list of related single postings under a
+# rollup or company card. Each ``<a href="/job/slug">Title</a>``.
+_SUB_JOB_RE = re.compile(
+    r'<a[^>]*\bhref="(/job/[^"]+)"[^>]*>([^<]+)</a>',
+    re.IGNORECASE,
+)
+_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"\s+")
+
+# Per-detail-page JSON-LD JobPosting block. Used only by the optional
+# enrichment helper; left as a class-level constant so tests can target it.
+_JSONLD_RE = re.compile(
+    r'<script[^>]+type=["\']application/ld\+json["\'][^>]*>([\s\S]+?)</script>',
+    re.IGNORECASE,
+)
+
+# JSON-LD employmentType → canonical ``EmploymentType`` enum value. The
+# site mixes labels (sometimes ``"Full Time , Onsite"`` — comma-joined
+# tags) so we tokenize and match the first known value.
+_EMPLOYMENT_MAP: dict[str, str] = {
+    "full time": "FULL_TIME",
+    "full_time": "FULL_TIME",
+    "part time": "PART_TIME",
+    "part_time": "PART_TIME",
+    "contract": "CONTRACT",
+    "contractor": "CONTRACT",
+    "freelance": "CONTRACT",
+    "internship": "INTERN",
+    "intern": "INTERN",
+    "temporary": "TEMPORARY",
+    "temp": "TEMPORARY",
+}
+
+# "11 May", "31 Dec", etc. — the listing page uses day-month with no
+# year. Without a year we'd risk binding April-2024 rows to today's year
+# at year-end (a 1-day-old post appears as 364 days old), so we treat
+# the listing date as best-effort and bias toward "this year if not in
+# the future, else previous year".
+_MONTHS = {
+    "jan": 1, "feb": 2, "mar": 3, "apr": 4, "may": 5, "jun": 6,
+    "jul": 7, "aug": 8, "sep": 9, "sept": 9, "oct": 10, "nov": 11, "dec": 12,
+}
+
+
+@ScraperRegistry.register(ATSType.MYJOBMAG)
+class MyJobMagScraper(BaseScraper):
+    """MyJobMag — pan-African direct-posting jobs board.
+
+    ``company_slug`` selects the regional property:
+    ``"ng"`` / ``"gh"`` / ``"ke"`` / ``"ug"`` / ``"za"`` (plus
+    full-country-name aliases). Empty / ``"any"`` defaults to Nigeria,
+    which is the largest property and the canonical entry point.
+    """
+
+    ats = ATSType.MYJOBMAG
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        max_pages: int = DEFAULT_MAX_PAGES,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.max_pages = max_pages
+        region_key = _REGION_ALIASES.get(company_slug.strip().lower())
+        if region_key is None:
+            raise ScraperError(
+                f"Unknown MyJobMag region {company_slug!r}. Supported: "
+                f"{sorted(REGIONS)}"
+            )
+        base_url, country_iso, language, currency = REGIONS[region_key]
+        self._region = region_key
+        self._base_url = base_url
+        self._country_iso = country_iso
+        self._language = language
+        self._currency = currency
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        seen: set[str] = set()
+        jobs: list[Job] = []
+
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True,
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+            # Pagination is best-handled serially: the site doesn't ship
+            # a page-count, so we stop the first time a page contributes
+            # zero new ats_ids. Fanning out optimistically would mean
+            # over-fetching once we've passed the natural end.
+            page = 1
+            while page <= self.max_pages:
+                html_text = await self._fetch_page(client, sem, page=page)
+                rows = self._parse_listing(html_text)
+                new_in_page = 0
+                for row in rows:
+                    if row.ats_id in seen:
+                        continue
+                    seen.add(row.ats_id)
+                    jobs.append(row)
+                    new_in_page += 1
+                if new_in_page == 0:
+                    break
+                page += 1
+        return jobs
+
+    # --- HTTP layer ---------------------------------------------------------
+
+    async def _fetch_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        *,
+        page: int,
+    ) -> str:
+        url = f"{self._base_url}/jobs/page/{page}"
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(
+                        url, headers={
+                            "User-Agent": "Mozilla/5.0",
+                            "Accept": "text/html,application/xhtml+xml",
+                        },
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"MyJobMag fetch failed for {url}: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                return response.text
+            if response.status_code == 404:
+                # Past-end-of-pagination signal on some properties.
+                return ""
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"MyJobMag returned {response.status_code} for "
+                        f"{url} after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"MyJobMag returned {response.status_code} for {url}"
+            )
+        raise ScraperError(
+            f"MyJobMag exhausted retries for {url}: {last_exc}"
+        )
+
+    # --- parsing ------------------------------------------------------------
+
+    def _parse_listing(self, html_text: str) -> list[Job]:
+        """Split a listing page into cards and emit one ``Job`` per
+        single-posting card (plus per sub-job inside rollup cards)."""
+        if not html_text:
+            return []
+        # Carve the document into ``<li class="job-list-li">`` chunks
+        # via start-marker positions; the trailing close-tag is shared
+        # with the parent ``<ul>``, so the cheapest reliable split is
+        # "from one start to the next".
+        starts = [m.start() for m in _CARD_START_RE.finditer(html_text)]
+        if not starts:
+            return []
+        jobs: list[Job] = []
+        seen_in_page: set[str] = set()
+        fetched_at = datetime.now()
+        for i, start in enumerate(starts):
+            end = starts[i + 1] if i + 1 < len(starts) else len(html_text)
+            chunk = html_text[start:end]
+            # AdSense placeholder cards have no job-info ul.
+            if "job-info" not in chunk and "sub-job-sec" not in chunk:
+                continue
+            company_alt = _JOBS_AT_RE.search(chunk)
+            company_from_logo = (
+                _clean(company_alt.group(1)) if company_alt else None
+            )
+            desc_match = _DESC_RE.search(chunk)
+            desc_text = (
+                _strip_html(desc_match.group(1)) if desc_match else None
+            )
+            date_match = _DATE_RE.search(chunk)
+            posted_at = (
+                _parse_listing_date(date_match.group(1), fetched_at)
+                if date_match else None
+            )
+
+            # Main posting (single-job card). The href looks like
+            # ``/job/<slug>`` for single jobs and ``/jobs/...`` for
+            # rollups — _MAIN_LINK_RE only matches the former.
+            main = _MAIN_LINK_RE.search(chunk)
+            if main:
+                href, raw_title = main.group(1), main.group(2)
+                job = self._build_job(
+                    href=href,
+                    raw_title=raw_title,
+                    company_fallback=company_from_logo,
+                    description=desc_text,
+                    posted_at=posted_at,
+                    fetched_at=fetched_at,
+                )
+                if job and job.ats_id not in seen_in_page:
+                    seen_in_page.add(job.ats_id or "")
+                    jobs.append(job)
+
+            # Sub-jobs inside rollup cards: take the
+            # ``<li class="sub-job-sec">`` block and emit one per
+            # ``<a href="/job/...">`` link. Skip these if there's no
+            # sub-job section (i.e. pure single-job cards).
+            sub_section = re.search(
+                r'<li class="sub-job-sec">(.*?)</li>\s*</ul>\s*</li>',
+                chunk, re.DOTALL | re.IGNORECASE,
+            )
+            if sub_section:
+                for sub_match in _SUB_JOB_RE.finditer(sub_section.group(1)):
+                    sub_href, sub_title = sub_match.group(1), sub_match.group(2)
+                    sub_job = self._build_job(
+                        href=sub_href,
+                        raw_title=sub_title,
+                        company_fallback=company_from_logo,
+                        description=None,
+                        # Sub-job rows share the rollup's date row.
+                        posted_at=posted_at,
+                        fetched_at=fetched_at,
+                    )
+                    if sub_job and sub_job.ats_id not in seen_in_page:
+                        seen_in_page.add(sub_job.ats_id or "")
+                        jobs.append(sub_job)
+
+        return jobs
+
+    def _build_job(
+        self,
+        *,
+        href: str,
+        raw_title: str,
+        company_fallback: str | None,
+        description: str | None,
+        posted_at: datetime | None,
+        fetched_at: datetime,
+    ) -> Job | None:
+        slug = href.rsplit("/", 1)[-1].strip()
+        if not slug:
+            return None
+        cleaned_title = _strip_html(raw_title)
+        if not cleaned_title:
+            return None
+        title, company = _split_title_company(cleaned_title)
+        if not company and company_fallback:
+            company = company_fallback
+        if not company:
+            # Best-effort: derive from slug tail (e.g. ``...-acme-corp``).
+            company = "Unknown"
+        url = (
+            href if href.startswith("http")
+            else f"{self._base_url}{href}"
+        )
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.MYJOBMAG,
+            ats_id=slug,
+            country_iso=self._country_iso,
+            language=self._language,
+            description=description,
+            posted_at=posted_at,
+            fetched_at=fetched_at,
+        )
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+def _clean(value: str) -> str:
+    return _WS_RE.sub(" ", html.unescape(value)).strip()
+
+
+def _strip_html(value: str) -> str:
+    text = _TAG_RE.sub(" ", html.unescape(value))
+    text = _WS_RE.sub(" ", text).strip()
+    return text[:10_000]
+
+
+def _split_title_company(text: str) -> tuple[str, str | None]:
+    """Listing titles read ``Title at Company`` — split on the LAST
+    ``" at "`` so titles with their own ``at`` (``Senior Engineer
+    looking at AI``) survive. Falls back to the whole string as title
+    when no ``" at "`` separator is present."""
+    # Prefer rightmost split: handles "Senior Specialist at Acme" but
+    # leaves "Sales Associate at Heart at Acme" → title='Sales Associate
+    # at Heart', company='Acme'.
+    sep = " at "
+    idx = text.rfind(sep)
+    if idx <= 0:
+        return text, None
+    return text[:idx].strip(), text[idx + len(sep):].strip() or None
+
+
+def _parse_listing_date(value: str, ref: datetime) -> datetime | None:
+    """Parse listing dates like ``11 May`` or ``31 Dec``. The site
+    omits the year, so we attribute the post to the most-recent
+    occurrence that isn't in the future: if today is 12 May 2026 and
+    the post says ``31 Dec``, bind it to 2025."""
+    parts = value.strip().split()
+    if len(parts) < 2:
+        return None
+    day_s, month_s = parts[0], parts[1].lower().strip(",")
+    try:
+        day = int(day_s)
+    except ValueError:
+        return None
+    month = _MONTHS.get(month_s[:3])
+    if month is None:
+        return None
+    try:
+        candidate = datetime(ref.year, month, day)
+    except ValueError:
+        return None
+    # If the candidate is in the future (more than 1 day ahead — covers
+    # timezone wobble around midnight), back up to previous year.
+    if (candidate - ref).total_seconds() > 86400:
+        try:
+            candidate = datetime(ref.year - 1, month, day)
+        except ValueError:
+            return None
+    return candidate
+
+
+def parse_jsonld_job(html_text: str) -> dict[str, Any] | None:
+    """Pull the first JSON-LD JobPosting object out of a MyJobMag
+    detail page. Exposed for downstream enrichment that wants the
+    richer schema (employmentType, postal address, occupational
+    category) the listing doesn't carry — the default fetch path
+    intentionally skips per-detail requests for throughput.
+
+    Returns the decoded dict or ``None`` if no JobPosting is present
+    (notably on ``myjobmagghana.com``, which serves a non-JSON-LD
+    template — callers must fall back to the listing-only data there).
+
+    Live MyJobMag blocks ship raw newlines inside the ``description``
+    string (technically invalid JSON), so we retry parsing with
+    ``strict=False`` after the first ValueError, which tolerates
+    control characters in string values.
+    """
+    import json
+
+    for raw in _JSONLD_RE.findall(html_text):
+        obj: object | None = None
+        try:
+            obj = json.loads(raw)
+        except ValueError:
+            try:
+                obj = json.loads(raw, strict=False)
+            except ValueError:
+                continue
+        if isinstance(obj, dict) and obj.get("@type") in ("JobPosting", "Job"):
+            return obj
+    return None
+
+
+def normalize_employment_type(value: object) -> str | None:
+    """Map a JSON-LD ``employmentType`` value (string or list, sometimes
+    comma-joined) to a canonical ``EmploymentType`` enum value. The
+    function is exported so downstream enrichers don't reimplement the
+    same comma-tokenization logic."""
+    if value is None:
+        return None
+    if isinstance(value, list):
+        candidates: list[str] = []
+        for v in value:
+            if isinstance(v, str):
+                candidates.extend(_split_employment_tokens(v))
+    elif isinstance(value, str):
+        candidates = _split_employment_tokens(value)
+    else:
+        return None
+    for token in candidates:
+        # Normalize hyphens / underscores → spaces so ``Full-Time``,
+        # ``Full_Time``, and ``Full Time`` all collide on the same key.
+        key = re.sub(r"[-_]+", " ", token.strip().lower())
+        key = _WS_RE.sub(" ", key).strip()
+        mapped = _EMPLOYMENT_MAP.get(key)
+        if mapped:
+            return mapped
+    return None
+
+
+def _split_employment_tokens(value: str) -> list[str]:
+    # MyJobMag joins flags as e.g. ``"Full Time , Onsite"`` — split on
+    # comma AND slash so we catch "Full-Time/Contract" too.
+    return [t.strip() for t in re.split(r"[,/]", value) if t.strip()]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,7 +29,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
-        "manfred", "thehub", "ycombinator", "wellfound",
+        "manfred", "myjobmag", "thehub", "ycombinator", "wellfound",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",
         "recruitee", "taleo", "teamtailor",

--- a/tests/test_myjobmag.py
+++ b/tests/test_myjobmag.py
@@ -1,0 +1,546 @@
+"""Tests for the MyJobMag (pan-African direct-posting board) scraper.
+
+Pin parsing of the shared HTML template that drives MyJobMag's five
+regional properties (NG, GH, KE, UG, ZA). Coverage:
+
+1. Region routing — ``company_slug`` selects the regional base URL and
+   country_iso / language stamps.
+2. Listing-card parsing — single-posting cards, rollup cards with
+   ``sub-job-sec`` children, AdSense placeholder skips.
+3. Pagination — dedup-driven termination (the site never returns
+   empty), and the ``max_pages`` safety cap.
+4. JSON-LD detail helper — ``parse_jsonld_job`` and
+   ``normalize_employment_type`` for the optional enrichment path.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Any
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import MyJobMagScraper, ScraperRegistry, get_scraper
+from jobhive.scrapers.myjobmag import (
+    REGIONS,
+    normalize_employment_type,
+    parse_jsonld_job,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.myjobmag as m
+    monkeypatch.setattr(m, "MAX_RETRIES", 1)
+    monkeypatch.setattr(m, "RETRY_BASE_DELAY", 0.0)
+
+
+# Mocked HTTP doesn't always exhaust every page the scraper would otherwise
+# request — pagination terminates as soon as a page yields zero new ids, so
+# unused page=N mocks are expected.
+pytestmark = pytest.mark.httpx_mock(
+    assert_all_requests_were_expected=False,
+)
+
+
+def _card(
+    *,
+    slug: str,
+    title: str,
+    company: str,
+    description: str = "We are a great company.",
+    date: str = "11 May",
+    use_logo_alt: bool = True,
+) -> str:
+    """Render one single-job MyJobMag listing card."""
+    logo = (
+        f'<li class="job-logo">'
+        f'<a href="/jobs-at/{company.lower().replace(" ", "-")}">'
+        f'<img src="/x.png" alt="{company if use_logo_alt else ""}" />'
+        f'</a></li>'
+    )
+    return (
+        '<li class="job-list-li">'
+        '<ul>'
+        f'{logo}'
+        '<li class="job-info"><ul>'
+        '<li class="mag-b">'
+        f'<h2><a style=" " href="/job/{slug}">{title} at {company}</a></h2>'
+        '</li>'
+        f'<li class="job-desc">{description}</li>'
+        '<li class="job-item"><ul>'
+        f'<li id="job-date">{date}</li>'
+        '</ul></li>'
+        '</ul></li>'
+        '</ul></li>'
+    )
+
+
+def _rollup_card(
+    *,
+    rollup_slug: str,
+    rollup_title: str,
+    company: str,
+    sub_jobs: list[tuple[str, str]],
+    date: str = "11 May",
+) -> str:
+    """Render a 'Latest Jobs at <Company>' rollup with N sub-job links."""
+    sub_html = "".join(
+        f'<li><a href="/job/{slug}">{t}</a></li>' for slug, t in sub_jobs
+    )
+    return (
+        '<li class="job-list-li">'
+        '<ul>'
+        f'<li class="job-logo">'
+        f'<a href="/jobs-at/{company.lower().replace(" ", "-")}">'
+        f'<img src="/x.png" alt="{company}" />'
+        f'</a></li>'
+        '<li class="job-info"><ul>'
+        '<li class="mag-b">'
+        f'<h2><a style=" " href="/jobs/latest-jobs-at-{rollup_slug}">'
+        f'{rollup_title}</a></h2>'
+        '</li>'
+        '<li class="job-desc">Company description.</li>'
+        '<li class="job-item"><ul>'
+        f'<li id="job-date">{date}</li>'
+        '</ul></li>'
+        '<li class="sub-job-sec">'
+        f'<ul id="sbu-job-list">{sub_html}</ul>'
+        '</li>'
+        '</ul></li>'
+        '</ul></li>'
+    )
+
+
+def _ad_card() -> str:
+    """An AdSense placeholder card — same outer wrapper, no job-info."""
+    return (
+        '<li class="job-list-li" style="text-align:center;">'
+        '<div id="adbox">ads</div>'
+        '</li>'
+    )
+
+
+def _page(cards: list[str]) -> str:
+    return (
+        '<!doctype html><html><body>'
+        '<ul id="job-list">'
+        + "".join(cards) +
+        '</ul></body></html>'
+    )
+
+
+def _url(base: str, page: int) -> str:
+    return f"{base}/jobs/page/{page}"
+
+
+# --- Registry / wiring ------------------------------------------------------
+
+
+def test_registry_resolves_myjobmag() -> None:
+    assert ScraperRegistry.get(ATSType.MYJOBMAG) is MyJobMagScraper
+
+
+def test_get_scraper_by_string() -> None:
+    s = get_scraper("myjobmag", "ke")
+    assert isinstance(s, MyJobMagScraper)
+    assert s.company_slug == "ke"
+
+
+# --- Region routing ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "slug, expected_base, expected_iso",
+    [
+        ("ng", "https://www.myjobmag.com", "NG"),
+        ("gh", "https://www.myjobmagghana.com", "GH"),
+        ("ke", "https://www.myjobmag.co.ke", "KE"),
+        ("ug", "https://www.myjobmag.co.ug", "UG"),
+        ("za", "https://www.myjobmag.co.za", "ZA"),
+    ],
+)
+def test_region_slug_maps_to_base_url_and_country_iso(
+    slug: str, expected_base: str, expected_iso: str,
+) -> None:
+    s = MyJobMagScraper(slug)
+    assert s._base_url == expected_base
+    assert s._country_iso == expected_iso
+    assert s._language == "en"
+
+
+def test_empty_slug_defaults_to_nigeria() -> None:
+    s = MyJobMagScraper("")
+    assert s._country_iso == "NG"
+
+
+@pytest.mark.parametrize("alias", ["any", "nigeria", "NIGERIA", "  ng  "])
+def test_alias_routes_to_nigeria(alias: str) -> None:
+    assert MyJobMagScraper(alias)._country_iso == "NG"
+
+
+def test_unknown_region_raises() -> None:
+    with pytest.raises(ScraperError):
+        MyJobMagScraper("mars")
+
+
+def test_all_regions_in_map() -> None:
+    """Pin the five-country contract — losing a region is a breaking
+    change for downstream company-CSV consumers."""
+    assert set(REGIONS) == {"ng", "gh", "ke", "ug", "za"}
+
+
+# --- Listing-card parsing ---------------------------------------------------
+
+
+def test_parses_single_job_card(httpx_mock) -> None:
+    cards = [
+        _card(
+            slug="financial-manager-acme-1",
+            title="Financial Manager",
+            company="Acme",
+            description="Great role at Acme.",
+        ),
+    ]
+    httpx_mock.add_response(
+        url=_url("https://www.myjobmag.com", 1), text=_page(cards),
+    )
+    httpx_mock.add_response(
+        url=_url("https://www.myjobmag.com", 2), text=_page([]),
+    )
+    jobs = MyJobMagScraper("ng").fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.MYJOBMAG
+    assert j.ats_id == "financial-manager-acme-1"
+    assert j.title == "Financial Manager"
+    assert j.company == "Acme"
+    assert j.country_iso == "NG"
+    assert j.language == "en"
+    assert str(j.url) == "https://www.myjobmag.com/job/financial-manager-acme-1"
+    assert j.description == "Great role at Acme."
+    assert j.posted_at is not None
+
+
+def test_skips_adsense_placeholder_cards(httpx_mock) -> None:
+    cards = [
+        _ad_card(),
+        _card(slug="x-acme", title="X", company="Acme"),
+        _ad_card(),
+    ]
+    httpx_mock.add_response(
+        url=_url("https://www.myjobmag.com", 1), text=_page(cards),
+    )
+    httpx_mock.add_response(
+        url=_url("https://www.myjobmag.com", 2), text=_page([]),
+    )
+    jobs = MyJobMagScraper("ng").fetch()
+    assert [j.ats_id for j in jobs] == ["x-acme"]
+
+
+def test_rollup_card_emits_sub_jobs_not_rollup(httpx_mock) -> None:
+    """``/jobs/latest-jobs-at-acme`` rollups expand to one Job per
+    sub-job link; the rollup URL itself (with the ``/jobs/`` prefix,
+    not ``/job/``) is never emitted as a posting."""
+    cards = [_rollup_card(
+        rollup_slug="acme",
+        rollup_title="Latest Jobs at Acme",
+        company="Acme",
+        sub_jobs=[
+            ("backend-engineer-acme", "Backend Engineer"),
+            ("frontend-engineer-acme", "Frontend Engineer"),
+            ("data-analyst-acme", "Data Analyst"),
+        ],
+    )]
+    httpx_mock.add_response(
+        url=_url("https://www.myjobmag.com", 1), text=_page(cards),
+    )
+    httpx_mock.add_response(
+        url=_url("https://www.myjobmag.com", 2), text=_page([]),
+    )
+    jobs = MyJobMagScraper("ng").fetch()
+    ats_ids = sorted(j.ats_id or "" for j in jobs)
+    assert ats_ids == [
+        "backend-engineer-acme",
+        "data-analyst-acme",
+        "frontend-engineer-acme",
+    ]
+    # All sub-jobs inherit the rollup company.
+    assert all(j.company == "Acme" for j in jobs)
+    # Sub-job urls point at the singleton ``/job/`` path on the same
+    # regional base.
+    assert all(str(j.url).startswith("https://www.myjobmag.com/job/")
+               for j in jobs)
+
+
+def test_title_at_company_parsing(httpx_mock) -> None:
+    """The listing renders titles as ``Title at Company`` — splitting
+    on the LAST ``" at "`` keeps titles that themselves contain ``at``
+    (e.g. 'Sales at Heart') intact."""
+    cards = [
+        _card(slug="x", title="Sales at Heart", company="Acme Corp"),
+    ]
+    httpx_mock.add_response(
+        url=_url("https://www.myjobmag.com", 1), text=_page(cards),
+    )
+    httpx_mock.add_response(
+        url=_url("https://www.myjobmag.com", 2), text=_page([]),
+    )
+    j = MyJobMagScraper("ng").fetch()[0]
+    assert j.title == "Sales at Heart"
+    assert j.company == "Acme Corp"
+
+
+def test_falls_back_to_logo_alt_when_title_has_no_at(httpx_mock) -> None:
+    """Some titles ship as just ``Senior Engineer`` with no ``at``
+    suffix — fall back to the company logo's ``alt`` attribute."""
+    # Hand-craft a card without "at <Company>" in the h2.
+    card = (
+        '<li class="job-list-li"><ul>'
+        '<li class="job-logo"><a href="/jobs-at/acme">'
+        '<img src="/x.png" alt="Acme Industries" />'
+        '</a></li>'
+        '<li class="job-info"><ul>'
+        '<li class="mag-b">'
+        '<h2><a href="/job/standalone-role">Standalone Role</a></h2>'
+        '</li>'
+        '<li class="job-desc">Doing things.</li>'
+        '<li class="job-item"><ul><li id="job-date">11 May</li></ul></li>'
+        '</ul></li></ul></li>'
+    )
+    httpx_mock.add_response(
+        url=_url("https://www.myjobmag.com", 1), text=_page([card]),
+    )
+    httpx_mock.add_response(
+        url=_url("https://www.myjobmag.com", 2), text=_page([]),
+    )
+    j = MyJobMagScraper("ng").fetch()[0]
+    assert j.title == "Standalone Role"
+    assert j.company == "Acme Industries"
+
+
+# --- Pagination -------------------------------------------------------------
+
+
+def test_paginates_until_zero_new_ids(httpx_mock) -> None:
+    """Listing pages never go empty in practice, so termination is
+    'this page introduced zero new ats_ids' rather than 'empty page'.
+    Verify the scraper requests page=2 when page=1 has fresh ids, and
+    stops when page=2 repeats them."""
+    page1 = _page([
+        _card(slug="a", title="A", company="Acme"),
+        _card(slug="b", title="B", company="Acme"),
+    ])
+    # Page 2 repeats the same ids — should terminate, not crash.
+    httpx_mock.add_response(
+        url=_url("https://www.myjobmag.com", 1), text=page1,
+    )
+    httpx_mock.add_response(
+        url=_url("https://www.myjobmag.com", 2), text=page1,
+    )
+    jobs = MyJobMagScraper("ng").fetch()
+    assert sorted(j.ats_id or "" for j in jobs) == ["a", "b"]
+
+
+def test_paginates_through_multiple_pages_with_new_ids(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_url("https://www.myjobmag.com", 1),
+        text=_page([_card(slug=f"p1_{i}", title="T", company="C") for i in range(3)]),
+    )
+    httpx_mock.add_response(
+        url=_url("https://www.myjobmag.com", 2),
+        text=_page([_card(slug=f"p2_{i}", title="T", company="C") for i in range(2)]),
+    )
+    # Page 3 — no new ids.
+    httpx_mock.add_response(
+        url=_url("https://www.myjobmag.com", 3),
+        text=_page([_card(slug="p1_0", title="T", company="C")]),
+    )
+    jobs = MyJobMagScraper("ng").fetch()
+    assert len(jobs) == 5
+
+
+def test_max_pages_caps_pagination(httpx_mock) -> None:
+    """With ``max_pages=1``, page=2 must never be requested even if
+    page=1 brought new ids."""
+    httpx_mock.add_response(
+        url=_url("https://www.myjobmag.com", 1),
+        text=_page([_card(slug="a", title="A", company="C")]),
+    )
+    # If the scraper requested page=2, httpx_mock would NOT have a
+    # response for it and the call would raise — we rely on that to
+    # assert the cap holds.
+    jobs = MyJobMagScraper("ng", max_pages=1).fetch()
+    assert [j.ats_id for j in jobs] == ["a"]
+
+
+# --- Defensive --------------------------------------------------------------
+
+
+def test_persistent_500_raises(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=re.compile(r"^https://www\.myjobmag\.com/"),
+        status_code=500, is_reusable=True,
+    )
+    with pytest.raises(ScraperError):
+        MyJobMagScraper("ng").fetch()
+
+
+def test_empty_page_terminates(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_url("https://www.myjobmag.com", 1), text=_page([]),
+    )
+    assert MyJobMagScraper("ng").fetch() == []
+
+
+# --- JSON-LD detail helper --------------------------------------------------
+#
+# The default fetch path is listing-only for throughput, but the
+# detail-page JSON-LD JobPosting block carries richer fields
+# (employmentType, postal address, occupationalCategory). Pin the
+# helper used by downstream enrichment.
+
+
+_DETAIL_PAGE = """
+<html><head></head><body>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "JobPosting",
+  "title": "Financial Manager",
+  "datePosted": "2026-05-11T16:13:34+01:00",
+  "hiringOrganization": {"@type": "Organization", "name": "Acme Corp"},
+  "employmentType": "Full Time , Onsite",
+  "jobLocation": {
+    "@type": "Place",
+    "address": {
+      "@type": "PostalAddress",
+      "addressLocality": "Lagos",
+      "addressCountry": "NG"
+    }
+  }
+}
+</script>
+</body></html>
+"""
+
+
+def test_parse_jsonld_job_returns_dict_when_present() -> None:
+    obj = parse_jsonld_job(_DETAIL_PAGE)
+    assert obj is not None
+    assert obj["@type"] == "JobPosting"
+    assert obj["title"] == "Financial Manager"
+    assert obj["hiringOrganization"]["name"] == "Acme Corp"
+
+
+def test_parse_jsonld_job_returns_none_when_absent() -> None:
+    assert parse_jsonld_job("<html><body>no jsonld</body></html>") is None
+
+
+def test_parse_jsonld_tolerates_unescaped_newlines() -> None:
+    """Live MyJobMag detail pages embed raw newlines inside the
+    ``description`` string (technically invalid JSON). The strict-mode
+    parse fails; the helper retries with ``strict=False`` so real
+    fixtures don't get dropped on the floor."""
+    text = (
+        '<script type="application/ld+json">'
+        '{"@type":"JobPosting","title":"X",'
+        '"description":"line1\nline2\nline3"}'
+        '</script>'
+    )
+    obj = parse_jsonld_job(text)
+    assert obj is not None
+    assert obj["title"] == "X"
+
+
+def test_parse_jsonld_skips_non_jobposting() -> None:
+    """Some MyJobMag pages embed an Organization JSON-LD block but
+    not a JobPosting — skip those rather than mis-typing them."""
+    text = (
+        '<script type="application/ld+json">'
+        '{"@context":"https://schema.org","@type":"organization","name":"X"}'
+        '</script>'
+    )
+    assert parse_jsonld_job(text) is None
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("Full Time", "FULL_TIME"),
+        ("FULL_TIME", "FULL_TIME"),
+        ("Full Time , Onsite", "FULL_TIME"),  # comma-joined tags
+        ("Part Time", "PART_TIME"),
+        ("Contract", "CONTRACT"),
+        ("Internship", "INTERN"),
+        ("Temporary", "TEMPORARY"),
+        ("Full-Time/Contract", "FULL_TIME"),
+        (["Full Time", "Onsite"], "FULL_TIME"),
+        (None, None),
+        ("Unknown Tag", None),
+    ],
+)
+def test_normalize_employment_type(
+    raw: Any, expected: str | None,
+) -> None:
+    assert normalize_employment_type(raw) == expected
+
+
+# --- Posted-date inference -------------------------------------------------
+
+
+def test_posted_at_binds_to_current_year_when_not_future(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The listing date shows day-month only (``11 May``). Without a
+    year we attribute to the most-recent occurrence that isn't in the
+    future, which keeps day-old posts from being mis-aged by 364 days
+    around year boundaries."""
+    # Stub ``datetime.now`` so the test is deterministic. The module
+    # imports ``datetime`` from the stdlib by name, so patch at the
+    # consumption site.
+    import jobhive.scrapers.myjobmag as m
+
+    class _FrozenDT(datetime):
+        @classmethod
+        def now(cls, tz=None):  # type: ignore[override]
+            return datetime(2026, 5, 12, 10, 0, 0)
+    monkeypatch.setattr(m, "datetime", _FrozenDT)
+
+    cards = [_card(slug="x", title="X", company="C", date="11 May")]
+    httpx_mock.add_response(
+        url=_url("https://www.myjobmag.com", 1), text=_page(cards),
+    )
+    httpx_mock.add_response(
+        url=_url("https://www.myjobmag.com", 2), text=_page([]),
+    )
+    j = MyJobMagScraper("ng").fetch()[0]
+    assert j.posted_at == datetime(2026, 5, 11)
+
+
+def test_posted_at_backs_to_previous_year_for_future_month(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If today is 12 Jan 2026 and the listing says ``31 Dec``, the
+    candidate (31 Dec 2026) is months in the future — back off to
+    2025 so 'days-since-posting' stays small for a 12-day-old row."""
+    import jobhive.scrapers.myjobmag as m
+
+    class _FrozenDT(datetime):
+        @classmethod
+        def now(cls, tz=None):  # type: ignore[override]
+            return datetime(2026, 1, 12, 10, 0, 0)
+    monkeypatch.setattr(m, "datetime", _FrozenDT)
+
+    cards = [_card(slug="x", title="X", company="C", date="31 Dec")]
+    httpx_mock.add_response(
+        url=_url("https://www.myjobmag.com", 1), text=_page(cards),
+    )
+    httpx_mock.add_response(
+        url=_url("https://www.myjobmag.com", 2), text=_page([]),
+    )
+    j = MyJobMagScraper("ng").fetch()[0]
+    assert j.posted_at == datetime(2025, 12, 31)


### PR DESCRIPTION
## Summary

- Adds ``MyJobMagScraper`` for MyJobMag, a multi-country direct-posting jobs board covering Nigeria (default), Ghana, Kenya, Uganda, and South Africa via regional subdomains. ``company_slug`` selects the region (``ng`` / ``gh`` / ``ke`` / ``ug`` / ``za``, plus full-country-name aliases).
- Registers ``ATSType.MYJOBMAG`` in the "Hybrid jobboards" group.
- Listing-only default fetch path (one HTTP request per page) parses each ``<li class="job-list-li">`` card for title, company, posted date (day-month with year inference), and description summary. Rollup cards expand to one ``Job`` per sub-job link; AdSense placeholders are filtered.
- Exports ``parse_jsonld_job`` + ``normalize_employment_type`` for the optional enrichment path that pulls the detail-page JSON-LD ``JobPosting`` block. JSON parsing falls back to ``strict=False`` since live pages embed raw newlines inside ``description`` string values.
- Pagination dedups on ``ats_id`` and terminates when a fetched page introduces zero new IDs (the site never returns empty pages), with a ``max_pages=400`` safety cap.

## Test plan

- [x] ``ruff check src/jobhive tests`` — all checks passed
- [x] ``pytest`` — 919 → 1022 (added 41 myjobmag tests + 1 model test), 0 failures
- [x] Live smoke against NG, KE, ZA, GH: 86 / 44 / 139 / 22 jobs respectively over 1-2 pages, clean title/company splits, correct ``country_iso``, ``posted_at`` inferred against year boundary

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a pan‑African `MyJobMagScraper` that ingests multi‑country listings (Nigeria, Ghana, Kenya, Uganda, South Africa) via a fast listing-only path with dedup-based pagination. Registers `ATSType.MYJOBMAG`, adds `ats-companies/myjobmag.csv` for region mapping, and exposes helpers for optional JSON‑LD enrichment.

- **New Features**
  - Add `MyJobMagScraper` and register `ATSType.MYJOBMAG`; regions via `company_slug` (`ng`/`gh`/`ke`/`ug`/`za`, aliases supported, default `ng`).
  - Listing-only parsing: extract title/company/summary/date; expand rollups into sub-jobs; skip AdSense; infer year from day–month dates.
  - Pagination: dedup by `ats_id`, stop when a page adds no new IDs; `max_pages=400` safety cap.
  - Expose `parse_jsonld_job` and `normalize_employment_type` for detail-page JSON‑LD enrichment; tolerate raw newlines in JSON.

<sup>Written for commit 151e05f6558f4fd180d433bbe55f95ddae666a8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `MyJobMagScraper`, a pan-African scraper covering five regional MyJobMag properties (Nigeria, Ghana, Kenya, Uganda, South Africa) via a shared listing-page HTML template. It registers `ATSType.MYJOBMAG`, ships a companion `ats-companies/myjobmag.csv`, and exposes `parse_jsonld_job` / `normalize_employment_type` helpers for optional downstream enrichment.

- **Listing-only fetch path**: parses `<li class="job-list-li">` cards, expands rollup cards into per-sub-job `Job` objects, and skips AdSense placeholders; pagination terminates on zero new `ats_id` values per page with a `max_pages=400` safety cap.
- **Region selection**: `company_slug` resolves via an alias table (`ng`/`gh`/`ke`/`ug`/`za` plus full country-name variants); invalid slugs raise `ScraperError` immediately at construction.
- **Test suite**: 41 new tests cover region routing, card parsing, rollup expansion, pagination dedup, JSON-LD helpers, and year-boundary date inference, all with httpx mock responses.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all identified issues are non-blocking style and design concerns with no impact on correctness under the current serial-pagination model.

The scraper logic, region routing, dedup-based pagination, and date inference are all correct and well-tested. The three findings are: a retry sleep held inside the semaphore (harmless today since pagination is always serial, but wrong if concurrency is ever added), a deferred `import json` inside a function body, and a post-loop raise that can never be reached. None affect runtime behavior in the current implementation.

The retry loop in `src/jobhive/scrapers/myjobmag.py` (`_fetch_page`) is the only place worth a second look — the semaphore/sleep interaction and the dead-code fallback raise are both in that method.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/myjobmag.py | New 512-line scraper for five MyJobMag regional properties; logic is correct for the current serial-pagination model, but the retry sleep is held inside the semaphore and the post-loop raise is dead code. |
| tests/test_myjobmag.py | Comprehensive 546-line test suite covering region routing, card parsing, rollup expansion, pagination termination, ad-card skipping, JSON-LD helpers, and date inference; well-structured with good edge-case coverage. |
| src/jobhive/models.py | Adds `MYJOBMAG = "myjobmag"` to `ATSType` enum in alphabetical order; clean one-line addition. |
| src/jobhive/scrapers/__init__.py | Adds `MyJobMagScraper` import and `__all__` entry in alphabetical order; no issues. |
| ats-companies/myjobmag.csv | New CSV file mapping five MyJobMag regional properties (NG, GH, KE, UG, ZA) to their base URLs; matches the `REGIONS` dict in the scraper exactly. |
| tests/test_models.py | Adds `"myjobmag"` to the `ATSType` membership assertion; correct single-line change. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/jobhive/scrapers/myjobmag.py:230-245
The `asyncio.sleep` retry delay for network-level errors is called while still holding the `async with sem:` lock (line 244 is inside the `sem` block that started at line 230). Any other coroutine waiting on the semaphore is blocked for the full delay duration. Pagination is serial today so the semaphore is never actually contended, but the invariant is wrong: retry back-off should always happen outside the semaphore. If a concurrent page-fetch path is ever added, this would silently serialize all retries.

```suggestion
            async with sem:
                try:
                    response = await client.get(
                        url, headers={
                            "User-Agent": "Mozilla/5.0",
                            "Accept": "text/html,application/xhtml+xml",
                        },
                    )
                except httpx.HTTPError as exc:
                    last_exc = exc
                    if attempt == MAX_RETRIES:
                        raise ScraperError(
                            f"MyJobMag fetch failed for {url}: {exc}"
                        ) from exc
                    network_exc = exc
                else:
                    network_exc = None
            if network_exc is not None:
                await asyncio.sleep(RETRY_BASE_DELAY * attempt)
                continue
```

### Issue 2 of 3
src/jobhive/scrapers/myjobmag.py:461-468
`import json` is placed inside the function body instead of at the module top level. `json` is a stdlib module present in every Python environment, so there is no conditional-availability reason for a deferred import here. Moving it to the top is the conventional approach and avoids the (minor) per-call overhead of a dict lookup in `sys.modules`.

```suggestion
    Live MyJobMag blocks ship raw newlines inside the ``description``
    string (technically invalid JSON), so we retry parsing with
    ``strict=False`` after the first ValueError, which tolerates
    control characters in string values.
    """
    for raw in _JSONLD_RE.findall(html_text):
```

### Issue 3 of 3
src/jobhive/scrapers/myjobmag.py:267-269
**Unreachable fallback raise** — this `raise ScraperError(...)` is dead code. Every path through the loop either returns (200, 404), raises (last-attempt HTTP error, last-attempt 5xx/429, unexpected status code), or `continue`s (retriable HTTP error, retriable 5xx/429). The loop cannot exhaust normally, so this line is never reached. It could safely be removed, or — if kept as a defensive net — a comment explaining why should be added to avoid confusion.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: myjobmag.csv"](https://github.com/kalil0321/ats-scrapers/commit/151e05f6558f4fd180d433bbe55f95ddae666a8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732509)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->