### PR TITLE
bumeran: add multi-country Navent LATAM scraper

### DIFF
--- a/ats-companies/bumeran.csv
+++ b/ats-companies/bumeran.csv
@@ -1,0 +1,7 @@
+name,slug,url
+Bumeran Argentina,ar,https://www.bumeran.com.ar
+Bumeran Peru,pe,https://www.bumeran.com.pe
+Bumeran Ecuador,ec,https://www.bumeran.com.ec
+Bumeran Venezuela,ve,https://www.bumeran.com.ve
+Zona Jobs,ar-zonajobs,https://www.zonajobs.com.ar
+Multitrabajos,ec-multitrabajos,https://www.multitrabajos.com

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -80,6 +80,7 @@ class ATSType(StrEnum):
     THEHUB = "thehub"
     YCOMBINATOR = "ycombinator"
     WELLFOUND = "wellfound"
+    BUMERAN = "bumeran"
     # Additional multi-tenant ATSes (post-0.1)
     BAMBOOHR = "bamboohr"
     BREEZY = "breezy"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -17,6 +17,7 @@ from jobhive.scrapers.bamboohr import BambooHRScraper
 from jobhive.scrapers.base import BaseScraper, ScraperRegistry, get_scraper
 from jobhive.scrapers.breezy import BreezyScraper
 from jobhive.scrapers.builtin import BuiltInScraper
+from jobhive.scrapers.bumeran import BumeranScraper
 from jobhive.scrapers.bundesagentur import BundesagenturScraper
 from jobhive.scrapers.cornerstone import CornerstoneScraper
 from jobhive.scrapers.eightfold import EightfoldScraper
