### PR TITLE
bdjobs: add scraper for Bangladesh's largest job portal

### DIFF
--- a/ats-companies/bdjobs.csv
+++ b/ats-companies/bdjobs.csv
@@ -1,0 +1,2 @@
+name,slug,url
+Bdjobs,bdjobs,https://www.bdjobs.com

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -80,6 +80,7 @@ class ATSType(StrEnum):
     THEHUB = "thehub"
     YCOMBINATOR = "ycombinator"
     WELLFOUND = "wellfound"
+    BDJOBS = "bdjobs"
     # Additional multi-tenant ATSes (post-0.1)
     BAMBOOHR = "bamboohr"
     BREEZY = "breezy"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -15,6 +15,7 @@ from jobhive.scrapers.ashby import AshbyScraper
 from jobhive.scrapers.avature import AvatureScraper
 from jobhive.scrapers.bamboohr import BambooHRScraper
 from jobhive.scrapers.base import BaseScraper, ScraperRegistry, get_scraper
+from jobhive.scrapers.bdjobs import BdjobsScraper
 from jobhive.scrapers.breezy import BreezyScraper
 from jobhive.scrapers.builtin import BuiltInScraper
 from jobhive.scrapers.bundesagentur import BundesagenturScraper
@@ -67,6 +68,7 @@ __all__ = [
     "AvatureScraper",
     "BambooHRScraper",
     "BaseScraper",
+    "BdjobsScraper",
     "BreezyScraper",
     "BuiltInScraper",
     "BundesagenturScraper",

--- a/src/jobhive/scrapers/bdjobs.py
+++ b/src/jobhive/scrapers/bdjobs.py
@@ -195,11 +195,45 @@ class BdjobsScraper(BaseScraper):
         *,
         params: dict[str, str] | None,
     ) -> list[dict[str, Any]]:
-        """Fetch one ``GetJobSearch`` call and return the union of its
-        ``data`` and ``premiumData`` arrays. The endpoint splits its
-        response into a "premium" spotlight and a regular ``data``
-        list; we treat them as one stream since both shapes share the
-        same field names."""
+        """Fetch all ``GetJobSearch`` pages for one query seed.
+
+        The endpoint reports pagination under ``common.totalpages`` and
+        uses ``pg`` as the page parameter. Each page splits rows between
+        ``premiumData`` and ``data`` arrays; both shapes share fields.
+        """
+        items: list[dict[str, Any]] = []
+        page = 1
+        total_pages = 1
+        while page <= total_pages:
+            page_params = dict(params or {})
+            if page > 1:
+                page_params["pg"] = str(page)
+            payload = await self._fetch_payload(
+                client, sem, params=page_params or None,
+            )
+            premium = payload.get("premiumData") or []
+            data = payload.get("data") or []
+            if not isinstance(premium, list) or not isinstance(data, list):
+                raise ScraperError(
+                    f"bdjobs returned malformed job arrays for params={page_params}"
+                )
+            items.extend([*premium, *data])
+            common = payload.get("common") or {}
+            if isinstance(common, dict):
+                reported_pages = _to_int(common.get("totalpages"))
+                if reported_pages is not None and reported_pages > total_pages:
+                    total_pages = reported_pages
+            page += 1
+        return items
+
+    async def _fetch_payload(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        *,
+        params: dict[str, str] | None,
+    ) -> dict[str, Any]:
+        """Fetch one ``GetJobSearch`` page and return its JSON object."""
         last_exc: Exception | None = None
         for attempt in range(1, MAX_RETRIES + 1):
             try:
@@ -230,13 +264,7 @@ class BdjobsScraper(BaseScraper):
                     raise ScraperError(
                         f"bdjobs returned malformed JSON for params={params}"
                     )
-                premium = payload.get("premiumData") or []
-                data = payload.get("data") or []
-                if not isinstance(premium, list) or not isinstance(data, list):
-                    raise ScraperError(
-                        f"bdjobs returned malformed job arrays for params={params}"
-                    )
-                return [*premium, *data]
+                return payload
             if response.status_code in (429,) or 500 <= response.status_code < 600:
                 if attempt == MAX_RETRIES:
                     raise ScraperError(
@@ -311,6 +339,16 @@ class BdjobsScraper(BaseScraper):
             raw=raw or None,
         )
 
