### PR TITLE
Add SuperJob.ru Russia #2 job board scraper (merge later: requires API key)

### DIFF
--- a/ats-companies/superjob.csv
+++ b/ats-companies/superjob.csv
@@ -1,0 +1,2 @@
+name,slug,url
+SuperJob,superjob,https://www.superjob.ru

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -80,6 +80,7 @@ class ATSType(StrEnum):
     THEHUB = "thehub"
     YCOMBINATOR = "ycombinator"
     WELLFOUND = "wellfound"
+    SUPERJOB = "superjob"
     # Additional multi-tenant ATSes (post-0.1)
     BAMBOOHR = "bamboohr"
     BREEZY = "breezy"

--- a/src/jobhive/scrapers/__init__.py
+++ b/src/jobhive/scrapers/__init__.py
@@ -44,6 +44,7 @@ from jobhive.scrapers.remoteok import RemoteOKScraper
 from jobhive.scrapers.rippling import RipplingScraper
 from jobhive.scrapers.smartrecruiters import SmartRecruitersScraper
 from jobhive.scrapers.successfactors import SuccessFactorsScraper
+from jobhive.scrapers.superjob import SuperJobScraper
 from jobhive.scrapers.taleo import TaleoScraper
 from jobhive.scrapers.teamtailor import TeamtailorScraper
 from jobhive.scrapers.tesla import TeslaScraper
@@ -96,6 +97,7 @@ __all__ = [
     "ScraperRegistry",
     "SmartRecruitersScraper",
     "SuccessFactorsScraper",
+    "SuperJobScraper",
     "TaleoScraper",
     "TeamtailorScraper",
     "TeslaScraper",

--- a/src/jobhive/scrapers/superjob.py
+++ b/src/jobhive/scrapers/superjob.py
@@ -162,7 +162,7 @@ def _resolve_proxy_url(raw: str | None) -> str | None:
     if not raw:
         return None
     raw = raw.strip()
-    m = re.match(r"^http://([^:/@]+):(\d+):([^:]+):(.+)$", raw)
+    m = re.match(r"^(?:https?://)?([^:/@]+):(\d+):([^:]+):(.+)$", raw)
     if m:
         host, port, user, pw = m.groups()
         return f"http://{user}:{pw}@{host}:{port}"

--- a/src/jobhive/scrapers/superjob.py
+++ b/src/jobhive/scrapers/superjob.py
@@ -222,7 +222,9 @@ class SuperJobScraper(BaseScraper):
             )
         self.slice_by = slice_by
         self.towns = towns if towns is not None else TOWNS
-        self.max_pages_per_slice = min(max_pages_per_slice, MAX_PAGES_PER_SLICE)
+        self.max_pages_per_slice = max(
+            1, min(max_pages_per_slice, MAX_PAGES_PER_SLICE)
+        )
 
     # --- public entry ------------------------------------------------------
 
@@ -249,10 +251,6 @@ class SuperJobScraper(BaseScraper):
         }
         if self.proxy_url:
             client_kwargs["proxy"] = self.proxy_url
-            # Residential proxies occasionally MITM TLS with a CA chain
-            # that isn't in the system trust store; the requests carry
-            # no PII so the cost of disabling verify is low.
-            client_kwargs["verify"] = False
 
         async with httpx.AsyncClient(**client_kwargs) as client:
             sem = asyncio.Semaphore(MAX_CONCURRENCY)