@@ -69,6 +70,7 @@ __all__ = [
     "BaseScraper",
     "BreezyScraper",
     "BuiltInScraper",
+    "BumeranScraper",
     "BundesagenturScraper",
     "CornerstoneScraper",
     "EightfoldScraper",

--- a/src/jobhive/scrapers/bumeran.py
+++ b/src/jobhive/scrapers/bumeran.py
@@ -1,0 +1,472 @@
+"""Bumeran / Navent (LATAM family) — multi-country jobboard scraper.
+
+Bumeran is the consumer brand of Navent, a regional jobboard platform
+that serves 5+ Spanish-speaking Latin American countries from a single
+shared backend. The same React/SPA frontend and same ``/api/avisos/...``
+JSON API power every regional site — only the brand, ``x-site-id``
+header, and country in the data differ. The sister brands
+``zonajobs.com.ar`` (Argentina) and ``multitrabajos.com`` (Ecuador)
+also ride on the same backend.
+
+Public JSON API at ``POST /api/avisos/searchV2`` — no auth, no API key.
+The request is gated by Cloudflare's bot manager: a bare ``httpx``
+request returns 403, but TLS+h2 fingerprint impersonation via
+``httpcloak`` (already in the ``scrapers`` extra) plus a one-shot
+landing-page GET to acquire the ``__cf_*`` cookies is enough to clear
+the WAF for the full session. The same pattern is documented in
+``builtin.py`` / ``jazzhr.py``.
+
+API contract reverse-engineered from
+``/candidate/static/js/main.<hash>.js`` on the live frontend:
+
+    POST /api/avisos/searchV2?pageSize=<n>&page=<p>&sort=RELEVANTES
+    Headers:
+      x-site-id: BMAR | BMPE | BMEC | BMVE | ZJAR | ...
+      Origin / Referer: matching site
+      Content-Type: application/json
+    Body: { "filtros": [], "query": "", "internacional": false }
+    Response: { number, size, total, content: [aviso, ...], ... }
+
+Each ``aviso`` in ``content`` ships ``id``, ``titulo``, ``detalle``
+(plain-text body, ~10kB), ``empresa``, ``localizacion``,
+``fechaHoraPublicacion`` (``"DD-MM-YYYY HH:MM:SS"``), ``tipoTrabajo``
+(``Full-time``/``Part-time``/...), ``modalidadTrabajo``
+(``Presencial``/``Remoto``/``Hibrido``), plus ``idArea`` / ``idSubarea``
+classification ids. We map the structured fields to the canonical
+``Job`` schema and keep the area / portal / modality on ``raw`` so the
+downstream pipeline doesn't lose Navent-specific signal.
+
+``company_slug`` picks the region — one of ``ar``, ``pe``, ``ec``,
+``ve``, ``ar-zonajobs``, ``ec-multitrabajos``. The ``cl`` (Chile) and
+``pe-konzerta`` aliases are recognised in the region table but the
+underlying Trabajando.com / Konzerta stacks don't share this API; they
+fall through to an empty result with a logged warning rather than
+crashing the publish pipeline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html as _html
+import json
+import logging
+import re
+from datetime import datetime
+from importlib.util import find_spec
+from typing import TYPE_CHECKING
+
+from jobhive.exceptions import CompanyNotFoundError, ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+log = logging.getLogger(__name__)
+
+# Per-region: base URL, site-id header value, ISO 3166-1 alpha-2 country,
+# ISO 4217 currency (best-effort — the API rarely exposes salary).
+# Order matters for the public-API docstring but not for behaviour.
+REGIONS: dict[str, tuple[str, str, str, str, str]] = {
+    # company_slug -> (base_url, x_site_id, country_iso, language, currency)
+    "ar": ("https://www.bumeran.com.ar", "BMAR", "AR", "es", "ARS"),
+    "pe": ("https://www.bumeran.com.pe", "BMPE", "PE", "es", "PEN"),
+    "ec": ("https://www.bumeran.com.ec", "BMEC", "EC", "es", "USD"),
+    "ve": ("https://www.bumeran.com.ve", "BMVE", "VE", "es", "VES"),
+    "cl": ("https://www.bumeran.cl", "BMCL", "CL", "es", "CLP"),
+    "ar-zonajobs": ("https://www.zonajobs.com.ar", "ZJAR", "AR", "es", "ARS"),
+    "pe-konzerta": ("https://www.konzerta.com.pe", "BMPE", "PE", "es", "PEN"),
+    # multitrabajos shares the BMEC site-id with bumeran.com.ec — same
+    # backend tenant, different brand surface.
+    "ec-multitrabajos": ("https://www.multitrabajos.com", "BMEC", "EC", "es", "USD"),
+}
+
+# Sites whose backend isn't on the shared searchV2 API. The scraper
+# accepts the slug (so the caller can keep a uniform config) but logs a
+# warning and returns an empty list. Move out once a working endpoint
+# is documented.
+_UNSUPPORTED_SLUGS: frozenset[str] = frozenset({"cl", "pe-konzerta"})
+
+PAGE_SIZE = 100  # API hard-caps at 100; lower values just paginate more.
+MAX_RETRIES = 4
+RETRY_BASE_DELAY = 2.0
+# Cloudflare rate-limits aggressive bursts on the same edge cookie.
+# Three concurrent page fetches finishes a 100k-row country in ~5min.
+MAX_CONCURRENCY = 3
+
+# Per ``tipoTrabajo`` value -> canonical EmploymentType. Lowercased
+# before lookup so "Full-time" / "FULL_TIME" / "full-time" all match.
+_TIPO_TRABAJO_MAP: dict[str, str] = {
+    "full-time": "FULL_TIME",
+    "full time": "FULL_TIME",
+    "tiempo completo": "FULL_TIME",
+    "part-time": "PART_TIME",
+    "part time": "PART_TIME",
+    "medio tiempo": "PART_TIME",
+    "tiempo parcial": "PART_TIME",
+    "freelance": "CONTRACT",
+    "contractor": "CONTRACT",
+    "por hora": "CONTRACT",
+    "temporario": "TEMPORARY",
+    "temporal": "TEMPORARY",
+    "pasantia": "INTERN",
+    "pasantía": "INTERN",
+    "practicas": "INTERN",
+    "prácticas": "INTERN",
+    "internship": "INTERN",
+    "becario": "INTERN",
+    "primer empleo": "FULL_TIME",
+}
+
+_TAG_RE = re.compile(r"<[^>]+>")
+# Bumeran's API ships ``fechaHoraPublicacion`` as ``DD-MM-YYYY HH:MM:SS``
+# in the site's local time. We only have date-level granularity for
+# matching, so the time part is best-effort.
+_DATE_FMT = "%d-%m-%Y %H:%M:%S"
+_DATE_ONLY_FMT = "%d-%m-%Y"
+
+
+@ScraperRegistry.register(ATSType.BUMERAN)
+class BumeranScraper(BaseScraper):
+    """Bumeran / Navent (LATAM family) — multi-country jobboard.
+
+    ``company_slug`` selects the country / brand. Recognised values:
+
+    - ``ar`` — bumeran.com.ar (Argentina)
+    - ``pe`` — bumeran.com.pe (Peru)
+    - ``ec`` — bumeran.com.ec (Ecuador)
+    - ``ve`` — bumeran.com.ve (Venezuela)
+    - ``cl`` — bumeran.cl (Chile) — *not on shared API; returns []*
+    - ``ar-zonajobs`` — zonajobs.com.ar (Argentina alt brand)
+    - ``pe-konzerta`` — konzerta.com.pe (Peru alt brand) — *unreachable*
+    - ``ec-multitrabajos`` — multitrabajos.com (Ecuador alt brand)
+
+    Optional knobs:
+
+    - ``max_pages`` — pagination cap (default 1000, covers every
+      currently active country at PAGE_SIZE=100).
+    - ``client_kind`` — ``"httpcloak"`` (default) uses TLS+h2
+      impersonation to clear Cloudflare; ``"httpx"`` skips httpcloak
+      for diagnostic comparison and will 403 in production.
+
+    The class returns ``[]`` (with a warning log) when ``httpcloak``
+    isn't installed so the publish pipeline doesn't crash on operators
+    that haven't picked up the ``scrapers`` extra.
+    """
+
+    ats = ATSType.BUMERAN
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        max_pages: int = 1000,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        if company_slug not in REGIONS:
+            raise CompanyNotFoundError(
+                f"Bumeran: unknown region {company_slug!r}. "
+                f"Known: {sorted(REGIONS)}"
+            )
+        self.max_pages = max_pages
+        (
+            self._base_url,
+            self._site_id,
+            self._country_iso,
+            self._language,
+            self._currency,
+        ) = REGIONS[company_slug]
+
+    def fetch(self) -> list[Job]:
+        if self.company_slug in _UNSUPPORTED_SLUGS:
+            log.warning(
+                "Bumeran: region %r is recognised but its backend is not "
+                "on the shared searchV2 API yet — returning [].",
+                self.company_slug,
+            )
+            return []
+        if find_spec("httpcloak") is None:
+            log.warning(
+                "Bumeran: httpcloak is required to clear Cloudflare on "
+                "Navent's API — install with `pip install jobhive[scrapers]`. "
+                "Returning []."
+            )
+            return []
+        return asyncio.run(self._fetch_async())
+
+    # --- listing fetch ------------------------------------------------------
+
+    async def _fetch_async(self) -> list[Job]:
+        # Establish a single httpcloak session for the whole scrape. The
+        # landing-page GET seeds Cloudflare's __cf_* cookies that the
+        # subsequent /api/avisos/searchV2 POSTs need to pass the WAF.
+        session = await asyncio.to_thread(self._open_session)
+        first = await asyncio.to_thread(self._search_page, session, 0)
+        total = int(first.get("total") or 0)
+        size = int(first.get("size") or PAGE_SIZE)
+        if size <= 0:
+            size = PAGE_SIZE
+        # ``size`` from the API is the number of rows actually returned
+        # on this page, not the requested pageSize — when only a handful
+        # of jobs exist, ``size`` is small but the math still holds.
+        total_pages = min(
+            self.max_pages,
+            (total + size - 1) // size if total else 1,
+        )
+
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        lock = asyncio.Lock()
+
+        async def absorb(payload: dict[str, Any]) -> None:
+            parsed = [self._parse_job(item) for item in (payload.get("content") or [])]
+            async with lock:
+                for j in parsed:
+                    if j is None or j.ats_id in seen:
+                        continue
+                    seen.add(j.ats_id)
+                    jobs.append(j)
+
+        await absorb(first)
+        if total_pages <= 1:
+            return jobs
+
+        sem = asyncio.Semaphore(MAX_CONCURRENCY)
+
+        async def per_page(page: int) -> None:
+            async with sem:
+                payload = await asyncio.to_thread(
+                    self._search_page, session, page,
+                )
+            await absorb(payload)
+
+        await asyncio.gather(*(per_page(p) for p in range(1, total_pages)))
+        return jobs
+
+    # --- httpcloak transport ------------------------------------------------
+
+    def _open_session(self) -> Any:
+        """Create an httpcloak Session, prime it with the landing page so
+        Cloudflare drops the right cookies, and return it."""
+        import httpcloak
+
+        session = httpcloak.Session()
+        landing = f"{self._base_url}/empleos.html"
+        try:
+            response = session.get(landing, timeout=self.timeout)
+        except Exception as exc:
+            raise ScraperError(
+                f"Bumeran ({self.company_slug}): landing-page fetch "
+                f"failed: {exc}"
+            ) from exc
+        if response.status_code != 200:
+            raise ScraperError(
+                f"Bumeran ({self.company_slug}): landing returned "
+                f"{response.status_code} (expected 200)"
+            )
+        return session
+
+    def _search_page(self, session: Any, page: int) -> dict[str, Any]:
+        url = (
+            f"{self._base_url}/api/avisos/searchV2"
+            f"?pageSize={PAGE_SIZE}&page={page}&sort=RELEVANTES"
+        )
+        body = {"filtros": [], "query": "", "internacional": False}
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/plain, */*",
+            "Accept-Language": "es-AR,es;q=0.9,en;q=0.8",
+            "Origin": self._base_url,
+            "Referer": f"{self._base_url}/empleos.html",
+            "x-site-id": self._site_id,
+        }
+
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                response = session.post(
+                    url, headers=headers, json=body, timeout=self.timeout,
+                )
+            except Exception as exc:
+                last_exc = exc
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Bumeran ({self.company_slug}) page {page}: "
+                        f"transport failed: {exc}"
+                    ) from exc
+                _sleep(RETRY_BASE_DELAY * attempt)
+                continue
+            status = int(getattr(response, "status_code", 0))
+            text = _response_text(response)
+            if status == 200:
+                try:
+                    return json.loads(text)
+                except ValueError as exc:
+                    # Cloudflare sometimes returns 200 + HTML challenge
+                    # body on transient flaky edges — retry rather than
+                    # surface a misleading parse error.
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"Bumeran ({self.company_slug}) page {page}: "
+                            f"non-JSON 200 body: {exc}"
+                        ) from exc
+                    _sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if status == 404:
+                # Past the last page — caller treats empty content as EOF.
+                return {"content": [], "total": 0, "size": 0, "number": page}
+            if status == 403 or status == 429 or 500 <= status < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Bumeran ({self.company_slug}) page {page}: "
+                        f"status {status} after {MAX_RETRIES} retries"
+                    )
+                _sleep(RETRY_BASE_DELAY * (2 ** attempt))
+                continue
+            raise ScraperError(
+                f"Bumeran ({self.company_slug}) page {page}: "
+                f"unexpected status {status}"
+            )
+        raise ScraperError(
+            f"Bumeran ({self.company_slug}) page {page}: "
+            f"exhausted retries: {last_exc}"
+        )
+
+    # --- parsing ------------------------------------------------------------
+
+    def _parse_job(self, item: dict[str, Any]) -> Job | None:
+        raw_id = item.get("id")
+        if raw_id is None:
+            return None
+        ats_id = str(raw_id)
+        title = (item.get("titulo") or "").strip()
+        if not ats_id or not title:
+            return None
+
+        # Synthesize the canonical detail URL — Bumeran's frontend uses
+        # ``/empleos/<slug>-<id>.html`` and accepts ``aviso-<id>.html``
+        # as an alias (verified live: 200 with the SPA shell, which
+        # then bootstraps the same detail data we already have from the
+        # listing). Use the alias so we don't have to slugify titles
+        # with diacritics.
+        url = f"{self._base_url}/empleos/aviso-{ats_id}.html"
+
+        company_name = (item.get("empresa") or "").strip()
+        # Bumeran flags confidential listings — keep the empty company
+        # value visible as "Confidencial" so downstream rows don't
+        # silently fall back to a numeric employer id.
+        if item.get("confidencial") and not company_name:
+            company_name = "Confidencial"
+        if not company_name:
+            company_name = "Unknown"
+
+        location = (item.get("localizacion") or "").strip() or None
+
+        modalidad = (item.get("modalidadTrabajo") or "").strip()
+        is_remote: bool | None = None
+        if modalidad:
+            mlow = modalidad.lower()
+            if "remoto" in mlow or "remote" in mlow or "home office" in mlow:
+                is_remote = True
+            elif "presencial" in mlow:
+                is_remote = False
+            # Hybrid / mixed leaves is_remote=None — the downstream
+            # enrichment can decide once it sees the description.
+
+        tipo = (item.get("tipoTrabajo") or "").strip()
+        employment_type = _TIPO_TRABAJO_MAP.get(tipo.lower())
+
+        description = _clean_description(item.get("detalle"))
+
+        posted_at = _parse_datetime(
+            item.get("fechaHoraPublicacion") or item.get("fechaPublicacion"),
+        )
+
+        raw: dict[str, Any] = {}
+        for key in (
+            "idArea", "idSubarea", "idEmpresa", "idPais",
+            "portal", "planPublicacion", "modalidadTrabajo",
+            "tipoTrabajo", "tipoAviso", "cantidadVacantes",
+            "aptoDiscapacitado", "confidencial", "empresaPro",
+            "postulacionRapida",
+        ):
+            v = item.get(key)
+            if v not in (None, "", []):
+                raw[key] = v
+        raw["country_alias"] = self.company_slug
+        raw["site_id"] = self._site_id
+
+        return Job(
+            url=url,
+            title=title,
+            company=company_name,
+            ats_type=ATSType.BUMERAN,
+            ats_id=ats_id,
+            location=location,
+            country_iso=self._country_iso,
+            region="South America",
+            is_remote=is_remote,
+            employment_type=employment_type,
+            commitment=tipo or None,
+            description=description,
+            posted_at=posted_at,
+            fetched_at=datetime.now(),
+            language=self._language,
+            raw=raw or None,
+        )
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+def _response_text(response: Any) -> str:
+    """Return response body as text, tolerating httpcloak's variable API."""
+    text = getattr(response, "text", None)
+    if isinstance(text, str):
+        return text
+    content = getattr(response, "content", b"")
+    if isinstance(content, bytes):
+        return content.decode("utf-8", errors="replace")
+    return str(content)
+
+
+def _sleep(seconds: float) -> None:
+    """Synchronous sleep used inside the httpcloak (blocking) path. We
+    can't call ``asyncio.sleep`` here because the function runs inside
+    ``asyncio.to_thread`` so the event loop is on another thread."""
+    import time
+
+    time.sleep(seconds)
+
+
+def _clean_description(value: object) -> str | None:
+    """Bumeran's ``detalle`` ships as plain text but with HTML entities
+    (``&#x1f50e;``, ``&amp;``) interleaved. Decode entities, strip any
+    stray tags, collapse whitespace, and truncate to the canonical
+    ~10kB description budget."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    cleaned = _TAG_RE.sub(" ", value)
+    cleaned = _html.unescape(cleaned)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    if not cleaned:
+        return None
+    return cleaned[:10_000]
+
+
+def _parse_datetime(value: object) -> datetime | None:
+    """Parse Bumeran's ``DD-MM-YYYY HH:MM:SS`` (and date-only fallback).
+
+    The API ships local time without a zone — we keep it as naive
+    datetime and let the downstream enrichment localize. Returns None
+    for any unparsable input rather than guessing."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    s = value.strip()
+    for fmt in (_DATE_FMT, _DATE_ONLY_FMT):
+        try:
+            return datetime.strptime(s, fmt)
+        except ValueError:
+            continue
+    return None

--- a/tests/test_bumeran.py
+++ b/tests/test_bumeran.py
@@ -1,0 +1,521 @@
+"""Tests for the Bumeran / Navent (LATAM) scraper.
+
+Bumeran sits behind Cloudflare and so uses ``httpcloak`` for transport
+instead of ``httpx``. ``httpx_mock`` doesn't intercept httpcloak, so the
+test suite stubs the two seams the scraper exposes:
+
+- ``BumeranScraper._open_session`` — returns a sentinel "session"
+- ``BumeranScraper._search_page`` — returns a canned API payload
+
+Both are thin wrappers around the blocking httpcloak path, so faking
+them lets us exercise pagination, multi-region wiring, and field
+mapping without ever hitting the network.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from jobhive.exceptions import CompanyNotFoundError, ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import BumeranScraper, ScraperRegistry
+from jobhive.scrapers.bumeran import (
+    PAGE_SIZE,
+    REGIONS,
+    _clean_description,
+    _parse_datetime,
+)
+
+# --- fixtures ---------------------------------------------------------------
+
+
+def _aviso(
+    *,
+    job_id: int = 1,
+    titulo: str = "Analista de Datos",
+    empresa: str = "Acme S.A.",
+    localizacion: str = "Buenos Aires, Argentina",
+    tipo_trabajo: str = "Full-time",
+    modalidad: str = "Presencial",
+    fecha: str = "11-05-2026 23:43:58",
+    detalle: str = "Buscamos analista de datos con experiencia en SQL.",
+    confidencial: bool = False,
+    id_area: int = 23,
+    id_subarea: int = 2569,
+    id_empresa: int = 13480073,
+    portal: str = "bumeran",
+    cantidad_vacantes: int = 1,
+) -> dict[str, Any]:
+    """Build a single ``content[i]`` entry matching the live searchV2 shape."""
+    return {
+        "id": job_id,
+        "titulo": titulo,
+        "detalle": detalle,
+        "aptoDiscapacitado": False,
+        "idEmpresa": id_empresa,
+        "empresa": empresa,
+        "confidencial": confidencial,
+        "logoURL": None,
+        "validada": None,
+        "empresaPro": False,
+        "fechaHoraPublicacion": fecha,
+        "fechaPublicacion": fecha.split(" ")[0] if " " in fecha else fecha,
+        "fechaModificado": fecha,
+        "planPublicacion": {"id": 1020, "nombre": "Aviso Talento"},
+        "portal": portal,
+        "tipoTrabajo": tipo_trabajo,
+        "idPais": 1,
+        "idArea": id_area,
+        "idSubarea": id_subarea,
+        "leido": None,
+        "visitadoPorPostulante": None,
+        "localizacion": localizacion,
+        "cantidadVacantes": cantidad_vacantes,
+        "guardado": None,
+        "gptwUrl": None,
+        "promedioEmpresa": None,
+        "modalidadTrabajo": modalidad,
+        "tienePreguntas": False,
+        "salarioObligatorio": False,
+        "altaRevisionPerfiles": False,
+        "postulacionRapida": True,
+        "tipoAviso": "talento",
+    }
+
+
+def _page_response(
+    items: list[dict[str, Any]],
+    *,
+    page: int = 0,
+    total: int | None = None,
+    size: int | None = None,
+) -> dict[str, Any]:
+    """Build a full searchV2 envelope around the provided ``content`` items."""
+    return {
+        "number": page,
+        "size": size if size is not None else len(items),
+        "total": total if total is not None else len(items),
+        "content": items,
+        "filters": [],
+        "filtersApplied": [],
+        "totalSearched": total if total is not None else len(items),
+        "homeList": None,
+    }
+
+
+@pytest.fixture
+def patched_scraper(monkeypatch: pytest.MonkeyPatch):
+    """Return a factory that builds a ``BumeranScraper`` with the
+    network seams (``_open_session`` / ``_search_page``) stubbed to a
+    page-indexed payload map. Any page index not in the map yields an
+    empty page (mirrors how the live API responds past the last page).
+    """
+
+    def _factory(
+        company_slug: str = "ar",
+        *,
+        pages: dict[int, dict[str, Any]] | None = None,
+    ) -> BumeranScraper:
+        pages = pages or {}
+        # Always make httpcloak look installed so .fetch() doesn't
+        # short-circuit to []. The Session itself is never used because
+        # ``_search_page`` is also stubbed.
+        monkeypatch.setattr(
+            "jobhive.scrapers.bumeran.find_spec", lambda _name: object(),
+        )
+        scraper = BumeranScraper(company_slug)
+        monkeypatch.setattr(
+            scraper, "_open_session", lambda: object(),
+        )
+
+        def fake_search(_session: Any, page: int) -> dict[str, Any]:
+            return pages.get(page, _page_response([], page=page, total=0, size=0))
+
+        monkeypatch.setattr(scraper, "_search_page", fake_search)
+        return scraper
+
+    return _factory
+
+
+# --- registry / wiring ------------------------------------------------------
+
+
+def test_registry_resolves_bumeran() -> None:
+    assert ScraperRegistry.get(ATSType.BUMERAN) is BumeranScraper
+
+
+def test_unknown_region_raises_company_not_found() -> None:
+    with pytest.raises(CompanyNotFoundError):
+        BumeranScraper("mx")  # MX isn't in the LATAM Navent footprint
+
+
+@pytest.mark.parametrize(
+    "slug,base_url,country_iso,site_id",
+    [
+        ("ar", "https://www.bumeran.com.ar", "AR", "BMAR"),
+        ("pe", "https://www.bumeran.com.pe", "PE", "BMPE"),
+        ("ec", "https://www.bumeran.com.ec", "EC", "BMEC"),
+        ("ve", "https://www.bumeran.com.ve", "VE", "BMVE"),
+        ("ar-zonajobs", "https://www.zonajobs.com.ar", "AR", "ZJAR"),
+        ("ec-multitrabajos", "https://www.multitrabajos.com", "EC", "BMEC"),
+    ],
+)
+def test_region_table_resolves(
+    slug: str, base_url: str, country_iso: str, site_id: str,
+) -> None:
+    """Every documented slug maps to its known base / country / site-id.
+
+    Catches accidental table edits — the slugs are part of the public
+    interface (companies CSV references them by name)."""
+    assert slug in REGIONS
+    rec = REGIONS[slug]
+    assert rec[0] == base_url
+    assert rec[1] == site_id
+    assert rec[2] == country_iso
+
+
+# --- httpcloak gating -------------------------------------------------------
+
+
+def test_fetch_returns_empty_when_httpcloak_missing(
+    monkeypatch: pytest.MonkeyPatch, caplog,
+) -> None:
+    """When httpcloak isn't installed, the publish pipeline must keep
+    running. The scraper logs a warning and returns []."""
+    import logging
+
+    monkeypatch.setattr(
+        "jobhive.scrapers.bumeran.find_spec", lambda _name: None,
+    )
+    with caplog.at_level(logging.WARNING, logger="jobhive.scrapers.bumeran"):
+        jobs = BumeranScraper("ar").fetch()
+    assert jobs == []
+    assert any("httpcloak" in r.getMessage() for r in caplog.records)
+
+
+def test_unsupported_region_returns_empty_with_warning(
+    monkeypatch: pytest.MonkeyPatch, caplog,
+) -> None:
+    """``cl`` and ``pe-konzerta`` slugs are recognised so callers can keep
+    a uniform company list, but the underlying stacks aren't on the
+    shared searchV2 API. Scraper short-circuits with a warning."""
+    import logging
+
+    # Pretend httpcloak is installed so the early-return is purely about
+    # the slug being unsupported.
+    monkeypatch.setattr(
+        "jobhive.scrapers.bumeran.find_spec", lambda _name: object(),
+    )
+    with caplog.at_level(logging.WARNING, logger="jobhive.scrapers.bumeran"):
+        jobs = BumeranScraper("cl").fetch()
+    assert jobs == []
+    assert any("backend is not" in r.getMessage() for r in caplog.records)
+
+
+# --- happy path: field mapping ----------------------------------------------
+
+
+def test_parses_full_aviso_payload(patched_scraper) -> None:
+    """Every populated Bumeran field maps to the right canonical Job slot.
+
+    Anchors the contract on listings — adding/removing a mapping here is
+    a breaking change for the published dataset."""
+    item = _aviso(
+        job_id=1118287655,
+        titulo="Analista de Control de Calidad",
+        empresa="Follow the Sun",
+        localizacion="Grand Bourg, Buenos Aires",
+        tipo_trabajo="Full-time",
+        modalidad="Presencial",
+        fecha="11-05-2026 23:43:58",
+        detalle="&#x1f50e; Analista con experiencia en HPLC, UV e IR.",
+    )
+    scraper = patched_scraper("ar", pages={0: _page_response([item])})
+    jobs = scraper.fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.BUMERAN
+    assert j.ats_id == "1118287655"
+    assert j.title == "Analista de Control de Calidad"
+    assert j.company == "Follow the Sun"
+    assert str(j.url) == (
+        "https://www.bumeran.com.ar/empleos/aviso-1118287655.html"
+    )
+    assert j.location == "Grand Bourg, Buenos Aires"
+    assert j.country_iso == "AR"
+    assert j.region == "South America"
+    assert j.language == "es"
+    assert j.employment_type == "FULL_TIME"
+    assert j.commitment == "Full-time"
+    assert j.is_remote is False  # Presencial
+    # Description: HTML entities decoded, whitespace collapsed.
+    assert j.description is not None
+    assert "🔎" in j.description or "Analista" in j.description
+    # raw carries Navent-specific fields the canonical schema can't hold.
+    assert j.raw is not None
+    assert j.raw["idArea"] == 23
+    assert j.raw["portal"] == "bumeran"
+    assert j.raw["country_alias"] == "ar"
+    assert j.raw["site_id"] == "BMAR"
+    # posted_at parsed from DD-MM-YYYY HH:MM:SS
+    assert j.posted_at is not None
+    assert j.posted_at.year == 2026
+    assert j.posted_at.month == 5
+    assert j.posted_at.day == 11
+
+
+def test_remoto_modalidad_marks_is_remote_true(patched_scraper) -> None:
+    item = _aviso(modalidad="Remoto")
+    scraper = patched_scraper("pe", pages={0: _page_response([item])})
+    jobs = scraper.fetch()
+    assert jobs[0].is_remote is True
+
+
+def test_hybrid_modalidad_leaves_is_remote_unset(patched_scraper) -> None:
+    """``Híbrido`` postings could be either — defer to the downstream
+    enrichment instead of guessing."""
+    item = _aviso(modalidad="Híbrido")
+    scraper = patched_scraper("ar", pages={0: _page_response([item])})
+    jobs = scraper.fetch()
+    assert jobs[0].is_remote is None
+
+
+def test_confidential_empty_company_maps_to_confidencial(
+    patched_scraper,
+) -> None:
+    """Confidential listings have ``empresa=""``; emit "Confidencial"
+    rather than letting the row default to a numeric employer id."""
+    item = _aviso(empresa="", confidencial=True)
+    scraper = patched_scraper("ar", pages={0: _page_response([item])})
+    jobs = scraper.fetch()
+    assert jobs[0].company == "Confidencial"
+
+
+def test_pasantia_tipo_trabajo_maps_to_intern(patched_scraper) -> None:
+    item = _aviso(tipo_trabajo="Pasantía")
+    scraper = patched_scraper("ar", pages={0: _page_response([item])})
+    jobs = scraper.fetch()
+    assert jobs[0].employment_type == "INTERN"
+
+
+# --- multi-country wiring ---------------------------------------------------
+
+
+def test_zonajobs_country_iso_and_portal(patched_scraper) -> None:
+    """zonajobs.com.ar lives on the AR backend tenant — same currency /
+    country, but the ``portal`` field on the response is ``zonajobs``
+    and the URL we synthesize points at zonajobs.com.ar."""
+    item = _aviso(portal="zonajobs")
+    scraper = patched_scraper("ar-zonajobs", pages={0: _page_response([item])})
+    jobs = scraper.fetch()
+    assert jobs[0].country_iso == "AR"
+    assert str(jobs[0].url).startswith("https://www.zonajobs.com.ar/")
+    assert jobs[0].raw is not None
+    assert jobs[0].raw["country_alias"] == "ar-zonajobs"
+    assert jobs[0].raw["site_id"] == "ZJAR"
+
+
+def test_multitrabajos_uses_ec_country(patched_scraper) -> None:
+    """multitrabajos.com is the EC alt brand — country_iso must follow."""
+    item = _aviso()
+    scraper = patched_scraper(
+        "ec-multitrabajos", pages={0: _page_response([item])},
+    )
+    jobs = scraper.fetch()
+    assert jobs[0].country_iso == "EC"
+    assert str(jobs[0].url).startswith("https://www.multitrabajos.com/")
+    assert jobs[0].raw is not None
+    assert jobs[0].raw["site_id"] == "BMEC"
+
+
+# --- pagination -------------------------------------------------------------
+
+
+def test_paginates_until_total_reached(patched_scraper) -> None:
+    """The first page reports ``total`` and ``size``; subsequent pages
+    are walked until the math says we've covered every row."""
+    page0 = _page_response(
+        [_aviso(job_id=i) for i in range(PAGE_SIZE)],
+        page=0, total=250, size=PAGE_SIZE,
+    )
+    page1 = _page_response(
+        [_aviso(job_id=PAGE_SIZE + i) for i in range(PAGE_SIZE)],
+        page=1, total=250, size=PAGE_SIZE,
+    )
+    page2 = _page_response(
+        [_aviso(job_id=2 * PAGE_SIZE + i) for i in range(50)],
+        page=2, total=250, size=50,
+    )
+    scraper = patched_scraper(
+        "ar", pages={0: page0, 1: page1, 2: page2},
+    )
+    jobs = scraper.fetch()
+    assert len(jobs) == 250
+    assert {int(j.ats_id) for j in jobs} == set(range(250))
+
+
+def test_dedupes_overlapping_pages(patched_scraper) -> None:
+    """A row that appears on consecutive pages must collapse on ats_id —
+    Navent's listing isn't strictly stable across rapid pagination."""
+    page0 = _page_response(
+        [_aviso(job_id=i) for i in range(5)],
+        page=0, total=8, size=5,
+    )
+    page1 = _page_response(
+        [_aviso(job_id=i) for i in (3, 4, 5, 6, 7)],
+        page=1, total=8, size=5,
+    )
+    scraper = patched_scraper("ar", pages={0: page0, 1: page1})
+    jobs = scraper.fetch()
+    assert len({j.ats_id for j in jobs}) == 8
+
+
+def test_single_page_when_total_fits(patched_scraper) -> None:
+    """``total <= size`` should not trigger a second fetch."""
+    fetches: list[int] = []
+
+    def _build(monkey, scraper: BumeranScraper) -> None:
+        original = scraper._search_page
+
+        def _spy(session: Any, page: int) -> dict[str, Any]:
+            fetches.append(page)
+            return original(session, page)
+
+        monkey.setattr(scraper, "_search_page", _spy)
+
+    page0 = _page_response(
+        [_aviso(job_id=i) for i in range(3)], page=0, total=3, size=3,
+    )
+    scraper = patched_scraper("ar", pages={0: page0})
+
+    # The factory already monkey-patched _search_page; wrap it once more
+    # to spy on call counts.
+    with pytest.MonkeyPatch.context() as mp:
+        _build(mp, scraper)
+        jobs = scraper.fetch()
+    assert len(jobs) == 3
+    assert fetches == [0]
+
+
+def test_max_pages_caps_pagination(patched_scraper) -> None:
+    """The ``max_pages`` knob protects against runaway scrapes when the
+    API reports a wildly inflated ``total``."""
+    page0 = _page_response(
+        [_aviso(job_id=i) for i in range(2)],
+        page=0, total=10_000, size=2,
+    )
+    page1 = _page_response(
+        [_aviso(job_id=2 + i) for i in range(2)],
+        page=1, total=10_000, size=2,
+    )
+    scraper = BumeranScraper("ar", max_pages=2)
+    # Re-apply the same stubs the factory uses.
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "jobhive.scrapers.bumeran.find_spec", lambda _name: object(),
+        )
+        mp.setattr(scraper, "_open_session", lambda: object())
+
+        pages = {0: page0, 1: page1}
+
+        def fake(_s: Any, p: int) -> dict[str, Any]:
+            return pages.get(p, _page_response([], page=p, total=0, size=0))
+
+        mp.setattr(scraper, "_search_page", fake)
+        jobs = scraper.fetch()
+    assert len(jobs) == 4
+
+
+# --- defensive parsing ------------------------------------------------------
+
+
+def test_skips_items_missing_id_or_title(patched_scraper) -> None:
+    page0 = _page_response([
+        _aviso(job_id=1, titulo="Good"),
+        {"id": 2, "empresa": "no-title", "detalle": ""},  # no title
+        {"titulo": "no-id"},  # no id
+    ])
+    scraper = patched_scraper("ar", pages={0: page0})
+    jobs = scraper.fetch()
+    assert [j.ats_id for j in jobs] == ["1"]
+
+
+def test_falls_back_for_unparsable_date(patched_scraper) -> None:
+    """If the API ships a weird date, the row still gets emitted with
+    ``posted_at=None`` rather than crashing the whole page."""
+    item = _aviso(fecha="not-a-date")
+    scraper = patched_scraper("ar", pages={0: _page_response([item])})
+    jobs = scraper.fetch()
+    assert jobs[0].posted_at is None
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+def test_clean_description_decodes_entities_and_trims() -> None:
+    assert _clean_description("Hola &amp; <b>mundo</b>  ") == "Hola & mundo"
+
+
+def test_clean_description_returns_none_for_empty() -> None:
+    assert _clean_description("") is None
+    assert _clean_description("   ") is None
+    assert _clean_description(None) is None
+
+
+def test_clean_description_truncates_at_10k() -> None:
+    out = _clean_description("x" * 20_000)
+    assert out is not None
+    assert len(out) == 10_000
+
+
+def test_parse_datetime_accepts_full_and_date_only() -> None:
+    full = _parse_datetime("11-05-2026 23:43:58")
+    assert full is not None
+    assert (full.year, full.month, full.day) == (2026, 5, 11)
+    assert (full.hour, full.minute, full.second) == (23, 43, 58)
+
+    date_only = _parse_datetime("11-05-2026")
+    assert date_only is not None
+    assert (date_only.year, date_only.month, date_only.day) == (2026, 5, 11)
+    assert (date_only.hour, date_only.minute, date_only.second) == (0, 0, 0)
+
+
+def test_parse_datetime_returns_none_for_garbage() -> None:
+    assert _parse_datetime("") is None
+    assert _parse_datetime(None) is None
+    assert _parse_datetime("2026-05-11") is None  # wrong format
+    assert _parse_datetime(12345) is None
+
+
+# --- error handling ---------------------------------------------------------
+
+
+def test_search_page_raises_on_persistent_5xx(monkeypatch) -> None:
+    """Real server failures should surface, not silently emit []."""
+    import jobhive.scrapers.bumeran as bm
+
+    monkeypatch.setattr(bm, "find_spec", lambda _name: object())
+    monkeypatch.setattr(bm, "MAX_RETRIES", 2)
+    monkeypatch.setattr(bm, "RETRY_BASE_DELAY", 0.0)
+
+    class FakeResp:
+        def __init__(self, status: int):
+            self.status_code = status
+            self.text = "boom"
+            self.content = b"boom"
+
+    class FakeSession:
+        def get(self, url: str, timeout: float) -> Any:
+            return FakeResp(200)
+
+        def post(self, url: str, *, headers: Any, json: Any, timeout: float) -> Any:
+            return FakeResp(500)
+
+    scraper = BumeranScraper("ar")
+    monkeypatch.setattr(scraper, "_open_session", lambda: FakeSession())
+    # Use the real _search_page so the retry/raise path is exercised end
+    # to end via the FakeSession above.
+    with pytest.raises(ScraperError):
+        scraper.fetch()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,7 +29,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
-        "manfred", "thehub", "ycombinator", "wellfound",
+        "manfred", "thehub", "ycombinator", "wellfound", "bumeran",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",
         "recruitee", "taleo", "teamtailor",


