### PR TITLE
Add Morocco Rekrute + Avito Maroc scrapers

### DIFF
--- a/ats-companies/avito_ma.csv
+++ b/ats-companies/avito_ma.csv
@@ -1,0 +1,2 @@
+name,slug,url
+"Avito Maroc",avito_ma,https://www.avito.ma/fr/maroc/emploi

--- a/ats-companies/rekrute.csv
+++ b/ats-companies/rekrute.csv
@@ -1,0 +1,2 @@
+name,slug,url
+Rekrute,rekrute,https://www.rekrute.com

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -90,7 +90,7 @@ class ATSType(StrEnum):
     TEAMTAILOR = "teamtailor"
     # Moroccan job boards
     REKRUTE = "rekrute"
-    AVITOMA = "avitoma"
+    AVITOMA = "avito_ma"
     CUSTOM = "custom"
 
 

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -88,6 +88,9 @@ class ATSType(StrEnum):
     RECRUITEE = "recruitee"
     TALEO = "taleo"
     TEAMTAILOR = "teamtailor"
+    # Moroccan job boards
+    REKRUTE = "rekrute"
+    AVITOMA = "avitoma"
     CUSTOM = "custom"
 
 

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -13,6 +13,7 @@ from jobhive.scrapers.apple import AppleScraper
 from jobhive.scrapers.arbetsformedlingen import ArbetsformedlingenScraper
 from jobhive.scrapers.ashby import AshbyScraper
 from jobhive.scrapers.avature import AvatureScraper
+from jobhive.scrapers.avito_ma import AvitoMarocScraper
 from jobhive.scrapers.bamboohr import BambooHRScraper
 from jobhive.scrapers.base import BaseScraper, ScraperRegistry, get_scraper
 from jobhive.scrapers.breezy import BreezyScraper
@@ -40,6 +41,7 @@ from jobhive.scrapers.pinpoint import PinpointScraper
 from jobhive.scrapers.programathor import ProgramathorScraper
 from jobhive.scrapers.recruitee import RecruiteeScraper
 from jobhive.scrapers.recruiterbox import RecruiterboxScraper
+from jobhive.scrapers.rekrute import RekruteScraper
 from jobhive.scrapers.remoteok import RemoteOKScraper
 from jobhive.scrapers.rippling import RipplingScraper
 from jobhive.scrapers.smartrecruiters import SmartRecruitersScraper
@@ -65,6 +67,7 @@ __all__ = [
     "ArbetsformedlingenScraper",
     "AshbyScraper",
     "AvatureScraper",
+    "AvitoMarocScraper",
     "BambooHRScraper",
     "BaseScraper",
     "BreezyScraper",
@@ -91,6 +94,7 @@ __all__ = [
     "ProgramathorScraper",
     "RecruiteeScraper",
     "RecruiterboxScraper",
+    "RekruteScraper",
     "RemoteOKScraper",
     "RipplingScraper",
     "ScraperRegistry",

--- a/src/jobhive/scrapers/avito_ma.py
+++ b/src/jobhive/scrapers/avito_ma.py
@@ -311,7 +311,9 @@ def _extract_ads(html_body: str) -> list[dict[str, Any]]:
         raise _AdsParseError("__NEXT_DATA__ shape changed — no ads list") from exc
     if not isinstance(ads, list):
         raise _AdsParseError("__NEXT_DATA__ ads field is not a list")
-    return [a for a in ads if isinstance(a, dict)]
+    if any(not isinstance(a, dict) for a in ads):
+        raise _AdsParseError("__NEXT_DATA__ ads list contains non-object entries")
+    return ads
 
 
 def _parse_ad(ad: dict[str, Any], *, fetched_at: datetime) -> Job | None:
@@ -344,8 +346,8 @@ def _parse_ad(ad: dict[str, Any], *, fetched_at: datetime) -> Job | None:
     company = (seller.get("name") or "").strip() or "Unknown"
 
     description = (ad.get("description") or "").strip() or None
-    if description and len(description) > 5000:
-        description = description[:5000].rstrip() + "…"
+    if description and len(description) > 10_000:
+        description = description[:10_000].rstrip() + "…"
 
     location = (ad.get("location") or "").strip() or None
 

--- a/src/jobhive/scrapers/avito_ma.py
+++ b/src/jobhive/scrapers/avito_ma.py
@@ -164,6 +164,7 @@ class AvitoMarocScraper(BaseScraper):
         jobs: list[Job] = []
         sem = asyncio.Semaphore(self.concurrency)
         stop_at_page: int | None = None
+        skipped_fetch_pages: set[int] = set()
         skipped_parse_pages: set[int] = set()
 
         async def fetch_page(page_no: int) -> list[Job]:
@@ -173,6 +174,7 @@ class AvitoMarocScraper(BaseScraper):
                     return []
                 html_body = await self._get_listing_page(client, page_no)
             if html_body is None:
+                skipped_fetch_pages.add(page_no)
                 return []
             try:
                 ads = _extract_ads(html_body)
@@ -209,9 +211,12 @@ class AvitoMarocScraper(BaseScraper):
                     seen.add(job.ats_id)
                     jobs.append(job)
             wave_pages = range(page_no, wave_end)
-            wave_had_parse_skip = any(p in skipped_parse_pages for p in wave_pages)
+            wave_had_skip = any(
+                p in skipped_fetch_pages or p in skipped_parse_pages
+                for p in wave_pages
+            )
             if stop_at_page is not None or (
-                not wave_had_rows and not wave_had_parse_skip
+                not wave_had_rows and not wave_had_skip
             ):
                 break
             page_no = wave_end

--- a/src/jobhive/scrapers/avito_ma.py
+++ b/src/jobhive/scrapers/avito_ma.py
@@ -54,7 +54,7 @@ import asyncio
 import json
 import logging
 import re
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 import httpx
@@ -151,7 +151,7 @@ class AvitoMarocScraper(BaseScraper):
         return asyncio.run(self._fetch_async())
 
     async def _fetch_async(self) -> list[Job]:
-        fetched_at = datetime.now()
+        fetched_at = datetime.now(tz=UTC)
         async with httpx.AsyncClient(
             timeout=self.timeout, follow_redirects=True,
         ) as client:
@@ -163,14 +163,13 @@ class AvitoMarocScraper(BaseScraper):
         seen: set[str] = set()
         jobs: list[Job] = []
         sem = asyncio.Semaphore(self.concurrency)
-        stop_at_page: dict[str, int | None] = {"value": None}
+        stop_at_page: int | None = None
+        skipped_parse_pages: set[int] = set()
 
         async def fetch_page(page_no: int) -> list[Job]:
+            nonlocal stop_at_page
             async with sem:
-                if (
-                    stop_at_page["value"] is not None
-                    and page_no >= stop_at_page["value"]
-                ):
+                if stop_at_page is not None and page_no >= stop_at_page:
                     return []
                 html_body = await self._get_listing_page(client, page_no)
             if html_body is None:
@@ -178,15 +177,15 @@ class AvitoMarocScraper(BaseScraper):
             try:
                 ads = _extract_ads(html_body)
             except _AdsParseError as exc:
-                # A broken 200-OK response — do NOT treat as the last
-                # page, or one bad response would truncate pagination.
+                # A broken 200-OK response must not look like the last page.
                 log.warning(
                     "Avito Maroc page=%d: %s — skipping page", page_no, exc,
                 )
+                skipped_parse_pages.add(page_no)
                 return []
             if not ads:
-                if stop_at_page["value"] is None or page_no < stop_at_page["value"]:
-                    stop_at_page["value"] = page_no
+                if stop_at_page is None or page_no < stop_at_page:
+                    stop_at_page = page_no
                 return []
             return [
                 job
@@ -209,7 +208,11 @@ class AvitoMarocScraper(BaseScraper):
                         continue
                     seen.add(job.ats_id)
                     jobs.append(job)
-            if not wave_had_rows or stop_at_page["value"] is not None:
+            wave_pages = range(page_no, wave_end)
+            wave_had_parse_skip = any(p in skipped_parse_pages for p in wave_pages)
+            if stop_at_page is not None or (
+                not wave_had_rows and not wave_had_parse_skip
+            ):
                 break
             page_no = wave_end
         log.info("Avito Maroc: fetched %d unique jobs", len(jobs))
@@ -221,12 +224,10 @@ class AvitoMarocScraper(BaseScraper):
         """Fetch one ``/fr/maroc/emploi?o=N`` listing page. Returns the
         HTML body or ``None`` to halt the walk."""
         url = LISTING_URL_TEMPLATE.format(page=page_no)
-        last_exc: Exception | None = None
         for attempt in range(1, MAX_RETRIES + 1):
             try:
                 response = await client.get(url, headers=_HEADERS)
             except httpx.HTTPError as exc:
-                last_exc = exc
                 if attempt == MAX_RETRIES:
                     log.warning(
                         "Avito Maroc page=%d transport error after %d retries: %s",
@@ -257,11 +258,6 @@ class AvitoMarocScraper(BaseScraper):
                 page_no, status,
             )
             return None
-        log.warning(
-            "Avito Maroc page=%d exhausted retries: %s",
-            page_no, last_exc,
-        )
-        return None
 
 
 # --- module-level helpers ---------------------------------------------

--- a/src/jobhive/scrapers/avito_ma.py
+++ b/src/jobhive/scrapers/avito_ma.py
@@ -190,11 +190,19 @@ class AvitoMarocScraper(BaseScraper):
                 if stop_at_page is None or page_no < stop_at_page:
                     stop_at_page = page_no
                 return []
-            return [
-                job
-                for ad in ads
-                if (job := _parse_ad(ad, fetched_at=fetched_at)) is not None
-            ]
+            page_jobs: list[Job] = []
+            for idx, ad in enumerate(ads):
+                try:
+                    job = _parse_ad(ad, fetched_at=fetched_at)
+                except (AttributeError, TypeError, ValueError) as exc:
+                    log.warning(
+                        "Avito Maroc page=%d ad=%d parse error — skipping ad: %s",
+                        page_no, idx, exc,
+                    )
+                    continue
+                if job is not None:
+                    page_jobs.append(job)
+            return page_jobs
 
         page_no = 1
         while page_no <= self.max_pages:

--- a/src/jobhive/scrapers/avito_ma.py
+++ b/src/jobhive/scrapers/avito_ma.py
@@ -436,9 +436,9 @@ def _parse_relative_date(
     value: object, *, now: datetime,
 ) -> datetime | None:
     """Convert ``"il y a 7 minutes"`` / ``"il y a 2 jours"`` into a
-    UTC-naive datetime relative to ``now``. Returns ``None`` for
-    unrecognised phrases — better to leave the field empty than
-    fabricate a wrong timestamp.
+    datetime relative to now. The result preserves now's timezone
+    awareness. Returns None for unrecognised phrases -- better to leave
+    the field empty than fabricate a wrong timestamp.
 
     Approximations:
       - 1 ``mois`` = 30 days

--- a/src/jobhive/scrapers/avito_ma.py
+++ b/src/jobhive/scrapers/avito_ma.py
@@ -175,7 +175,15 @@ class AvitoMarocScraper(BaseScraper):
                 html_body = await self._get_listing_page(client, page_no)
             if html_body is None:
                 return []
-            ads = _extract_ads(html_body)
+            try:
+                ads = _extract_ads(html_body)
+            except _AdsParseError as exc:
+                # A broken 200-OK response — do NOT treat as the last
+                # page, or one bad response would truncate pagination.
+                log.warning(
+                    "Avito Maroc page=%d: %s — skipping page", page_no, exc,
+                )
+                return []
             if not ads:
                 if stop_at_page["value"] is None or page_no < stop_at_page["value"]:
                     stop_at_page["value"] = page_no
@@ -259,27 +267,34 @@ class AvitoMarocScraper(BaseScraper):
 # --- module-level helpers ---------------------------------------------
 
 
+class _AdsParseError(Exception):
+    """Raised when a 200-OK page's ``__NEXT_DATA__`` blob is missing or
+    malformed. Distinct from a genuinely empty last page (an empty ads
+    list) so pagination doesn't mistake a broken response for the end."""
+
+
 def _extract_ads(html_body: str) -> list[dict[str, Any]]:
     """Pull the ad list from a page's ``__NEXT_DATA__`` blob.
 
-    Returns ``[]`` when the blob is missing, malformed, or doesn't
-    contain ads — pagination uses ``[]`` as the "stop here" signal.
+    Returns the (possibly empty) list of ad dicts. An empty list means
+    a genuine empty page — pagination uses it as the "stop here"
+    signal. Raises :class:`_AdsParseError` when the blob is missing or
+    malformed, so the caller can distinguish a broken response (retry)
+    from a real last page.
     """
     m = _NEXT_DATA_RE.search(html_body)
     if m is None:
-        return []
+        raise _AdsParseError("__NEXT_DATA__ blob not found")
     try:
         data = json.loads(m.group("json"))
-    except (ValueError, json.JSONDecodeError):
-        log.warning("Avito Maroc: __NEXT_DATA__ JSON parse failed")
-        return []
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise _AdsParseError("__NEXT_DATA__ JSON parse failed") from exc
     try:
         ads = data["props"]["pageProps"]["componentProps"]["ads"]["ads"]
-    except (KeyError, TypeError):
-        log.warning("Avito Maroc: __NEXT_DATA__ shape changed — no ads list")
-        return []
+    except (KeyError, TypeError) as exc:
+        raise _AdsParseError("__NEXT_DATA__ shape changed — no ads list") from exc
     if not isinstance(ads, list):
-        return []
+        raise _AdsParseError("__NEXT_DATA__ ads field is not a list")
     return [a for a in ads if isinstance(a, dict)]
 
 

--- a/src/jobhive/scrapers/avito_ma.py
+++ b/src/jobhive/scrapers/avito_ma.py
@@ -234,7 +234,7 @@ class AvitoMarocScraper(BaseScraper):
         self, client: httpx.AsyncClient, page_no: int,
     ) -> str | None:
         """Fetch one ``/fr/maroc/emploi?o=N`` listing page. Returns the
-        HTML body or ``None`` to halt the walk."""
+        HTML body or ``None`` when this page should be skipped."""
         url = LISTING_URL_TEMPLATE.format(page=page_no)
         for attempt in range(1, MAX_RETRIES + 1):
             try:
@@ -242,7 +242,7 @@ class AvitoMarocScraper(BaseScraper):
             except httpx.HTTPError as exc:
                 if attempt == MAX_RETRIES:
                     log.warning(
-                        "Avito Maroc page=%d transport error after %d retries: %s",
+                        "Avito Maroc page=%d transport error after %d retries — skipping page: %s",
                         page_no, MAX_RETRIES, exc,
                     )
                     return None
@@ -254,7 +254,7 @@ class AvitoMarocScraper(BaseScraper):
             if status in (429,) or 500 <= status < 600:
                 if attempt == MAX_RETRIES:
                     log.warning(
-                        "Avito Maroc page=%d returned %d after %d retries — stopping",
+                        "Avito Maroc page=%d returned %d after %d retries — skipping page",
                         page_no, status, MAX_RETRIES,
                     )
                     return None
@@ -266,7 +266,7 @@ class AvitoMarocScraper(BaseScraper):
                 await asyncio.sleep(delay)
                 continue
             log.warning(
-                "Avito Maroc page=%d returned %d — stopping pagination",
+                "Avito Maroc page=%d returned %d — skipping page",
                 page_no, status,
             )
             return None

--- a/src/jobhive/scrapers/avito_ma.py
+++ b/src/jobhive/scrapers/avito_ma.py
@@ -1,0 +1,443 @@
+"""Avito Maroc (avito.ma) — Morocco's largest classifieds, jobs section.
+
+Avito is the Schibsted-spun, OLX-style classifieds giant for Morocco.
+Beyond the cars / real-estate / electronics verticals it runs an
+``Emploi`` jobs section with ~800–1k active postings — mostly
+informal-economy (call centres, retail, hospitality, drivers) but
+also a growing share of corporate listings. Coverage is
+complementary to Rekrute: where Rekrute leans recruiter-portal and
+white-collar, Avito leans direct-employer and blue-collar.
+
+Avito's front-end is a Next.js SPA at
+``https://www.avito.ma/fr/maroc/emploi`` — every page ships its
+server-side data embedded in a ``<script id="__NEXT_DATA__">`` blob
+as JSON. Parsing that JSON is dramatically more robust than DOM
+walking (Avito redesigns the visual layout frequently, the data
+shape moves slowly). The pagination param is ``?o=N`` (1-based).
+
+Important: the *non-restricted* ``/fr/maroc/offres_d_emploi`` URL
+folds in "boosted" ads from other categories (electronics, real
+estate, …) — we use ``/fr/maroc/emploi`` which restricts to the
+``Emploi`` (cat 6200) parent.
+
+JSON row shape (one entry in ``props.pageProps.componentProps.ads.ads``):
+
+    {
+      "id": "77081446",
+      "listId": "57625044",
+      "subject": "Femme de ménage, garde malade, nounours...",
+      "description": "2TG business international est une société…",
+      "category": {
+        "formatted": "Emploi - Centre d'appels",
+        "name": "Centre d'appels", "id": "6050",
+        "parent": {"id": "6200", "name": "Emploi"}
+      },
+      "seller": {"id": "7373", "type": "STORE", "name": "2TG …"},
+      "location": "Oujda, Bd Hassan II",
+      "date": "il y a 7 minutes",
+      "images": [...],
+      "href": "https://www.avito.ma/fr/bd_hassan_ii/centre_d_appels/Femme_de_ménage_…_57625044.htm"
+    }
+
+We treat ``id`` as Avito's canonical ATS id (a numeric posting id).
+``date`` is a relative French phrase — we parse it on a best-effort
+basis to produce ``posted_at``; ambiguous values stay ``None`` so the
+LLM enrichment downstream can fill in.
+
+Single-source scraper: ``company_slug`` is informational and ignored.
+All rows are emitted with ``country_iso="MA"`` and ``region="Africa"``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+log = logging.getLogger(__name__)
+
+# --- URL constants ----------------------------------------------------
+
+SITE_BASE = "https://www.avito.ma"
+# ``/fr/maroc/emploi`` restricts to the Emploi parent category (6200).
+# The alternate ``/fr/maroc/offres_d_emploi`` URL mixes in boosted ads
+# from non-job categories — easy to mis-classify, so we avoid it.
+LISTING_URL_TEMPLATE = "https://www.avito.ma/fr/maroc/emploi?o={page}"
+
+# Cat 6200 is the ``Emploi`` parent that scopes the listing. We use
+# it as a guard to drop the occasional ad that slips through.
+JOBS_PARENT_CATEGORY_ID = "6200"
+JOBS_PARENT_CATEGORY_NAME = "Emploi"
+
+DEFAULT_MAX_PAGES = 100  # ~800 / 30 per page = ~27 normally.
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1.5
+
+_HEADERS: dict[str, str] = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/127.0.0.0 Safari/537.36"
+    ),
+    "Accept": (
+        "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+    ),
+    "Accept-Language": "fr-FR,fr;q=0.9",
+}
+
+# --- __NEXT_DATA__ parsing --------------------------------------------
+#
+# Avito embeds its server-rendered state in a single
+# ``<script id="__NEXT_DATA__" type="application/json">…</script>``
+# block. We slice it out with a tolerant regex and parse the JSON.
+_NEXT_DATA_RE = re.compile(
+    r'<script[^>]*id="__NEXT_DATA__"[^>]*>(?P<json>.*?)</script>',
+    re.DOTALL,
+)
+
+# Relative French time phrases Avito serves on ``date``. We translate
+# them to a posted-at timestamp anchored at fetch time. Avito doesn't
+# expose an absolute timestamp on the listing endpoint so this is a
+# best-effort signal — LLM enrichment downstream can refine if
+# needed.
+_REL_TIME_RE = re.compile(
+    r"il\s+y\s+a\s+(\d+)\s+(minute|minutes|heure|heures|jour|jours|"
+    r"semaine|semaines|mois|an|ans|année|années)",
+    re.IGNORECASE,
+)
+
+
+@ScraperRegistry.register(ATSType.AVITOMA)
+class AvitoMarocScraper(BaseScraper):
+    """Avito.ma — Morocco's largest classifieds (jobs section).
+
+    Single-source scraper: ``company_slug`` is ignored. Pass anything
+    (``"any"``, ``""``).
+
+    Knobs:
+    - ``max_pages``: safety cap. Real catalogue is ~30 pages; default
+      100 leaves headroom.
+    - ``concurrency``: parallel page fetches. Default 4 — Avito is
+      generous but we stay polite.
+    """
+
+    ats = ATSType.AVITOMA
+
+    def __init__(
+        self,
+        company_slug: str = "any",
+        *,
+        timeout: float = 60.0,
+        max_pages: int = DEFAULT_MAX_PAGES,
+        concurrency: int = MAX_CONCURRENCY,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.max_pages = max_pages
+        self.concurrency = max(1, concurrency)
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        fetched_at = datetime.now()
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True,
+        ) as client:
+            return await self._walk_pages(client, fetched_at)
+
+    async def _walk_pages(
+        self, client: httpx.AsyncClient, fetched_at: datetime,
+    ) -> list[Job]:
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        sem = asyncio.Semaphore(self.concurrency)
+        stop_at_page: dict[str, int | None] = {"value": None}
+
+        async def fetch_page(page_no: int) -> list[Job]:
+            async with sem:
+                if (
+                    stop_at_page["value"] is not None
+                    and page_no >= stop_at_page["value"]
+                ):
+                    return []
+                html_body = await self._get_listing_page(client, page_no)
+            if html_body is None:
+                return []
+            ads = _extract_ads(html_body)
+            if not ads:
+                if stop_at_page["value"] is None or page_no < stop_at_page["value"]:
+                    stop_at_page["value"] = page_no
+                return []
+            return [
+                job
+                for ad in ads
+                if (job := _parse_ad(ad, fetched_at=fetched_at)) is not None
+            ]
+
+        page_no = 1
+        while page_no <= self.max_pages:
+            wave_end = min(page_no + self.concurrency, self.max_pages + 1)
+            results = await asyncio.gather(
+                *(fetch_page(p) for p in range(page_no, wave_end))
+            )
+            wave_had_rows = False
+            for page_jobs in results:
+                if page_jobs:
+                    wave_had_rows = True
+                for job in page_jobs:
+                    if job.ats_id is None or job.ats_id in seen:
+                        continue
+                    seen.add(job.ats_id)
+                    jobs.append(job)
+            if not wave_had_rows or stop_at_page["value"] is not None:
+                break
+            page_no = wave_end
+        log.info("Avito Maroc: fetched %d unique jobs", len(jobs))
+        return jobs
+
+    async def _get_listing_page(
+        self, client: httpx.AsyncClient, page_no: int,
+    ) -> str | None:
+        """Fetch one ``/fr/maroc/emploi?o=N`` listing page. Returns the
+        HTML body or ``None`` to halt the walk."""
+        url = LISTING_URL_TEMPLATE.format(page=page_no)
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                response = await client.get(url, headers=_HEADERS)
+            except httpx.HTTPError as exc:
+                last_exc = exc
+                if attempt == MAX_RETRIES:
+                    log.warning(
+                        "Avito Maroc page=%d transport error after %d retries: %s",
+                        page_no, MAX_RETRIES, exc,
+                    )
+                    return None
+                await asyncio.sleep(RETRY_BASE_DELAY * (2 ** (attempt - 1)))
+                continue
+            status = response.status_code
+            if status == 200:
+                return response.text
+            if status in (429,) or 500 <= status < 600:
+                if attempt == MAX_RETRIES:
+                    log.warning(
+                        "Avito Maroc page=%d returned %d after %d retries — stopping",
+                        page_no, status, MAX_RETRIES,
+                    )
+                    return None
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** (attempt - 1))
+                )
+                await asyncio.sleep(delay)
+                continue
+            log.warning(
+                "Avito Maroc page=%d returned %d — stopping pagination",
+                page_no, status,
+            )
+            return None
+        log.warning(
+            "Avito Maroc page=%d exhausted retries: %s",
+            page_no, last_exc,
+        )
+        return None
+
+
+# --- module-level helpers ---------------------------------------------
+
+
+def _extract_ads(html_body: str) -> list[dict[str, Any]]:
+    """Pull the ad list from a page's ``__NEXT_DATA__`` blob.
+
+    Returns ``[]`` when the blob is missing, malformed, or doesn't
+    contain ads — pagination uses ``[]`` as the "stop here" signal.
+    """
+    m = _NEXT_DATA_RE.search(html_body)
+    if m is None:
+        return []
+    try:
+        data = json.loads(m.group("json"))
+    except (ValueError, json.JSONDecodeError):
+        log.warning("Avito Maroc: __NEXT_DATA__ JSON parse failed")
+        return []
+    try:
+        ads = data["props"]["pageProps"]["componentProps"]["ads"]["ads"]
+    except (KeyError, TypeError):
+        log.warning("Avito Maroc: __NEXT_DATA__ shape changed — no ads list")
+        return []
+    if not isinstance(ads, list):
+        return []
+    return [a for a in ads if isinstance(a, dict)]
+
+
+def _parse_ad(ad: dict[str, Any], *, fetched_at: datetime) -> Job | None:
+    """Parse one ad dict into a Job. Returns ``None`` when:
+
+    - the ad isn't in the ``Emploi`` parent category (a boosted ad
+      from elsewhere — we drop rather than mis-classify);
+    - the id / subject / href is missing.
+    """
+    if not _is_jobs_ad(ad):
+        return None
+
+    raw_id = ad.get("id") or ad.get("listId")
+    if raw_id is None:
+        return None
+    ats_id = str(raw_id).strip()
+    if not ats_id:
+        return None
+
+    title = (ad.get("subject") or "").strip()
+    if not title:
+        return None
+
+    href = (ad.get("href") or "").strip()
+    if not href:
+        return None
+    url = _absolute_url(href)
+
+    seller = ad.get("seller") or {}
+    company = (seller.get("name") or "").strip() or "Unknown"
+
+    description = (ad.get("description") or "").strip() or None
+    if description and len(description) > 5000:
+        description = description[:5000].rstrip() + "…"
+
+    location = (ad.get("location") or "").strip() or None
+
+    category = ad.get("category") or {}
+    category_name = (category.get("formatted") or category.get("name") or "").strip()
+    department = category_name or None
+
+    posted_at = _parse_relative_date(ad.get("date"), now=fetched_at)
+
+    raw: dict[str, Any] = {}
+    if seller.get("type"):
+        raw["seller_type"] = seller["type"]
+    if seller.get("id"):
+        raw["seller_id"] = str(seller["id"])
+    images = ad.get("images")
+    if isinstance(images, list) and images:
+        raw["image_count"] = len(images)
+    list_id = ad.get("listId")
+    if list_id and str(list_id) != ats_id:
+        raw["list_id"] = str(list_id)
+    if category.get("id"):
+        raw["category_id"] = str(category["id"])
+    if ad.get("isShop"):
+        raw["is_shop"] = True
+    if ad.get("isPremium"):
+        raw["is_premium"] = True
+    if ad.get("isUrgent"):
+        raw["is_urgent"] = True
+
+    return Job(
+        url=url,
+        title=title,
+        company=company,
+        ats_type=ATSType.AVITOMA,
+        ats_id=ats_id,
+        location=location,
+        country_iso="MA",
+        region="Africa",
+        department=department,
+        description=description,
+        posted_at=posted_at,
+        fetched_at=fetched_at,
+        language="fr",
+        raw=raw or None,
+    )
+
+
+def _is_jobs_ad(ad: dict[str, Any]) -> bool:
+    """True when the ad belongs to the Avito ``Emploi`` parent
+    category. Boosted / cross-promoted listings from other categories
+    sometimes appear on the jobs URL; we filter them out so the
+    dataset stays clean."""
+    category = ad.get("category") or {}
+    parent = category.get("parent") or {}
+    parent_id = str(parent.get("id") or "")
+    parent_name = (parent.get("name") or "").strip()
+    cat_id = str(category.get("id") or "")
+    if parent_id == JOBS_PARENT_CATEGORY_ID:
+        return True
+    if parent_name.lower() == JOBS_PARENT_CATEGORY_NAME.lower():
+        return True
+    # The parent itself could be the Emploi root on top-level ads.
+    return cat_id == JOBS_PARENT_CATEGORY_ID
+
+
+def _absolute_url(path_or_url: str) -> str:
+    if path_or_url.startswith(("http://", "https://")):
+        return path_or_url
+    if not path_or_url.startswith("/"):
+        path_or_url = "/" + path_or_url
+    return SITE_BASE + path_or_url
+
+
+# Map French relative-time unit → timedelta-compatible kwarg.
+_UNIT_TO_KW: dict[str, str] = {
+    "minute": "minutes", "minutes": "minutes",
+    "heure": "hours", "heures": "hours",
+    "jour": "days", "jours": "days",
+    "semaine": "weeks", "semaines": "weeks",
+    # ``mois`` / years are approximated — Avito surfaces "il y a 2
+    # mois" so we approximate at 30 days per month.
+}
+
+
+def _parse_relative_date(
+    value: object, *, now: datetime,
+) -> datetime | None:
+    """Convert ``"il y a 7 minutes"`` / ``"il y a 2 jours"`` into a
+    UTC-naive datetime relative to ``now``. Returns ``None`` for
+    unrecognised phrases — better to leave the field empty than
+    fabricate a wrong timestamp.
+
+    Approximations:
+      - 1 ``mois`` = 30 days
+      - 1 ``an`` / ``année`` = 365 days
+
+    These are coarse but consistent — consumers know Avito's relative
+    timestamps are not minute-precise anyway.
+    """
+    if not isinstance(value, str):
+        return None
+    text = value.strip().lower()
+    if not text:
+        return None
+    m = _REL_TIME_RE.search(text)
+    if m is None:
+        return None
+    try:
+        count = int(m.group(1))
+    except (TypeError, ValueError):
+        return None
+    unit = m.group(2).lower()
+    if unit in _UNIT_TO_KW:
+        delta = timedelta(**{_UNIT_TO_KW[unit]: count})
+    elif unit in ("mois",):
+        delta = timedelta(days=30 * count)
+    elif unit in ("an", "ans", "année", "années"):
+        delta = timedelta(days=365 * count)
+    else:
+        return None
+    return now - delta
+
+
+__all__ = [
+    "AvitoMarocScraper",
+]