@@ -281,7 +279,7 @@ class SuperJobScraper(BaseScraper):
         ``"keyword"`` modes can slot in without changing iteration
         code.
         """
-        if self.slice_by == "none" or not self.towns:
+        if self.slice_by == "none":
             return [{}]
         return [{"town": code} for code in self.towns]
 
@@ -328,18 +326,18 @@ class SuperJobScraper(BaseScraper):
         }
         last_exc: Exception | None = None
         for attempt in range(1, MAX_RETRIES + 1):
-            async with sem:
-                try:
+            try:
+                async with sem:
                     response = await client.get(url, params=params, headers=headers)
-                except httpx.HTTPError as exc:
-                    last_exc = exc
-                    if attempt == MAX_RETRIES:
-                        raise ScraperError(
-                            f"superjob fetch failed for {url} "
-                            f"params={params}: {exc}"
-                        ) from exc
-                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
-                    continue
+            except httpx.HTTPError as exc:
+                last_exc = exc
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"superjob fetch failed for {url} "
+                        f"params={params}: {exc}"
+                    ) from exc
+                await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                continue
             if response.status_code == 200:
                 try:
                     payload: dict[str, Any] = response.json()

--- a/src/jobhive/scrapers/superjob.py
+++ b/src/jobhive/scrapers/superjob.py
@@ -48,6 +48,7 @@ import re
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 
@@ -165,7 +166,9 @@ def _resolve_proxy_url(raw: str | None) -> str | None:
     m = re.match(r"^(?:https?://)?([^:/@]+):(\d+):([^:]+):(.+)$", raw)
     if m:
         host, port, user, pw = m.groups()
-        return f"http://{user}:{pw}@{host}:{port}"
+        safe_user = quote(user, safe="")
+        safe_pw = quote(pw, safe="")
+        return f"http://{safe_user}:{safe_pw}@{host}:{port}"
     return raw
 
 

--- a/src/jobhive/scrapers/superjob.py
+++ b/src/jobhive/scrapers/superjob.py
@@ -1,0 +1,558 @@
+"""SuperJob.ru — Russia's #2 job board after hh.ru.
+
+SuperJob exposes a documented public REST API at
+``api.superjob.ru/2.0/`` (docs: https://api.superjob.ru/). The
+``/vacancies/`` endpoint requires a per-application secret in the
+``X-Api-App-Id`` header — registration is free at
+https://api.superjob.ru/register/. The scraper reads the secret from
+the ``SUPERJOB_API_KEY`` env var; without it, ``fetch()`` raises a
+``ScraperError`` pointing the operator at the registration page.
+
+Like every Russian-internet job board, SuperJob geo-blocks non-CIS
+IPs at the edge — even with a valid ``X-Api-App-Id``, requests from
+US/EU datacenter ranges return ``403`` from ``server: sw`` (the
+SuperJob edge) before the API ever sees them. Production runs must
+route through a residential proxy with a CIS exit. Pass ``proxy_url``
+explicitly or set the ``PROXY`` env var; both the standard
+``http://user:pass@host:port`` URL form and the 4-colon
+``host:port:user:pass`` shape some providers ship are accepted (same
+helper jobs.ch / Programathor / hh.ru use).
+
+The Evomi residential pool the rest of this project uses currently
+exits in Chile / Vietnam — the request *reaches* SuperJob but the
+API still rejects the missing app-id. This is the same operational
+shape as the hh.ru scraper (PR #100): the code is correct, but a
+CIS-exit residential proxy is required to actually populate the
+dataset.
+
+The "company" in ``company_slug`` is fixed to ``"superjob"`` since
+SuperJob is a single-source job board (no per-tenant slugs).
+
+API caps ``page * count`` at 500 results per filter combination, so
+enumerating the whole corpus requires slicing the search space.
+``slice_by`` controls the slicing strategy:
+
+- ``"none"`` (default) — single query, capped at 500 results. Fine
+  for tests and tiny markets.
+- ``"town"`` — iterate the documented top-level town IDs (Moscow,
+  Saint Petersburg, …). Cheapest fan-out with good coverage.
+
+Doc reference: https://api.superjob.ru/
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType, Job
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+# --- API constants ----------------------------------------------------------
+
+API_HOST = "api.superjob.ru"
+API_VERSION = "2.0"
+COUNTRY_ISO = "RU"
+LANGUAGE = "ru"
+
+# Per-app-id auth header. SuperJob's docs label it ``X-Api-App-Id``;
+# the value is the per-application "secret_key" returned by the
+# registration form at https://api.superjob.ru/register/.
+ENV_API_KEY = "SUPERJOB_API_KEY"
+
+# Per-page result count. Documented max is 100 for /vacancies/.
+PER_PAGE = 100
+# API hard cap: page * count <= 500 → at count=100, pages 0..4 inclusive.
+MAX_PAGES_PER_SLICE = 5
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 4
+RETRY_BASE_DELAY = 1.5
+DEFAULT_TIMEOUT = 30.0
+
+# SuperJob wants a contact in the UA, same as hh.ru.
+USER_AGENT = "jobhive/1.0 (kalil.bouzigues@gmail.com)"
+
+# Top-level town IDs for slicing by city — taken from
+# api.superjob.ru/2.0/towns/?all=1. Moscow + Saint Petersburg
+# account for the majority of the corpus; the rest are densely-
+# populated regional capitals where the slice keeps the result
+# set under the 500-cap per query.
+#
+# References:
+# - https://api.superjob.ru/#towns — towns endpoint (open, no auth)
+# - The codes are stable; SuperJob hasn't renumbered since v2.0
+#   shipped.
+TOWNS: list[int] = [
+    4,      # Moscow
+    14,     # Saint Petersburg
+    9,      # Yekaterinburg
+    1118,   # Novosibirsk
+    34,     # Nizhny Novgorod
+    44,     # Kazan
+    74,     # Rostov-on-Don
+    78,     # Samara
+    284,    # Krasnodar
+    102,    # Krasnoyarsk
+    1095,   # Volgograd
+    1133,   # Voronezh
+    49,     # Perm
+    77,     # Saratov
+    47,     # Ufa
+    1136,   # Ulyanovsk
+    1132,   # Tver
+    1131,   # Vladimir
+    2114,   # Sochi
+    1119,   # Tyumen
+]
+
+# Map SuperJob ``type_of_work.title`` strings onto the canonical
+# EmploymentType enum. SuperJob uses Russian labels; the values
+# below are the exact strings the API returns (we match
+# case-insensitively defensively). ``Сменный график`` (shift work)
+# and ``Гибкий график`` (flexible hours) collapse to FULL_TIME —
+# neither is a literal fit but FULL_TIME is the closest cross-ATS
+# bucket consumers expect for "salaried but non-standard hours".
+EMPLOYMENT_MAP: dict[str, str] = {
+    "полный рабочий день": "FULL_TIME",
+    "полная занятость": "FULL_TIME",
+    "сменный график": "FULL_TIME",
+    "гибкий график": "FULL_TIME",
+    "частичная занятость": "PART_TIME",
+    "неполный рабочий день": "PART_TIME",
+    "временная работа": "TEMPORARY",
+    "сезонная работа": "TEMPORARY",
+    "стажировка": "INTERN",
+    "вахтовый метод": "CONTRACT",
+    "удаленная работа": "FULL_TIME",
+}
+
+# SuperJob ships a tiny ``currency`` set on /vacancies/ items —
+# ``rub`` / ``uah`` / ``usd`` / ``eur`` / ``kzt`` / ``byn``. Normalize
+# to ISO 4217 uppercase. Everything outside the whitelist is treated
+# as "no signal" (the canonical schema needs an ISO code or nothing).
+CURRENCY_MAP: dict[str, str] = {
+    "rub": "RUB",
+    "rur": "RUB",  # legacy alias, defensive
+    "usd": "USD",
+    "eur": "EUR",
+    "uah": "UAH",
+    "kzt": "KZT",
+    "byn": "BYN",
+    "byr": "BYN",  # legacy alias, defensive
+}
+
+
+def _resolve_proxy_url(raw: str | None) -> str | None:
+    """Accept the 4-colon ``host:port:user:pass`` shape some
+    residential-proxy providers ship and convert to the standard
+    ``http://user:pass@host:port`` URL httpx expects. Plain
+    ``http(s)://…`` URLs pass through.
+
+    Mirrors the helper in ``hhru.py`` / ``programathor.py`` /
+    ``jobsch.py``; kept local so the scraper has no internal
+    cross-imports.
+    """
+    if not raw:
+        return None
+    raw = raw.strip()
+    m = re.match(r"^http://([^:/@]+):(\d+):([^:]+):(.+)$", raw)
+    if m:
+        host, port, user, pw = m.groups()
+        return f"http://{user}:{pw}@{host}:{port}"
+    return raw
+
+
+@ScraperRegistry.register(ATSType.SUPERJOB)
+class SuperJobScraper(BaseScraper):
+    """SuperJob.ru scraper.
+
+    ``company_slug`` is conventionally ``"superjob"`` — SuperJob is a
+    single-source board so the slug is metadata, not a tenant key.
+    Any value is accepted; it's only used to label the scraper.
+
+    Knobs:
+
+    - ``api_key`` — explicit SuperJob app secret. Falls back to the
+      ``SUPERJOB_API_KEY`` env var. Required — without it the
+      ``/vacancies/`` endpoint returns ``403`` with a Russian-language
+      error pointing at the registration page.
+    - ``proxy_url`` — explicit proxy URL. Falls back to ``PROXY`` env
+      var (4-colon shape auto-converted), then to direct connection.
+      SuperJob's edge returns ``403`` to US/EU datacenter IPs (even
+      *with* a valid app-id) — pretty much always needed in production.
+    - ``slice_by`` — slicing strategy to fan past the 500-result API
+      cap. ``"none"`` (default) runs a single unsliced query;
+      ``"town"`` iterates the town codes in :data:`TOWNS`.
+    - ``towns`` — explicit override of the town code list, useful for
+      testing or for narrowing the run to a single city.
+    - ``max_pages_per_slice`` — pagination ceiling within one slice.
+      Clamped to 5 (page 0..4 × count 100 = 500 results — the API's
+      hard cap).
+    """
+
+    ats = ATSType.SUPERJOB
+
+    def __init__(
+        self,
+        company_slug: str = "superjob",
+        *,
+        timeout: float = DEFAULT_TIMEOUT,
+        api_key: str | None = None,
+        proxy_url: str | None = None,
+        slice_by: str = "none",
+        towns: list[int] | None = None,
+        max_pages_per_slice: int = MAX_PAGES_PER_SLICE,
+    ) -> None:
+        super().__init__(company_slug, timeout=timeout)
+        self.api_key = api_key or os.environ.get(ENV_API_KEY, "").strip() or None
+        self.proxy_url = _resolve_proxy_url(proxy_url) or _resolve_proxy_url(
+            os.environ.get("PROXY")
+        )
+        if slice_by not in {"none", "town"}:
+            raise ScraperError(
+                f"SuperJobScraper: unsupported slice_by={slice_by!r}; "
+                "expected 'none' or 'town'"
+            )
+        self.slice_by = slice_by
+        self.towns = towns if towns is not None else TOWNS
+        self.max_pages_per_slice = min(max_pages_per_slice, MAX_PAGES_PER_SLICE)
+
+    # --- public entry ------------------------------------------------------
+
+    def fetch(self) -> list[Job]:
+        if not self.api_key:
+            raise ScraperError(
+                f"{ENV_API_KEY} env var is required. SuperJob's /vacancies/ "
+                "endpoint returns 403 without an X-Api-App-Id header. "
+                "Register a free app at https://api.superjob.ru/register/ "
+                "to obtain a secret_key."
+            )
+        return asyncio.run(self._fetch_async())
+
+    async def _fetch_async(self) -> list[Job]:
+        slices = self._build_slices()
+
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        lock = asyncio.Lock()
+
+        client_kwargs: dict[str, Any] = {
+            "timeout": self.timeout,
+            "follow_redirects": True,
+        }
+        if self.proxy_url:
+            client_kwargs["proxy"] = self.proxy_url
+            # Residential proxies occasionally MITM TLS with a CA chain
+            # that isn't in the system trust store; the requests carry
+            # no PII so the cost of disabling verify is low.
+            client_kwargs["verify"] = False
+
+        async with httpx.AsyncClient(**client_kwargs) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+
+            async def run_slice(slice_params: dict[str, str | int]) -> None:
+                async for item in self._iter_slice(client, sem, slice_params):
+                    job = self._build_job(item)
+                    if job is None or job.ats_id is None:
+                        continue
+                    async with lock:
+                        if job.ats_id in seen:
+                            continue
+                        seen.add(job.ats_id)
+                        jobs.append(job)
+
+            await asyncio.gather(*(run_slice(s) for s in slices))
+
+        return jobs
+
+    # --- slicing -----------------------------------------------------------
+
+    def _build_slices(self) -> list[dict[str, str | int]]:
+        """Cartesian product of the active slicing dimensions.
+
+        Kept dict-shaped so future ``slice_by="catalogue"`` /
+        ``"keyword"`` modes can slot in without changing iteration
+        code.
+        """
+        if self.slice_by == "none" or not self.towns:
+            return [{}]
+        return [{"town": code} for code in self.towns]
+
+    async def _iter_slice(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        slice_params: dict[str, str | int],
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Walk pages within a single slice."""
+        page = 0
+        while page < self.max_pages_per_slice:
+            payload = await self._fetch_page(client, sem, slice_params, page)
+            items = payload.get("objects") or []
+            if not items:
+                return
+            for item in items:
+                yield item
+            # SuperJob's pagination uses ``total`` + ``more`` — if
+            # ``more`` is False the next page would be empty.
+            if not payload.get("more"):
+                return
+            page += 1
+
+    # --- HTTP --------------------------------------------------------------
+
+    async def _fetch_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        slice_params: dict[str, str | int],
+        page: int,
+    ) -> dict[str, Any]:
+        url = f"https://{API_HOST}/{API_VERSION}/vacancies/"
+        params: dict[str, str | int] = {
+            "count": PER_PAGE,
+            "page": page,
+            **slice_params,
+        }
+        headers = {
+            "User-Agent": USER_AGENT,
+            "Accept": "application/json",
+            "X-Api-App-Id": self.api_key or "",
+        }
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(url, params=params, headers=headers)
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"superjob fetch failed for {url} "
+                            f"params={params}: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                try:
+                    payload: dict[str, Any] = response.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"superjob returned non-JSON 200 for {url} "
+                        f"params={params}: {exc}"
+                    ) from exc
+                return payload
+            if response.status_code == 403:
+                # Distinguish edge-level geo-block vs API-level missing
+                # app-id by sniffing the response body — the edge ships
+                # ``server: sw`` HTML or empty JSON; the API ships a
+                # ``{"error":{...}}`` envelope with a Russian message.
+                body_hint = (response.text or "")[:200]
+                raise ScraperError(
+                    f"superjob returned 403 for {url}. Either the "
+                    f"{ENV_API_KEY} secret is missing/invalid or the "
+                    "edge geo-blocked the request — production needs a "
+                    "CIS-exit residential proxy (set PROXY env var). "
+                    f"Body: {body_hint!r}"
+                )
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"superjob returned {response.status_code} for "
+                        f"{url} params={params} after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after)
+                    if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"superjob returned {response.status_code} for {url} "
+                f"params={params}"
+            )
+        raise ScraperError(
+            f"superjob exhausted retries for {url} params={params}: "
+            f"{last_exc}"
+        )
+
+    # --- parsing -----------------------------------------------------------
+
+    def _build_job(self, item: dict[str, Any]) -> Job | None:
+        ats_id = item.get("id")
+        url = item.get("link")
+        title = item.get("profession")
+        if not ats_id or not url or not title:
+            return None
+
+        # ``firm_name`` is the most common employer-name field; some
+        # listings (especially anonymized "Конфиденциально" ones) only
+        # populate ``client.title``. Keep both paths.
+        company = item.get("firm_name") or ""
+        if not company:
+            client = item.get("client") or {}
+            if isinstance(client, dict):
+                company = client.get("title") or ""
+        if not company:
+            company = "Конфиденциально"  # "Confidential" — SuperJob's own label
+
+        town = item.get("town") or {}
+        location = town.get("title") if isinstance(town, dict) else None
+
+        # SuperJob always returns ``payment_from`` / ``payment_to`` as
+        # ints (0 when unknown — not None). Treat 0 as "no signal".
+        payment_from_raw = item.get("payment_from")
+        payment_to_raw = item.get("payment_to")
+        payment_from = _as_positive_float(payment_from_raw)
+        payment_to = _as_positive_float(payment_to_raw)
+        currency_raw = item.get("currency")
+        salary_currency: str | None = None
+        salary_period: str | None = None
+        salary_min: float | None = None
+        salary_max: float | None = None
+        if currency_raw and isinstance(currency_raw, str):
+            mapped = CURRENCY_MAP.get(currency_raw.lower())
+            if mapped and (payment_from is not None or payment_to is not None):
+                salary_currency = mapped
+                salary_period = "MONTH"  # SuperJob salaries are always monthly
+                salary_min = payment_from
+                salary_max = payment_to
+
+        type_of_work = item.get("type_of_work") or {}
+        type_title = (
+            type_of_work.get("title") if isinstance(type_of_work, dict) else None
+        )
+        employment_type = _map_employment(type_title)
+        commitment = type_title if type_title else None
+
+        # Description: SuperJob ships ``candidat`` (requirements) +
+        # ``vacancyRichText`` (HTML body) — combine them and strip
+        # HTML for the canonical schema.
+        description = _join_description(
+            item.get("candidat"), item.get("vacancyRichText")
+        )
+
+        # ``date_published`` is a unix timestamp (seconds, UTC).
+        posted_at = _parse_unix(item.get("date_published"))
+
+        raw: dict[str, Any] = {}
+        for key in (
+            "experience",
+            "education",
+            "place_of_work",
+            "agency",
+            "moveable",
+            "languages",
+        ):
+            v = item.get(key)
+            if v is not None:
+                raw[key] = v
+        if isinstance(town, dict) and town.get("id"):
+            raw["town_id"] = town["id"]
+        category = item.get("catalogues")
+        if category:
+            raw["catalogues"] = category
+
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.SUPERJOB,
+            ats_id=str(ats_id),
+            location=location,
+            country_iso=COUNTRY_ISO,
+            salary_currency=salary_currency,
+            salary_period=salary_period,  # type: ignore[arg-type]
+            salary_min=salary_min,
+            salary_max=salary_max,
+            employment_type=employment_type,  # type: ignore[arg-type]
+            commitment=commitment,
+            description=description,
+            posted_at=posted_at,
+            fetched_at=datetime.now(),
+            language=LANGUAGE,
+            raw=raw or None,
+        )
+
+
+# --- module-level helpers ---------------------------------------------------
+
+
+def _as_positive_float(value: object) -> float | None:
+    """SuperJob ships ``payment_from`` / ``payment_to`` as ints —
+    ``0`` is the sentinel for "no value", not a literal zero salary.
+    Drop 0 / negative / non-numeric values to ``None``."""
+    if value is None:
+        return None
+    try:
+        out = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    if out <= 0:
+        return None
+    return out
+
+
+def _map_employment(label: str | None) -> str | None:
+    """Case-insensitive lookup against :data:`EMPLOYMENT_MAP`.
+
+    SuperJob mixes capitalization between API responses (``"Полный
+    рабочий день"`` vs ``"полный рабочий день"`` seen across the
+    corpus); the map is keyed lowercase and the lookup folds case.
+    """
+    if not label:
+        return None
+    return EMPLOYMENT_MAP.get(label.strip().lower())
+
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _join_description(
+    candidat: str | None, rich_text: str | None
+) -> str | None:
+    """SuperJob's ``candidat`` is plain text (requirements paragraph);
+    ``vacancyRichText`` is HTML (full body). Combine, strip HTML,
+    collapse whitespace."""
+    parts = [p for p in (candidat, rich_text) if p]
+    if not parts:
+        return None
+    joined = "\n".join(parts)
+    cleaned = _HTML_TAG_RE.sub("", joined)
+    cleaned = (
+        cleaned.replace("&nbsp;", " ")
+        .replace("&amp;", "&")
+        .replace("&quot;", '"')
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+    )
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned or None
+
+
+def _parse_unix(value: object) -> datetime | None:
+    """``date_published`` is a unix timestamp in seconds (UTC).
+
+    Defensive ``float()`` since the field has been observed as a
+    stringified int on legacy listings."""
+    if value is None:
+        return None
+    try:
+        ts = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    if ts <= 0:
+        return None
+    try:
+        return datetime.fromtimestamp(ts, tz=UTC)
+    except (OverflowError, OSError, ValueError):
+        return None

--- a/src/jobhive/scrapers/superjob.py
+++ b/src/jobhive/scrapers/superjob.py
@@ -479,7 +479,7 @@ class SuperJobScraper(BaseScraper):
             commitment=commitment,
             description=description,
             posted_at=posted_at,
-            fetched_at=datetime.now(),
+            fetched_at=datetime.now(UTC),
             language=LANGUAGE,
             raw=raw or None,
         )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,7 +29,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # Hybrid jobboards (companies post directly)
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
-        "manfred", "thehub", "ycombinator", "wellfound",
+        "manfred", "thehub", "ycombinator", "wellfound", "superjob",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr", "jobvite",
         "recruitee", "taleo", "teamtailor",

--- a/tests/test_superjob.py
+++ b/tests/test_superjob.py
@@ -206,6 +206,8 @@ def test_parses_full_item(httpx_mock) -> None:
     assert "backend" in j.description
     assert j.posted_at is not None
     assert j.posted_at.year == 2025
+    assert j.fetched_at.tzinfo is not None
+    assert j.fetched_at.utcoffset() is not None
     assert j.raw is not None
     assert j.raw["town_id"] == 4
     assert j.raw["experience"]["id"] == 2

--- a/tests/test_superjob.py
+++ b/tests/test_superjob.py
@@ -139,9 +139,11 @@ def test_unknown_slice_by_raises() -> None:
 
 def test_max_pages_per_slice_is_clamped() -> None:
     """API hard cap is 5 (500 results) — even when the operator passes
-    a higher value, the scraper clamps."""
+    a value outside the valid range, the scraper clamps."""
     scraper = SuperJobScraper("superjob", max_pages_per_slice=500)
     assert scraper.max_pages_per_slice == 5
+    scraper = SuperJobScraper("superjob", max_pages_per_slice=0)
+    assert scraper.max_pages_per_slice == 1
 
 
 def test_picks_up_proxy_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -451,6 +453,7 @@ def test_deduplicates_across_slices(httpx_mock) -> None:
     jobs = SuperJobScraper(
         "superjob", slice_by="town", towns=[4, 14]
     ).fetch()
+    assert len(jobs) == 2
     assert {j.ats_id for j in jobs} == {"42", "43"}
 
 
@@ -470,6 +473,12 @@ def test_slice_by_town_fans_out_per_code(httpx_mock) -> None:
         "superjob", slice_by="town", towns=[4, 14]
     ).fetch()
     assert {j.ats_id for j in jobs} == {"100", "200"}
+
+
+def test_slice_by_town_with_empty_towns_fetches_no_slices(httpx_mock) -> None:
+    jobs = SuperJobScraper("superjob", slice_by="town", towns=[]).fetch()
+    assert jobs == []
+    assert httpx_mock.get_requests() == []
 
 
 # --- error handling --------------------------------------------------------

--- a/tests/test_superjob.py
+++ b/tests/test_superjob.py
@@ -115,6 +115,14 @@ def test_proxy_url_quad_colon_format_without_scheme_converted() -> None:
     assert out == "http://alice:secret@proxy.example.com:1000"
 
 
+def test_proxy_url_quad_colon_format_escapes_credentials() -> None:
+    out = _resolve_proxy_url("proxy.example.com:1000:alice@corp:p/a?s#word")
+    assert (
+        out
+        == "http://alice%40corp:p%2Fa%3Fs%23word@proxy.example.com:1000"
+    )
+
+
 def test_proxy_url_already_canonical_passes_through() -> None:
     out = _resolve_proxy_url("http://user:pw@host.example:8080")
     assert out == "http://user:pw@host.example:8080"

--- a/tests/test_superjob.py
+++ b/tests/test_superjob.py
@@ -1,0 +1,507 @@
+"""Tests for the SuperJob.ru scraper.
+
+SuperJob's ``/vacancies/`` endpoint is auth-gated (``X-Api-App-Id``)
+and geo-blocked at the edge to non-CIS IPs. These tests exercise:
+
+- The ``SUPERJOB_API_KEY`` env var contract (``fetch()`` raises a
+  pointed ``ScraperError`` when the key is missing).
+- Item parsing — every documented SuperJob field maps onto the right
+  ``Job`` slot (``payment_from``/``payment_to`` with the 0 sentinel,
+  ``currency`` → ISO 4217, ``type_of_work.title`` → EmploymentType
+  via the Russian-label map, ``date_published`` unix timestamp →
+  ``posted_at`` UTC, HTML stripped from ``vacancyRichText``).
+- Pagination — the scraper walks ``page=0..`` while ``more=True`` and
+  stops on empty ``objects`` or the ``more=false`` flag.
+- Slicing — ``slice_by='town'`` fans out by town code;
+  ``slice_by='none'`` runs a single unsliced query.
+- The proxy URL helper (the 4-colon Evomi shape converts).
+- 403 → ``ScraperError`` that points the operator at both the API
+  key and proxy knobs.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from jobhive.exceptions import ScraperError
+from jobhive.models import ATSType
+from jobhive.scrapers import ScraperRegistry, SuperJobScraper
+from jobhive.scrapers.superjob import (
+    CURRENCY_MAP,
+    EMPLOYMENT_MAP,
+    _as_positive_float,
+    _join_description,
+    _map_employment,
+    _parse_unix,
+    _resolve_proxy_url,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jobhive.scrapers.superjob as sj
+
+    monkeypatch.setattr(sj, "MAX_RETRIES", 1)
+    monkeypatch.setattr(sj, "RETRY_BASE_DELAY", 0.0)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tests assume a clean env — no proxy and a known API key so
+    httpx_mock doesn't get bypassed and ``fetch()`` doesn't bail on
+    the missing-key check."""
+    monkeypatch.delenv("PROXY", raising=False)
+    monkeypatch.setenv("SUPERJOB_API_KEY", "test-secret")
+
+
+# --- fixture helpers --------------------------------------------------------
+
+
+def _item(
+    *,
+    job_id: int = 12345678,
+    profession: str = "Senior Python Developer",
+    firm_name: str = "Yandex",
+    town_id: int = 4,
+    town_title: str = "Москва",
+    payment_from: int = 200000,
+    payment_to: int = 350000,
+    currency: str | None = "rub",
+    type_of_work_title: str | None = "Полный рабочий день",
+    candidat: str | None = "Опыт Python от 1 года.",
+    vacancy_rich_text: str | None = "<p>Разработка <b>backend</b> сервисов.</p>",
+    date_published: int = 1747037400,  # 2025-05-12T10:30:00Z
+    link: str | None = None,
+) -> dict:
+    return {
+        "id": job_id,
+        "profession": profession,
+        "firm_name": firm_name,
+        "town": {"id": town_id, "title": town_title},
+        "payment_from": payment_from,
+        "payment_to": payment_to,
+        "currency": currency,
+        "type_of_work": {"id": 6, "title": type_of_work_title},
+        "candidat": candidat,
+        "vacancyRichText": vacancy_rich_text,
+        "date_published": date_published,
+        "link": link or f"https://www.superjob.ru/vakansii/{job_id}.html",
+        "experience": {"id": 2, "title": "От 1 года"},
+        "education": {"id": 200, "title": "Высшее"},
+        "catalogues": [{"id": 33, "title": "IT, Интернет, связь, телеком"}],
+    }
+
+
+def _page(items: list[dict], *, total: int | None = None, more: bool = False) -> dict:
+    return {
+        "objects": items,
+        "total": total if total is not None else len(items),
+        "more": more,
+    }
+
+
+# --- proxy URL helper -------------------------------------------------------
+
+
+def test_proxy_url_quad_colon_format_converted() -> None:
+    out = _resolve_proxy_url("http://proxy.example.com:1000:alice:secret")
+    assert out == "http://alice:secret@proxy.example.com:1000"
+
+
+def test_proxy_url_already_canonical_passes_through() -> None:
+    out = _resolve_proxy_url("http://user:pw@host.example:8080")
+    assert out == "http://user:pw@host.example:8080"
+
+
+def test_proxy_url_none_or_empty_returns_none() -> None:
+    assert _resolve_proxy_url(None) is None
+    assert _resolve_proxy_url("") is None
+
+
+# --- registry / constructor -------------------------------------------------
+
+
+def test_registry_resolves_superjob() -> None:
+    assert ScraperRegistry.get(ATSType.SUPERJOB) is SuperJobScraper
+
+
+def test_unknown_slice_by_raises() -> None:
+    with pytest.raises(ScraperError, match="unsupported slice_by"):
+        SuperJobScraper("superjob", slice_by="region")
+
+
+def test_max_pages_per_slice_is_clamped() -> None:
+    """API hard cap is 5 (500 results) — even when the operator passes
+    a higher value, the scraper clamps."""
+    scraper = SuperJobScraper("superjob", max_pages_per_slice=500)
+    assert scraper.max_pages_per_slice == 5
+
+
+def test_picks_up_proxy_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROXY", "http://proxy.example.com:1000:alice:secret")
+    scraper = SuperJobScraper("superjob")
+    assert scraper.proxy_url == "http://alice:secret@proxy.example.com:1000"
+
+
+def test_picks_up_api_key_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SUPERJOB_API_KEY", "abc123")
+    scraper = SuperJobScraper("superjob")
+    assert scraper.api_key == "abc123"
+
+
+def test_fetch_without_api_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The whole point of the env-var contract: no key → no fetch,
+    with a hint pointing at the registration page."""
+    monkeypatch.delenv("SUPERJOB_API_KEY", raising=False)
+    scraper = SuperJobScraper("superjob")
+    with pytest.raises(ScraperError, match="SUPERJOB_API_KEY"):
+        scraper.fetch()
+
+
+# --- happy path -------------------------------------------------------------
+
+
+def test_parses_full_item(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.superjob\.ru/2\.0/vacancies/\?.*"),
+        json=_page([_item()], more=False),
+    )
+    jobs = SuperJobScraper("superjob", slice_by="none").fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.SUPERJOB
+    assert j.ats_id == "12345678"
+    assert str(j.url) == "https://www.superjob.ru/vakansii/12345678.html"
+    assert j.title == "Senior Python Developer"
+    assert j.company == "Yandex"
+    assert j.location == "Москва"
+    assert j.country_iso == "RU"
+    assert j.language == "ru"
+    assert j.salary_currency == "RUB"
+    assert j.salary_period == "MONTH"
+    assert j.salary_min == 200000.0
+    assert j.salary_max == 350000.0
+    assert j.employment_type == "FULL_TIME"
+    assert j.commitment == "Полный рабочий день"
+    assert j.description is not None
+    assert "<" not in j.description and ">" not in j.description
+    assert "Python" in j.description
+    assert "backend" in j.description
+    assert j.posted_at is not None
+    assert j.posted_at.year == 2025
+    assert j.raw is not None
+    assert j.raw["town_id"] == 4
+    assert j.raw["experience"]["id"] == 2
+
+
+def test_sends_app_id_header(httpx_mock, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``X-Api-App-Id`` must be on every outbound request — the API
+    rejects everything else with 403."""
+    monkeypatch.setenv("SUPERJOB_API_KEY", "my-secret-key")
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.superjob\.ru/2\.0/vacancies/\?.*"),
+        json=_page([_item()]),
+    )
+    SuperJobScraper("superjob", slice_by="none").fetch()
+    req = httpx_mock.get_requests()[0]
+    assert req.headers["X-Api-App-Id"] == "my-secret-key"
+
+
+def test_falls_back_to_confidential_when_no_employer(httpx_mock) -> None:
+    """SuperJob ships anonymized listings with no ``firm_name`` and an
+    empty ``client``. The canonical schema requires ``company`` so we
+    stamp the SuperJob-native fallback ('Конфиденциально')."""
+    item = _item(firm_name="")
+    item.pop("firm_name")
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.superjob\.ru/2\.0/vacancies/\?.*"),
+        json=_page([item]),
+    )
+    jobs = SuperJobScraper("superjob", slice_by="none").fetch()
+    assert jobs[0].company == "Конфиденциально"
+
+
+def test_falls_back_to_client_title_when_firm_name_missing(httpx_mock) -> None:
+    """When ``firm_name`` is empty but ``client.title`` is set,
+    prefer the latter (common on agency-posted listings)."""
+    item = _item(firm_name="")
+    item["client"] = {"title": "Agency Acme"}
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.superjob\.ru/2\.0/vacancies/\?.*"),
+        json=_page([item]),
+    )
+    jobs = SuperJobScraper("superjob", slice_by="none").fetch()
+    assert jobs[0].company == "Agency Acme"
+
+
+# --- salary -----------------------------------------------------------------
+
+
+def test_currency_map_covers_known_codes() -> None:
+    """Pin the legacy → ISO normalization. ``rub`` (the canonical
+    lowercase shape SuperJob ships) → ``RUB``; ``rur`` legacy alias
+    folds to ``RUB`` too."""
+    assert CURRENCY_MAP["rub"] == "RUB"
+    assert CURRENCY_MAP["rur"] == "RUB"
+    assert CURRENCY_MAP["usd"] == "USD"
+    assert CURRENCY_MAP["eur"] == "EUR"
+    assert CURRENCY_MAP["kzt"] == "KZT"
+    assert CURRENCY_MAP["byn"] == "BYN"
+
+
+def test_payment_zero_is_treated_as_missing(httpx_mock) -> None:
+    """SuperJob uses ``0`` as the sentinel for ``payment_from`` /
+    ``payment_to`` when the listing doesn't specify a side. Drop to
+    ``None`` rather than ship a literal zero salary."""
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.superjob\.ru/2\.0/vacancies/\?.*"),
+        json=_page([_item(payment_from=0, payment_to=200000)]),
+    )
+    jobs = SuperJobScraper("superjob", slice_by="none").fetch()
+    assert jobs[0].salary_min is None
+    assert jobs[0].salary_max == 200000.0
+    assert jobs[0].salary_currency == "RUB"
+
+
+def test_payment_both_zero_drops_salary_block(httpx_mock) -> None:
+    """No salary signal at all — all four salary fields must be
+    ``None`` rather than carrying a free currency without amounts."""
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.superjob\.ru/2\.0/vacancies/\?.*"),
+        json=_page([_item(payment_from=0, payment_to=0)]),
+    )
+    jobs = SuperJobScraper("superjob", slice_by="none").fetch()
+    assert jobs[0].salary_currency is None
+    assert jobs[0].salary_min is None
+    assert jobs[0].salary_max is None
+    assert jobs[0].salary_period is None
+
+
+def test_unknown_currency_drops_salary(httpx_mock) -> None:
+    """Anything outside the known whitelist is treated as 'no signal'.
+    Defensive — keeps the canonical schema clean."""
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.superjob\.ru/2\.0/vacancies/\?.*"),
+        json=_page([_item(currency="xyz")]),
+    )
+    jobs = SuperJobScraper("superjob", slice_by="none").fetch()
+    assert jobs[0].salary_currency is None
+    assert jobs[0].salary_min is None
+    assert jobs[0].salary_max is None
+
+
+def test_as_positive_float_handles_sentinels() -> None:
+    assert _as_positive_float(0) is None
+    assert _as_positive_float(-1) is None
+    assert _as_positive_float(None) is None
+    assert _as_positive_float("abc") is None
+    assert _as_positive_float(150_000) == 150_000.0
+    assert _as_positive_float("150000") == 150_000.0
+
+
+# --- employment / experience -----------------------------------------------
+
+
+@pytest.mark.parametrize("label, expected", [
+    ("полный рабочий день", "FULL_TIME"),
+    ("полная занятость", "FULL_TIME"),
+    ("частичная занятость", "PART_TIME"),
+    ("неполный рабочий день", "PART_TIME"),
+    ("стажировка", "INTERN"),
+    ("временная работа", "TEMPORARY"),
+    ("сезонная работа", "TEMPORARY"),
+    ("вахтовый метод", "CONTRACT"),
+])
+def test_employment_map_covers_known_labels(label: str, expected: str) -> None:
+    assert EMPLOYMENT_MAP[label] == expected
+
+
+def test_map_employment_folds_case() -> None:
+    """SuperJob mixes ``"Полный рабочий день"`` and the lowercase
+    variant across the corpus — the lookup should fold case so both
+    map onto ``FULL_TIME``."""
+    assert _map_employment("Полный рабочий день") == "FULL_TIME"
+    assert _map_employment("ПОЛНЫЙ РАБОЧИЙ ДЕНЬ") == "FULL_TIME"
+    assert _map_employment("  полный рабочий день  ") == "FULL_TIME"
+
+
+def test_map_employment_unknown_returns_none() -> None:
+    assert _map_employment("unknown-label") is None
+    assert _map_employment(None) is None
+    assert _map_employment("") is None
+
+
+def test_unknown_type_of_work_leaves_field_none(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.superjob\.ru/2\.0/vacancies/\?.*"),
+        json=_page([_item(type_of_work_title="Что-то новое")]),
+    )
+    jobs = SuperJobScraper("superjob", slice_by="none").fetch()
+    assert jobs[0].employment_type is None
+    # commitment still preserves the original Russian label
+    assert jobs[0].commitment == "Что-то новое"
+
+
+# --- description --------------------------------------------------
+
+
+def test_join_description_strips_html_tags() -> None:
+    out = _join_description(
+        "Опыт Python от 1 года.",
+        "<p>Разработка <b>backend</b> сервисов.</p>",
+    )
+    assert out is not None
+    assert "<" not in out
+    assert ">" not in out
+    assert "Python" in out
+    assert "backend" in out
+    assert "Разработка" in out
+
+
+def test_join_description_collapses_html_entities() -> None:
+    out = _join_description(None, "Tom &amp; Jerry &nbsp;&quot;quoted&quot;")
+    assert out is not None
+    assert "&amp;" not in out
+    assert "&nbsp;" not in out
+    assert "Tom & Jerry" in out
+    assert '"quoted"' in out
+
+
+def test_join_description_both_none_returns_none() -> None:
+    assert _join_description(None, None) is None
+    assert _join_description("", "") is None
+
+
+def test_join_description_one_side_only() -> None:
+    out = _join_description("Только candidat.", None)
+    assert out == "Только candidat."
+
+
+# --- published_at parsing ---------------------------------------------------
+
+
+def test_parse_unix_handles_int() -> None:
+    dt = _parse_unix(1747037400)
+    assert dt is not None
+    assert dt.year == 2025 and dt.month == 5
+    assert dt.tzinfo is not None  # UTC-aware
+
+
+def test_parse_unix_handles_str() -> None:
+    """Defensive: ``date_published`` has been observed as a stringified
+    int on legacy listings."""
+    dt = _parse_unix("1747037400")
+    assert dt is not None
+    assert dt.year == 2025
+
+
+def test_parse_unix_zero_and_none_returns_none() -> None:
+    assert _parse_unix(0) is None
+    assert _parse_unix(None) is None
+    assert _parse_unix("not-a-number") is None
+
+
+# --- pagination -------------------------------------------------------------
+
+
+def test_walks_pages_while_more_is_true(httpx_mock) -> None:
+    """Two pages with ``more=True`` on page 0, then ``more=False`` on
+    page 1 — scraper stops after page 1."""
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.superjob\.ru/2\.0/vacancies/\?.*page=0(&|$)"),
+        json=_page([_item(job_id=1)], more=True),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.superjob\.ru/2\.0/vacancies/\?.*page=1(&|$)"),
+        json=_page([_item(job_id=2)], more=False),
+    )
+    jobs = SuperJobScraper("superjob", slice_by="none").fetch()
+    assert {j.ats_id for j in jobs} == {"1", "2"}
+
+
+def test_stops_when_objects_empty(httpx_mock) -> None:
+    """``more=True`` but ``objects=[]`` — bail rather than loop."""
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.superjob\.ru/2\.0/vacancies/\?.*page=0(&|$)"),
+        json=_page([_item(job_id=1)], more=True),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.superjob\.ru/2\.0/vacancies/\?.*page=1(&|$)"),
+        json=_page([], more=True),
+    )
+    jobs = SuperJobScraper("superjob", slice_by="none").fetch()
+    assert {j.ats_id for j in jobs} == {"1"}
+
+
+def test_deduplicates_across_slices(httpx_mock) -> None:
+    """The same job can show up under two overlapping towns (rare —
+    usually town-scoped — but defensively handle the case)."""
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.superjob\.ru/2\.0/vacancies/\?.*"),
+        json=_page([_item(job_id=42), _item(job_id=43)], more=False),
+        is_reusable=True,
+    )
+    jobs = SuperJobScraper(
+        "superjob", slice_by="town", towns=[4, 14]
+    ).fetch()
+    assert {j.ats_id for j in jobs} == {"42", "43"}
+
+
+# --- slicing ---------------------------------------------------------------
+
+
+def test_slice_by_town_fans_out_per_code(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.superjob\.ru/2\.0/vacancies/\?.*town=4(&|$)"),
+        json=_page([_item(job_id=100)], more=False),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.superjob\.ru/2\.0/vacancies/\?.*town=14(&|$)"),
+        json=_page([_item(job_id=200)], more=False),
+    )
+    jobs = SuperJobScraper(
+        "superjob", slice_by="town", towns=[4, 14]
+    ).fetch()
+    assert {j.ats_id for j in jobs} == {"100", "200"}
+
+
+# --- error handling --------------------------------------------------------
+
+
+def test_403_raises_with_helpful_hint(httpx_mock) -> None:
+    """403 could be either the API rejecting the app-id or the edge
+    geo-blocking — error message should call out both paths."""
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.superjob\.ru/2\.0/vacancies/\?.*"),
+        status_code=403,
+        json={"error": {"code": 403, "message": "test"}},
+        is_reusable=True,
+    )
+    with pytest.raises(ScraperError, match="SUPERJOB_API_KEY"):
+        SuperJobScraper("superjob", slice_by="none").fetch()
+
+
+def test_persistent_500_raises(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.superjob\.ru/2\.0/vacancies/\?.*"),
+        status_code=500,
+        is_reusable=True,
+    )
+    with pytest.raises(ScraperError):
+        SuperJobScraper("superjob", slice_by="none").fetch()
+
+
+def test_skips_items_missing_required_fields(httpx_mock) -> None:
+    """Defensive: items missing ``id`` / ``link`` / ``profession``
+    are dropped silently."""
+    good = _item(job_id=1)
+    bad_no_id = {**_item(job_id=2), "id": None}
+    bad_no_link = {**_item(job_id=3), "link": None}
+    httpx_mock.add_response(
+        url=re.compile(r"^https://api\.superjob\.ru/2\.0/vacancies/\?.*"),
+        json=_page([good, bad_no_id, bad_no_link]),
+    )
+    jobs = SuperJobScraper("superjob", slice_by="none").fetch()
+    assert {j.ats_id for j in jobs} == {"1"}