### PR DESCRIPTION
## Summary

- New `BumeranScraper` covering Navent's shared LATAM job-board platform: `bumeran.com.{ar,pe,ec,ve}`, `zonajobs.com.ar`, and `multitrabajos.com`. All ride the same `POST /api/avisos/searchV2` backend; only the `x-site-id` header and brand surface differ.
- `company_slug` selects the region (`ar`, `pe`, `ec`, `ve`, `cl`, `ar-zonajobs`, `pe-konzerta`, `ec-multitrabajos`). `cl` and `pe-konzerta` are recognised but their underlying stacks aren't on the shared API yet — they short-circuit to `[]` with a warning so a uniform companies CSV doesn't crash the pipeline.
- Cloudflare blocks bare httpx on the API. The scraper uses `httpcloak` (already shipped in the `[scrapers]` extra by builtin / jazzhr) — fetch the landing page once to seed `__cf_*` cookies, then POST searches in the same `httpcloak.Session`. Returns `[]` (warns) if `httpcloak` isn't installed.
- Added `ATSType.BUMERAN` (Hybrid jobboards group), registered the scraper, exported `BumeranScraper` from `jobhive.scrapers`, updated `test_models.py` enum coverage.

## Reverse-engineering notes

The frontend bundle (`/candidate/static/js/main.<hash>.js`) calls `api/avisos/searchV2` with:

