### PR TITLE
shine: add India multi-sector job board scraper

### DIFF
--- a/ats-companies/shine.csv
+++ b/ats-companies/shine.csv
@@ -1,0 +1,2 @@
+name,slug,url
+Shine,shine,https://www.shine.com

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -80,6 +80,7 @@ class ATSType(StrEnum):
     THEHUB = "thehub"
     YCOMBINATOR = "ycombinator"
     WELLFOUND = "wellfound"
+    SHINE = "shine"
     # Additional multi-tenant ATSes (post-0.1)
     BAMBOOHR = "bamboohr"
     BREEZY = "breezy"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -42,6 +42,7 @@ from jobhive.scrapers.recruitee import RecruiteeScraper
 from jobhive.scrapers.recruiterbox import RecruiterboxScraper
 from jobhive.scrapers.remoteok import RemoteOKScraper
 from jobhive.scrapers.rippling import RipplingScraper
+from jobhive.scrapers.shine import ShineScraper
 from jobhive.scrapers.smartrecruiters import SmartRecruitersScraper
 from jobhive.scrapers.successfactors import SuccessFactorsScraper
 from jobhive.scrapers.taleo import TaleoScraper
@@ -94,6 +95,7 @@ __all__ = [
     "RemoteOKScraper",
     "RipplingScraper",
     "ScraperRegistry",
+    "ShineScraper",
     "SmartRecruitersScraper",
     "SuccessFactorsScraper",
     "TaleoScraper",

--- a/src/jobhive/scrapers/shine.py
+++ b/src/jobhive/scrapers/shine.py
@@ -1,0 +1,435 @@
+"""Shine.com (https://www.shine.com) — India-focused jobs board scraper.
+
+Shine.com is one of India's top general-purpose jobs boards (alongside
+Naukri, Foundit and TimesJobs). It carries ~240k live postings across
+every sector — IT, BFSI, BPO, manufacturing, healthcare, etc. — with
+companies (employers and recruiting agencies) posting directly through
+Shine's recruiter product.
+
+The site is a Next.js SPA. Each ``/job-search/all-jobs[-N]`` listing page
+ships a ``<script id="__NEXT_DATA__">`` block with the fully-populated
+``jsrp.searchresult.data.results`` array — no separate JSON API hop, no
+CSR-only fetch. Each result entry carries enough fields that we don't
+need per-job detail requests:
+
+  id        → posting ID (``jSlug`` embeds it too)
+  jJT       → title
+  jCName    → company name
+  jSlug     → URL slug (``{title-slug}/{company-slug}/{id}``)
+  jLoc      → list of locations (``["All India", "Bangalore"]``)
+  jJD       → description text
+  jExp      → experience range (``"3 to 7 Yrs"``)
+  jPDate    → posted-at ISO timestamp
+  jKwd      → comma-separated skills/keywords
+  jInd      → industry
+  jSal      → salary string (almost always ``"[Salary Hidden]"``)
+  jJobType  → employment type code (1=Full-time, in observed data)
+
+Pagination: ``/job-search/all-jobs`` is page 1, ``/job-search/all-jobs-2``
+is page 2, etc. The payload's ``num_pages`` field reports the total
+(~12k pages × 20 = ~240k jobs). We cap at ``max_pages`` to keep a single
+sweep tractable; the default (300) yields ~6,000 most-recent jobs.
+
+Single-source scraper: ``company_slug`` is informational and ignored
+(matches the bundesagentur / wanted / getonbrd pattern). Output rows
+carry the publishing employer's name as ``company`` so cross-ATS dedup
+still works.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import json
+import logging
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+log = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from typing import Any
+
+API_ROOT = "https://www.shine.com"
+LISTING_PATH = "/job-search/all-jobs"
+DEFAULT_MAX_PAGES = 300  # ~6,000 most-recent jobs.
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 4
+RETRY_BASE_DELAY = 1.5
+
+_NEXT_DATA_RE = re.compile(
+    r'<script id="__NEXT_DATA__"[^>]*>(.+?)</script>',
+    re.DOTALL,
+)
+_EXPERIENCE_RE = re.compile(
+    r"(?P<lo>\d+)\s*(?:to|-)\s*(?P<hi>\d+)\s*(?:Yr|Year)",
+    re.IGNORECASE,
+)
+_SINGLE_EXP_RE = re.compile(r"(\d+)\s*(?:Yr|Year)", re.IGNORECASE)
+_TAG_RE = re.compile(r"<[^>]+>")
+
+# Shine ``jJobType`` code → canonical EmploymentType. The observed live
+# data only ever surfaces ``1`` (Full-Time); the rest are best-effort
+# guesses from Shine's recruiter docs and are safe defaults if/when
+# they appear.
+_JOBTYPE_MAP: dict[int, str] = {
+    1: "FULL_TIME",
+    2: "PART_TIME",
+    3: "CONTRACT",
+    4: "INTERN",
+    5: "TEMPORARY",
+}
+
+
+@ScraperRegistry.register(ATSType.SHINE)
+class ShineScraper(BaseScraper):
+    """Shine.com (shine.com) — India-focused multi-sector jobs board.
+
+    Single-source: ``company_slug`` is ignored. Pass anything (``"any"``,
+    ``""``) — the scraper paginates the full ``all-jobs`` listing.
+
+    Knobs:
+    - ``max_pages`` — pagination cap (default 300 → ~6,000 jobs). Shine's
+      ``num_pages`` is ~12k so a full sweep is impractical for a single
+      run; cap small and re-run for newest postings.
+    """
+
+    ats = ATSType.SHINE
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        max_pages: int = DEFAULT_MAX_PAGES,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.max_pages = max_pages
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        lock = asyncio.Lock()
+
+        async def absorb(items: list[Job]) -> int:
+            new = 0
+            async with lock:
+                for j in items:
+                    if j.ats_id in seen:
+                        continue
+                    seen.add(j.ats_id)
+                    jobs.append(j)
+                    new += 1
+            return new
+
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True,
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+
+            # Probe page 1 — learn ``num_pages`` so we don't blindly hit
+            # the per-instance cap when the listing is shorter.
+            first_text = await self._fetch_listing_text(client, sem, page=1)
+            first_payload = self._extract_next_data(first_text)
+            first_data = self._search_data(first_payload)
+            num_pages = int(first_data.get("num_pages") or 1)
+            await absorb(list(self._parse_results(first_data)))
+
+            last_page = min(num_pages, self.max_pages)
+            if last_page <= 1:
+                return jobs
+
+            consecutive_empty = 0
+
+            async def one(page: int) -> None:
+                nonlocal consecutive_empty
+                try:
+                    text = await self._fetch_listing_text(client, sem, page=page)
+                except ScraperError as exc:
+                    # Deep pagination can hit transient blocks; keep what
+                    # we've already gathered rather than blow up.
+                    log.warning(
+                        "Shine: stopping at page %d (%s); keeping %d jobs",
+                        page, exc, len(jobs),
+                    )
+                    return
+                payload = self._extract_next_data(text)
+                data = self._search_data(payload)
+                new = await absorb(list(self._parse_results(data)))
+                if new == 0:
+                    consecutive_empty += 1
+                else:
+                    consecutive_empty = 0
+
+            for page in range(2, last_page + 1):
+                if consecutive_empty >= 3:
+                    break
+                await one(page)
+        return jobs
+
+    # --- HTTP layer ---------------------------------------------------------
+
+    async def _fetch_listing_text(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        *,
+        page: int,
+    ) -> str:
+        suffix = "" if page == 1 else f"-{page}"
+        url = f"{API_ROOT}{LISTING_PATH}{suffix}"
+        return await self._request_html(client, sem, url)
+
+    async def _request_html(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        url: str,
+    ) -> str:
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(
+                        url, headers={
+                            "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) "
+                                          "AppleWebKit/537.36 (KHTML, like Gecko) "
+                                          "Chrome/120.0.0.0 Safari/537.36",
+                            "Accept": "text/html,*/*",
+                            "Accept-Language": "en-IN,en;q=0.9",
+                        },
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"Shine fetch failed for {url}: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                return response.text
+            if response.status_code == 404:
+                # Page past the end — caller treats as "no data".
+                return ""
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Shine returned {response.status_code} for {url} "
+                        f"after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"Shine returned {response.status_code} for {url}"
+            )
+        raise ScraperError(f"Shine exhausted retries for {url}: {last_exc}")
+
+    # --- parsing ------------------------------------------------------------
+
+    def _extract_next_data(self, text: str) -> dict[str, Any]:
+        if not text:
+            return {}
+        match = _NEXT_DATA_RE.search(text)
+        if not match:
+            return {}
+        try:
+            return json.loads(match.group(1))
+        except json.JSONDecodeError as exc:
+            raise ScraperError(
+                f"Shine __NEXT_DATA__ payload was not valid JSON: {exc}"
+            ) from exc
+
+    def _search_data(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Drill down to ``jsrp.searchresult.data`` defensively — the
+        Next.js page-prop tree is hand-wired, so any of the intermediate
+        keys can in theory be missing on edge cases."""
+        try:
+            return (
+                payload["props"]["pageProps"]
+                ["initialState"]["jsrp"]["searchresult"]["data"]
+            ) or {}
+        except (KeyError, TypeError):
+            return {}
+
+    def _parse_results(self, data: dict[str, Any]):
+        for item in data.get("results") or []:
+            job = self._parse_item(item)
+            if job is not None:
+                yield job
+
+    def _parse_item(self, item: dict[str, Any]) -> Job | None:
+        raw_id = item.get("id")
+        if raw_id is None:
+            return None
+        ats_id = str(raw_id).strip()
+        title = _clean_text(item.get("jJT") or "")
+        if not ats_id or not title:
+            return None
+
+        company = _clean_text(item.get("jCName") or "") or "Unknown"
+        slug = (item.get("jSlug") or "").strip().strip("/")
+        url = (
+            f"{API_ROOT}/jobs/{slug}"
+            if slug
+            else f"{API_ROOT}/jobs/{ats_id}"
+        )
+
+        location, country_iso = _format_location(item.get("jLoc"))
+
+        experience_min, experience_max = _parse_experience(
+            item.get("jExp") or ""
+        )
+
+        description = _clean_text(item.get("jJD") or "")[:10_000] or None
+
+        posted_at = _parse_iso(item.get("jPDate"))
+
+        employment_type = _JOBTYPE_MAP.get(_to_int(item.get("jJobType")))
+
+        salary_summary = _clean_salary(item.get("jSal"))
+
+        skills = _parse_skills(item.get("jKwd"))
+
+        raw: dict[str, Any] = {}
+        if experience_min is not None:
+            raw["experience_min"] = experience_min
+        if experience_max is not None:
+            raw["experience_max"] = experience_max
+        if skills:
+            raw["skills"] = skills[:30]
+        industry = _clean_text(item.get("jInd") or "")
+        if industry:
+            raw["industry"] = industry
+
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.SHINE,
+            ats_id=ats_id,
+            location=location,
+            country_iso=country_iso,
+            language="en",
+            experience=experience_min,
+            employment_type=employment_type,
+            salary_summary=salary_summary,
+            description=description,
+            posted_at=posted_at,
+            fetched_at=datetime.now(),
+            raw=raw or None,
+        )
+
+
+# --- module-level helpers ---------------------------------------------------
+
+
+def _clean_text(text: str) -> str:
+    if not text:
+        return ""
+    cleaned = _TAG_RE.sub(" ", text)
+    cleaned = html.unescape(cleaned)
+    return re.sub(r"\s+", " ", cleaned).strip()
+
+
+def _clean_salary(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    # Shine renders hidden ranges as ``"[Salary Hidden]"``. Treat as no
+    # signal — there's no number to extract and the literal isn't useful
+    # downstream.
+    if "salary hidden" in cleaned.lower():
+        return None
+    return cleaned
+
+
+def _format_location(value: object) -> tuple[str | None, str | None]:
+    """Shine's ``jLoc`` is a list of city strings (``["All India"]``,
+    ``["Bangalore", "Pune"]``). Most postings live in India; a handful
+    list Gulf / SEA cities. Return the comma-joined display + an ISO
+    country guess (defaults to ``IN`` for India-specific markers, ``None``
+    when the location is ambiguous so LLM enrichment fills it in).
+    """
+    if not isinstance(value, list):
+        return None, "IN" if isinstance(value, str) and value.strip() else None
+    parts = [p.strip() for p in value if isinstance(p, str) and p.strip()]
+    if not parts:
+        return None, None
+    display = ", ".join(parts[:5])
+    lowered = display.lower()
+    # "All India" / "Bangalore" / "Mumbai" etc. → India. Outside-India
+    # cities (Dubai, Singapore, …) are rare and ambiguous; defer to
+    # the downstream country-from-location enrichment by returning None.
+    india_markers = (
+        "india", "bangalore", "bengaluru", "mumbai", "pune", "chennai",
+        "hyderabad", "delhi", "noida", "gurgaon", "gurugram", "kolkata",
+        "ahmedabad", "kochi", "thiruvananthapuram", "jaipur", "lucknow",
+        "indore", "chandigarh", "coimbatore", "nagpur", "bhubaneswar",
+    )
+    if any(m in lowered for m in india_markers):
+        return display, "IN"
+    return display, None
+
+
+def _parse_experience(raw: str) -> tuple[int | None, int | None]:
+    """``"3 to 7 Yrs"`` → ``(3, 7)``; ``"5 Yrs"`` → ``(5, 5)``."""
+    if not raw:
+        return None, None
+    m = _EXPERIENCE_RE.search(raw)
+    if m:
+        try:
+            return int(m.group("lo")), int(m.group("hi"))
+        except ValueError:
+            return None, None
+    m = _SINGLE_EXP_RE.search(raw)
+    if m:
+        try:
+            v = int(m.group(1))
+        except ValueError:
+            return None, None
+        return v, v
+    return None, None
+
+
+def _parse_skills(raw: object) -> list[str]:
+    if not isinstance(raw, str):
+        return []
+    parts = re.split(r"[,;]", raw)
+    return [p.strip() for p in parts if p and p.strip()]
+
+
+def _parse_iso(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return datetime.fromisoformat(value.strip())
+    except ValueError:
+        return None
+
+
+def _to_int(value: object) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip().isdigit():
+        return int(value.strip())
+    return 0

--- a/src/jobhive/scrapers/shine.py
+++ b/src/jobhive/scrapers/shine.py
@@ -150,18 +150,20 @@ class ShineScraper(BaseScraper):
                 return jobs
 
             consecutive_empty = 0
+            stop = False
 
             async def one(page: int) -> None:
-                nonlocal consecutive_empty
+                nonlocal consecutive_empty, stop
                 try:
                     text = await self._fetch_listing_text(client, sem, page=page)
                 except ScraperError as exc:
-                    # Deep pagination can hit transient blocks; keep what
-                    # we've already gathered rather than blow up.
+                    # Deep pagination can hit a hard block; stop paginating
+                    # rather than burn retries against a blocking server.
                     log.warning(
                         "Shine: stopping at page %d (%s); keeping %d jobs",
                         page, exc, len(jobs),
                     )
+                    stop = True
                     return
                 payload = self._extract_next_data(text)
                 data = self._search_data(payload)
@@ -172,7 +174,7 @@ class ShineScraper(BaseScraper):
                     consecutive_empty = 0
 
             for page in range(2, last_page + 1):
-                if consecutive_empty >= 3:
+                if stop or consecutive_empty >= 3:
                     break
                 await one(page)
         return jobs
@@ -369,7 +371,9 @@ def _format_location(value: object) -> tuple[str | None, str | None]:
     when the location is ambiguous so LLM enrichment fills it in).
     """
     if not isinstance(value, list):
-        return None, "IN" if isinstance(value, str) and value.strip() else None
+        if isinstance(value, str) and value.strip():
+            return value.strip(), "IN"
+        return None, None
     parts = [p.strip() for p in value if isinstance(p, str) and p.strip()]
     if not parts:
         return None, None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,7 +29,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
-        "manfred", "thehub", "ycombinator", "wellfound",
+        "manfred", "thehub", "ycombinator", "wellfound", "shine",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",
         "recruitee", "taleo", "teamtailor",

--- a/tests/test_shine.py
+++ b/tests/test_shine.py
@@ -1,0 +1,357 @@
+"""Tests for the Shine.com (India) scraper.
+
+Pin parsing of the embedded ``__NEXT_DATA__`` payload (one row per
+``jsrp.searchresult.data.results`` entry), the ``all-jobs-N`` pagination
+shape, and the experience-range / location / India ISO inference.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import ScraperRegistry, ShineScraper
+
+_LISTING_RE = re.compile(r"^https://www\.shine\.com/job-search/all-jobs")
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.shine as s
+    monkeypatch.setattr(s, "MAX_RETRIES", 1)
+    monkeypatch.setattr(s, "RETRY_BASE_DELAY", 0.0)
+
+
+# --- payload builders -------------------------------------------------------
+
+
+def _result(
+    *,
+    job_id: int = 18798429,
+    title: str = "Wealth Management",
+    company: str = "JPMorgan Chase & Co.",
+    slug: str | None = None,
+    locations: list[str] | None = None,
+    description: str = "Role Overview: A great gig.",
+    experience: str = "2 to 6 Yrs",
+    posted_at: str = "2026-03-23T00:08:47",
+    skills: str = "Portfolio Analysis, Client Service, Risk Analysis",
+    industry: str = "BFSI",
+    salary: str = "[Salary Hidden]",
+    job_type: int = 1,
+) -> dict[str, Any]:
+    if slug is None:
+        slug_title = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+        slug_company = re.sub(r"[^a-z0-9]+", "-", company.lower()).strip("-")
+        slug = f"{slug_title}/{slug_company}/{job_id}"
+    return {
+        "id": job_id,
+        "jJT": title,
+        "jCName": company,
+        "jSlug": slug,
+        "jLoc": locations if locations is not None else ["All India"],
+        "jJD": description,
+        "jExp": experience,
+        "jPDate": posted_at,
+        "jKwd": skills,
+        "jInd": industry,
+        "jSal": salary,
+        "jJobType": job_type,
+        "jEType": 1,
+    }
+
+
+def _page(
+    results: list[dict[str, Any]],
+    *,
+    page: int = 1,
+    count: int = 100,
+    num_pages: int = 1,
+) -> str:
+    payload = {
+        "props": {
+            "pageProps": {
+                "initialState": {
+                    "jsrp": {
+                        "searchresult": {
+                            "isLoaded": True,
+                            "data": {
+                                "count": count,
+                                "next": page < num_pages,
+                                "previous": None if page == 1 else True,
+                                "results": results,
+                                "num_pages": num_pages,
+                                "page": page,
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+    body = json.dumps(payload)
+    return (
+        "<!DOCTYPE html><html><body>"
+        f'<script id="__NEXT_DATA__" type="application/json">{body}</script>'
+        "</body></html>"
+    )
+
+
+# --- registry / wiring ------------------------------------------------------
+
+
+def test_registry_resolves_shine() -> None:
+    assert ScraperRegistry.get(ATSType.SHINE) is ShineScraper
+
+
+def test_ats_type_value() -> None:
+    assert ATSType.SHINE.value == "shine"
+
+
+# --- happy path -------------------------------------------------------------
+
+
+def test_parses_full_shine_payload(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_LISTING_RE,
+        html=_page([_result()]),
+    )
+
+    jobs = ShineScraper("any").fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.SHINE
+    assert j.ats_id == "18798429"
+    assert j.title == "Wealth Management"
+    assert j.company == "JPMorgan Chase & Co."
+    assert j.location == "All India"
+    assert j.country_iso == "IN"
+    assert j.language == "en"
+    assert j.experience == 2  # min from "2 to 6 Yrs"
+    assert j.employment_type == "FULL_TIME"
+    assert j.salary_summary is None  # "[Salary Hidden]" is dropped
+    assert j.description == "Role Overview: A great gig."
+    assert j.posted_at is not None
+    assert j.posted_at.year == 2026 and j.posted_at.month == 3
+    assert str(j.url) == (
+        "https://www.shine.com/jobs/wealth-management/"
+        "jpmorgan-chase-co/18798429"
+    )
+    assert j.raw is not None
+    assert j.raw.get("experience_min") == 2
+    assert j.raw.get("experience_max") == 6
+    assert j.raw.get("industry") == "BFSI"
+    assert "Portfolio Analysis" in (j.raw.get("skills") or [])
+    assert j.global_id == "shine:18798429"
+
+
+# --- pagination -------------------------------------------------------------
+
+
+def test_paginates_via_all_jobs_dash_n(httpx_mock) -> None:
+    """Page 1 lives at ``/job-search/all-jobs`` (no suffix), page 2 at
+    ``-2``, etc. ``num_pages`` from page 1 tells us how far to go."""
+    httpx_mock.add_response(
+        url="https://www.shine.com/job-search/all-jobs",
+        html=_page(
+            [_result(job_id=1, title="One"), _result(job_id=2, title="Two")],
+            page=1, num_pages=3,
+        ),
+    )
+    httpx_mock.add_response(
+        url="https://www.shine.com/job-search/all-jobs-2",
+        html=_page(
+            [_result(job_id=3, title="Three")],
+            page=2, num_pages=3,
+        ),
+    )
+    httpx_mock.add_response(
+        url="https://www.shine.com/job-search/all-jobs-3",
+        html=_page(
+            [_result(job_id=4, title="Four")],
+            page=3, num_pages=3,
+        ),
+    )
+
+    jobs = ShineScraper("any").fetch()
+    assert {j.ats_id for j in jobs} == {"1", "2", "3", "4"}
+
+
+def test_respects_max_pages_cap(httpx_mock) -> None:
+    """``num_pages`` may report 12k+ on the live site — instance cap
+    must hard-stop the sweep regardless."""
+    httpx_mock.add_response(
+        url="https://www.shine.com/job-search/all-jobs",
+        html=_page(
+            [_result(job_id=1)], page=1, num_pages=100,
+        ),
+    )
+    # No mock for page 2 onwards — if the scraper requested them, the
+    # mock library would raise.
+    jobs = ShineScraper("any", max_pages=1).fetch()
+    assert [j.ats_id for j in jobs] == ["1"]
+
+
+def test_dedupes_overlapping_pages(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://www.shine.com/job-search/all-jobs",
+        html=_page(
+            [_result(job_id=i) for i in range(5)],
+            page=1, num_pages=2,
+        ),
+    )
+    httpx_mock.add_response(
+        url="https://www.shine.com/job-search/all-jobs-2",
+        html=_page(
+            # Repeats ids 3 and 4 from page 1.
+            [_result(job_id=i) for i in [3, 4, 5, 6]],
+            page=2, num_pages=2,
+        ),
+    )
+    jobs = ShineScraper("any").fetch()
+    assert sorted(j.ats_id for j in jobs) == ["0", "1", "2", "3", "4", "5", "6"]
+
+
+# --- location / country inference -------------------------------------------
+
+
+def test_all_india_marker_sets_country_iso_in(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_LISTING_RE,
+        html=_page([_result(locations=["All India"])]),
+    )
+    jobs = ShineScraper("any").fetch()
+    assert jobs[0].country_iso == "IN"
+    assert jobs[0].location == "All India"
+
+
+def test_city_list_joins_and_keeps_in(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_LISTING_RE,
+        html=_page([_result(locations=["Bangalore", "Pune"])]),
+    )
+    jobs = ShineScraper("any").fetch()
+    assert jobs[0].location == "Bangalore, Pune"
+    assert jobs[0].country_iso == "IN"
+
+
+def test_non_india_location_leaves_country_iso_blank(httpx_mock) -> None:
+    """Shine carries occasional Gulf / SEA listings (``Dubai``,
+    ``Singapore``). Don't claim ``IN`` for those — leave it None so
+    downstream enrichment can fix."""
+    httpx_mock.add_response(
+        url=_LISTING_RE,
+        html=_page([_result(locations=["Dubai"])]),
+    )
+    jobs = ShineScraper("any").fetch()
+    assert jobs[0].location == "Dubai"
+    assert jobs[0].country_iso is None
+
+
+def test_empty_location_list_yields_none(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_LISTING_RE,
+        html=_page([_result(locations=[])]),
+    )
+    jobs = ShineScraper("any").fetch()
+    assert jobs[0].location is None
+    assert jobs[0].country_iso is None
+
+
+# --- field parsing edge cases -----------------------------------------------
+
+
+def test_experience_range_parses_min_and_max(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_LISTING_RE,
+        html=_page([
+            _result(job_id=1, experience="3 to 7 Yrs"),
+            _result(job_id=2, experience="15 to 19 Yrs"),
+        ]),
+    )
+    jobs = sorted(ShineScraper("any").fetch(), key=lambda j: j.ats_id)
+    assert jobs[0].experience == 3
+    assert jobs[0].raw["experience_max"] == 7
+    assert jobs[1].experience == 15
+    assert jobs[1].raw["experience_max"] == 19
+
+
+def test_experience_missing_leaves_none(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_LISTING_RE,
+        html=_page([_result(experience="")]),
+    )
+    j = ShineScraper("any").fetch()[0]
+    assert j.experience is None
+    assert (j.raw or {}).get("experience_max") is None
+
+
+def test_hidden_salary_dropped(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_LISTING_RE,
+        html=_page([_result(salary="[Salary Hidden]")]),
+    )
+    j = ShineScraper("any").fetch()[0]
+    assert j.salary_summary is None
+    assert j.salary_currency is None
+
+
+def test_explicit_salary_kept_as_summary(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_LISTING_RE,
+        html=_page([_result(salary="6 to 12 Lakh")]),
+    )
+    j = ShineScraper("any").fetch()[0]
+    assert j.salary_summary == "6 to 12 Lakh"
+
+
+def test_skips_jobs_missing_id_or_title(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_LISTING_RE,
+        html=_page([
+            _result(job_id=1, title="Good"),
+            {"id": 2, "jCName": "X"},  # no title
+            {"jJT": "No id", "jCName": "X"},  # no id
+        ]),
+    )
+    jobs = ShineScraper("any").fetch()
+    assert [j.ats_id for j in jobs] == ["1"]
+
+
+def test_fallback_url_when_slug_missing(httpx_mock) -> None:
+    """Defensive: if ``jSlug`` is ever absent or empty, build the
+    URL from the bare id so we still emit a usable Job."""
+    httpx_mock.add_response(
+        url=_LISTING_RE,
+        html=_page([_result(job_id=99, slug="")]),
+    )
+    j = ShineScraper("any").fetch()[0]
+    assert str(j.url) == "https://www.shine.com/jobs/99"
+
+
+# --- error handling ---------------------------------------------------------
+
+
+def test_persistent_500_raises(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_LISTING_RE, status_code=500, is_reusable=True,
+    )
+    with pytest.raises(ScraperError):
+        ShineScraper("any").fetch()
+
+
+def test_missing_next_data_returns_empty(httpx_mock) -> None:
+    """If Shine ever serves a listing without the embedded payload
+    (or a Cloudflare interstitial), we should yield zero jobs rather
+    than blow up the entire fetch."""
+    httpx_mock.add_response(
+        url=_LISTING_RE,
+        html="<html><body>no payload here</body></html>",
+    )
+    jobs = ShineScraper("any").fetch()
+    assert jobs == []


### PR DESCRIPTION
## Summary

- New `ShineScraper` for [Shine.com](https://www.shine.com) — one of India's top general-purpose jobs boards (~240k live postings, ~12k pages of 20 results each). Single-source pattern matches `wanted` / `getonbrd` / `bundesagentur`.
- Parses the embedded `__NEXT_DATA__` Next.js payload on each `/job-search/all-jobs[-N]` listing page — no per-job detail fetches needed. Each result entry carries title, company, locations, posted-at, description, experience range, industry, skills.
- `country_iso="IN"` set when the location matches an India marker (`All India` / `Bangalore` / `Mumbai` / … ); left `None` for ambiguous Gulf / SEA postings so downstream enrichment can fix them.
- Adds `ATSType.SHINE = "shine"` and registers the scraper. Updates `tests/test_models.py` to keep the enum-membership contract in sync.

## Notes

- Live smoke verified — 40 jobs across 2 pages with proper IDs, URLs, locations, experience ranges.
- Listing salaries are uniformly `[Salary Hidden]` in observed live data; we drop that literal so `salary_summary` stays clean. Real salary strings (rare) pass through verbatim.
- `max_pages` defaults to 300 (~6,000 jobs) because a full 12k-page sweep is impractical; re-run picks up newest postings.
- Pagination shape: page 1 is `/job-search/all-jobs` (no suffix), page N≥2 is `/job-search/all-jobs-N`.

## Test plan

- [x] `uv run pytest tests/test_shine.py tests/test_models.py` — 80 passed
- [x] `uv run pytest -q --ignore=tests/test_cli.py` — 884 passed, no regressions
- [x] `uv run ruff check src tests` — clean
- [x] Live smoke against shine.com — `ShineScraper("any", max_pages=2).fetch()` returned 40 valid jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `ShineScraper` for Shine.com to ingest India job listings by parsing embedded Next.js `__NEXT_DATA__` on listing pages, avoiding per‑job requests. Fixes pagination to stop on persistent fetch errors and corrects `_format_location` so non‑list strings produce a display location and proper `country_iso`.

- **New Features**
  - Scrapes `/job-search/all-jobs` and `/job-search/all-jobs-N` via the `__NEXT_DATA__` results array.
  - Captures title, company, locations, posted date, description, experience range, industry, skills, salary.
  - Sets `country_iso="IN"` for India markers; `None` for non‑India/ambiguous locations.
  - Drops “[Salary Hidden]”; keeps explicit salaries.
  - Defaults to `max_pages=300` (~6k jobs), respects `num_pages`.
  - Adds `ats-companies/shine.csv` seed (name, slug, URL).

<sup>Written for commit fa19a4f17958669fa5878617205b387f19612229. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `ShineScraper`, a new single-source scraper for Shine.com (India's general-purpose job board) that paginates `/job-search/all-jobs[-N]` pages and parses the embedded Next.js `__NEXT_DATA__` payload to extract job listings without per-job detail fetches. The supporting wiring (`ATSType.SHINE`, registry, tests) is clean and follows the established pattern.

- **`shine.py`**: Core scraper; parses `__NEXT_DATA__`, infers `country_iso` from location strings, handles salary/experience/skills extraction, and retries on 429/5xx — but has a pagination-control bug where a `ScraperError` during deep pagination is logged as \"stopping\" while the outer loop actually continues, hammering the server unnecessarily.
- **`tests/test_shine.py`**: Good coverage of parsing edge cases, pagination, deduplication, and error paths; the early-exit-on-error scenario is not tested, which is why the bug above was not caught.

<h3>Confidence Score: 3/5</h3>

The scraper wiring and parsing logic are solid, but the pagination error-handling in shine.py does not work as documented — after a persistent fetch failure the loop continues hitting subsequent pages rather than stopping, which can turn a brief rate-limit block into hundreds of redundant retries.

The core scraping, parsing, and deduplication logic is well-written and well-tested. The bug in `one()` — where returning on `ScraperError` is logged as "stopping" but the outer for-loop silently continues to the next page — is a real behavioral defect on the retry/error path.

src/jobhive/scrapers/shine.py — specifically the `one()` inner function and the outer pagination loop around lines 155–185.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/shine.py | New ShineScraper implementation; has a real bug where ScraperError on any page is logged as "stopping" but pagination silently continues, plus a dead semaphore and a minor operator-precedence issue in _format_location. |
| tests/test_shine.py | Comprehensive test suite covering pagination, deduplication, location/country inference, salary, experience parsing, and error paths; no issues found. |
| src/jobhive/models.py | Adds ATSType.SHINE enum value in the correct "Hybrid jobboards" section; straightforward and correct. |
| src/jobhive/scrapers/__init__.py | Registers ShineScraper import and __all__ export; follows existing conventions correctly. |
| tests/test_models.py | Adds "shine" to the enum-membership contract check; correct and minimal change. |
| ats-companies/shine.csv | Single-row seed file for Shine company metadata; correct format. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/jobhive/scrapers/shine.py:168-180
**`one()` logs "stopping" but the outer loop keeps going**

When `_fetch_listing_text` raises `ScraperError` (e.g. after `MAX_RETRIES` 429s or 5xx responses), `one()` logs `"Shine: stopping at page %d … keeping %d jobs"` and returns — but returning from the inner function does NOT break the outer `for` loop. The loop immediately calls `one(page + 1)`, repeating the same failing requests all the way to `last_page`. This is both semantically wrong (the log message says "stopping") and counterproductive: you keep hammering a server that is already blocking you, burning retries and time on every subsequent page before finally giving up. A flag checked by the outer loop (or re-raising) is needed to make the early-exit intent work.

### Issue 2 of 3
src/jobhive/scrapers/shine.py:371-372
**`_format_location` always returns `None` as the display location for non-list string input**

Due to Python operator-precedence rules, `return None, "IN" if … else None` is parsed as `return (None, ("IN" if … else None))` — the first tuple element (location display) is always `None` regardless of the string value. If `jLoc` ever arrives as a bare string rather than a list, the job location field is silently dropped. The intent appears to be to return the string itself as the location.

```suggestion
    if not isinstance(value, list):
        if isinstance(value, str) and value.strip():
            return value.strip(), "IN"
        return None, None
```

### Issue 3 of 3
src/jobhive/scrapers/shine.py:139-160
**`MAX_CONCURRENCY` semaphore has no effect in sequential pagination**

`sem = asyncio.Semaphore(MAX_CONCURRENCY)` is created and passed down to every HTTP call, but the outer loop does `await one(page)` — awaiting each page to completion before starting the next. With only one coroutine ever awaiting the semaphore at a time, it cannot provide any parallelism; the constant `MAX_CONCURRENCY = 4` and all the semaphore machinery are dead weight. This isn't a correctness bug, but it will surprise anyone who reads the code expecting concurrent fetching, and it means the scraper runs slower than it could (300 pages × ~1 s each).

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ats-companies seed CSV: shine.csv"](https://github.com/kalil0321/ats-scrapers/commit/272ac2e05c8d2abe3a863b3032a5ffe6341c7e11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732514)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->