### PR TITLE
[codex] phenom: add 13 live tenants

### DIFF
--- a/ats-companies/phenom.csv
+++ b/ats-companies/phenom.csv
@@ -84,3 +84,16 @@ https://jobs.advanceautoparts.com,Advance Auto Parts,,en_us,us
 https://jobs.ascension.org,Ascension,,en_us,us
 https://jobs.tjx.com,TJX,,en_global,global
 https://jobs.virginia.edu,University of Virginia,,en_us,us
+https://career.electroluxgroup.com,Electrolux Group,,en_us,us
+https://careers.molsoncoors.com,Molson Coors,,en_us,us
+https://careers.avantorsciences.com,Avantor,,en_us,us
+https://careers.landolakesinc.com,Land O'Lakes,,en_us,us
+https://jobs.organon.com,Organon,,en_us,us
+https://careers.icf.com,ICF,,en_us,us
+https://careers.ace.aaa.com,AAA - Auto Club Enterprises,,en_us,us
+https://workwithus.circlek.com,Circle K,,en_us,us
+https://jobs.sutterhealth.org,Sutter Health,,en_us,us
+https://careers.baptisthealth.net,Baptist Health,,en_us,us
+https://jobs.ecolab.com,Ecolab,,en_global,global
+https://careers.lilly.com,Lilly,,en_us,us
+https://jobs.veralto.com,Veralto,,en_global,global


### PR DESCRIPTION
## Summary

- Rebuild the stale Phenom expansion on current `main`.
- Add 13 unique tenants that still work through the current `PhenomScraper`.
- Remove 28 proposed tenants that now return 404s, malformed widget responses, blocking responses, or certificate failures.

## Live validation

Every added tenant completed a full end-to-end scraper fetch on 2026-07-23:

| Tenant | Live jobs |
| --- | ---: |
| Electrolux Group | 295 |
| Molson Coors | 201 |
| Avantor | 227 |
| Land O'Lakes | 147 |
| Organon | 142 |
| ICF | 395 |
| AAA - Auto Club Enterprises | 448 |
| Circle K | 9,867 |
| Sutter Health | 1,211 |
| Baptist Health | 1,102 |
| Ecolab | 1,169 |
| Lilly | 692 |
| Veralto | 389 |

Total at validation time: **16,285 live jobs**.

## Checks

- CSV integrity: 98 rows, 98 unique normalized URLs.
- `pytest tests/test_phenom.py tests/test_run_pipeline_guards.py -q` — 41 passed.
- `pytest -q` — 1,167 passed, 2 skipped, 20 deselected.
- `git diff --check`.