+
+
+def _to_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip().isdigit():
+        return int(value)
+    return None
 
 def _concat_description(item: dict[str, Any]) -> str | None:
     """Bdjobs splits posting prose across ``jobContext`` (about the

--- a/src/jobhive/scrapers/bdjobs.py
+++ b/src/jobhive/scrapers/bdjobs.py
@@ -1,0 +1,332 @@
+"""Bdjobs (https://www.bdjobs.com) — Bangladesh's largest job portal.
+
+Bdjobs is the dominant job board in Bangladesh (170M+ population) with
+~25k active vacancies across thousands of postings spanning every
+sector (private, NGO, government, banking, garments, IT). The May 2026
+audit had Bangladesh at near-zero coverage — this scraper closes a
+huge gap in South-Asia representation.
+
+Public REST API at ``https://api.bdjobs.com/Jobs/api/JobSearch/GetJobSearch``
+(GET; no auth, no key). The endpoint is a "premium spotlight" feed —
+each request returns up to ten freshly-listed premium postings plus
+``common.total_records_found`` / ``total_vacancies`` totals describing
+the full live board (which sits behind a separate logged-in SPA we
+can't hit unauthenticated).
+
+To widen coverage beyond the unfiltered top ten we issue the same
+endpoint under a curated set of ``Keyword`` and ``Category`` filters
+(verified live 2026-05-12: a single ``Keyword=engineer`` query has its
+own ten-row spotlight independent of the base feed). Results across
+queries are deduped by ``Jobid``. This pattern matches the
+``jobsch.py`` seed-segmentation approach.
+
+Job detail page lives at the legacy ASP URL pattern documented in
+``robots.txt`` and the sitemap:
+``https://jobs.bdjobs.com/jobdetails.asp?id={Jobid}&ln={JobLang}``
+(the SPA redirects this to its hashed ``/jobdetails/`` route but the
+ASP form is the stable canonical link).
+
+Single-source scraper: ``company_slug`` is informational and ignored.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import logging
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+log = logging.getLogger(__name__)
+
+API_URL = "https://api.bdjobs.com/Jobs/api/JobSearch/GetJobSearch"
+DETAIL_URL_TEMPLATE = "https://jobs.bdjobs.com/jobdetails.asp?id={job_id}&ln={lang}"
+
+MAX_CONCURRENCY = 3
+MAX_RETRIES = 4
+RETRY_BASE_DELAY = 1.5
+
+# Keyword seeds — each yields its own ten-row premium spotlight, mostly
+# disjoint from the unfiltered base feed. Covers the dominant Bangladesh
+# job categories (private sector white-collar, banking, IT, garments/RMG,
+# NGO, healthcare, education, hospitality). All values are English; the
+# Bdjobs search engine accepts English query strings against
+# bilingually-tagged postings.
+_KEYWORD_SEEDS: tuple[str, ...] = (
+    # White-collar private sector — the long tail of Bdjobs.
+    "manager", "executive", "officer", "assistant", "coordinator",
+    "supervisor", "consultant", "specialist", "analyst", "director",
+    # Sales / marketing / customer-facing.
+    "sales", "marketing", "customer", "business development",
+    "merchandiser", "retail",
+    # Finance / accounting / banking (Bangladesh has a large bank sector).
+    "accountant", "finance", "audit", "banking",
+    # IT / engineering (smaller in absolute terms but high-signal).
+    "engineer", "developer", "software", "system", "network",
+    # Garments / textiles (RMG is ~80% of Bangladesh exports).
+    "garments", "textile", "production", "quality",
+    # NGO / aid sector (Bangladesh hosts hundreds of NGOs).
+    "ngo", "project", "program",
+    # Healthcare / education.
+    "nurse", "doctor", "teacher", "lecturer",
+    # Operations / admin.
+    "admin", "hr", "operations", "logistics",
+)
+
+# Category IDs the Bdjobs search engine recognises on ``Category`` —
+# these are functional-category IDs (NOT industry IDs). Probed live
+# 2026-05-12: IDs 1..30 all return non-empty totals. The seed-segmentation
+# pattern means we union over both keywords AND categories to maximise
+# unique-id coverage.
+_CATEGORY_IDS: tuple[int, ...] = tuple(range(1, 31))
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"\s+")
+
+
+@ScraperRegistry.register(ATSType.BDJOBS)
+class BdjobsScraper(BaseScraper):
+    """Bdjobs (bdjobs.com) — Bangladesh's largest job board.
+
+    Single-source: ``company_slug`` is ignored. Pass anything
+    (``"any"``, ``""``, ``"bangladesh"``) — the scraper enumerates the
+    entire site's premium spotlight feed across a curated set of
+    keyword and category seeds.
+
+    Knobs:
+    - ``keyword_seeds`` / ``category_ids`` — override the default seed
+      lists. Pass ``()`` to either to disable that axis. Pass
+      ``keyword_seeds=()`` AND ``category_ids=()`` to fetch only the
+      unfiltered top ten.
+    """
+
+    ats = ATSType.BDJOBS
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        keyword_seeds: tuple[str, ...] | None = None,
+        category_ids: tuple[int, ...] | None = None,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        # ``None`` keeps the production defaults; explicit ``()`` disables.
+        self.keyword_seeds: tuple[str, ...] = (
+            _KEYWORD_SEEDS if keyword_seeds is None else tuple(keyword_seeds)
+        )
+        self.category_ids: tuple[int, ...] = (
+            _CATEGORY_IDS if category_ids is None else tuple(category_ids)
+        )
+
+    def fetch(self) -> list[Job]:
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        seen: set[str] = set()
+        jobs: list[Job] = []
+
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True,
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+
+            # Base feed — the unfiltered top ten premium postings.
+            base = await self._fetch_query(client, sem, params=None)
+            self._absorb(base, seen, jobs)
+            log.info(
+                "bdjobs: base feed → %d rows (total %d)",
+                len(base), len(jobs),
+            )
+
+            # Seed-segmented widening — each keyword + category yields
+            # its own (mostly disjoint) ten-row spotlight. Run them
+            # concurrently behind ``MAX_CONCURRENCY`` so a full sweep
+            # over ~60 seeds completes in well under a minute.
+            queries: list[dict[str, str]] = [
+                {"Keyword": kw} for kw in self.keyword_seeds
+            ] + [{"Category": str(cid)} for cid in self.category_ids]
+
+            async def one(params: dict[str, str]) -> list[dict[str, Any]]:
+                try:
+                    return await self._fetch_query(client, sem, params=params)
+                except ScraperError as exc:
+                    log.warning(
+                        "bdjobs: query %s failed: %s — skipping seed", params, exc,
+                    )
+                    return []
+
+            slices = await asyncio.gather(*(one(p) for p in queries))
+            for items in slices:
+                self._absorb(items, seen, jobs)
+
+        log.info("bdjobs: total unique jobs → %d", len(jobs))
+        return jobs
+
+    def _absorb(
+        self,
+        items: list[dict[str, Any]],
+        seen: set[str],
+        jobs: list[Job],
+    ) -> None:
+        for item in items:
+            job = self._parse(item)
+            if job is None or job.ats_id in seen:
+                continue
+            seen.add(job.ats_id)
+            jobs.append(job)
+
+    # --- HTTP layer ---------------------------------------------------------
+
+    async def _fetch_query(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        *,
+        params: dict[str, str] | None,
+    ) -> list[dict[str, Any]]:
+        """Fetch one ``GetJobSearch`` call and return the union of its
+        ``data`` and ``premiumData`` arrays. The endpoint splits its
+        response into a "premium" spotlight and a regular ``data``
+        list; we treat them as one stream since both shapes share the
+        same field names."""
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(
+                        API_URL, params=params or {}, headers={
+                            "User-Agent": "Mozilla/5.0",
+                            "Accept": "application/json",
+                            "Origin": "https://jobs.bdjobs.com",
+                        },
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"bdjobs fetch failed for params={params}: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                try:
+                    payload = response.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"bdjobs returned non-JSON for params={params}: {exc}"
+                    ) from exc
+                premium = payload.get("premiumData") or []
+                data = payload.get("data") or []
+                return [*premium, *data]
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"bdjobs returned {response.status_code} for "
+                        f"params={params} after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"bdjobs returned {response.status_code} for params={params}"
+            )
+        raise ScraperError(
+            f"bdjobs exhausted retries for params={params}: {last_exc}"
+        )
+
+    # --- parsing ------------------------------------------------------------
+
+    def _parse(self, item: dict[str, Any]) -> Job | None:
+        ats_id = str(item.get("Jobid") or "").strip()
+        title = (item.get("jobTitle") or "").strip()
+        company = (item.get("companyName") or "").strip()
+        if not ats_id or not title:
+            return None
+
+        # ``JobLang`` is the response-side language flag: ``"1"`` =
+        # English listing, ``"2"`` = Bengali. Map to ISO-639-1.
+        lang_raw = str(item.get("JobLang") or "1").strip()
+        language = "bn" if lang_raw == "2" else "en"
+
+        url = DETAIL_URL_TEMPLATE.format(job_id=ats_id, lang=lang_raw or "1")
+
+        location = (item.get("location") or "").strip() or None
+
+        description = _concat_description(item)
+
+        posted_at = _parse_iso(item.get("publishDate"))
+
+        raw: dict[str, Any] = {}
+        for source_key, raw_key in (
+            ("experience", "experience"),
+            ("eduRec", "education"),
+            ("jobContext", "context"),
+            ("AdType", "ad_type"),
+            ("deadlineDB", "deadline"),
+            ("standout", "standout"),
+            ("OnlineJob", "online_job"),
+            ("isEarlyAccess", "early_access"),
+            ("logoUrl", "logo_url"),
+            ("JobTitleBng", "title_bn"),
+        ):
+            value = item.get(source_key)
+            if value not in (None, "", []):
+                raw[raw_key] = value
+
+        return Job(
+            url=url,
+            title=title,
+            company=company or "Unknown",
+            ats_type=ATSType.BDJOBS,
+            ats_id=ats_id,
+            location=location,
+            country_iso="BD",
+            language=language,
+            description=description,
+            posted_at=posted_at,
+            fetched_at=datetime.now(),
+            raw=raw or None,
+        )
+
+
+def _concat_description(item: dict[str, Any]) -> str | None:
+    """Bdjobs splits posting prose across ``jobContext`` (about the
+    role) and ``jobDescription`` (qualifications + responsibilities).
+    Concatenate the populated ones into a single body and strip the
+    HTML the API ships verbatim."""
+    parts: list[str] = []
+    for key in ("jobContext", "jobDescription", "eduRec"):
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            parts.append(value)
+    if not parts:
+        return None
+    body = "\n\n".join(parts)
+    body = _TAG_RE.sub(" ", body)
+    body = html.unescape(body)
+    body = _WS_RE.sub(" ", body).strip()
+    return body[:10_000] or None
+
+
+def _parse_iso(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None

--- a/src/jobhive/scrapers/bdjobs.py
+++ b/src/jobhive/scrapers/bdjobs.py
@@ -35,7 +35,7 @@ import asyncio
 import html
 import logging
 import re
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import httpx
@@ -202,8 +202,8 @@ class BdjobsScraper(BaseScraper):
         same field names."""
         last_exc: Exception | None = None
         for attempt in range(1, MAX_RETRIES + 1):
-            async with sem:
-                try:
+            try:
+                async with sem:
                     response = await client.get(
                         API_URL, params=params or {}, headers={
                             "User-Agent": "Mozilla/5.0",
@@ -211,14 +211,14 @@ class BdjobsScraper(BaseScraper):
                             "Origin": "https://jobs.bdjobs.com",
                         },
                     )
-                except httpx.HTTPError as exc:
-                    last_exc = exc
-                    if attempt == MAX_RETRIES:
-                        raise ScraperError(
-                            f"bdjobs fetch failed for params={params}: {exc}"
-                        ) from exc
-                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
-                    continue
+            except httpx.HTTPError as exc:
+                last_exc = exc
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"bdjobs fetch failed for params={params}: {exc}"
+                    ) from exc
+                await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                continue
             if response.status_code == 200:
                 try:
                     payload = response.json()
@@ -226,8 +226,16 @@ class BdjobsScraper(BaseScraper):
                     raise ScraperError(
                         f"bdjobs returned non-JSON for params={params}: {exc}"
                     ) from exc
+                if not isinstance(payload, dict):
+                    raise ScraperError(
+                        f"bdjobs returned malformed JSON for params={params}"
+                    )
                 premium = payload.get("premiumData") or []
                 data = payload.get("data") or []
+                if not isinstance(premium, list) or not isinstance(data, list):
+                    raise ScraperError(
+                        f"bdjobs returned malformed job arrays for params={params}"
+                    )
                 return [*premium, *data]
             if response.status_code in (429,) or 500 <= response.status_code < 600:
                 if attempt == MAX_RETRIES:
@@ -299,7 +307,7 @@ class BdjobsScraper(BaseScraper):
             language=language,
             description=description,
             posted_at=posted_at,
-            fetched_at=datetime.now(),
+            fetched_at=datetime.now(tz=UTC),
             raw=raw or None,
         )
 

--- a/tests/test_bdjobs.py
+++ b/tests/test_bdjobs.py
@@ -1,0 +1,293 @@
+"""Tests for the Bdjobs (Bangladesh) scraper.
+
+Pin parsing of the ``GetJobSearch`` payload (jobid, title, company,
+JobLang→language, BD country-iso, jobContext+jobDescription concat
++ HTML strip, ISO date) and the seed-segmented dedup behaviour
+(unfiltered base feed plus a curated keyword / category seed list,
+deduped by ``Jobid``).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import BdjobsScraper, ScraperRegistry
+
+_API = "https://api.bdjobs.com/Jobs/api/JobSearch/GetJobSearch"
+_API_RE = re.compile(r"^https://api\.bdjobs\.com/Jobs/api/JobSearch/GetJobSearch")
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.bdjobs as bd
+    monkeypatch.setattr(bd, "MAX_RETRIES", 1)
+    monkeypatch.setattr(bd, "RETRY_BASE_DELAY", 0.0)
+
+
+def _job(
+    *,
+    job_id: str = "1487391",
+    title: str = "Client Relationship Executive",
+    company: str = "Pattern Properties Limited",
+    location: str = "Rajshahi Sadar",
+    lang: str = "1",
+    experience: str = "At least 1 years",
+    publish_date: str = "2026-05-11T23:34:00Z",
+    deadline_db: str = "2026-06-10T18:00:00Z",
+    job_context: str | None = None,
+    job_description: str = "<ul><li><p>Minimum HSC / Bachelor running preferred.</p></li></ul>",
+    edu_rec: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "Jobid": job_id,
+        "AdType": "2",
+        "jobTitle": title,
+        "companyName": company,
+        "JobTitleBng": title,
+        "deadline": "Jun 10, 2026",
+        "deadlineDB": deadline_db,
+        "publishDate": publish_date,
+        "eduRec": edu_rec or "",
+        "experience": experience,
+        "standout": 0,
+        "logo": "",
+        "lantype": 0,
+        "location": location,
+        "JobLang": lang,
+        "jobContext": job_context,
+        "isEarlyAccess": False,
+        "OnlineJob": True,
+        "logoUrl": "",
+        "jobDescription": job_description,
+    }
+
+
+def _payload(
+    premium: list[dict[str, Any]] | None = None,
+    data: list[dict[str, Any]] | None = None,
+    *,
+    total: int = 1,
+    total_pages: int = 1,
+) -> dict[str, Any]:
+    return {
+        "message": "Success",
+        "statuscode": "1",
+        "data": data or [],
+        "premiumData": premium or [],
+        "common": {
+            "total_records_found": total,
+            "showd": "1",
+            "totalpages": total_pages,
+            "total_vacancies": total,
+        },
+    }
+
+
+# --- registry / wiring ------------------------------------------------------
+
+
+def test_registry_resolves_bdjobs() -> None:
+    assert ScraperRegistry.get(ATSType.BDJOBS) is BdjobsScraper
+
+
+def test_ats_type_value() -> None:
+    assert ATSType.BDJOBS.value == "bdjobs"
+
+
+# --- happy path -------------------------------------------------------------
+
+
+def test_parses_full_premium_job(httpx_mock) -> None:
+    """Premium-data row → Job. Verifies country_iso=BD, language=en
+    (JobLang='1'), description concat + HTML strip, ISO date parse,
+    and ``raw`` overflow capture of experience / education /
+    deadline."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_payload(premium=[_job(
+            job_context="<p>Build client relationships.</p>",
+            job_description="<ul><li>HSC required</li></ul>",
+            edu_rec="Bachelor preferred",
+        )]),
+        is_reusable=True,
+    )
+
+    jobs = BdjobsScraper(
+        "any", keyword_seeds=(), category_ids=(),
+    ).fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.BDJOBS
+    assert j.ats_id == "1487391"
+    assert j.title == "Client Relationship Executive"
+    assert j.company == "Pattern Properties Limited"
+    assert j.country_iso == "BD"
+    assert j.language == "en"
+    assert j.location == "Rajshahi Sadar"
+    assert str(j.url) == "https://jobs.bdjobs.com/jobdetails.asp?id=1487391&ln=1"
+    # Description must concatenate context+description+education and
+    # strip HTML.
+    assert j.description is not None
+    assert "Build client relationships" in j.description
+    assert "HSC required" in j.description
+    assert "Bachelor preferred" in j.description
+    assert "<" not in j.description and ">" not in j.description
+    # Posted_at parsed from ISO Z string.
+    assert j.posted_at is not None
+    assert j.posted_at.year == 2026 and j.posted_at.month == 5
+    # ``raw`` captures the rich fields the canonical schema can't hold.
+    assert j.raw is not None
+    assert j.raw["experience"] == "At least 1 years"
+    assert j.raw["deadline"] == "2026-06-10T18:00:00Z"
+    assert j.raw["education"] == "Bachelor preferred"
+    assert j.raw["title_bn"] == j.title  # mirrored in JobTitleBng for english listings
+
+
+def test_bengali_listing_maps_to_bn_language(httpx_mock) -> None:
+    """JobLang='2' → language='bn' and ln=2 in the detail URL."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_payload(premium=[_job(job_id="555", lang="2")]),
+        is_reusable=True,
+    )
+
+    jobs = BdjobsScraper("any", keyword_seeds=(), category_ids=()).fetch()
+    assert len(jobs) == 1
+    assert jobs[0].language == "bn"
+    assert "ln=2" in str(jobs[0].url)
+
+
+# --- pagination / dedup -----------------------------------------------------
+
+
+def test_data_and_premium_arrays_both_consumed(httpx_mock) -> None:
+    """The endpoint may put rows in EITHER ``data`` OR ``premiumData``;
+    parser unions both arrays."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_payload(
+            premium=[_job(job_id="a-1", title="From Premium")],
+            data=[_job(job_id="a-2", title="From Data")],
+        ),
+        is_reusable=True,
+    )
+
+    jobs = BdjobsScraper("any", keyword_seeds=(), category_ids=()).fetch()
+    ids = {j.ats_id for j in jobs}
+    assert ids == {"a-1", "a-2"}
+
+
+def test_seed_segmentation_dedupes_across_queries(httpx_mock) -> None:
+    """Base + keyword + category queries each return their own slice;
+    overlapping Jobids must be deduped to ``len(unique)`` jobs."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_payload(premium=[
+            _job(job_id="shared-1", title="Shared Job"),
+            _job(job_id="base-only", title="Base Only"),
+            _job(job_id="kw-only", title="Keyword Only"),
+        ]),
+        is_reusable=True,
+    )
+
+    jobs = BdjobsScraper(
+        "any",
+        keyword_seeds=("manager", "engineer"),
+        category_ids=(2, 3),
+    ).fetch()
+    # All seeds hit the same mock → dedup down to 3 unique rows.
+    assert {j.ats_id for j in jobs} == {"shared-1", "base-only", "kw-only"}
+
+
+def test_keyword_and_category_params_are_sent(httpx_mock) -> None:
+    """Verify the scraper passes ``Keyword`` and ``Category`` query
+    params (case matters — bdjobs is case-sensitive on these)."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_payload(premium=[_job()]),
+        is_reusable=True,
+    )
+
+    BdjobsScraper(
+        "any",
+        keyword_seeds=("engineer",),
+        category_ids=(7,),
+    ).fetch()
+
+    sent_params: list[dict[str, list[str]]] = []
+    for r in httpx_mock.get_requests():
+        sent_params.append(parse_qs(urlparse(str(r.url)).query))
+
+    # Three calls expected: base (empty params) + 1 keyword + 1 category.
+    assert len(sent_params) == 3
+    assert {"Keyword": ["engineer"]} in sent_params
+    assert {"Category": ["7"]} in sent_params
+    # The base call sends no params.
+    assert {} in sent_params
+
+
+# --- error handling ---------------------------------------------------------
+
+
+def test_missing_jobid_or_title_is_skipped(httpx_mock) -> None:
+    """Rows missing required fields are dropped silently — no
+    fallback UUID, no half-formed Job objects."""
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_payload(premium=[
+            _job(job_id="ok-1", title="Valid"),
+            {"Jobid": "", "jobTitle": "No Id"},
+            {"Jobid": "x-2", "jobTitle": ""},
+        ]),
+        is_reusable=True,
+    )
+
+    jobs = BdjobsScraper("any", keyword_seeds=(), category_ids=()).fetch()
+    assert {j.ats_id for j in jobs} == {"ok-1"}
+
+
+def test_seed_query_failure_is_demoted_to_warning(
+    httpx_mock, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A 500 on one keyword seed must not poison the whole sweep —
+    the base feed and the other seeds still contribute their rows."""
+    # Base call succeeds.
+    httpx_mock.add_response(
+        url=re.compile(rf"^{re.escape(_API)}$"),
+        json=_payload(premium=[_job(job_id="base-1", title="Base Job")]),
+    )
+    # The failing keyword seed.
+    httpx_mock.add_response(
+        url=re.compile(rf"^{re.escape(_API)}\?Keyword=engineer$"),
+        status_code=500,
+    )
+    # The succeeding category seed.
+    httpx_mock.add_response(
+        url=re.compile(rf"^{re.escape(_API)}\?Category=5$"),
+        json=_payload(premium=[_job(job_id="cat-1", title="Cat Job")]),
+    )
+
+    with caplog.at_level("WARNING"):
+        jobs = BdjobsScraper(
+            "any", keyword_seeds=("engineer",), category_ids=(5,),
+        ).fetch()
+    assert {j.ats_id for j in jobs} == {"base-1", "cat-1"}
+    assert any("bdjobs" in r.message.lower() for r in caplog.records)
+
+
+def test_base_failure_after_retries_raises(httpx_mock) -> None:
+    """Sustained server error on the *base* call (no params) raises
+    rather than silently returning ``[]`` — the failure mode must be
+    loud so monitoring sees it."""
+    httpx_mock.add_response(
+        url=re.compile(rf"^{re.escape(_API)}$"),
+        status_code=500,
+    )
+    with pytest.raises(ScraperError, match="bdjobs"):
+        BdjobsScraper("any", keyword_seeds=(), category_ids=()).fetch()