--- a/tests/test_superjob.py
+++ b/tests/test_superjob.py
@@ -110,6 +110,11 @@ def test_proxy_url_quad_colon_format_converted() -> None:
     assert out == "http://alice:secret@proxy.example.com:1000"
 
 
+def test_proxy_url_quad_colon_format_without_scheme_converted() -> None:
+    out = _resolve_proxy_url("proxy.example.com:1000:alice:secret")
+    assert out == "http://alice:secret@proxy.example.com:1000"
+
+
 def test_proxy_url_already_canonical_passes_through() -> None:
     out = _resolve_proxy_url("http://user:pw@host.example:8080")
     assert out == "http://user:pw@host.example:8080"


### PR DESCRIPTION
## Summary

- Adds `SuperJobScraper` (single-source, `ats_type=ATSType.SUPERJOB`) targeting `api.superjob.ru/2.0/vacancies/` — SuperJob is Russia's #2 job board after hh.ru with hundreds of thousands of postings.
- Same operational shape as the hh.ru scraper (PR #100): routes through the project's `PROXY` env, and additionally reads `SUPERJOB_API_KEY` for the required `X-Api-App-Id` header (free registration at https://api.superjob.ru/register/).
- Parses every documented field (`payment_from/to`/`currency` → ISO 4217 RUB, `type_of_work.title` → EmploymentType via Russian-label map, `date_published` unix ts → `posted_at` UTC, HTML stripped from `vacancyRichText`).
- Supports `slice_by="town"` to fan past the 500-results-per-query API cap by iterating documented town IDs (Moscow, SPb, Yekaterinburg, …).

## Probe results

| Path | Status |
|---|---|
| Direct US IP | `403 server: sw` (edge geo-block) |
| Evomi proxy (currently Chile/Vietnam exit) → `/vacancies/` | reaches origin, but `403` "Необходимо передать ключ приложения" — needs `X-Api-App-Id` |
| Proxy → `/towns/` (no-auth endpoint) | `200` with proper data |

So the proxy unlocks the edge, but production additionally needs (a) an `SUPERJOB_API_KEY` set and ideally (b) a CIS-exit residential proxy. The scraper raises a pointed `ScraperError` for each failure mode.

## Test plan

- [x] `ruff check` clean on touched files (and full repo).
- [x] `pytest tests/test_superjob.py tests/test_models.py` — 43 superjob tests + 62 model tests = 105 passed.
- [x] Full suite `pytest tests/` — 922 passed, no regressions.
- [ ] Manual end-to-end fetch once a SuperJob app secret + CIS-exit proxy are in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `SuperJobScraper` for SuperJob.ru (`/2.0/vacancies/`) with town-based slicing, robust parsing, and non-blocking retries. Registers `ATSType.SUPERJOB`, integrates into `ScraperRegistry`, seeds `ats-companies/superjob.csv`, normalizes proxy credentials, and records UTC `posted_at` and `fetched_at`.

- **New Features**
  - New `SuperJobScraper` with pagination and de-dup; supports `slice_by="town"` to bypass the 500-result cap.
  - Parses salaries (ISO currency, monthly), employment type (RU label map), strips HTML, and sets UTC `posted_at` and `fetched_at`.
  - Proxy handling and retries: accepts `PROXY`/`proxy_url` in `host:port:user:pass` or URL form (credentials URL-encoded); retry backoff runs outside the concurrency semaphore.

- **Migration**
  - Set `SUPERJOB_API_KEY` for the required `X-Api-App-Id` header.
  - Use a CIS-exit residential proxy via `PROXY` (or pass `proxy_url`) to avoid geo-blocked 403s.
  - Optional: enable `slice_by="town"` (override `towns` if needed) for broader coverage.

<sup>Written for commit bb8a2c6f6a221402b09a266ec779125c18742a52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `SuperJobScraper`, a new single-source scraper targeting Russia's #2 job board (`api.superjob.ru/2.0/vacancies/`), following the same operational pattern as the existing hh.ru scraper. It registers `ATSType.SUPERJOB`, seeds the company CSV, and ships 43 new tests.

- Implements pagination, town-based slicing to work around the 500-result API cap, cross-slice de-duplication, and retry/backoff logic with the semaphore correctly released before sleep.
- Parses all documented SuperJob fields: salary with the zero-sentinel convention, Russian employment-type labels via a lookup map, unix timestamps to UTC `posted_at`, and HTML-stripped descriptions.
- Reads `SUPERJOB_API_KEY` for the required `X-Api-App-Id` header and normalises the `PROXY` env var (both URL and 4-colon `host:port:user:pass` formats).

<h3>Confidence Score: 5/5</h3>

Safe to merge; the scraper is well-structured and the test coverage is thorough.

The implementation follows established patterns in the codebase, the retry semaphore is handled correctly, and all new fields are parsed defensively. The only finding is a minor content-quality gap in HTML entity decoding that leaves uncommon entities as raw strings in job descriptions.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/superjob.py | New SuperJob scraper with pagination, town-slicing, and de-dup; retry sleeps correctly outside the semaphore. HTML entity decoding in `_join_description` is incomplete (5 hardcoded entities instead of `html.unescape()`). |
| tests/test_superjob.py | Comprehensive test suite (43 tests) covering proxy helper, parsing, pagination, slicing, de-dup, and error paths; autouse fixtures cleanly isolate env and speed up retries. |
| src/jobhive/models.py | Adds `ATSType.SUPERJOB = "superjob"` in the correct position before the multi-tenant section; no other changes. |
| src/jobhive/scrapers/__init__.py | Registers `SuperJobScraper` in the public import and `__all__` list, alphabetically ordered correctly. |
| tests/test_models.py | Adds `"superjob"` to the exhaustive ATSType membership assertion; no other changes. |
| ats-companies/superjob.csv | Seeds the company registry with a single SuperJob entry; format matches the rest of the CSV files. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Use UTC fetched timestamps for SuperJob"](https://github.com/kalil0321/ats-scrapers/commit/bb8a2c6f6a221402b09a266ec779125c18742a52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38396677)</sub>

<!-- /greptile_comment -->