--- a/src/jobhive/scrapers/avito_ma.py
+++ b/src/jobhive/scrapers/avito_ma.py
@@ -166,6 +166,7 @@ class AvitoMarocScraper(BaseScraper):
         stop_at_page: int | None = None
         skipped_fetch_pages: set[int] = set()
         skipped_parse_pages: set[int] = set()
+        consecutive_empty_skip_waves = 0
 
         async def fetch_page(page_no: int) -> list[Job]:
             nonlocal stop_at_page
@@ -215,9 +216,15 @@ class AvitoMarocScraper(BaseScraper):
                 p in skipped_fetch_pages or p in skipped_parse_pages
                 for p in wave_pages
             )
-            if stop_at_page is not None or (
-                not wave_had_rows and not wave_had_skip
-            ):
+            if stop_at_page is not None:
+                break
+            if wave_had_rows:
+                consecutive_empty_skip_waves = 0
+            elif wave_had_skip:
+                consecutive_empty_skip_waves += 1
+                if consecutive_empty_skip_waves > 1:
+                    break
+            else:
                 break
             page_no = wave_end
         log.info("Avito Maroc: fetched %d unique jobs", len(jobs))

--- a/src/jobhive/scrapers/rekrute.py
+++ b/src/jobhive/scrapers/rekrute.py
@@ -1,0 +1,617 @@
+"""Rekrute.com — Morocco's largest dedicated job board.
+
+Rekrute is the dominant general-purpose job board in Morocco, with
+~1,700 active postings across every sector (finance, IT, healthcare,
+industry, retail, …). Companies post directly through Rekrute's
+recruiter dashboard — not a LinkedIn / Indeed syndication aggregator.
+
+There is no public JSON API: the listing page is plain SSR HTML at
+``https://www.rekrute.com/offres-emploi-maroc.html`` and the
+``/offres.html`` search endpoint serves the same markup with ``?p=N``
+pagination (10 jobs per page). Plain ``httpx`` clears the host
+without any Cloudflare / Datadome challenge — we paginate with a
+modest concurrency cap and parse each page's HTML directly.
+
+Listing row shape (one ``<li class="post-id" id="…">`` per job):
+
+    <li class="post-id" id="182716">
+      <div>
+        <div class="col-sm-2 …">
+          <a href="/huir-emploi-recrutement-343150.html">
+            <img alt="HUIR - L'Hôpital Universitaire …" …>
+          </a>
+        </div>
+        <div class="col-sm-10 …">
+          <h2><a class="titreJob" href="/offre-emploi-…-182716.html">
+            Directeur (trice) de l'Hébergement | Rabat (Maroc)
+          </a></h2>
+          <div class="holder">
+            <em class="date">… Publication : du <span>12/05/2026</span>
+              au <span>12/07/2026</span></em>
+            <ul>
+              <li>Secteur d'activité : <a>Pharmacie / Santé</a></li>
+              <li>Fonction : <a>Médical / Paramédical</a></li>
+              <li>Expérience requise : <a>Expert (10 à 20 ans)</a></li>
+              <li>Niveau d'étude demandé : <a>Bac +5 et plus</a></li>
+              <li>Type de contrat proposé : <a>CDI</a>
+                  - Télétravail : Non</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </li>
+
+The ``id="…"`` attribute is Rekrute's internal numeric job id — we
+use it as the canonical ``ats_id``. The recruiter's display name
+comes from the logo anchor's ``alt`` attribute (or the link text on
+the rare rows where the logo is missing). Locations are appended to
+the title as ``"… | Ville (Maroc)"`` — we strip the trailing
+``(Maroc)`` token and surface the city as ``location``.
+
+Single-source scraper: ``company_slug`` is informational and ignored
+(matches the bundesagentur / wanted / manfred pattern). All rows are
+emitted with ``country_iso="MA"`` and ``region="Africa"``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from typing import Any
+
+log = logging.getLogger(__name__)
+
+# --- URL constants ----------------------------------------------------
+
+SITE_BASE = "https://www.rekrute.com"
+# ``/offres.html?p=N&s=1&o=1`` is what the pagination links resolve to;
+# ``s=1`` selects "sorted by posting date desc" and ``o=1`` "office =
+# any country" (Rekrute also surfaces a small International section
+# we keep visible for completeness — country filtering lives in the
+# scraper-side ``country_iso`` resolver, not the URL).
+LISTING_URL_TEMPLATE = (
+    "https://www.rekrute.com/offres.html?p={page}&s=1&o=1"
+)
+
+DEFAULT_MAX_PAGES = 250  # ~1.7k jobs / 10 per page → 170 normally.
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1.5
+
+# A real-browser UA is enough — Rekrute doesn't ship a bot challenge.
+# We still set Accept-Language to French so the (occasionally
+# bilingual) titles come back in their canonical FR form.
+_HEADERS: dict[str, str] = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/127.0.0.0 Safari/537.36"
+    ),
+    "Accept": (
+        "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+    ),
+    "Accept-Language": "fr-FR,fr;q=0.9,en;q=0.6",
+}
+
+# --- HTML parsing -----------------------------------------------------
+#
+# We use a tolerant regex to slice each ``<li class="post-id" id="…">``
+# block out of the page (matching Bayt's approach) and then feed the
+# slice into BeautifulSoup for structured field extraction. Trying to
+# CSS-select the rows directly works too, but a regex slice halves
+# the parse time on a 200KB page and keeps the per-row scopes small.
+_ROW_BOUNDARY_RE = re.compile(
+    r'<li\s+class="post-id"\s+id="(?P<id>\d+)"\s*>',
+    re.IGNORECASE,
+)
+
+# ``Publication : du <span>DD/MM/YYYY</span>`` — the first span in the
+# ``<em class="date">`` block is always the publication date.
+_DATE_DDMMYYYY_RE = re.compile(r"(\d{1,2})/(\d{1,2})/(\d{2,4})")
+
+# Title suffix the listing appends after a vertical bar:
+# ``"Job title here | Casablanca (Maroc)"`` → city is "Casablanca".
+# ``"(Maroc)"`` is the canonical country suffix Rekrute uses;
+# alternates like ``"(Tunisie)"`` show up rarely (the very small
+# international section). We surface the country code from the
+# suffix when we recognise it, otherwise default to MA.
+_LOCATION_FROM_TITLE_RE = re.compile(
+    r"\|\s*([^|]+?)\s*\(([^)]+)\)\s*$",
+)
+
+# Map title-suffix country names (FR) → ISO 3166-1 alpha-2. Rekrute
+# is Morocco-centric so this stays small.
+_TITLE_COUNTRY_TO_ISO: dict[str, str] = {
+    "maroc": "MA",
+    "tunisie": "TN",
+    "algérie": "DZ",
+    "algerie": "DZ",
+    "france": "FR",
+    "sénégal": "SN",
+    "senegal": "SN",
+    "côte d'ivoire": "CI",
+    "cote d'ivoire": "CI",
+    "espagne": "ES",
+    "émirats arabes unis": "AE",
+    "emirats arabes unis": "AE",
+    "qatar": "QA",
+    "arabie saoudite": "SA",
+}
+
+# ISO → continent. Morocco-centric so the table stays tight.
+_ISO_TO_REGION: dict[str, str] = {
+    "MA": "Africa", "TN": "Africa", "DZ": "Africa", "SN": "Africa",
+    "CI": "Africa",
+    "FR": "Europe", "ES": "Europe",
+    "AE": "Asia", "QA": "Asia", "SA": "Asia",
+}
+
+# Translate Rekrute's French contract labels into the canonical
+# normalised ``employment_type`` enum. Anything not in the map stays
+# in ``commitment`` (the verbatim French label) — the canonical enum
+# is a lossy normalisation, ``commitment`` preserves the original.
+_CONTRACT_TO_EMPLOYMENT: dict[str, str] = {
+    "cdi": "FULL_TIME",
+    "cdd": "TEMPORARY",
+    "freelance": "CONTRACT",
+    "stage": "INTERN",
+    "stage pfe": "INTERN",
+    "intérim": "TEMPORARY",
+    "interim": "TEMPORARY",
+    "temps partiel": "PART_TIME",
+}
+
+
+@ScraperRegistry.register(ATSType.REKRUTE)
+class RekruteScraper(BaseScraper):
+    """Rekrute.com — Morocco's largest dedicated job board.
+
+    Single-source scraper: ``company_slug`` is ignored. Pass anything
+    (``"any"``, ``""``).
+
+    Knobs:
+    - ``max_pages``: safety cap. Rekrute normally pages out at ~170;
+      keep some headroom for spikes.
+    - ``concurrency``: parallel page fetches. Default 4 — the site
+      tolerates more but we stay polite.
+    """
+
+    ats = ATSType.REKRUTE
+
+    def __init__(
+        self,
+        company_slug: str = "any",
+        *,
+        timeout: float = 60.0,
+        max_pages: int = DEFAULT_MAX_PAGES,
+        concurrency: int = MAX_CONCURRENCY,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.max_pages = max_pages
+        self.concurrency = max(1, concurrency)
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        fetched_at = datetime.now()
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True,
+        ) as client:
+            # We don't know the total page count up front so we walk
+            # serially-with-a-window: keep ``concurrency`` requests
+            # in flight, stop submitting once a page returns zero
+            # rows. This avoids over-fetching at the tail (Rekrute's
+            # last page is small) while staying mostly parallel.
+            return await self._walk_pages(client, fetched_at)
+
+    async def _walk_pages(
+        self, client: httpx.AsyncClient, fetched_at: datetime,
+    ) -> list[Job]:
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        sem = asyncio.Semaphore(self.concurrency)
+        stop_at_page: dict[str, int | None] = {"value": None}
+
+        async def fetch_page(page_no: int) -> list[Job]:
+            async with sem:
+                if (
+                    stop_at_page["value"] is not None
+                    and page_no >= stop_at_page["value"]
+                ):
+                    return []
+                html_body = await self._get_listing_page(client, page_no)
+            if html_body is None:
+                return []
+            rows = list(_iter_rows(html_body))
+            if not rows:
+                # First fully-empty page — mark it as the upper bound
+                # so concurrent tasks at later pages bail out.
+                if stop_at_page["value"] is None or page_no < stop_at_page["value"]:
+                    stop_at_page["value"] = page_no
+                return []
+            page_jobs: list[Job] = []
+            for row_id, row_html in rows:
+                job = _parse_row(row_id, row_html, fetched_at=fetched_at)
+                if job is not None:
+                    page_jobs.append(job)
+            return page_jobs
+
+        # Submit pages in waves of ``concurrency`` so the early-stop
+        # signal from a wave actually short-circuits the next wave.
+        page_no = 1
+        while page_no <= self.max_pages:
+            wave_end = min(page_no + self.concurrency, self.max_pages + 1)
+            results = await asyncio.gather(
+                *(fetch_page(p) for p in range(page_no, wave_end))
+            )
+            wave_had_rows = False
+            for page_jobs in results:
+                if page_jobs:
+                    wave_had_rows = True
+                for job in page_jobs:
+                    if job.ats_id is None or job.ats_id in seen:
+                        continue
+                    seen.add(job.ats_id)
+                    jobs.append(job)
+            if not wave_had_rows or stop_at_page["value"] is not None:
+                break
+            page_no = wave_end
+        log.info("Rekrute: fetched %d unique jobs", len(jobs))
+        return jobs
+
+    async def _get_listing_page(
+        self, client: httpx.AsyncClient, page_no: int,
+    ) -> str | None:
+        """Fetch one listing page with retry on transient errors.
+
+        Returns the HTML body on success, ``None`` to stop walking
+        when terminal. The ``p`` index Rekrute uses is 0-based on the
+        wire (``?p=0`` is page 1) — we keep callers 1-based here and
+        translate at the URL boundary.
+        """
+        url = LISTING_URL_TEMPLATE.format(page=page_no - 1)
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                response = await client.get(url, headers=_HEADERS)
+            except httpx.HTTPError as exc:
+                last_exc = exc
+                if attempt == MAX_RETRIES:
+                    log.warning(
+                        "Rekrute page=%d transport error after %d retries: %s",
+                        page_no, MAX_RETRIES, exc,
+                    )
+                    return None
+                await asyncio.sleep(RETRY_BASE_DELAY * (2 ** (attempt - 1)))
+                continue
+            status = response.status_code
+            if status == 200:
+                return response.text
+            if status in (429,) or 500 <= status < 600:
+                if attempt == MAX_RETRIES:
+                    log.warning(
+                        "Rekrute page=%d returned %d after %d retries — stopping",
+                        page_no, status, MAX_RETRIES,
+                    )
+                    return None
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** (attempt - 1))
+                )
+                await asyncio.sleep(delay)
+                continue
+            log.warning(
+                "Rekrute page=%d returned %d — stopping pagination",
+                page_no, status,
+            )
+            return None
+        log.warning(
+            "Rekrute page=%d exhausted retries: %s", page_no, last_exc,
+        )
+        return None
+
+
+# --- module-level helpers ---------------------------------------------
+
+
+def _iter_rows(html_body: str) -> Iterable[tuple[str, str]]:
+    """Yield ``(post_id, row_html)`` for every job tile on the page.
+
+    We slice from the start of one ``<li class="post-id">`` to the
+    start of the next — the trailing slice for the last row is capped
+    at 50 KB so we never pull in the page footer. Each row is ~2 KB
+    in practice.
+    """
+    matches = list(_ROW_BOUNDARY_RE.finditer(html_body))
+    for idx, m in enumerate(matches):
+        start = m.start()
+        end = (
+            matches[idx + 1].start() if idx + 1 < len(matches)
+            else min(start + 50_000, len(html_body))
+        )
+        yield m.group("id"), html_body[start:end]
+
+
+def _parse_row(
+    row_id: str, row_html: str, *, fetched_at: datetime,
+) -> Job | None:
+    """Parse one ``<li class="post-id">`` into a Job. Returns ``None``
+    when the row is missing the bare minimum (id + title + href)."""
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(row_html, "html.parser")
+    title_anchor = soup.find("a", class_="titreJob")
+    if title_anchor is None:
+        return None
+    title_full = title_anchor.get_text(" ", strip=True)
+    href = title_anchor.get("href")
+    if not title_full or not href:
+        return None
+    url = _absolute_url(str(href))
+
+    # Split title into ``title | location (country)``. Rekrute always
+    # appends the city + country to the visible title.
+    title, location, country_iso = _split_title(title_full)
+
+    company = _extract_company(soup)
+    description = _extract_description(soup)
+    posted_at = _extract_posted_at(row_html)
+    contract_label, employment_type, is_remote = _extract_contract(soup)
+    sector, function = _extract_sector_function(soup)
+    experience_label, study_level = _extract_experience_study(soup)
+
+    raw: dict[str, Any] = {}
+    if sector:
+        raw["sector"] = sector
+    if function:
+        raw["function"] = function
+    if experience_label:
+        raw["experience_label"] = experience_label
+    if study_level:
+        raw["study_level"] = study_level
+    if contract_label:
+        raw["contract_label"] = contract_label
+
+    return Job(
+        url=url,
+        title=title or title_full,
+        company=company or "Unknown",
+        ats_type=ATSType.REKRUTE,
+        ats_id=row_id,
+        location=location,
+        country_iso=country_iso,
+        region=_ISO_TO_REGION.get(country_iso or ""),
+        is_remote=is_remote,
+        employment_type=employment_type,  # type: ignore[arg-type]
+        department=sector,
+        commitment=contract_label,
+        description=description,
+        posted_at=posted_at,
+        fetched_at=fetched_at,
+        language="fr",
+        raw=raw or None,
+    )
+
+
+def _absolute_url(path_or_url: str) -> str:
+    if path_or_url.startswith(("http://", "https://")):
+        return path_or_url
+    if not path_or_url.startswith("/"):
+        path_or_url = "/" + path_or_url
+    return SITE_BASE + path_or_url
+
+
+def _split_title(title_full: str) -> tuple[str, str | None, str | None]:
+    """Split ``"Job title | Casablanca (Maroc)"`` into
+    ``("Job title", "Casablanca", "MA")``.
+
+    Falls back to ``(title_full, None, "MA")`` when the suffix isn't
+    present — Rekrute *is* a Morocco board so we default to MA when
+    the city/country tag is missing.
+    """
+    m = _LOCATION_FROM_TITLE_RE.search(title_full)
+    if m is None:
+        # No "| City (Country)" suffix — keep the whole thing as the
+        # title and assume MA (Rekrute's overwhelming majority).
+        return title_full.strip(), None, "MA"
+    city = m.group(1).strip()
+    country_name = m.group(2).strip().lower()
+    iso = _TITLE_COUNTRY_TO_ISO.get(country_name, "MA")
+    title = title_full[: m.start()].strip()
+    return title, city or None, iso
+
+
+def _extract_company(soup: Any) -> str | None:
+    """Recruiter name comes from the ``alt`` / ``title`` of the logo
+    image. The site sometimes serves a placeholder logo for new
+    recruiters — in that case ``alt`` is empty and we fall back to
+    ``None`` (downstream resolves to "Unknown" at Job construction).
+    """
+    img = soup.find("img", class_="photo")
+    if img is not None:
+        alt = (img.get("alt") or img.get("title") or "").strip()
+        if alt and not _is_placeholder_alt(alt):
+            return alt
+    return None
+
+
+def _is_placeholder_alt(value: str) -> bool:
+    """Rekrute occasionally serves a literal ``"Logo"`` / ``"photo"``
+    placeholder when the recruiter hasn't uploaded a brand image. Skip
+    those so we don't surface ``company="Logo"`` rows."""
+    lowered = value.lower()
+    return lowered in {"logo", "photo", "rekrute"}
+
+
+def _extract_description(soup: Any) -> str | None:
+    """The short blurb lives in ``<div class="info"><span>…</span></div>``
+    at the top of the row body — Rekrute uses the ``info`` class for
+    several blocks so we pick the *first* one that contains a span.
+    """
+    for div in soup.find_all("div", class_="info"):
+        span = div.find("span")
+        if span is not None:
+            text = span.get_text(" ", strip=True)
+            if text:
+                return text
+    return None
+
+
+def _extract_posted_at(row_html: str) -> datetime | None:
+    """Pull ``Publication : du DD/MM/YYYY au DD/MM/YYYY`` — the first
+    date is the posting date. Defensive: if Rekrute changes the date
+    format we get ``None`` rather than a crash."""
+    # Anchor the search on the ``Publication`` token so we don't
+    # accidentally pick a date from elsewhere on the row.
+    pub_idx = row_html.find("Publication")
+    if pub_idx == -1:
+        return None
+    m = _DATE_DDMMYYYY_RE.search(row_html, pub_idx)
+    if m is None:
+        return None
+    day, month, year = m.group(1), m.group(2), m.group(3)
+    if len(year) == 2:
+        year = "20" + year
+    try:
+        return datetime(int(year), int(month), int(day))
+    except (ValueError, TypeError):
+        return None
+
+
+def _iter_facet_lis(soup: Any) -> Iterable[Any]:
+    """Yield only the ``<li>`` elements inside the facet ``<ul>`` that
+    holds the ``Secteur / Fonction / Expérience / Type de contrat``
+    rows. The outer row container itself is a ``<li class="post-id">``
+    so a naïve ``soup.find_all("li")`` would walk into it and grab
+    the whole row's text — we scope tightly to the facet ``<ul>``
+    inside the ``<div class="info">`` block."""
+    for ul in soup.find_all("ul"):
+        children = list(ul.find_all("li", recursive=False))
+        if not children:
+            continue
+        # Heuristic: a facet ``<ul>`` is the one whose lis' joined text
+        # mentions at least one canonical facet label. Avoids picking
+        # an unrelated ``<ul>`` (nav, related-jobs widget, etc.).
+        joined = " ".join(li.get_text(" ", strip=True) for li in children).lower()
+        if any(
+            token in joined for token in (
+                "type de contrat", "secteur d'activité", "fonction",
+                "expérience requise", "niveau d'étude",
+            )
+        ):
+            yield from children
+            return
+
+
+def _extract_contract(soup: Any) -> tuple[str | None, str | None, bool | None]:
+    """Parse the ``Type de contrat proposé : <a>CDI</a> - Télétravail : Non``
+    row. Returns ``(raw_label, normalised_employment_type, is_remote)``.
+
+    The remote flag is tri-state: ``True`` (Oui), ``False`` (Non), or
+    ``None`` (not mentioned). We surface ``False`` explicitly when the
+    site says so — that's signal too.
+    """
+    contract_label: str | None = None
+    employment_type: str | None = None
+    is_remote: bool | None = None
+    for li in _iter_facet_lis(soup):
+        text = li.get_text(" ", strip=True)
+        lowered = text.lower()
+        if "type de contrat" in lowered and contract_label is None:
+            a = li.find("a")
+            if a is not None:
+                contract_label = a.get_text(strip=True) or None
+            else:
+                after = text.split(":", 1)[-1].strip()
+                contract_label = after.split("-")[0].strip() or None
+            if contract_label:
+                employment_type = _CONTRACT_TO_EMPLOYMENT.get(
+                    contract_label.lower().strip(),
+                )
+        if "télétravail" in lowered or "teletravail" in lowered:
+            # Pull the value after the ``Télétravail`` label specifically —
+            # the same ``<li>`` often holds ``Type de contrat proposé : CDI -
+            # Télétravail : Non`` so a plain first-colon split would grab
+            # the contract value instead.
+            tt_match = re.search(
+                r"t[ée]l[ée]travail\s*[:：]\s*([^|\-–]+)",
+                text,
+                re.IGNORECASE,
+            )
+            if tt_match:
+                tt_value = tt_match.group(1).strip().lower()
+                if (
+                    tt_value.startswith("oui")
+                    or "hybride" in tt_value
+                    or "partiel" in tt_value
+                ):
+                    is_remote = True
+                elif tt_value.startswith("non"):
+                    is_remote = False
+    return contract_label, employment_type, is_remote
+
+
+def _extract_sector_function(soup: Any) -> tuple[str | None, str | None]:
+    """Pull the ``Secteur d'activité`` and ``Fonction`` rows. Both
+    are inline anchor labels and we keep the human-readable value."""
+    sector: str | None = None
+    function: str | None = None
+    for li in _iter_facet_lis(soup):
+        text = li.get_text(" ", strip=True)
+        lowered = text.lower()
+        if "secteur" in lowered and sector is None:
+            sector = _value_after_colon(li, text)
+        elif "fonction" in lowered and function is None:
+            function = _value_after_colon(li, text)
+    return sector, function
+
+
+def _extract_experience_study(soup: Any) -> tuple[str | None, str | None]:
+    """Pull the ``Expérience requise`` and ``Niveau d'étude`` rows.
+    Stored verbatim in ``raw`` — we don't map to the canonical
+    ``experience`` integer because Rekrute's labels are bucketed
+    ranges (``"Expert (10 à 20 ans)"``) not single numbers."""
+    experience: str | None = None
+    study: str | None = None
+    for li in _iter_facet_lis(soup):
+        text = li.get_text(" ", strip=True)
+        lowered = text.lower()
+        if "expérience requise" in lowered and experience is None:
+            experience = _value_after_colon(li, text)
+        elif "niveau d'étude" in lowered and study is None:
+            study = _value_after_colon(li, text)
+    return experience, study
+
+
+def _value_after_colon(li: Any, text: str) -> str | None:
+    """Best-effort value extraction: prefer the ``<a>`` anchor's text
+    (Rekrute wraps every value in a filter link), fall back to the
+    substring after the first colon."""
+    a = li.find("a")
+    if a is not None:
+        anchor_text = a.get_text(" ", strip=True)
+        if anchor_text:
+            return anchor_text
+    if ":" in text:
+        after = text.split(":", 1)[-1].strip()
+        if after:
+            return after
+    return None
+
+
+__all__ = [
+    "RekruteScraper",
+]