--- a/tests/test_bdjobs.py
+++ b/tests/test_bdjobs.py
@@ -207,6 +207,21 @@ def test_seed_segmentation_dedupes_across_queries(httpx_mock) -> None:
     assert {j.ats_id for j in jobs} == {"shared-1", "base-only", "kw-only"}
 
 
+def test_fetch_query_walks_all_reported_pages(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=re.compile(rf"^{re.escape(_API)}$"),
+        json=_payload(premium=[_job(job_id="page-1")], total=2, total_pages=2),
+    )
+    httpx_mock.add_response(
+        url=re.compile(rf"^{re.escape(_API)}\?pg=2$"),
+        json=_payload(premium=[_job(job_id="page-2")], total=2, total_pages=2),
+    )
+
+    jobs = BdjobsScraper("any", keyword_seeds=(), category_ids=()).fetch()
+
+    assert [j.ats_id for j in jobs] == ["page-1", "page-2"]
+
+
 def test_keyword_and_category_params_are_sent(httpx_mock) -> None:
     """Verify the scraper passes ``Keyword`` and ``Category`` query
     params (case matters — bdjobs is case-sensitive on these)."""

--- a/tests/test_bdjobs.py
+++ b/tests/test_bdjobs.py
@@ -141,6 +141,7 @@ def test_parses_full_premium_job(httpx_mock) -> None:
     # Posted_at parsed from ISO Z string.
     assert j.posted_at is not None
     assert j.posted_at.year == 2026 and j.posted_at.month == 5
