### PR TITLE
Expand Beisen coverage from 8 to 90 live tenants

### DIFF
--- a/ats-companies/beisen.csv
+++ b/ats-companies/beisen.csv
@@ -7,3 +7,85 @@ Mindray,mindray,https://mindray.zhiye.com
 Starbucks China,starbucks,https://starbucks.zhiye.com
 Uniqlo China,uniqlo,https://uniqlo.zhiye.com
 Vivo,vivo,https://vivo.zhiye.com
+360 Group Campus,360campus,https://360campus.zhiye.com
+3SBio,3sbio,https://3sbio.zhiye.com
+51Talk,51talk,https://51talk.zhiye.com
+Amoytop Biotech,amoytop,https://amoytop.zhiye.com
+ASUS (Suzhou),asustek,https://asustek.zhiye.com
+Asymchem,asymchem,https://asymchem.zhiye.com
+AUX Group,auxgroup,https://auxgroup.zhiye.com
+BAIC Group,baicgroup,https://baicgroup.zhiye.com
+Bank of Beijing,bankofbeijing,https://bankofbeijing.zhiye.com
+Bank of Suzhou,suzhoubank,https://suzhoubank.zhiye.com
+Bette Pharmaceutical,btyy,https://btyy.zhiye.com
+Biwin Storage,biwin,https://biwin.zhiye.com
+Canon China,canon,https://canon.zhiye.com
+CCD Cabin Design,ccd,https://ccd.zhiye.com
+CETC Chip Technology,cetccq,https://cetccq.zhiye.com
+Changan Auto,changan,https://changan.zhiye.com
+ChangXin Memory (CXMT),cxmt,https://cxmt.zhiye.com
+China Merchants Group,cmhk,https://cmhk.zhiye.com
+China Unicom,chinaunicom,https://chinaunicom.zhiye.com
+China Unicom (Legacy),unicom,https://unicom.zhiye.com
+CICC,cicc,https://cicc.zhiye.com
+Cosmx Battery,cosmx,https://cosmx.zhiye.com
+CTTQ Pharma,cttq,https://cttq.zhiye.com
+Dahua,dahua,https://dahua.zhiye.com
+Delixi,delixi,https://delixi.zhiye.com
+Denso China,denso,https://denso.zhiye.com
+Dongfeng Nissan,dongfengnissan,https://dongfengnissan.zhiye.com
+ENN Group,enn,https://enn.zhiye.com
+Genertec,genertec,https://genertec.zhiye.com
+Goldwind,goldwind,https://goldwind.zhiye.com
+Gotion High-Tech,gotion,https://gotion.zhiye.com
+Haitian Group,haitian,https://haitian.zhiye.com
+Hand Enterprise,hand-china,https://hand-china.zhiye.com
+Hello (Hellobike),hellobike,https://hellobike.zhiye.com
+Henlius,henlius,https://henlius.zhiye.com
+HeyTea,heytea,https://heytea.zhiye.com
+Higher Education Press,zhaopinhep,https://zhaopinhep.zhiye.com
+Hitachi Energy,hitachienergy,https://hitachienergy.zhiye.com
+Hollyland,hollyland,https://hollyland.zhiye.com
+Hudong-Zhonghua Shipbuilding,hudong,https://hudong.zhiye.com
+Huolala (Lalamove),huolala,https://huolala.zhiye.com
+Hupu,hupu,https://hupu.zhiye.com
+JAC Motors,jac,https://jac.zhiye.com
+JMC (Jiangling Motors),jmc,https://jmc.zhiye.com
+Kaiyue Group,mu,https://mu.zhiye.com
+Lvshou,lvshou,https://lvshou.zhiye.com
+Manner Coffee,mannercoffee,https://mannercoffee.zhiye.com
+Michelin China,michelin,https://michelin.zhiye.com
+OMRON China,omron,https://omron.zhiye.com
+PICC,picc,https://picc.zhiye.com
+Poly Developments,polycareer,https://polycareer.zhiye.com
+Qilu Pharma,qilu-pharma,https://qilu-pharma.zhiye.com
+Risen Energy,risen,https://risen.zhiye.com
+RT-Mart,rt-mart,https://rt-mart.zhiye.com
+Sansure Biotech,sansurehr,https://sansurehr.zhiye.com
+Sany,sany,https://sany.zhiye.com
+Seven Star (Huachuang Precision),sevenstar,https://sevenstar.zhiye.com
+Shanghai Industrial Investment (SIIC),siic,https://siic.zhiye.com
+Shenergy,shenergy,https://shenergy.zhiye.com
+Shiseido China,shiseido,https://shiseido.zhiye.com
+Sinopharm Guoda,guoyao,https://guoyao.zhiye.com
+Sinotrans,sinotrans,https://sinotrans.zhiye.com
+Solar East,solareast,https://solareast.zhiye.com
+Sugon,sugon,https://sugon.zhiye.com
+Sunwoda,sunwoda,https://sunwoda.zhiye.com
+Tongwei,tongwei,https://tongwei.zhiye.com
+Transsion Holdings,transsion,https://transsion.zhiye.com
+Tsingtao Brewery,tsingtao,https://tsingtao.zhiye.com
+UCloud,ucloud,https://ucloud.zhiye.com
+Uni-President China,uni-president,https://uni-president.zhiye.com
+Wasion Electric,wasionelectric,https://wasionelectric.zhiye.com
+Weichai,weichai,https://weichai.zhiye.com
+Wondershare Campus,wondersharecampus,https://wondersharecampus.zhiye.com
+WuXi AppTec,wuxiapptec,https://wuxiapptec.zhiye.com
+Xinhua Group,xinhua,https://xinhua.zhiye.com
+Yaskawa China,yaskawa,https://yaskawa.zhiye.com
+YMTC (Yangtze Memory),ymtc,https://ymtc.zhiye.com
+ZCZY,zczy,https://zczy.zhiye.com
+Zhejiang Daily Press Group,zjrbjob,https://zjrbjob.zhiye.com
+Zhenghai Magnetics,zhmag,https://zhmag.zhiye.com
+Zhenghai Tech,zh-tech,https://zh-tech.zhiye.com
+Zongshen,zongshen,https://zongshen.zhiye.com


### PR DESCRIPTION
## Summary
- expand the merged Beisen seed from 8 to 90 endpoint-unique live tenants (+82)
- keep this PR data-only; Beisen enum, scraper, resolver, and pipeline support are already merged in #98
- exclude empty portals `fosun` and `mlily`
- exclude alias `sanycampus`, which resolves to the same Beisen `PortalId` as canonical `sany`

## Live validation
Every row was fetched end-to-end through the production `BeisenScraper`, including all pagination and job parsing:

- 90/90 tenants succeeded
- 90 unique slugs and URLs
- 90 unique Beisen `PortalId` values
- 57,691 current jobs
- unique job IDs within every tenant

The two China Unicom endpoints are intentionally retained: they use distinct portal IDs and currently return 19 and 3 jobs with zero overlapping `JobAdId` values.

## CSV checks
- exact `name,slug,url` schema
- every URL matches `https://<slug>.zhiye.com`
- no duplicate slug, URL, or underlying portal
- `git diff --check` passes

Only `ats-companies/beisen.csv` changes.