### PR TITLE
phenom: fix Cisco slug (jobs.cisco.com -> careers.cisco.com), dedupe rows

### DIFF
--- a/ats-companies/phenom.csv
+++ b/ats-companies/phenom.csv
@@ -52,16 +52,12 @@ https://careers.rtx.com,rtx,,en_us,us
 https://careers.dupont.com,dupont,,en_us,us
 https://careers.ppg.com,ppg,,en_us,us
 https://jobs.applied.com,applied,,en_us,us
-https://careers.thermofisher.com,thermofisher,,en_us,us
 https://jobs.danaher.com,danaher,,en_us,us
 https://careers.snowflake.com,snowflake,,en_us,us
 https://careers.adobe.com,adobe,,en_us,us
 https://careers.mcafee.com,mcafee,,en_us,us
-https://careers.snowflake.com,snowflake,,en_us,us
-https://careers.mcafee.com,mcafee,,en_us,us
 https://careers.fiserv.com,fiserv,,en_us,us
 https://careers.statestreet.com,statestreet,,en_us,us
-https://careers.fiserv.com,fiserv,,en_us,us
 https://qualtricscareers.com,qualtrics,,en_us,us
 https://jobs.abbott.com,abbott,,en_us,us
 https://jobs.msd.com,msd,,en_us,us
@@ -70,5 +66,4 @@ https://careers.labcorp.com,labcorp,,en_us,us
 https://questcareers.com,quest,,en_us,us
 https://careers.fortrea.com,fortrea,,en_us,us
 https://careers.catalent.com,catalent,,en_us,us
-https://jobs.abbott.com,abbott,,en_us,us
 https://careers.zimmerbiomet.com,zimmerbiomet,,en_us,us

--- a/ats-companies/phenom.csv
+++ b/ats-companies/phenom.csv
@@ -12,7 +12,7 @@ https://jobs.thecignagroup.com,Cigna Group,,en_us,us
 https://careers.chenmed.com,ChenMed,,en_us,us
 https://careers.fisglobal.com,FIS,,en_us,us
 https://careers.allianz.com,Allianz,,en_us,us
-https://jobs.cisco.com,Cisco,,en_us,us
+https://careers.cisco.com,Cisco,,en_us,us
 https://careers.abb,ABB,,en_us,us
 https://jobs.chop.edu,Children's Hospital of Philadelphia,,en_us,us
 https://careers.dhl.com,DHL,,en_us,us
@@ -46,7 +46,6 @@ https://careers.aspendental.com,aspendental,,en_us,us
 https://careers.gianteagle.com,gianteagle,,en_us,us
 https://careers.bonsecours.com,bonsecours,,en_us,us
 https://careers.omnicable.com,omnicable,,en_us,us
-https://careers.cisco.com,cisco,,en_us,us
 https://careers.itw.com,itw,,en_us,us
 https://jobs.raytheon.com,raytheon,,en_us,us
 https://careers.rtx.com,rtx,,en_us,us
@@ -59,13 +58,11 @@ https://careers.snowflake.com,snowflake,,en_us,us
 https://careers.adobe.com,adobe,,en_us,us
 https://careers.mcafee.com,mcafee,,en_us,us
 https://careers.snowflake.com,snowflake,,en_us,us
-https://careers.cisco.com,cisco,,en_us,us
 https://careers.mcafee.com,mcafee,,en_us,us
 https://careers.fiserv.com,fiserv,,en_us,us
 https://careers.statestreet.com,statestreet,,en_us,us
 https://careers.fiserv.com,fiserv,,en_us,us
 https://qualtricscareers.com,qualtrics,,en_us,us
-https://careers.cisco.com,cisco,,en_us,us
 https://jobs.abbott.com,abbott,,en_us,us
 https://jobs.msd.com,msd,,en_us,us
 https://careers.covance.com,covance,,en_us,us