--- a/src/jobhive/scrapers/rekrute.py
+++ b/src/jobhive/scrapers/rekrute.py
@@ -58,7 +58,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import httpx
@@ -205,7 +205,7 @@ class RekruteScraper(BaseScraper):
         return asyncio.run(self._fetch_async())
 
     async def _fetch_async(self) -> list[Job]:
-        fetched_at = datetime.now()
+        fetched_at = datetime.now(tz=UTC)
         async with httpx.AsyncClient(
             timeout=self.timeout, follow_redirects=True,
         ) as client:
@@ -222,24 +222,30 @@ class RekruteScraper(BaseScraper):
         seen: set[str] = set()
         jobs: list[Job] = []
         sem = asyncio.Semaphore(self.concurrency)
-        stop_at_page: dict[str, int | None] = {"value": None}
+        stop_at_page: int | None = None
+        skipped_parse_pages: set[int] = set()
 
         async def fetch_page(page_no: int) -> list[Job]:
+            nonlocal stop_at_page
             async with sem:
-                if (
-                    stop_at_page["value"] is not None
-                    and page_no >= stop_at_page["value"]
-                ):
+                if stop_at_page is not None and page_no >= stop_at_page:
                     return []
                 html_body = await self._get_listing_page(client, page_no)
             if html_body is None:
                 return []