+    assert j.fetched_at.tzinfo is not None
     # ``raw`` captures the rich fields the canonical schema can't hold.
     assert j.raw is not None
     assert j.raw["experience"] == "At least 1 years"
@@ -202,6 +203,7 @@ def test_seed_segmentation_dedupes_across_queries(httpx_mock) -> None:
         category_ids=(2, 3),
     ).fetch()
     # All seeds hit the same mock → dedup down to 3 unique rows.
+    assert len(jobs) == 3
     assert {j.ats_id for j in jobs} == {"shared-1", "base-only", "kw-only"}
 
 
@@ -290,4 +292,14 @@ def test_base_failure_after_retries_raises(httpx_mock) -> None:
         status_code=500,
     )
     with pytest.raises(ScraperError, match="bdjobs"):
+        BdjobsScraper("any", keyword_seeds=(), category_ids=()).fetch()
+
+
+def test_malformed_json_payload_raises_scraper_error(httpx_mock) -> None:
+    """A 200 response must still have the expected object shape."""
+    httpx_mock.add_response(
+        url=re.compile(rf"^{re.escape(_API)}$"),
+        json=[{"not": "a payload object"}],
+    )
+    with pytest.raises(ScraperError, match="malformed JSON"):
         BdjobsScraper("any", keyword_seeds=(), category_ids=()).fetch()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,7 +29,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
