### PR TITLE
Add 88 validated Darwinbox tenants

### DIFF
--- a/ats-companies/darwinbox.csv
+++ b/ats-companies/darwinbox.csv
@@ -7,3 +7,91 @@ Evalueserve (Lighthouse),lighthouse.com,https://lighthouse.darwinbox.com/ms/cand
 Mygate,mygate,https://mygate.darwinbox.in/ms/candidate/careers
 PwC Asia,pwc.com,https://pwc.darwinbox.com/ms/candidate/careers
 Security Bank Cards (SBC Hero),sbchero.com,https://sbchero.darwinbox.com/ms/candidate/careers
+1mg (Tata 1mg),1mg,https://1mg.darwinbox.in/ms/candidate/careers
+Aarti Industries,aartiindustries,https://aartiindustries.darwinbox.in/ms/candidate/careers
+ABP Network,abpnetwork,https://abpnetwork.darwinbox.in/ms/candidate/careers
+Addof,addof.com,https://addof.darwinbox.com/ms/candidate/careers
+Affle,affle,https://affle.darwinbox.in/ms/candidate/careers
+AgroStar,agrostar,https://agrostar.darwinbox.in/ms/candidate/careers
+Al Fardan Group,alfardan.com,https://alfardan.darwinbox.com/ms/candidate/careers
+Allcargo,allcargo,https://allcargo.darwinbox.in/ms/candidate/careers
+Aragen Life Sciences,aragen,https://aragen.darwinbox.in/ms/candidate/careers
+Arvind,arvind,https://arvind.darwinbox.in/ms/candidate/careers
+Ather Energy,atherenergy,https://atherenergy.darwinbox.in/ms/candidate/careers
+Bajaj Electricals,bel.com,https://bel.darwinbox.com/ms/candidate/careers
+Bank BTPN,btpn.com,https://btpn.darwinbox.com/ms/candidate/careers
+Bharti Airtel Foundation,bhartifoundation,https://bhartifoundation.darwinbox.in/ms/candidate/careers
+Botree Software (HRMS Botree),hrmsbotree,https://hrmsbotree.darwinbox.in/ms/candidate/careers
+Brigade Group,brigadegroup,https://brigadegroup.darwinbox.in/ms/candidate/careers
+BSA,bsa.com,https://bsa.darwinbox.com/ms/candidate/careers
+Busy Bees Asia,busybeesasia.com,https://busybeesasia.darwinbox.com/ms/candidate/careers
+Casagrand,casagrand,https://casagrand.darwinbox.in/ms/candidate/careers
+Coding Ninjas,codingninjas,https://codingninjas.darwinbox.in/ms/candidate/careers
+Cure.fit (Curefit Healthcare),curefit,https://curefit.darwinbox.in/ms/candidate/careers
+Darwinbox (dbx),dbx,https://dbx.darwinbox.in/ms/candidate/careers
+Darwinbox Digital Solutions (dbox),dbox,https://dbox.darwinbox.in/ms/candidate/careers
+Deepak Group,deepak,https://deepak.darwinbox.in/ms/candidate/careers
+DMI Unify (DMI Finance),dmiunify,https://dmiunify.darwinbox.in/ms/candidate/careers
+Duroflex Group,duroflex,https://duroflex.darwinbox.in/ms/candidate/careers
+Edelweiss Life Insurance,edelweisslife,https://edelweisslife.darwinbox.in/ms/candidate/careers
+Emeritus,emeritus,https://emeritus.darwinbox.in/ms/candidate/careers
+Excelra,excelra,https://excelra.darwinbox.in/ms/candidate/careers
+Galaxy Surfactants,mygalaxy,https://mygalaxy.darwinbox.in/ms/candidate/careers
+Glenmark,glenmark,https://glenmark.darwinbox.in/ms/candidate/careers
+Great Learning,greatlearning,https://greatlearning.darwinbox.in/ms/candidate/careers
+GYS,gys.com,https://gys.darwinbox.com/ms/candidate/careers
+Hetero,hetero,https://hetero.darwinbox.in/ms/candidate/careers
+HL Mando India,hrmsmandoindia,https://hrmsmandoindia.darwinbox.in/ms/candidate/careers
+HOH / HFS,hoh,https://hoh.darwinbox.in/ms/candidate/careers
+Honasa Consumer (Mamaearth),honasa,https://honasa.darwinbox.in/ms/candidate/careers
+ITC Hotels,itchotels,https://itchotels.darwinbox.in/ms/candidate/careers
+JSW (My JSW),myjsw,https://myjsw.darwinbox.in/ms/candidate/careers
+Kirloskar Oil Engines,koel,https://koel.darwinbox.in/ms/candidate/careers
+Kissht,ring,https://ring.darwinbox.in/ms/candidate/careers
+Kopi Kenangan,kopikenangan.com,https://kopikenangan.darwinbox.com/ms/candidate/careers
+Kotak Securities,kotaksecurities,https://kotaksecurities.darwinbox.in/ms/candidate/careers
+LeadSquared,leadsquaredhrms,https://leadsquaredhrms.darwinbox.in/ms/candidate/careers
+Licious,licious,https://licious.darwinbox.in/ms/candidate/careers
+Mahindra Logistics,nectar,https://nectar.darwinbox.in/ms/candidate/careers
+MatchMove,matchmove.com,https://matchmove.darwinbox.com/ms/candidate/careers
+Maxicare Healthcare (Philippines),onehrad.com,https://onehrad.darwinbox.com/ms/candidate/careers
+MobiKwik,mobikwik,https://mobikwik.darwinbox.in/ms/candidate/careers
+Modinity Group,modinity.com,https://modinity.darwinbox.com/ms/candidate/careers
+Mordor Intelligence,mordorintelligence,https://mordorintelligence.darwinbox.in/ms/candidate/careers
+More Retail,hrmsmoreretail,https://hrmsmoreretail.darwinbox.in/ms/candidate/careers
+MOVIN Express,movin,https://movin.darwinbox.in/ms/candidate/careers
+MyHR,myhr,https://myhr.darwinbox.in/ms/candidate/careers
+Ninjacart,ninjacart,https://ninjacart.darwinbox.in/ms/candidate/careers
+Niva Bupa Health Insurance (Disha),disha,https://disha.darwinbox.in/ms/candidate/careers
+NIVEA India,nivea,https://nivea.darwinbox.in/ms/candidate/careers
+NoBroker,nobroker,https://nobroker.darwinbox.in/ms/candidate/careers
+OneSource Specialty Pharma (Stelis),stelis,https://stelis.darwinbox.in/ms/candidate/careers
+PDAX (Philippine Digital Asset Exchange),pdax.com,https://pdax.darwinbox.com/ms/candidate/careers
+Piramal,piramal,https://piramal.darwinbox.in/ms/candidate/careers
+Piramal Finance,piramalfinance,https://piramalfinance.darwinbox.in/ms/candidate/careers
+Pluang,pluanghrms.com,https://pluanghrms.darwinbox.com/ms/candidate/careers
+Polycab,polycab,https://polycab.darwinbox.in/ms/candidate/careers
+Porter,porter,https://porter.darwinbox.in/ms/candidate/careers
+RateGain,rategain.com,https://rategain.darwinbox.com/ms/candidate/careers
+RustanCoffee (Starbucks Philippines),partnerconnect.com,https://partnerconnect.darwinbox.com/ms/candidate/careers
+SBI Life Insurance,sbilife,https://sbilife.darwinbox.in/ms/candidate/careers
+Shakey's Group,shakeys.com,https://shakeys.darwinbox.com/ms/candidate/careers
+Singland,singland.com,https://singland.darwinbox.com/ms/candidate/careers
+Singlife,singlife.com,https://singlife.darwinbox.com/ms/candidate/careers
+Spinzone,spinzone,https://spinzone.darwinbox.in/ms/candidate/careers
+SPML Infra,spml,https://spml.darwinbox.in/ms/candidate/careers
+SteriScience Specialties,steriscience.com,https://steriscience.darwinbox.com/ms/candidate/careers
+Strides Pharma Science,strides,https://strides.darwinbox.in/ms/candidate/careers
+Suzlon,suzlon,https://suzlon.darwinbox.in/ms/candidate/careers
+TBO.com,tbo,https://tbo.darwinbox.in/ms/candidate/careers
+Times Internet,timesinternet,https://timesinternet.darwinbox.in/ms/candidate/careers
+TV9 Network (ABCPL),tv9,https://tv9.darwinbox.in/ms/candidate/careers
+Unacademy,unacademy,https://unacademy.darwinbox.in/ms/candidate/careers
+Upstox,upstox,https://upstox.darwinbox.in/ms/candidate/careers
+Vedanta,vhr,https://vhr.darwinbox.in/ms/candidate/careers
+Vivriti Capital,vivriti,https://vivriti.darwinbox.in/ms/candidate/careers
+Yashoda Hospitals Group,yashoda,https://yashoda.darwinbox.in/ms/candidate/careers
+YES Bank,yesforyou,https://yesforyou.darwinbox.in/ms/candidate/careers
+Yotta Infrastructure,yotta,https://yotta.darwinbox.in/ms/candidate/careers
+Zee Media Group,zeemedia,https://zeemedia.darwinbox.in/ms/candidate/careers
+Zydus Group,zydusgroup,https://zydusgroup.darwinbox.in/ms/candidate/careers


### PR DESCRIPTION
## Summary

- Adds 88 new Darwinbox tenants, expanding the seed list from 8 to 96 unique endpoints.
- Rebuilt on the merged current Darwinbox scraper and validated through the live `POST /ms/candidateapi/job/alljobs` API.
- Preserves `.com` in scraper slugs so APAC/GCC tenants resolve to the correct Darwinbox cluster.
- Removes empty/dead candidates and nine duplicate aliases that pointed at already-listed endpoints.

## Live validation

- 145 candidate rows checked through the current scraper.
- 105 rows returned jobs, collapsing to 96 unique live tenant endpoints after alias deduplication.
- 38 empty tenants and 2 dead tenants excluded.
- 5,730 live jobs returned across the 96 unique endpoints.
- No duplicate names, slugs, or URLs in the final CSV.

## Test plan

- [x] Branch rebuilt from current `main` after the Darwinbox scraper merged.
- [x] Final CSV reproduced exactly from the saved live-validation results.
- [x] `.in` and `.com` URL/slug consistency checked.
- [x] Full test suite: 1,241 passed, 2 skipped, 20 deselected.
- [x] Only `ats-companies/darwinbox.csv` changed.