--- a/src/jobhive/scrapers/phenom.py
+++ b/src/jobhive/scrapers/phenom.py
@@ -1,7 +1,7 @@
 """Phenom (PhenomPeople) scraper.
 
-Phenom-powered career sites (Bell Canada, GE Healthcare, T-Mobile, etc.) all
-share the same search widget endpoint:
+Phenom-powered career sites (Bell Canada, GE Healthcare, T-Mobile, Cisco,
+etc.) all share the same search widget endpoint:
 
     POST {base_url}/widgets
 
@@ -86,7 +86,12 @@ class PhenomScraper(BaseScraper):
     The canonical tenant list at ``ats-companies/phenom.csv`` ships the
     correct ``locale``/``country`` per tenant (columns:
     ``url,name,company_code,locale,country``). For brand-new tenants the
-    default ``"en_us"``/``"us"`` works for the majority of US sites."""
+    default ``"en_us"``/``"us"`` works for the majority of US sites.
+
+    Note: pass the canonical Phenom hostname, not a vanity domain that
+    redirects to it. e.g. Cisco uses ``https://careers.cisco.com``;
+    ``https://jobs.cisco.com`` redirects there but the CSRF cookie does
+    not survive the cross-host redirect, so widget POSTs return 403/HTML."""
 
     ats = ATSType.PHENOM
 


### PR DESCRIPTION
## Summary
- Repoint the canonical Cisco row in `ats-companies/phenom.csv` from `https://jobs.cisco.com` to `https://careers.cisco.com`. The vanity host 301-redirects to the canonical Phenom host, but the CSRF cookie seeded on the initial GET does not survive the cross-host redirect, so the subsequent `POST /widgets` returns HTML and the scraper crashes with a JSON decode error.
- Drop three duplicate lowercase `careers.cisco.com,cisco,...` rows that snuck in via the Tranco import.
- Add a docstring note in `PhenomScraper` so the next person reaches for the canonical Phenom host first (and add Cisco to the tenant-example list at the top of the module).

Verified live: `PhenomScraper("https://careers.cisco.com", locale="en_us", country="us").fetch()` returns 984 jobs.

## Test plan
- [x] `uv run ruff check src tests` clean
- [x] `uv run pytest tests` — 879 passed
- [x] Live fetch against `careers.cisco.com` returns 984 jobs (sample: "Director, Sales" @ Frankfurt, Germany)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched Cisco’s Phenom tenant to `https://careers.cisco.com` to avoid CSRF loss on cross-host redirects that returned HTML and crashed the scraper. Also deduped Phenom tenant rows and added a note to prefer canonical hosts.

- **Bug Fixes**
  - Switch to `https://careers.cisco.com` (from `https://jobs.cisco.com`) so widget POSTs return JSON; live fetch returns 984 jobs.
  - Remove duplicate rows for Cisco, Thermo Fisher, Snowflake, McAfee, Fiserv, and Abbott; add a docstring note in `PhenomScraper` to use canonical Phenom hosts.

<sup>Written for commit 3a65184fa54a77409eb0d1cae4d8aecad7f7c86c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the Cisco tenant's scraper crash by switching its CSV entry from the vanity redirect host (`jobs.cisco.com`) to the canonical Phenom host (`careers.cisco.com`), preventing CSRF cookie loss on the cross-host redirect. It also removes three duplicate lowercase Cisco rows imported via Tranco and adds a docstring note to steer future callers toward canonical hosts.

- **Cisco URL fix**: `https://jobs.cisco.com` → `https://careers.cisco.com` in `phenom.csv`; live fetch confirmed at 984 jobs.
- **Deduplication**: Three extra `careers.cisco.com,cisco,...` rows dropped; five other duplicate pairs (`thermofisher`, `snowflake`, `mcafee`, `fiserv`, `abbott`) remain in the file and will each be scraped twice per run.
- **Docstring**: `PhenomScraper` now explicitly warns that vanity redirect domains break CSRF, with Cisco as the named example.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the Cisco URL fix is correct and live-verified, and the docstring change is informational only.

The two changed files are a targeted data fix (one URL swap, three row removals) and a docstring addition. The root cause of the crash (cross-host CSRF loss) is well-understood and the chosen fix matches the live verification result. No logic changes were made to the scraper itself.

ats-companies/phenom.csv still contains duplicate rows for thermofisher, snowflake, mcafee, fiserv, and abbott — those tenants will be scraped twice per run until cleaned up, but this is a pre-existing condition not introduced by this PR.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| ats-companies/phenom.csv | Repoints Cisco from jobs.cisco.com to careers.cisco.com and removes 3 duplicate cisco rows; several other duplicate URLs (thermofisher, snowflake, mcafee, fiserv, abbott) remain unfixed |
| src/jobhive/scrapers/phenom.py | Docstring-only change: adds Cisco to the module-level example list and adds a canonical-hostname note warning against vanity redirect domains |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `ats-companies/phenom.csv`, line 57-74 ([link](https://github.com/kalil0321/ats-scrapers/blob/ed5e9d2a846b210b947c0b206cbd760d92fdd2ea/ats-companies/phenom.csv#L57-L74)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Remaining duplicate URLs after cisco cleanup**

   The PR deduplicates the cisco rows but several other duplicate URLs survive in the file, which will cause each of those tenants to be scraped twice per run: `careers.snowflake.com` (lines 57 & 60), `careers.mcafee.com` (lines 59 & 61), `careers.fiserv.com` (lines 62 & 64), `careers.thermofisher.com` (lines 43 & 55), and `jobs.abbott.com` (lines 66 & 73). Worth folding into this cleanup pass since the dedup tooling is already being exercised here.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: ats-companies/phenom.csv
   Line: 57-74

   Comment:
   **Remaining duplicate URLs after cisco cleanup**

   The PR deduplicates the cisco rows but several other duplicate URLs survive in the file, which will cause each of those tenants to be scraped twice per run: `careers.snowflake.com` (lines 57 & 60), `careers.mcafee.com` (lines 59 & 61), `careers.fiserv.com` (lines 62 & 64), `careers.thermofisher.com` (lines 43 & 55), and `jobs.abbott.com` (lines 66 & 73). Worth folding into this cleanup pass since the dedup tooling is already being exercised here.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["phenom: fix Cisco slug (jobs.cisco.com →..."](https://github.com/kalil0321/ats-scrapers/commit/ed5e9d2a846b210b947c0b206cbd760d92fdd2ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31751975)</sub>

<!-- /greptile_comment -->