-            rows = list(_iter_rows(html_body))
+            try:
+                rows = list(_iter_rows(html_body))
+            except _RowsParseError as exc:
+                log.warning(
+                    "Rekrute page=%d: %s — skipping page", page_no, exc,
+                )
+                skipped_parse_pages.add(page_no)
+                return []
             if not rows:
                 # First fully-empty page — mark it as the upper bound
                 # so concurrent tasks at later pages bail out.
-                if stop_at_page["value"] is None or page_no < stop_at_page["value"]:
-                    stop_at_page["value"] = page_no
+                if stop_at_page is None or page_no < stop_at_page:
+                    stop_at_page = page_no
                 return []
             page_jobs: list[Job] = []
             for row_id, row_html in rows:
@@ -265,7 +271,11 @@ class RekruteScraper(BaseScraper):
                         continue
                     seen.add(job.ats_id)
                     jobs.append(job)
-            if not wave_had_rows or stop_at_page["value"] is not None:
+            wave_pages = range(page_no, wave_end)
+            wave_had_parse_skip = any(p in skipped_parse_pages for p in wave_pages)
+            if stop_at_page is not None or (
+                not wave_had_rows and not wave_had_parse_skip
+            ):
                 break
             page_no = wave_end
         log.info("Rekrute: fetched %d unique jobs", len(jobs))
@@ -282,12 +292,10 @@ class RekruteScraper(BaseScraper):
         translate at the URL boundary.
         """
         url = LISTING_URL_TEMPLATE.format(page=page_no - 1)
-        last_exc: Exception | None = None
         for attempt in range(1, MAX_RETRIES + 1):
             try:
                 response = await client.get(url, headers=_HEADERS)
             except httpx.HTTPError as exc:
-                last_exc = exc
                 if attempt == MAX_RETRIES:
                     log.warning(
                         "Rekrute page=%d transport error after %d retries: %s",
@@ -318,13 +326,13 @@ class RekruteScraper(BaseScraper):
                 page_no, status,
             )
             return None
-        log.warning(
-            "Rekrute page=%d exhausted retries: %s", page_no, last_exc,
-        )
-        return None
 
 
 # --- module-level helpers ---------------------------------------------
+
+
+class _RowsParseError(Exception):
+    """Raised when a 200-OK page does not contain Rekrute's job list shell."""
 
 
 def _iter_rows(html_body: str) -> Iterable[tuple[str, str]]:
@@ -336,6 +344,8 @@ def _iter_rows(html_body: str) -> Iterable[tuple[str, str]]:
     in practice.
     """
     matches = list(_ROW_BOUNDARY_RE.finditer(html_body))
+    if not matches and "post-list" not in html_body:
+        raise _RowsParseError("job list shell not found")
     for idx, m in enumerate(matches):
         start = m.start()
         end = (
@@ -429,22 +439,30 @@ def _split_title(title_full: str) -> tuple[str, str | None, str | None]:
         return title_full.strip(), None, "MA"
     city = m.group(1).strip()
     country_name = m.group(2).strip().lower()
-    iso = _TITLE_COUNTRY_TO_ISO.get(country_name, "MA")
+    iso = _TITLE_COUNTRY_TO_ISO.get(country_name)
     title = title_full[: m.start()].strip()
     return title, city or None, iso
 
 
 def _extract_company(soup: Any) -> str | None:
-    """Recruiter name comes from the ``alt`` / ``title`` of the logo
-    image. The site sometimes serves a placeholder logo for new
-    recruiters — in that case ``alt`` is empty and we fall back to
-    ``None`` (downstream resolves to "Unknown" at Job construction).
+    """Recruiter name comes from logo metadata or the logo link text.
+
+    Some rows omit a real logo image but keep the recruiter name as text
+    in the same left-column anchor. Use that before falling back to
+    ``Unknown`` at Job construction.
     """
     img = soup.find("img", class_="photo")
     if img is not None:
         alt = (img.get("alt") or img.get("title") or "").strip()
         if alt and not _is_placeholder_alt(alt):
             return alt
+    for anchor in soup.select(".col-sm-2 a"):
+        text = anchor.get_text(" ", strip=True)
+        if text and not _is_placeholder_alt(text):
+            return text
+        label = (anchor.get("title") or "").strip()
+        if label and not _is_placeholder_alt(label):
+            return label
     return None
 
 

--- a/src/jobhive/scrapers/rekrute.py
+++ b/src/jobhive/scrapers/rekrute.py
@@ -542,7 +542,7 @@ def _extract_posted_at(row_html: str) -> datetime | None:
     if len(year) == 2:
         year = "20" + year
     try:
-        return datetime(int(year), int(month), int(day))
+        return datetime(int(year), int(month), int(day), tzinfo=UTC)
     except (ValueError, TypeError):
         return None
 

--- a/src/jobhive/scrapers/rekrute.py
+++ b/src/jobhive/scrapers/rekrute.py
@@ -309,8 +309,8 @@ class RekruteScraper(BaseScraper):
     ) -> str | None:
         """Fetch one listing page with retry on transient errors.
 
-        Returns the HTML body on success, ``None`` to stop walking
-        when terminal. The ``p`` index Rekrute uses is 0-based on the
+        Returns the HTML body on success, ``None`` when this page
+        should be skipped. The ``p`` index Rekrute uses is 0-based on the
         wire (``?p=0`` is page 1) — we keep callers 1-based here and
         translate at the URL boundary.
         """
@@ -321,7 +321,7 @@ class RekruteScraper(BaseScraper):
             except httpx.HTTPError as exc:
                 if attempt == MAX_RETRIES:
                     log.warning(
-                        "Rekrute page=%d transport error after %d retries: %s",
+                        "Rekrute page=%d transport error after %d retries — skipping page: %s",
                         page_no, MAX_RETRIES, exc,
                     )
                     return None
@@ -333,7 +333,7 @@ class RekruteScraper(BaseScraper):
             if status in (429,) or 500 <= status < 600:
                 if attempt == MAX_RETRIES:
                     log.warning(
-                        "Rekrute page=%d returned %d after %d retries — stopping",
+                        "Rekrute page=%d returned %d after %d retries — skipping page",
                         page_no, status, MAX_RETRIES,
                     )
                     return None
@@ -345,7 +345,7 @@ class RekruteScraper(BaseScraper):
                 await asyncio.sleep(delay)
                 continue
             log.warning(
-                "Rekrute page=%d returned %d — stopping pagination",
+                "Rekrute page=%d returned %d — skipping page",
                 page_no, status,
             )
             return None

--- a/src/jobhive/scrapers/rekrute.py
+++ b/src/jobhive/scrapers/rekrute.py
@@ -115,6 +115,16 @@ _ROW_BOUNDARY_RE = re.compile(
     r'<li\s+class="post-id"\s+id="(?P<id>\d+)"\s*>',
     re.IGNORECASE,
 )
+_RESULTS_LIST_RE = re.compile(
+    r"<ul\b[^>]*\bid=['\"]post-data['\"][^>]*>",
+    re.IGNORECASE,
+)
+_RESULTS_RANGE_RE = re.compile(
+    r"<span\s+class=['\"]pages['\"]>\s*<span>\s*"
+    r"(?P<start>[\d\s]+)\s*-\s*(?P<end>[\d\s]+)\s*</span>\s*"
+    r"sur\s*(?P<total>[\d\s]+)",
+    re.IGNORECASE,
+)
 
 # ``Publication : du <span>DD/MM/YYYY</span>`` — the first span in the
 # ``<em class="date">`` block is always the publication date.
@@ -344,7 +354,7 @@ def _iter_rows(html_body: str) -> Iterable[tuple[str, str]]:
     in practice.
     """
     matches = list(_ROW_BOUNDARY_RE.finditer(html_body))
-    if not matches and "post-list" not in html_body:
+    if not matches and not _is_empty_results_page(html_body):
         raise _RowsParseError("job list shell not found")
     for idx, m in enumerate(matches):
         start = m.start()
@@ -353,6 +363,29 @@ def _iter_rows(html_body: str) -> Iterable[tuple[str, str]]:
             else min(start + 50_000, len(html_body))
         )
         yield m.group("id"), html_body[start:end]
+
+
+def _is_empty_results_page(html_body: str) -> bool:
+    """Return true only for Rekrute's real empty results page.
+
+    A shell-only 200 page with no ``post-id`` rows should be treated as
+    malformed unless Rekrute's pagination says the requested range starts
+    past the total result count. That keeps transient empty shells from
+    looking like the end of pagination.
+    """
+    if _RESULTS_LIST_RE.search(html_body) is None:
+        return False
+    m = _RESULTS_RANGE_RE.search(html_body)
+    if m is None:
+        return False
+    start = _parse_compact_int(m.group("start"))
+    total = _parse_compact_int(m.group("total"))
+    return total == 0 or start > total
+
+
+def _parse_compact_int(value: str) -> int:
+    digits = re.sub(r"\D+", "", value)
+    return int(digits) if digits else 0
 
 
 def _parse_row(
@@ -428,9 +461,9 @@ def _split_title(title_full: str) -> tuple[str, str | None, str | None]:
     """Split ``"Job title | Casablanca (Maroc)"`` into
     ``("Job title", "Casablanca", "MA")``.
 