```
POST /api/avisos/searchV2?pageSize=<n>&page=<p>&sort=RELEVANTES
Headers: x-site-id, Origin, Referer, Content-Type: application/json
Body: { "filtros": [], "query": "", "internacional": false }
```

Verified live (2026-05-12): `bumeran.com.ar` total=9728, `bumeran.com.pe` total=32977, `bumeran.com.ve` total=610, `zonajobs.com.ar` total=9728, `multitrabajos.com` total=5395. `pageSize=100` is the hard cap.

Each `content[i]` item ships `id`, `titulo`, `detalle`, `empresa`, `localizacion`, `fechaHoraPublicacion` (DD-MM-YYYY HH:MM:SS), `tipoTrabajo`, `modalidadTrabajo`, plus `idArea`/`idSubarea`/`portal` classification ids. All mapped to canonical `Job` fields; ATS-specific fields land on `raw`.

## Test plan

- [x] `uv run pytest tests/test_bumeran.py tests/test_models.py` — 91 passed
- [x] `uv run pytest` — 908 passed (no regressions)
- [x] `uv run ruff check src tests` — clean
- [x] Live smoke test: `BumeranScraper("ar", max_pages=1).fetch()` returned 100 jobs with full title/company/location/description/posted_at populated
- [x] Verified region table: AR/PE/EC/VE/ZJ/MT all reachable via the shared API, CL and konzerta gracefully degrade