-        "manfred", "thehub", "ycombinator", "wellfound",
+        "manfred", "thehub", "ycombinator", "wellfound", "bdjobs",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",
         "recruitee", "taleo", "teamtailor",


### PR DESCRIPTION
## Summary

- Adds `BdjobsScraper` for [Bdjobs.com](https://www.bdjobs.com), Bangladesh's #1 job portal (~25 k active vacancies, 170 M+ population — pre-this the dataset had near-zero BD representation).
- Hits the public `GET https://api.bdjobs.com/Jobs/api/JobSearch/GetJobSearch` endpoint (no auth, no key — verified live 2026-05-12).
- Single-source pattern: `company_slug` is ignored. Tags every row with `country_iso="BD"` and `language="en"`/`"bn"` (mapped from the `JobLang` flag).

## API quirks

The endpoint is a "premium spotlight" feed — each call returns up to 10 freshly-listed premium rows plus `common.total_records_found` totals describing the full board (which sits behind a logged-in SPA we can't hit unauthenticated). To widen coverage we issue the same endpoint under a curated set of `Keyword` and `Category` filters (each yields its own ~10-row spotlight, mostly disjoint from the base feed) and dedupe by `Jobid`. Same pattern as `jobsch.py`'s seed-segmentation.

Live smoke test (5 seeds): 16 unique jobs, all `country_iso="BD"`.

## Test plan

- [x] `uv run pytest tests/test_bdjobs.py tests/test_models.py` — 72 passed
- [x] `uv run pytest tests/ -x -q --ignore=tests/test_cli.py --ignore=tests/test_client.py` — 852 passed (no regressions)
- [x] `uv run ruff check src/jobhive/scrapers/bdjobs.py …` — All checks passed
- [x] Live smoke test against the real API returned 16 valid BD jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `BdjobsScraper` to pull Bangladesh jobs from Bdjobs.com’s public search API, now paging through all results per seed to improve coverage, and mapping `JobLang` to `en`/`bn`.

- **New Features**
  - Registers `ATSType.BDJOBS` and wires `BdjobsScraper` into the registry.
  - Adds seed CSV `ats-companies/bdjobs.csv`.
  - Fans out `GET https://api.bdjobs.com/Jobs/api/JobSearch/GetJobSearch` across keyword/category seeds; fetches all pages via `pg`, unions `premiumData` + `data`, and dedupes by `Jobid`.
  - Sets `country_iso="BD"`, builds stable detail URLs, and infers language from `JobLang`.
  - Test coverage for pagination, parsing, dedup, query params, and failure handling.

- **Bug Fixes**
  - Retry logic releases the semaphore before sleeping on `httpx.HTTPError` and 429/5xx, preventing concurrency stalls.
  - Stricter payload handling: validates object shape and raises `ScraperError` on malformed JSON.

<sup>Written for commit 11edb4e965b0e03b1bbc9a866ab0512e45b8131e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `BdjobsScraper`, a new single-source scraper for Bangladesh's dominant job board, using a public unauthenticated REST endpoint widened by keyword and category seeds to maximise unique-job coverage via deduplication on `Jobid`.

- **New scraper** (`bdjobs.py`): fans out across 76 keyword/category seeds concurrently behind a semaphore, paginates each seed via `common.totalpages`, strips HTML from concatenated description fields, maps `JobLang` to ISO-639-1 language codes, and hard-codes `country_iso=\"BD\"`.
- **Pagination risk**: the `while page <= total_pages` loop in `_fetch_query` has no upper-bound cap; the module docstring notes that `common.total_records_found` reflects the *full* board (~25 k vacancies), suggesting `totalpages` could be in the thousands, causing runaway requests per seed.
- **Wiring**: `ATSType.BDJOBS`, registry registration, seed CSV, and `__init__` exports are all correct; test coverage is thorough across parsing, dedup, multi-page walking, and failure paths.

<h3>Confidence Score: 4/5</h3>

Safe to merge after adding a pagination cap; the scraper logic, parsing, dedup, and retry handling are all correct, but the unbounded total_pages loop could cause the scraper to issue tens of thousands of requests per run if the API totalpages field reflects full-board pagination.

The pagination loop in _fetch_query trusts common.totalpages from the API without any ceiling. The module docstring explicitly notes the API returns full-board totals alongside the premium spotlight rows, meaning totalpages could be ~2500 rather than 1-2. With 77 seeds each walking that loop sequentially, a single production run could issue ~192k requests and still return only the same deduplicated premium rows. Adding a small constant cap before the while-loop would close the gap.

src/jobhive/scrapers/bdjobs.py — specifically the _fetch_query pagination loop (lines 204–227).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/bdjobs.py | New BdjobsScraper with seed-segmented concurrency, retry logic, and HTML description parsing; pagination loop lacks an upper-bound cap on total_pages, which can cause runaway requests given that the API totalpages likely reflects the full 25k-vacancy board rather than the premium spotlight. |
| tests/test_bdjobs.py | Comprehensive test suite covering happy-path parsing, language mapping, premiumData+data union, dedup across seeds, multi-page pagination, query param forwarding, and all error-handling paths; no issues found. |
| src/jobhive/models.py | Adds ATSType.BDJOBS = 'bdjobs' to the StrEnum; straightforward, no issues. |
| src/jobhive/scrapers/__init__.py | Wires BdjobsScraper into the package imports and __all__; no issues. |
| ats-companies/bdjobs.csv | Single-row seed CSV for the single-source bdjobs scraper; no issues. |
| tests/test_models.py | Adds 'bdjobs' to the expected ATSType exhaustive list; no issues. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Fetch all Bdjobs result pages"](https://github.com/kalil0321/ats-scrapers/commit/11edb4e965b0e03b1bbc9a866ab0512e45b8131e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732536)</sub>

<!-- /greptile_comment -->