-    Falls back to ``(title_full, None, "MA")`` when the suffix isn't
-    present — Rekrute *is* a Morocco board so we default to MA when
-    the city/country tag is missing.
+    Falls back to MA when the suffix is missing or unrecognized —
+    Rekrute is a Morocco board, and known non-Morocco suffixes are
+    mapped explicitly above.
     """
     m = _LOCATION_FROM_TITLE_RE.search(title_full)
     if m is None:
@@ -439,7 +472,7 @@ def _split_title(title_full: str) -> tuple[str, str | None, str | None]:
         return title_full.strip(), None, "MA"
     city = m.group(1).strip()
     country_name = m.group(2).strip().lower()
-    iso = _TITLE_COUNTRY_TO_ISO.get(country_name)
+    iso = _TITLE_COUNTRY_TO_ISO.get(country_name, "MA")
     title = title_full[: m.start()].strip()
     return title, city or None, iso
 

--- a/src/jobhive/scrapers/rekrute.py
+++ b/src/jobhive/scrapers/rekrute.py
@@ -112,7 +112,8 @@ _HEADERS: dict[str, str] = {
 # CSS-select the rows directly works too, but a regex slice halves
 # the parse time on a 200KB page and keeps the per-row scopes small.
 _ROW_BOUNDARY_RE = re.compile(
-    r'<li\s+class="post-id"\s+id="(?P<id>\d+)"\s*>',
+    r"<li\b(?=[^>]*\bclass=['\"][^'\"]*\bpost-id\b)"
+    r"(?=[^>]*\bid=['\"](?P<id>\d+)['\"])[^>]*>",
     re.IGNORECASE,
 )
 _RESULTS_LIST_RE = re.compile(
@@ -235,6 +236,7 @@ class RekruteScraper(BaseScraper):
         stop_at_page: int | None = None
         skipped_fetch_pages: set[int] = set()
         skipped_parse_pages: set[int] = set()
+        consecutive_empty_skip_waves = 0
 
         async def fetch_page(page_no: int) -> list[Job]:
             nonlocal stop_at_page
@@ -288,9 +290,15 @@ class RekruteScraper(BaseScraper):
                 p in skipped_fetch_pages or p in skipped_parse_pages
                 for p in wave_pages
             )
-            if stop_at_page is not None or (
-                not wave_had_rows and not wave_had_skip
-            ):
+            if stop_at_page is not None:
+                break
+            if wave_had_rows:
+                consecutive_empty_skip_waves = 0
+            elif wave_had_skip:
+                consecutive_empty_skip_waves += 1
+                if consecutive_empty_skip_waves > 1:
+                    break
+            else:
                 break
             page_no = wave_end
         log.info("Rekrute: fetched %d unique jobs", len(jobs))

--- a/src/jobhive/scrapers/rekrute.py
+++ b/src/jobhive/scrapers/rekrute.py
@@ -233,6 +233,7 @@ class RekruteScraper(BaseScraper):
         jobs: list[Job] = []
         sem = asyncio.Semaphore(self.concurrency)
         stop_at_page: int | None = None
+        skipped_fetch_pages: set[int] = set()
         skipped_parse_pages: set[int] = set()
 
         async def fetch_page(page_no: int) -> list[Job]:
@@ -242,6 +243,7 @@ class RekruteScraper(BaseScraper):
                     return []
                 html_body = await self._get_listing_page(client, page_no)
             if html_body is None:
+                skipped_fetch_pages.add(page_no)
                 return []
             try:
                 rows = list(_iter_rows(html_body))
@@ -282,9 +284,12 @@ class RekruteScraper(BaseScraper):
                     seen.add(job.ats_id)
                     jobs.append(job)
             wave_pages = range(page_no, wave_end)
-            wave_had_parse_skip = any(p in skipped_parse_pages for p in wave_pages)
+            wave_had_skip = any(
+                p in skipped_fetch_pages or p in skipped_parse_pages
+                for p in wave_pages
+            )
             if stop_at_page is not None or (
-                not wave_had_rows and not wave_had_parse_skip
+                not wave_had_rows and not wave_had_skip
             ):
                 break
             page_no = wave_end

--- a/tests/test_avito_ma.py
+++ b/tests/test_avito_ma.py
@@ -162,33 +162,34 @@ def test_extract_ads_returns_list() -> None:
     assert len(a_mod._extract_ads(page)) == 2
 
 
-def test_extract_ads_missing_blob_returns_empty() -> None:
-    assert a_mod._extract_ads("<html>no script</html>") == []
+def test_extract_ads_missing_blob_raises() -> None:
+    with pytest.raises(a_mod._AdsParseError):
+        a_mod._extract_ads("<html>no script</html>")
 
 
-def test_extract_ads_malformed_json_returns_empty(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
+def test_extract_ads_malformed_json_raises() -> None:
     """A page where Avito ships invalid JSON in the script tag must
-    degrade to ``[]`` not crash the scraper."""
+    raise a parse error — distinct from a genuine empty last page — so
+    pagination retries instead of truncating."""
     bad = (
         '<html><body><script id="__NEXT_DATA__" type="application/json">'
         '{this is not json'
         '</script></body></html>'
     )