Branch base: `origin/main`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

[Generated with Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a multi-country scraper for Navent’s LATAM jobboard platform, covering Bumeran (AR/PE/EC/VE) plus ZonaJobs (AR) and Multitrabajos (EC). Also ships a seed CSV with brand slugs and URLs for easier setup.

- **New Features**
  - Implemented `BumeranScraper` using the shared search API with `x-site-id`; supports `ar`, `pe`, `ec`, `ve`, `ar-zonajobs`, `ec-multitrabajos`.
  - Added `ATSType.BUMERAN`, registered the scraper, and exported it from `jobhive.scrapers`.
  - Robust fetch: `pageSize=100`, concurrent pagination (3 workers), de-dupe across pages, and date parsing from `DD-MM-YYYY HH:MM:SS`.
  - Field mapping: title, company (confidential handled), location, `is_remote` from modalidad, employment type from `tipoTrabajo`, description cleaned; Navent-specific fields stored in `raw`.
  - Graceful handling: `cl` and `pe-konzerta` are recognized but return `[]` with a warning until their stacks join the shared API. If `httpcloak` is missing, returns `[]` with a warning.
  - Tests: added `tests/test_bumeran.py` and updated enum coverage.
  - Seed CSV: added `ats-companies/bumeran.csv` with brand names, slugs, and URLs.

- **Migration**
  - Install the scrapers extra to enable Cloudflare bypass: `pip install jobhive[scrapers]` (includes `httpcloak`).
  - Use these `company_slug` values: `ar`, `pe`, `ec`, `ve`, `ar-zonajobs`, `ec-multitrabajos` (note: `cl` and `pe-konzerta` currently return no results).

<sup>Written for commit 34b23aa292d9cb8749eb63b10706b0a798e2187b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