-    assert a_mod._extract_ads(bad) == []
+    with pytest.raises(a_mod._AdsParseError):
+        a_mod._extract_ads(bad)
 
 
-def test_extract_ads_shape_changed_returns_empty(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """If Avito rearranges the JSON path, fall back to empty + log."""
+def test_extract_ads_shape_changed_raises() -> None:
+    """If Avito rearranges the JSON path, raise a parse error rather
+    than silently returning ``[]`` and ending pagination."""
     page = (
         '<script id="__NEXT_DATA__" type="application/json">'
         '{"props":{"pageProps":{"shape":"changed"}}}'
         '</script>'
     )
-    assert a_mod._extract_ads(page) == []
+    with pytest.raises(a_mod._AdsParseError):
+        a_mod._extract_ads(page)
 
 
 # --- Single-ad parsing -------------------------------------------------

--- a/tests/test_avito_ma.py
+++ b/tests/test_avito_ma.py
@@ -169,6 +169,13 @@ def test_extract_ads_returns_list() -> None:
     assert len(a_mod._extract_ads(page)) == 2
 
 
+def test_extract_ads_non_object_entry_raises() -> None:
+    page = _wrap_next_data([_make_ad()])
+    page = page.replace('"ads": [{', '"ads": [null, {', 1)
+    with pytest.raises(a_mod._AdsParseError):
+        a_mod._extract_ads(page)
+
+
 def test_extract_ads_missing_blob_raises() -> None:
     with pytest.raises(a_mod._AdsParseError):
         a_mod._extract_ads("<html>no script</html>")
@@ -289,15 +296,15 @@ def test_parse_ad_missing_seller_name_becomes_unknown() -> None:
 
 
 def test_parse_ad_long_description_truncated() -> None:
-    """Avito occasionally serves a 10kB description block. The Job
-    schema documents ``~10kB`` as the cap; we trim at 5k and append
-    an ellipsis so the row stays compact in the dataset."""
-    long_desc = "x" * 8000
+    """Avito occasionally serves a large description block. The Job
+    schema documents ``~10kB`` as the cap; trim there and append an
+    ellipsis so the row stays compact in the dataset."""
+    long_desc = "x" * 12_000
     ad = _make_ad(description=long_desc)
     job = a_mod._parse_ad(ad, fetched_at=datetime.now())
     assert job is not None
     assert job.description is not None
-    assert len(job.description) <= 5001
+    assert len(job.description) <= 10_001
     assert job.description.endswith("…")
 
 

--- a/tests/test_avito_ma.py
+++ b/tests/test_avito_ma.py
@@ -528,3 +528,23 @@ def test_fetch_skips_malformed_page_without_stopping(
     _patch_client(monkeypatch, transport)
     jobs = AvitoMarocScraper("any", max_pages=4, concurrency=1).fetch()
     assert [j.ats_id for j in jobs] == ["1", "3"]
+
+
+def test_fetch_skips_single_malformed_ad_without_stopping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A malformed row should not poison the whole page."""
+    malformed_ad = _make_ad(ad_id="bad", list_id="bad")
+    malformed_ad["seller"] = "not-a-dict"
+    good_ad = _make_ad(ad_id="2", list_id="22")
+    page1 = _wrap_next_data([malformed_ad, good_ad])
+    empty = _wrap_next_data([])
+    transport = _ScriptedTransport(
+        [
+            ("o=1", httpx.Response(200, text=page1)),
+            ("o=2", httpx.Response(200, text=empty)),
+        ],
+    )
+    _patch_client(monkeypatch, transport)
+    jobs = AvitoMarocScraper("any", max_pages=2, concurrency=1).fetch()
+    assert [j.ats_id for j in jobs] == ["2"]

--- a/tests/test_avito_ma.py
+++ b/tests/test_avito_ma.py
@@ -104,7 +104,7 @@ def _wrap_next_data(ads: list[dict[str, Any]], total: int | None = None) -> str:
 
 
 class _ScriptedTransport(httpx.MockTransport):
-    """URL-substring keyed response replay."""
+    """Query-aware response replay for pagination tests."""
 
     def __init__(
         self,
@@ -117,11 +117,18 @@ class _ScriptedTransport(httpx.MockTransport):
         def handler(request: httpx.Request) -> httpx.Response:
             self._record.append(str(request.url))
             for url_fragment, response in self._scripts:
-                if url_fragment in str(request.url):
+                if self._matches(url_fragment, request):
                     return response
             raise AssertionError(f"unexpected URL {request.url}")
 
         super().__init__(handler)
+
+    @staticmethod
+    def _matches(url_fragment: str, request: httpx.Request) -> bool:
+        key, sep, expected = url_fragment.partition("=")
+        if sep and key in request.url.params:
+            return request.url.params.get(key) == expected
+        return url_fragment in str(request.url)
 
 
 def _patch_client(

--- a/tests/test_avito_ma.py
+++ b/tests/test_avito_ma.py
@@ -1,0 +1,475 @@
+"""Tests for the Avito Maroc (avito.ma) scraper.
+
+Scope: __NEXT_DATA__ JSON extraction, category-filter guard (drop
+boosted ads from other categories), French relative-time parsing,
+pagination + dedup, retry/backoff, and registry wiring. The httpx
+network path is exercised via ``MockTransport`` so we never hit
+the live site.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from typing import Any
+
+import httpx
+import pytest
+
+from jobhive.models import ATSType
+from jobhive.scrapers import AvitoMarocScraper, ScraperRegistry
+from jobhive.scrapers import avito_ma as a_mod
+
+# --- Fixture builders -------------------------------------------------
+
+
+def _make_ad(
+    *,
+    ad_id: str = "77081446",
+    list_id: str = "57625044",
+    subject: str = "Femme de ménage",
+    description: str = "Service à domicile au Maroc.",
+    href: str | None = None,
+    seller_name: str = "2TG BUSINESS SERVICES",
+    seller_type: str = "STORE",
+    seller_id: str = "7373",
+    location: str = "Oujda, Bd Hassan II",
+    date_text: str = "il y a 7 minutes",
+    cat_id: str = "6050",
+    cat_name: str = "Centre d'appels",
+    parent_id: str = "6200",
+    parent_name: str = "Emploi",
+    images: list[str] | None = None,
+    is_premium: bool = False,
+    is_shop: bool = False,
+    is_urgent: bool = False,
+) -> dict[str, Any]:
+    """One realistic ad payload mirroring the shape captured from
+    ``componentProps.ads.ads[*]`` in the live ``__NEXT_DATA__``."""
+    if href is None:
+        href = f"https://www.avito.ma/fr/x/centre_d_appels/Job_{list_id}.htm"
+    if images is None:
+        images = ["https://content.avito.ma/classifieds/images/x1"]
+    return {
+        "id": ad_id,
+        "listId": list_id,
+        "subject": subject,
+        "description": description,
+        "href": href,
+        "location": location,
+        "date": date_text,
+        "category": {
+            "id": cat_id,
+            "name": cat_name,
+            "formatted": f"{parent_name} - {cat_name}",
+            "parent": {"id": parent_id, "name": parent_name},
+        },
+        "seller": {
+            "id": seller_id,
+            "name": seller_name,
+            "type": seller_type,
+        },
+        "images": images,
+        "isPremium": is_premium,
+        "isShop": is_shop,
+        "isUrgent": is_urgent,
+    }
+
+
+def _wrap_next_data(ads: list[dict[str, Any]], total: int | None = None) -> str:
+    """Wrap a list of ads in just enough of the Next.js page envelope
+    to mirror ``__NEXT_DATA__``."""
+    blob = {
+        "props": {
+            "pageProps": {
+                "componentProps": {
+                    "ads": {
+                        "ads": ads,
+                        "totalListingAds": total if total is not None else len(ads),
+                    },
+                },
+            },
+        },
+    }
+    blob_json = json.dumps(blob, ensure_ascii=False)
+    return f"""<!DOCTYPE html>
+<html lang="fr"><head><title>Emploi Maroc</title></head>
+<body>
+<div id="__next">…</div>
+<script id="__NEXT_DATA__" type="application/json">{blob_json}</script>
+</body></html>"""
+
+
+# --- httpx transport stub ---------------------------------------------
+
+
+class _ScriptedTransport(httpx.MockTransport):
+    """URL-substring keyed response replay."""
+
+    def __init__(
+        self,
+        scripts: list[tuple[str, httpx.Response]],
+        record: list[str] | None = None,
+    ) -> None:
+        self._scripts = scripts
+        self._record = record if record is not None else []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            self._record.append(str(request.url))
+            for url_fragment, response in self._scripts:
+                if url_fragment in str(request.url):
+                    return response
+            raise AssertionError(f"unexpected URL {request.url}")
+
+        super().__init__(handler)
+
+
+def _patch_client(
+    monkeypatch: pytest.MonkeyPatch, transport: httpx.MockTransport,
+) -> None:
+    real_ctor = httpx.AsyncClient
+
+    def factory(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_ctor(*args, **kwargs)
+
+    monkeypatch.setattr(a_mod.httpx, "AsyncClient", factory)
+
+
+# --- Registry / construction ------------------------------------------
+
+
+def test_registry_resolves_avito_ma() -> None:
+    assert ScraperRegistry.get(ATSType.AVITOMA) is AvitoMarocScraper
+
+
+def test_default_construction_works() -> None:
+    s = AvitoMarocScraper("any")
+    assert s.company_slug == "any"
+    assert s.max_pages > 0
+
+
+def test_concurrency_floor_is_one() -> None:
+    s = AvitoMarocScraper("any", concurrency=0)
+    assert s.concurrency == 1
+
+
+# --- __NEXT_DATA__ extraction -----------------------------------------
+
+
+def test_extract_ads_returns_list() -> None:
+    page = _wrap_next_data([_make_ad(), _make_ad(ad_id="2", list_id="22")])
+    assert len(a_mod._extract_ads(page)) == 2
+
+
+def test_extract_ads_missing_blob_returns_empty() -> None:
+    assert a_mod._extract_ads("<html>no script</html>") == []
+
+
+def test_extract_ads_malformed_json_returns_empty(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A page where Avito ships invalid JSON in the script tag must
+    degrade to ``[]`` not crash the scraper."""
+    bad = (
+        '<html><body><script id="__NEXT_DATA__" type="application/json">'
+        '{this is not json'
+        '</script></body></html>'
+    )
+    assert a_mod._extract_ads(bad) == []
+
+
+def test_extract_ads_shape_changed_returns_empty(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """If Avito rearranges the JSON path, fall back to empty + log."""
+    page = (
+        '<script id="__NEXT_DATA__" type="application/json">'
+        '{"props":{"pageProps":{"shape":"changed"}}}'
+        '</script>'
+    )
+    assert a_mod._extract_ads(page) == []
+
+
+# --- Single-ad parsing -------------------------------------------------
+
+
+def test_parse_ad_full_mapping() -> None:
+    """End-to-end parse of a realistic Emploi ad. Pins the field
+    mapping the public dataset relies on."""
+    fetched = datetime(2026, 5, 12, 10, 0, 0)
+    ad = _make_ad(
+        ad_id="42",
+        list_id="999",
+        subject="Recherche commercial",
+        description="Société cherche commercial dynamique.",
+        seller_name="SALWA NASSER",
+        location="Casablanca, 2 Mars",
+        cat_name="Commercial",
+        cat_id="6012",
+        date_text="il y a 2 heures",
+        is_shop=True,
+        is_premium=True,
+    )
+    job = a_mod._parse_ad(ad, fetched_at=fetched)
+    assert job is not None
+    assert job.ats_type is ATSType.AVITOMA
+    assert job.ats_id == "42"
+    assert job.title == "Recherche commercial"
+    assert job.company == "SALWA NASSER"
+    assert job.location == "Casablanca, 2 Mars"
+    assert job.country_iso == "MA"
+    assert job.region == "Africa"
+    assert job.language == "fr"
+    assert job.department == "Emploi - Commercial"
+    assert job.description is not None
+    assert "commercial" in job.description.lower()
+    assert job.posted_at == fetched - timedelta(hours=2)
+    assert job.fetched_at == fetched
+    assert job.raw is not None
+    assert job.raw["seller_type"] == "STORE"
+    assert job.raw["seller_id"] == "7373"
+    assert job.raw["list_id"] == "999"
+    assert job.raw["category_id"] == "6012"
+    assert job.raw["is_shop"] is True
+    assert job.raw["is_premium"] is True
+    assert job.raw["image_count"] == 1
+
+
+def test_parse_ad_drops_non_jobs_categories() -> None:
+    """Boosted ads from other categories slip into the listing URL —
+    the parent-id guard drops them so we don't surface laptops /
+    cars as jobs."""
+    ad = _make_ad(
+        cat_id="5030",
+        cat_name="Ordinateurs portables",
+        parent_id="5000",
+        parent_name="INFORMATIQUE ET MULTIMEDIA",
+    )
+    assert a_mod._parse_ad(ad, fetched_at=datetime.now()) is None
+
+
+def test_parse_ad_keeps_top_level_emploi_category() -> None:
+    """An ad posted at the Emploi root (``category.id == 6200``)
+    rather than under a subcategory should still pass the filter."""
+    ad = _make_ad(
+        cat_id="6200",
+        cat_name="Emploi",
+        parent_id="",
+        parent_name="",
+    )
+    job = a_mod._parse_ad(ad, fetched_at=datetime.now())
+    assert job is not None
+    assert job.country_iso == "MA"
+
+
+def test_parse_ad_missing_subject_returns_none() -> None:
+    ad = _make_ad(subject="")
+    assert a_mod._parse_ad(ad, fetched_at=datetime.now()) is None
+
+
+def test_parse_ad_missing_href_returns_none() -> None:
+    ad = _make_ad(href="")
+    assert a_mod._parse_ad(ad, fetched_at=datetime.now()) is None
+
+
+def test_parse_ad_missing_seller_name_becomes_unknown() -> None:
+    ad = _make_ad(seller_name="")
+    job = a_mod._parse_ad(ad, fetched_at=datetime.now())
+    assert job is not None
+    assert job.company == "Unknown"
+
+
+def test_parse_ad_long_description_truncated() -> None:
+    """Avito occasionally serves a 10kB description block. The Job
+    schema documents ``~10kB`` as the cap; we trim at 5k and append
+    an ellipsis so the row stays compact in the dataset."""
+    long_desc = "x" * 8000
+    ad = _make_ad(description=long_desc)
+    job = a_mod._parse_ad(ad, fetched_at=datetime.now())
+    assert job is not None
+    assert job.description is not None
+    assert len(job.description) <= 5001
+    assert job.description.endswith("…")
+
+
+def test_parse_ad_relative_href_resolved_to_absolute() -> None:
+    """Some payloads ship the href as a relative path. The scraper
+    should produce a fully-qualified URL on the canonical site."""
+    ad = _make_ad(href="/fr/x/y/Foo_123.htm")
+    job = a_mod._parse_ad(ad, fetched_at=datetime.now())
+    assert job is not None
+    assert str(job.url).startswith("https://www.avito.ma/")
+
+
+# --- French relative date parsing -------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_kwargs"),
+    [
+        ("il y a 5 minutes", {"minutes": 5}),
+        ("il y a 1 minute", {"minutes": 1}),
+        ("il y a 3 heures", {"hours": 3}),
+        ("il y a 1 heure", {"hours": 1}),
+        ("il y a 2 jours", {"days": 2}),
+        ("il y a 1 jour", {"days": 1}),
+        ("il y a 4 semaines", {"weeks": 4}),
+    ],
+)
+def test_parse_relative_date_known_units(
+    text: str, expected_kwargs: dict[str, int],
+) -> None:
+    now = datetime(2026, 5, 12, 12, 0, 0)
+    expected = now - timedelta(**expected_kwargs)
+    assert a_mod._parse_relative_date(text, now=now) == expected
+
+
+def test_parse_relative_date_months_approximated_at_30_days() -> None:
+    """Avito's ``il y a 2 mois`` is coarse — we approximate 30 days
+    per month so the timestamp stays plausible."""
+    now = datetime(2026, 5, 12)
+    out = a_mod._parse_relative_date("il y a 2 mois", now=now)
+    assert out == now - timedelta(days=60)
+
+
+def test_parse_relative_date_years_approximated_at_365_days() -> None:
+    now = datetime(2026, 5, 12)
+    out = a_mod._parse_relative_date("il y a 1 an", now=now)
+    assert out == now - timedelta(days=365)
+
+
+def test_parse_relative_date_unknown_phrase_returns_none() -> None:
+    assert a_mod._parse_relative_date("hier", now=datetime.now()) is None
+    assert a_mod._parse_relative_date(None, now=datetime.now()) is None
+    assert a_mod._parse_relative_date("", now=datetime.now()) is None
+
+
+# --- End-to-end fetch (httpx mock) ------------------------------------
+
+
+def test_fetch_walks_pages_until_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pagination halts when a page yields zero ads."""
+    page1 = _wrap_next_data(
+        [_make_ad(ad_id="1", list_id="11"), _make_ad(ad_id="2", list_id="22")],
+    )
+    page2 = _wrap_next_data([_make_ad(ad_id="3", list_id="33")])
+    empty = _wrap_next_data([])
+    transport = _ScriptedTransport(
+        [
+            ("o=1", httpx.Response(200, text=page1)),
+            ("o=2", httpx.Response(200, text=page2)),
+            ("o=3", httpx.Response(200, text=empty)),
+            ("o=4", httpx.Response(200, text=empty)),
+            ("o=5", httpx.Response(200, text=empty)),
+        ],
+    )
+    _patch_client(monkeypatch, transport)
+    jobs = AvitoMarocScraper("any", max_pages=5, concurrency=1).fetch()
+    assert sorted(j.ats_id for j in jobs) == ["1", "2", "3"]
+
+
+def test_fetch_dedupes_repeated_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Premium / repeated ads should surface once across the walk."""
+    sticky = _make_ad(ad_id="999", list_id="999")
+    page1 = _wrap_next_data([sticky, _make_ad(ad_id="1", list_id="11")])
+    page2 = _wrap_next_data([sticky, _make_ad(ad_id="2", list_id="22")])
+    empty = _wrap_next_data([])
+    transport = _ScriptedTransport(
+        [
+            ("o=1", httpx.Response(200, text=page1)),
+            ("o=2", httpx.Response(200, text=page2)),
+            ("o=3", httpx.Response(200, text=empty)),
+        ],
+    )
+    _patch_client(monkeypatch, transport)
+    jobs = AvitoMarocScraper("any", max_pages=5, concurrency=1).fetch()
+    assert sorted(j.ats_id for j in jobs) == ["1", "2", "999"]
+
+
+def test_fetch_respects_max_pages_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pages = [
+        (f"o={i + 1}", httpx.Response(200, text=_wrap_next_data(
+            [_make_ad(ad_id=str(i + 100), list_id=str(i + 200))],
+        )))
+        for i in range(20)
+    ]
+    transport = _ScriptedTransport(pages)
+    _patch_client(monkeypatch, transport)
+    jobs = AvitoMarocScraper("any", max_pages=3, concurrency=1).fetch()
+    assert len(jobs) == 3
+
+
+def test_fetch_uses_emploi_url_not_offres_d_emploi(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The scraper must hit ``/fr/maroc/emploi`` (category-restricted)
+    not the cross-category ``/fr/maroc/offres_d_emploi`` URL that
+    mixes in boosted non-job ads."""
+    record: list[str] = []
+    transport = _ScriptedTransport(
+        [("o=1", httpx.Response(200, text=_wrap_next_data([])))],
+        record=record,
+    )
+    _patch_client(monkeypatch, transport)
+    AvitoMarocScraper("any", max_pages=1, concurrency=1).fetch()
+    assert any("/fr/maroc/emploi" in u for u in record)
+    assert not any("offres_d_emploi" in u for u in record)
+
+
+def test_fetch_drops_boosted_non_jobs_in_listing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the listing JSON includes a boosted non-job ad we drop
+    it instead of surfacing it as a job."""
+    job_ad = _make_ad(ad_id="J1", list_id="JL")
+    boosted = _make_ad(
+        ad_id="B1", list_id="BL",
+        cat_id="5030", cat_name="Ordinateurs portables",
+        parent_id="5000", parent_name="INFORMATIQUE ET MULTIMEDIA",
+    )
+    page1 = _wrap_next_data([boosted, job_ad])
+    empty = _wrap_next_data([])
+    transport = _ScriptedTransport(
+        [
+            ("o=1", httpx.Response(200, text=page1)),
+            ("o=2", httpx.Response(200, text=empty)),
+        ],
+    )
+    _patch_client(monkeypatch, transport)
+    jobs = AvitoMarocScraper("any", max_pages=5, concurrency=1).fetch()
+    assert [j.ats_id for j in jobs] == ["J1"]
+
+
+@pytest.fixture
+def monkeypatch_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch ``asyncio.sleep`` so retry-path tests don't pay
+    wall-clock cost."""
+    async def _noop(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(a_mod.asyncio, "sleep", _noop)
+
+
+def test_fetch_handles_5xx_and_stops(
+    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch_sleep: None,
+) -> None:
+    """A 5xx after exhausted retries breaks the pagination loop but
+    leaves already-collected jobs intact."""
+    page1 = _wrap_next_data([_make_ad(ad_id="1", list_id="11")])
+    transport = _ScriptedTransport(
+        [
+            ("o=1", httpx.Response(200, text=page1)),
+            ("o=2", httpx.Response(503)),
+        ],
+    )
+    _patch_client(monkeypatch, transport)
+    jobs = AvitoMarocScraper("any", max_pages=5, concurrency=1).fetch()
+    assert [j.ats_id for j in jobs] == ["1"]

--- a/tests/test_avito_ma.py
+++ b/tests/test_avito_ma.py
@@ -474,3 +474,24 @@ def test_fetch_handles_5xx_and_stops(
     _patch_client(monkeypatch, transport)
     jobs = AvitoMarocScraper("any", max_pages=5, concurrency=1).fetch()
     assert [j.ats_id for j in jobs] == ["1"]
+
+
+def test_fetch_skips_malformed_page_without_stopping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A broken 200 page should not be treated as the empty tail page."""
+    page1 = _wrap_next_data([_make_ad(ad_id="1", list_id="11")])
+    malformed = "<html><body>maintenance</body></html>"
+    page3 = _wrap_next_data([_make_ad(ad_id="3", list_id="33")])
+    empty = _wrap_next_data([])
+    transport = _ScriptedTransport(
+        [
+            ("o=1", httpx.Response(200, text=page1)),
+            ("o=2", httpx.Response(200, text=malformed)),
+            ("o=3", httpx.Response(200, text=page3)),
+            ("o=4", httpx.Response(200, text=empty)),
+        ],
+    )
+    _patch_client(monkeypatch, transport)
+    jobs = AvitoMarocScraper("any", max_pages=4, concurrency=1).fetch()
+    assert [j.ats_id for j in jobs] == ["1", "3"]

--- a/tests/test_avito_ma.py
+++ b/tests/test_avito_ma.py
@@ -487,6 +487,28 @@ def test_fetch_skips_5xx_page_without_stopping(
     assert [j.ats_id for j in jobs] == ["1", "3"]
 
 
+def test_fetch_stops_after_repeated_5xx_pages(
+    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch_sleep: None,
+) -> None:
+    """One failed page is skipped; repeated empty failure waves stop the walk."""
+    page1 = _wrap_next_data([_make_ad(ad_id="1", list_id="11")])
+    record: list[str] = []
+    transport = _ScriptedTransport(
+        [
+            ("o=1", httpx.Response(200, text=page1)),
+            ("o=2", httpx.Response(503)),
+            ("o=3", httpx.Response(503)),
+        ],
+        record=record,
+    )
+    _patch_client(monkeypatch, transport)
+    jobs = AvitoMarocScraper("any", max_pages=5, concurrency=1).fetch()
+    assert [j.ats_id for j in jobs] == ["1"]
+    assert any("o=3" in u for u in record)
+    assert not any("o=4" in u for u in record)
+
+
 def test_fetch_skips_malformed_page_without_stopping(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_avito_ma.py
+++ b/tests/test_avito_ma.py
@@ -458,22 +458,26 @@ def monkeypatch_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(a_mod.asyncio, "sleep", _noop)
 
 
-def test_fetch_handles_5xx_and_stops(
+def test_fetch_skips_5xx_page_without_stopping(
     monkeypatch: pytest.MonkeyPatch,
     monkeypatch_sleep: None,
 ) -> None:
-    """A 5xx after exhausted retries breaks the pagination loop but
-    leaves already-collected jobs intact."""
+    """A 5xx after exhausted retries skips that page but does not
+    masquerade as the empty tail page."""
     page1 = _wrap_next_data([_make_ad(ad_id="1", list_id="11")])
+    page3 = _wrap_next_data([_make_ad(ad_id="3", list_id="33")])
+    empty = _wrap_next_data([])
     transport = _ScriptedTransport(
         [
             ("o=1", httpx.Response(200, text=page1)),
             ("o=2", httpx.Response(503)),
+            ("o=3", httpx.Response(200, text=page3)),
+            ("o=4", httpx.Response(200, text=empty)),
         ],
     )
     _patch_client(monkeypatch, transport)
-    jobs = AvitoMarocScraper("any", max_pages=5, concurrency=1).fetch()
-    assert [j.ats_id for j in jobs] == ["1"]
+    jobs = AvitoMarocScraper("any", max_pages=4, concurrency=1).fetch()
+    assert [j.ats_id for j in jobs] == ["1", "3"]
 
 
 def test_fetch_skips_malformed_page_without_stopping(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -33,6 +33,8 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",
         "recruitee", "taleo", "teamtailor",
+        # Moroccan job boards
+        "rekrute", "avitoma",
         # Catch-all
         "custom",
     }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -34,7 +34,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "bamboohr", "breezy", "jazzhr", "jobvite",
         "recruitee", "taleo", "teamtailor",
         # Moroccan job boards
-        "rekrute", "avitoma",
+        "rekrute", "avito_ma",
         # Catch-all
         "custom",
     }

--- a/tests/test_rekrute.py
+++ b/tests/test_rekrute.py
@@ -123,14 +123,23 @@ def _make_row(
 
 
 def _wrap_page(rows: list[str]) -> str:
-    """Wrap a list of ``<li class="post-id">`` rows in just enough
-    surrounding HTML to mirror Rekrute's page shell."""
+    """Wrap rows in the live Rekrute result shell.
+
+    Empty fixtures include an out-of-range pagination span, matching the
+    site's real empty tail pages. Rowless shells without that marker are
+    parse failures, not a legitimate stop signal.
+    """
     rows_html = "\n".join(rows)
+    result_count = len(rows)
+    range_start = 1 if rows else 11
+    range_end = result_count if rows else 10
+    total = result_count if rows else 10
     return f"""<!DOCTYPE html>
 <html lang="fr"><head><title>Offres d'emploi Maroc</title></head>
 <body>
 <div class="container">
-  <ul class="post-list">
+  <span class="pages"><span>{range_start} - {range_end}</span> sur {total}</span>
+  <ul class="job-list job-list2" id="post-data">
     {rows_html}
   </ul>
 </div>
@@ -332,13 +341,13 @@ def test_country_iso_recognises_non_morocco_suffix() -> None:
     assert job.location == "Tunis"
 
 
-def test_country_iso_unknown_country_suffix_stays_unknown() -> None:
-    """An explicit but unrecognized suffix is not safe to relabel as MA."""
+def test_country_iso_unknown_country_suffix_defaults_to_morocco() -> None:
+    """Unknown country suffixes fall back to Rekrute's Morocco-board default."""
     row = _make_row(city="Atlantis", country="Atlantide")
     job = r_mod._parse_row("1", row, fetched_at=datetime.now())
     assert job is not None
-    assert job.country_iso is None
-    assert job.region is None
+    assert job.country_iso == "MA"
+    assert job.region == "Africa"
 
 
 def test_parse_row_skips_when_title_anchor_missing() -> None:
@@ -489,6 +498,32 @@ def test_fetch_skips_malformed_page_without_stopping(
         [
             ("p=0", httpx.Response(200, text=page1)),
             ("p=1", httpx.Response(200, text=malformed)),
+            ("p=2", httpx.Response(200, text=page3)),
+            ("p=3", httpx.Response(200, text=empty)),
+        ],
+    )
+    _patch_client(monkeypatch, transport)
+    jobs = RekruteScraper("any", max_pages=4, concurrency=1).fetch()
+    assert [j.ats_id for j in jobs] == ["1", "3"]
+
+
+def test_fetch_skips_rowless_in_range_shell_without_stopping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A shell-only page within the reported result range is malformed,
+    not the empty tail page."""
+    page1 = _wrap_page([_make_row(job_id="1")])
+    malformed_shell = """<!DOCTYPE html>
+<html><body>
+  <span class="pages"><span>11 - 20</span> sur 30</span>
+  <ul class="job-list job-list2" id="post-data"></ul>
+</body></html>"""
+    page3 = _wrap_page([_make_row(job_id="3")])
+    empty = _wrap_page([])
+    transport = _ScriptedTransport(
+        [
+            ("p=0", httpx.Response(200, text=page1)),
+            ("p=1", httpx.Response(200, text=malformed_shell)),
             ("p=2", httpx.Response(200, text=page3)),
             ("p=3", httpx.Response(200, text=empty)),
         ],

--- a/tests/test_rekrute.py
+++ b/tests/test_rekrute.py
@@ -332,14 +332,13 @@ def test_country_iso_recognises_non_morocco_suffix() -> None:
     assert job.location == "Tunis"
 
 
-def test_country_iso_unknown_country_falls_back_to_morocco() -> None:
-    """Unknown country suffix (a new market Rekrute hasn't taught us
-    about) shouldn't crash — fall back to MA, the dominant geography.
-    """
+def test_country_iso_unknown_country_suffix_stays_unknown() -> None:
+    """An explicit but unrecognized suffix is not safe to relabel as MA."""
     row = _make_row(city="Atlantis", country="Atlantide")
     job = r_mod._parse_row("1", row, fetched_at=datetime.now())
     assert job is not None
-    assert job.country_iso == "MA"
+    assert job.country_iso is None
+    assert job.region is None
 
 
 def test_parse_row_skips_when_title_anchor_missing() -> None:
@@ -359,6 +358,18 @@ def test_parse_row_placeholder_company_logo_becomes_unknown() -> None:
     job = r_mod._parse_row("1", row, fetched_at=datetime.now())
     assert job is not None
     assert job.company == "Unknown"
+
+
+def test_parse_row_uses_non_logo_company_text_fallback() -> None:
+    """Rows without a logo image can still expose recruiter text."""
+    row = _make_row(company="Logo").replace(
+        '<img src="/logo/182716" width="115" alt="Logo"\n'
+        '             title="Logo" class="photo">',
+        'Société Sans Logo',
+    )
+    job = r_mod._parse_row("1", row, fetched_at=datetime.now())
+    assert job is not None
+    assert job.company == "Société Sans Logo"
 
 
 def test_invalid_pub_date_falls_back_to_none() -> None:
@@ -464,6 +475,27 @@ def test_fetch_handles_5xx_then_stops(
     _patch_client(monkeypatch, transport)
     jobs = RekruteScraper("any", max_pages=5, concurrency=1).fetch()
     assert [j.ats_id for j in jobs] == ["1"]
+
+
+def test_fetch_skips_malformed_page_without_stopping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A broken 200 page should not be treated as the empty tail page."""
+    page1 = _wrap_page([_make_row(job_id="1")])
+    malformed = "<html><body>maintenance</body></html>"
+    page3 = _wrap_page([_make_row(job_id="3")])
+    empty = _wrap_page([])
+    transport = _ScriptedTransport(
+        [
+            ("p=0", httpx.Response(200, text=page1)),
+            ("p=1", httpx.Response(200, text=malformed)),
+            ("p=2", httpx.Response(200, text=page3)),
+            ("p=3", httpx.Response(200, text=empty)),
+        ],
+    )
+    _patch_client(monkeypatch, transport)
+    jobs = RekruteScraper("any", max_pages=4, concurrency=1).fetch()
+    assert [j.ats_id for j in jobs] == ["1", "3"]
 
 
 @pytest.fixture

--- a/tests/test_rekrute.py
+++ b/tests/test_rekrute.py
@@ -152,9 +152,9 @@ def _wrap_page(rows: list[str]) -> str:
 class _ScriptedTransport(httpx.MockTransport):
     """Replays canned responses keyed by request URL.
 
-    Each entry is ``(url_predicate, response_factory)``; the first
-    matching predicate fires. URLs are matched by substring so tests
-    don't have to spell out the full query string.
+    ``p=N`` / ``o=N`` fragments match exact query-parameter values so
+    pagination tests cannot accidentally match page 1 against page 10.
+    Other fragments still fall back to substring matching.
     """
 
     def __init__(
@@ -168,11 +168,18 @@ class _ScriptedTransport(httpx.MockTransport):
         def handler(request: httpx.Request) -> httpx.Response:
             self._record.append(str(request.url))
             for url_fragment, response in self._scripts:
-                if url_fragment in str(request.url):
+                if self._matches(url_fragment, request):
                     return response
             raise AssertionError(f"unexpected URL {request.url}")
 
         super().__init__(handler)
+
+    @staticmethod
+    def _matches(url_fragment: str, request: httpx.Request) -> bool:
+        key, sep, expected = url_fragment.partition("=")
+        if sep and key in request.url.params:
+            return request.url.params.get(key) == expected
+        return url_fragment in str(request.url)
 
 
 def _patch_client(
@@ -258,7 +265,7 @@ def test_parse_row_minimal_realistic() -> None:
     # "Hybride" is treated as remote-true (partial-remote roles still
     # qualify as "is_remote" in our schema).
     assert job.is_remote is True
-    assert job.posted_at == datetime(2026, 5, 12)
+    assert job.posted_at == datetime(2026, 5, 12, tzinfo=r_mod.UTC)
     assert job.fetched_at == fetched
     assert job.description is not None
     assert "Bel recherche" in job.description

--- a/tests/test_rekrute.py
+++ b/tests/test_rekrute.py
@@ -1,0 +1,510 @@
+"""Tests for the Rekrute.com (Morocco) scraper.
+
+Scope: HTML row slicing, soup-based field extraction (title /
+company / location / posted_at / facets), title-suffix country
+resolution, title→location split, pagination + dedup, retry/backoff,
+and registry wiring. The httpx network path is exercised via
+``MockTransport`` so we never hit the live site.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import httpx
+import pytest
+
+from jobhive.models import ATSType
+from jobhive.scrapers import RekruteScraper, ScraperRegistry
+from jobhive.scrapers import rekrute as r_mod
+
+# --- HTML fixture builders --------------------------------------------
+
+
+def _make_row(
+    *,
+    job_id: str = "182716",
+    title: str = "Directeur de l'Hébergement",
+    city: str = "Casablanca",
+    country: str = "Maroc",
+    href: str | None = None,
+    company: str = "Auto Nejma Maroc S.A.",
+    description: str = "Auto Nejma recrute un poste à Casablanca.",
+    pub_date: str = "12/05/2026",
+    sector: str | None = "Automobile / Motos / Cycles",
+    function: str | None = "Administration des ventes / SAV",
+    experience: str | None = "Junior (1 à 3 ans)",
+    study_level: str | None = "Bac +5 et plus",
+    contract: str | None = "CDI",
+    teletravail: str | None = "Non",
+) -> str:
+    """Build one realistic ``<li class="post-id">`` block.
+
+    Mirrors the live markup captured 2026-05-12: the row body holds a
+    column-2 image anchor (recruiter logo), a column-10 details block
+    with the title anchor, a description span, a publication-date
+    ``<em>``, and a facet ``<ul>`` of sector/function/experience/etc.
+    """
+    if href is None:
+        href = (
+            f"/offre-emploi-{job_id}.html"
+        )
+    full_title = f"{title} | {city} ({country})" if city else title
+    facets: list[str] = []
+    if sector:
+        facets.append(
+            f'<li>Secteur d\'activité : <a href="/offres.html?sec=1">'
+            f"{sector}</a></li>"
+        )
+    if function:
+        facets.append(
+            f'<li>Fonction : <a href="/offres.html?fn=1">'
+            f"{function}</a></li>"
+        )
+    if experience:
+        facets.append(
+            f"<li>Expérience requise : "
+            f'<a href="/offres.html?wx=1">{experience}</a></li>'
+        )
+    if study_level:
+        facets.append(
+            f"<li>Niveau d'étude demandé : "
+            f'<a href="/offres.html?st=1">{study_level}</a></li>'
+        )
+    contract_line = ""
+    if contract:
+        contract_line = (
+            f'<li>Type de contrat proposé : '
+            f'<a href="/offres.html?ct=1">{contract}</a>'
+        )
+        if teletravail is not None:
+            contract_line += f" - Télétravail : {teletravail}"
+        contract_line += "</li>"
+    if contract_line:
+        facets.append(contract_line)
+    facets_html = "\n".join(facets)
+    return f"""
+<li class="post-id" id="{job_id}">
+  <div>
+    <div class="col-sm-2 col-xs-12">
+      <a href="/recruiter-page-{job_id}.html">
+        <img src="/logo/{job_id}" width="115" alt="{company}"
+             title="{company}" class="photo">
+      </a>
+    </div>
+    <div class="col-sm-10 col-xs-12">
+      <div class="section">
+        <h2 style="width:90%">
+          <a class="titreJob" href="{href}">{full_title}</a>
+        </h2>
+        <div class="holder">
+          <div class="info">
+            <img class="fa" src="/i/ai.svg">
+            <span>{description}</span>
+          </div>
+          <em class="date"><i class="fa fa-clock-o"></i>
+            Publication : du <span>{pub_date}</span>
+            au <span>12/07/2026</span>
+            | Postes proposés: <span>1</span>
+          </em>
+          <div class="info">
+            <i class="fa fa-info-circle"></i>
+            <ul style="display: block;">
+              {facets_html}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</li>
+""".strip()
+
+
+def _wrap_page(rows: list[str]) -> str:
+    """Wrap a list of ``<li class="post-id">`` rows in just enough
+    surrounding HTML to mirror Rekrute's page shell."""
+    rows_html = "\n".join(rows)
+    return f"""<!DOCTYPE html>
+<html lang="fr"><head><title>Offres d'emploi Maroc</title></head>
+<body>
+<div class="container">
+  <ul class="post-list">
+    {rows_html}
+  </ul>
+</div>
+</body></html>"""
+
+
+# --- httpx transport stub ---------------------------------------------
+
+
+class _ScriptedTransport(httpx.MockTransport):
+    """Replays canned responses keyed by request URL.
+
+    Each entry is ``(url_predicate, response_factory)``; the first
+    matching predicate fires. URLs are matched by substring so tests
+    don't have to spell out the full query string.
+    """
+
+    def __init__(
+        self,
+        scripts: list[tuple[str, httpx.Response]],
+        record: list[str] | None = None,
+    ) -> None:
+        self._scripts = scripts
+        self._record = record if record is not None else []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            self._record.append(str(request.url))
+            for url_fragment, response in self._scripts:
+                if url_fragment in str(request.url):
+                    return response
+            raise AssertionError(f"unexpected URL {request.url}")
+
+        super().__init__(handler)
+
+
+def _patch_client(
+    monkeypatch: pytest.MonkeyPatch, transport: httpx.MockTransport,
+) -> None:
+    """Replace ``httpx.AsyncClient`` so the scraper uses our transport."""
+    real_ctor = httpx.AsyncClient
+
+    def factory(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_ctor(*args, **kwargs)
+
+    monkeypatch.setattr(r_mod.httpx, "AsyncClient", factory)
+
+
+# --- Registry / construction ------------------------------------------
+
+
+def test_registry_resolves_rekrute() -> None:
+    assert ScraperRegistry.get(ATSType.REKRUTE) is RekruteScraper
+
+
+def test_default_construction_works() -> None:
+    s = RekruteScraper("any")
+    assert s.company_slug == "any"
+    assert s.max_pages > 0
+    assert s.concurrency >= 1
+
+
+def test_concurrency_floor_is_one() -> None:
+    """Defensive: a misconfigured ``concurrency=0`` would deadlock the
+    semaphore. The scraper bumps to 1."""
+    s = RekruteScraper("any", concurrency=0)
+    assert s.concurrency == 1
+
+
+# --- Row slicing ------------------------------------------------------
+
+
+def test_iter_rows_extracts_each_post() -> None:
+    page = _wrap_page([_make_row(job_id="1"), _make_row(job_id="2")])
+    rows = list(r_mod._iter_rows(page))
+    assert [rid for rid, _ in rows] == ["1", "2"]
+
+
+def test_iter_rows_empty_page() -> None:
+    assert list(r_mod._iter_rows(_wrap_page([]))) == []
+
+
+# --- Single-row parsing -----------------------------------------------
+
+
+def test_parse_row_minimal_realistic() -> None:
+    """End-to-end parse of a single canonical row pins the public
+    field mapping the dataset relies on."""
+    fetched = datetime(2026, 5, 12)
+    row = _make_row(
+        job_id="42",
+        title="Brand Manager",
+        city="Casablanca",
+        company="Groupe Bel",
+        description="Bel recherche un Brand Manager.",
+        sector="Agroalimentaire",
+        function="Marketing",
+        experience="Intermédiaire (3 à 5 ans)",
+        study_level="Bac +5 et plus",
+        contract="CDI",
+        teletravail="Hybride",
+    )
+    job = r_mod._parse_row("42", row, fetched_at=fetched)
+    assert job is not None
+    assert job.ats_type is ATSType.REKRUTE
+    assert job.ats_id == "42"
+    assert job.title == "Brand Manager"
+    assert job.company == "Groupe Bel"
+    assert job.location == "Casablanca"
+    assert job.country_iso == "MA"
+    assert job.region == "Africa"
+    assert job.language == "fr"
+    assert job.employment_type == "FULL_TIME"
+    assert job.commitment == "CDI"
+    assert job.department == "Agroalimentaire"
+    # "Hybride" is treated as remote-true (partial-remote roles still
+    # qualify as "is_remote" in our schema).
+    assert job.is_remote is True
+    assert job.posted_at == datetime(2026, 5, 12)
+    assert job.fetched_at == fetched
+    assert job.description is not None
+    assert "Bel recherche" in job.description
+    assert job.raw is not None
+    assert job.raw["sector"] == "Agroalimentaire"
+    assert job.raw["function"] == "Marketing"
+    assert job.raw["experience_label"] == "Intermédiaire (3 à 5 ans)"
+    assert job.raw["study_level"] == "Bac +5 et plus"
+    assert job.raw["contract_label"] == "CDI"
+
+
+def test_parse_row_teletravail_non_is_remote_false() -> None:
+    """``Télétravail : Non`` is explicit signal — surface ``False``,
+    not ``None``, so downstream filters can distinguish 'site says
+    on-site' from 'site didn't say'."""
+    row = _make_row(teletravail="Non")
+    job = r_mod._parse_row("1", row, fetched_at=datetime.now())
+    assert job is not None
+    assert job.is_remote is False
+
+
+def test_parse_row_teletravail_missing_leaves_is_remote_none() -> None:
+    row = _make_row(teletravail=None)
+    job = r_mod._parse_row("1", row, fetched_at=datetime.now())
+    assert job is not None
+    assert job.is_remote is None
+
+
+@pytest.mark.parametrize(
+    ("contract", "expected_enum"),
+    [
+        ("CDI", "FULL_TIME"),
+        ("CDD", "TEMPORARY"),
+        ("Stage", "INTERN"),
+        ("Freelance", "CONTRACT"),
+        ("Intérim", "TEMPORARY"),
+        ("Temps partiel", "PART_TIME"),
+    ],
+)
+def test_french_contract_maps_to_employment_type(
+    contract: str, expected_enum: str,
+) -> None:
+    row = _make_row(contract=contract)
+    job = r_mod._parse_row("1", row, fetched_at=datetime.now())
+    assert job is not None
+    assert job.commitment == contract
+    assert job.employment_type == expected_enum
+
+
+def test_unknown_contract_label_kept_in_commitment_employment_none() -> None:
+    """Custom contract labels (recruiter-specific) should round-trip
+    in ``commitment`` even when the normalised enum doesn't cover
+    them."""
+    row = _make_row(contract="Contrat spécial 18 mois")
+    job = r_mod._parse_row("1", row, fetched_at=datetime.now())
+    assert job is not None
+    assert job.commitment == "Contrat spécial 18 mois"
+    assert job.employment_type is None
+
+
+def test_country_iso_defaults_to_morocco_when_suffix_missing() -> None:
+    """No ``| City (Country)`` suffix? Rekrute is a Morocco board so
+    default to MA rather than leave the field empty."""
+    row = _make_row(city="", title="Senior Dev")
+    job = r_mod._parse_row("1", row, fetched_at=datetime.now())
+    assert job is not None
+    assert job.country_iso == "MA"
+    assert job.region == "Africa"
+    assert job.location is None
+
+
+def test_country_iso_recognises_non_morocco_suffix() -> None:
+    """Rekrute's small international section uses suffixes like
+    ``(Tunisie)`` / ``(France)``. Map to the right ISO."""
+    row = _make_row(city="Tunis", country="Tunisie")
+    job = r_mod._parse_row("1", row, fetched_at=datetime.now())
+    assert job is not None
+    assert job.country_iso == "TN"
+    assert job.region == "Africa"
+    assert job.location == "Tunis"
+
+
+def test_country_iso_unknown_country_falls_back_to_morocco() -> None:
+    """Unknown country suffix (a new market Rekrute hasn't taught us
+    about) shouldn't crash — fall back to MA, the dominant geography.
+    """
+    row = _make_row(city="Atlantis", country="Atlantide")
+    job = r_mod._parse_row("1", row, fetched_at=datetime.now())
+    assert job is not None
+    assert job.country_iso == "MA"
+
+
+def test_parse_row_skips_when_title_anchor_missing() -> None:
+    """A confidential / corrupted row without a titreJob anchor should
+    be skipped, not fabricated."""
+    row = (
+        '<li class="post-id" id="bad">'
+        '<div><h2>raw text only no anchor</h2></div></li>'
+    )
+    assert r_mod._parse_row("bad", row, fetched_at=datetime.now()) is None
+
+
+def test_parse_row_placeholder_company_logo_becomes_unknown() -> None:
+    """Some recruiters haven't uploaded a logo — Rekrute serves a
+    placeholder with alt='Logo'. Don't surface ``company='Logo'``."""
+    row = _make_row(company="Logo")
+    job = r_mod._parse_row("1", row, fetched_at=datetime.now())
+    assert job is not None
+    assert job.company == "Unknown"
+
+
+def test_invalid_pub_date_falls_back_to_none() -> None:
+    """A garbage date mustn't crash the parser — drop the field."""
+    row = _make_row(pub_date="99/99/9999")
+    job = r_mod._parse_row("1", row, fetched_at=datetime.now())
+    assert job is not None
+    assert job.posted_at is None
+
+
+def test_absolute_href_is_kept_as_is() -> None:
+    """Defensive: when Rekrute returns an absolute URL, don't
+    double-prefix the host."""
+    row = _make_row(href="https://www.rekrute.com/offre-emploi-abs-7.html")
+    job = r_mod._parse_row("7", row, fetched_at=datetime.now())
+    assert job is not None
+    assert str(job.url) == "https://www.rekrute.com/offre-emploi-abs-7.html"
+
+
+# --- End-to-end fetch (httpx mock) ------------------------------------
+
+
+def test_fetch_walks_pages_until_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pagination stops as soon as a page returns zero rows."""
+    page1 = _wrap_page([_make_row(job_id="1"), _make_row(job_id="2")])
+    page2 = _wrap_page([_make_row(job_id="3")])
+    empty = _wrap_page([])
+    record: list[str] = []
+    transport = _ScriptedTransport(
+        [
+            ("p=0", httpx.Response(200, text=page1)),
+            ("p=1", httpx.Response(200, text=page2)),
+            ("p=2", httpx.Response(200, text=empty)),
+            ("p=3", httpx.Response(200, text=empty)),
+            ("p=4", httpx.Response(200, text=empty)),
+            ("p=5", httpx.Response(200, text=empty)),
+        ],
+        record=record,
+    )
+    _patch_client(monkeypatch, transport)
+    jobs = RekruteScraper("any", max_pages=5, concurrency=1).fetch()
+    assert sorted(j.ats_id for j in jobs) == ["1", "2", "3"]
+    # First three requests are guaranteed; concurrency=1 + sequential
+    # waves means we stop after the empty page.
+    assert any("p=0" in u for u in record)
+    assert any("p=1" in u for u in record)
+    assert any("p=2" in u for u in record)
+
+
+def test_fetch_dedupes_repeated_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sticky / featured rows show up on every page — surface once
+    across the whole walk."""
+    sticky = _make_row(job_id="999")
+    page1 = _wrap_page([sticky, _make_row(job_id="1")])
+    page2 = _wrap_page([sticky, _make_row(job_id="2")])
+    empty = _wrap_page([])
+    transport = _ScriptedTransport(
+        [
+            ("p=0", httpx.Response(200, text=page1)),
+            ("p=1", httpx.Response(200, text=page2)),
+            ("p=2", httpx.Response(200, text=empty)),
+        ],
+    )
+    _patch_client(monkeypatch, transport)
+    jobs = RekruteScraper("any", max_pages=5, concurrency=1).fetch()
+    assert sorted(j.ats_id for j in jobs) == ["1", "2", "999"]
+
+
+def test_fetch_respects_max_pages_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A site that keeps returning fresh rows forever should still
+    stop at the safety cap."""
+    pages = [
+        (f"p={i}", httpx.Response(200, text=_wrap_page(
+            [_make_row(job_id=str(i + 100))],
+        )))
+        for i in range(20)
+    ]
+    transport = _ScriptedTransport(pages)
+    _patch_client(monkeypatch, transport)
+    jobs = RekruteScraper("any", max_pages=3, concurrency=1).fetch()
+    assert len(jobs) == 3
+
+
+def test_fetch_handles_5xx_then_stops(
+    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch_sleep: None,
+) -> None:
+    """A 5xx after exhausted retries breaks the pagination loop but
+    leaves already-collected jobs intact."""
+    page1 = _wrap_page([_make_row(job_id="1")])
+    transport = _ScriptedTransport(
+        [
+            ("p=0", httpx.Response(200, text=page1)),
+            ("p=1", httpx.Response(503)),
+        ],
+    )
+    _patch_client(monkeypatch, transport)
+    jobs = RekruteScraper("any", max_pages=5, concurrency=1).fetch()
+    assert [j.ats_id for j in jobs] == ["1"]
+
+
+@pytest.fixture
+def monkeypatch_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch ``asyncio.sleep`` so retry-path tests don't pay
+    wall-clock cost."""
+    async def _noop(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(r_mod.asyncio, "sleep", _noop)
+
+
+def test_url_uses_zero_based_p_param(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rekrute pagination is 0-indexed on the wire (``?p=0`` is page 1).
+    The scraper translates 1-based logical pages at the URL boundary.
+    """
+    record: list[str] = []
+    transport = _ScriptedTransport(
+        [("p=0", httpx.Response(200, text=_wrap_page([])))],
+        record=record,
+    )
+    _patch_client(monkeypatch, transport)
+    RekruteScraper("any", max_pages=1, concurrency=1).fetch()
+    assert any("p=0" in u for u in record)
+
+
+# --- Edge cases on title parsing --------------------------------------
+
+
+def test_title_with_multiple_pipes_keeps_only_last_segment_as_location() -> None:
+    """``Job title | Sub-title | City (Maroc)`` — the location regex is
+    greedy on the *final* ``|`` so the rest stays as title."""
+    row = _make_row(
+        title="Senior Dev | Backend Team",
+        city="Casablanca",
+        country="Maroc",
+    )
+    job = r_mod._parse_row("1", row, fetched_at=datetime.now())
+    assert job is not None
+    assert job.title == "Senior Dev | Backend Team"
+    assert job.location == "Casablanca"
+    assert job.country_iso == "MA"

--- a/tests/test_rekrute.py
+++ b/tests/test_rekrute.py
@@ -468,22 +468,26 @@ def test_fetch_respects_max_pages_cap(
     assert len(jobs) == 3
 
 
-def test_fetch_handles_5xx_then_stops(
+def test_fetch_skips_5xx_page_without_stopping(
     monkeypatch: pytest.MonkeyPatch,
     monkeypatch_sleep: None,
 ) -> None:
-    """A 5xx after exhausted retries breaks the pagination loop but
-    leaves already-collected jobs intact."""
+    """A 5xx after exhausted retries skips that page but does not
+    masquerade as the empty tail page."""
     page1 = _wrap_page([_make_row(job_id="1")])
+    page3 = _wrap_page([_make_row(job_id="3")])
+    empty = _wrap_page([])
     transport = _ScriptedTransport(
         [
             ("p=0", httpx.Response(200, text=page1)),
             ("p=1", httpx.Response(503)),
+            ("p=2", httpx.Response(200, text=page3)),
+            ("p=3", httpx.Response(200, text=empty)),
         ],
     )
     _patch_client(monkeypatch, transport)
-    jobs = RekruteScraper("any", max_pages=5, concurrency=1).fetch()
-    assert [j.ats_id for j in jobs] == ["1"]
+    jobs = RekruteScraper("any", max_pages=4, concurrency=1).fetch()
+    assert [j.ats_id for j in jobs] == ["1", "3"]
 
 
 def test_fetch_skips_malformed_page_without_stopping(

--- a/tests/test_rekrute.py
+++ b/tests/test_rekrute.py
@@ -225,6 +225,15 @@ def test_iter_rows_extracts_each_post() -> None:
     assert [rid for rid, _ in rows] == ["1", "2"]
 
 
+def test_iter_rows_accepts_reordered_li_attributes() -> None:
+    row = _make_row(job_id="7").replace(
+        '<li class="post-id" id="7">',
+        '<li data-x="1" id="7" class="featured post-id">',
+    )
+    rows = list(r_mod._iter_rows(_wrap_page([row])))
+    assert [rid for rid, _ in rows] == ["7"]
+
+
 def test_iter_rows_empty_page() -> None:
     assert list(r_mod._iter_rows(_wrap_page([]))) == []
 
@@ -495,6 +504,28 @@ def test_fetch_skips_5xx_page_without_stopping(
     _patch_client(monkeypatch, transport)
     jobs = RekruteScraper("any", max_pages=4, concurrency=1).fetch()
     assert [j.ats_id for j in jobs] == ["1", "3"]
+
+
+def test_fetch_stops_after_repeated_5xx_pages(
+    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch_sleep: None,
+) -> None:
+    """One failed page is skipped; repeated empty failure waves stop the walk."""
+    page1 = _wrap_page([_make_row(job_id="1")])
+    record: list[str] = []
+    transport = _ScriptedTransport(
+        [
+            ("p=0", httpx.Response(200, text=page1)),
+            ("p=1", httpx.Response(503)),
+            ("p=2", httpx.Response(503)),
+        ],
+        record=record,
+    )
+    _patch_client(monkeypatch, transport)
+    jobs = RekruteScraper("any", max_pages=5, concurrency=1).fetch()
+    assert [j.ats_id for j in jobs] == ["1"]
+    assert any("p=2" in u for u in record)
+    assert not any("p=3" in u for u in record)
 
 
 def test_fetch_skips_malformed_page_without_stopping(


### PR DESCRIPTION
## Summary

- **Rekrute** (`rekrute.com`) — Morocco's largest dedicated job board (~1.7k active postings, mostly white-collar). SSR HTML, `?p=N` 0-indexed pagination, soup-parsed facets (sector / function / experience / study level / contract / télétravail), title-suffix country resolution (defaults to MA, recognises FR/TN/DZ/SN/CI/ES/AE/QA/SA). French contract labels (CDI/CDD/Stage/Freelance/Intérim/Temps partiel) map to canonical `employment_type`.
- **Avito Maroc** (`avito.ma/fr/maroc/emploi`) — Morocco's biggest classifieds, jobs section (~800 active postings, mostly blue-collar / informal economy). Next.js page with `__NEXT_DATA__` JSON parsing, `?o=N` 1-indexed pagination, French relative-time parsing (`il y a X minutes/heures/jours/semaines/mois/an`), category-filter guard drops boosted ads from non-job categories.
- Both single-source scrapers (`company_slug` ignored), async pagination with concurrency cap + retry/backoff, all rows tagged `country_iso="MA"` `region="Africa"` `language="fr"`. New `ATSType.REKRUTE` / `ATSType.AVITOMA` enum values wired through registry, `__init__.py` exports, and `test_models` allow-list.

## Test plan

- [x] `uv run pytest` — 938 tests passing (was 880 pre-change; +58 new tests across rekrute / avito_ma / model enum)
- [x] `uv run ruff check .` — clean
- [x] Live smoke against rekrute.com: 10 jobs page 1, fields populated (title, company, location, contract, télétravail → is_remote)
- [x] Live smoke against avito.ma `/fr/maroc/emploi`: 70 jobs across 2 pages, boosted ads correctly filtered
- [ ] Pre-merge: re-run smoke once the publish pipeline picks up the new ATSTypes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Morocco job-board scrapers for `rekrute.com` and `avito.ma` with async wave-based pagination, French parsing, and UTC timestamps. Improves failure handling and hardens Avito JSON parsing to keep pagination reliable.

- **New Features**
  - `RekruteScraper`: SSR HTML; 0-based `?p=`; maps FR contract → `employment_type`; télétravail → `is_remote`; title suffix → city/country; UTC `posted_at`; adds `ATSType.REKRUTE` and registry wiring.
  - `AvitoMarocScraper`: parses `__NEXT_DATA__` JSON; 1-based `?o=`; filters boosted non-job ads; parses FR relative times; adds `ATSType.AVITOMA` and registry wiring; seeds `ats-companies` (`rekrute.csv`, `avito_ma.csv`).

- **Bug Fixes**
  - Pagination: wave-based early-stop; transient 5xx/429/transport errors retried then skipped; broken 200 pages no longer end the walk; clearer skip logs; stop after repeated empty/failed waves.
  - Avito: isolates malformed ad rows so one bad ad is skipped, not the page; hardens `__NEXT_DATA__` ads-shape checks so a broken blob/page is a parse-skip, not the last page; fixes enum value; corrects relative-date docstring.
  - Rekrute: `posted_at` uses UTC tzinfo; hardened empty-page detection.

<sup>Written for commit c156cb9cbc7a4f938895d886dc5531dbe07ebc58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two new Morocco-specific job-board scrapers — `RekruteScraper` (SSR HTML + BeautifulSoup) and `AvitoMarocScraper` (`__NEXT_DATA__` JSON) — along with registry wiring, CSV seed files, and 58 new tests. Both scrapers share the same wave-based concurrent pagination design with explicit separation between fetch failures, parse failures, and genuine empty pages, addressing the robustness issues flagged in earlier review rounds.

- **RekruteScraper** slices `<li class="post-id">` rows with a boundary regex, extracts facets (sector, function, experience, contract, télétravail) via BeautifulSoup, maps French contract labels to `employment_type`, derives city/country from the title suffix, and emits UTC-aware `posted_at` via `tzinfo=UTC`.
- **AvitoMarocScraper** parses the `__NEXT_DATA__` blob, raises `_AdsParseError` to distinguish malformed 200 responses from genuine empty pages, guards against boosted non-job ads via the `Emploi` parent category id, and converts French relative-time phrases to `posted_at` anchored on the aware `fetched_at`.

<h3>Confidence Score: 5/5</h3>

Both scrapers are additive and isolated behind new ATSType enum values; no existing scraper logic is touched.

The previous pagination and timezone issues flagged in earlier review rounds have been addressed. The remaining findings are documentation and test-quality observations that do not affect runtime correctness.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/avito_ma.py | New Avito Maroc scraper with __NEXT_DATA__ JSON parsing, wave-based pagination, French relative-time parsing, and boosted-ad category guard; one docstring inaccuracy (UTC-naive vs UTC-aware). |
| src/jobhive/scrapers/rekrute.py | New Rekrute scraper with regex row-slicing, BeautifulSoup facet extraction, UTC-aware posted_at, and French contract/télétravail mapping; logic looks correct. |
| tests/test_avito_ma.py | Comprehensive test suite covering JSON extraction, category filter, relative-date parsing, pagination, dedup, retry/backoff, and malformed-page isolation. |
| tests/test_rekrute.py | Broad coverage of row slicing, field extraction, title/country parsing, and pagination; primary pinning test passes naive fetched_at while production always uses UTC-aware. |
| src/jobhive/models.py | Adds REKRUTE and AVITOMA to ATSType enum before CUSTOM; straightforward additive change. |
| src/jobhive/scrapers/__init__.py | Imports and exports for AvitoMarocScraper and RekruteScraper correctly wired into the package. |
| tests/test_models.py | Allow-list updated with rekrute and avito_ma enum values; trivial additive change. |

</details>

<sub>Reviews (9): Last reviewed commit: ["Correct Avito relative date docstring"](https://github.com/kalil0321/ats-scrapers/commit/c156cb9cbc7a4f938895d886dc5531dbe07ebc58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732531)</sub>

<!-- /greptile_comment -->