### PR TITLE
[codex] Add cron scrape guards for empty provider outputs

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -708,7 +708,8 @@ async def run(ats: str, concurrency: int, max_tenants: int | None, timeout: floa
         if not csv_path.exists():
             print(f"[{ats}] No tenant CSV at {csv_path}; nothing to scrape.")
             return 0
-        rows = list(csv.DictReader(csv_path.open()))
+        with csv_path.open(newline="") as fh:
+            rows = list(csv.DictReader(fh))
         kwargs_factory = cfg.get("kwargs")
         for r in rows:
             slug = cfg["slug"](r)

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -1,0 +1,848 @@
+#!/usr/bin/env python3
+"""Generic pipeline runner: scrape every tenant of an ATS and write one CSV.
+
+Used by ``full_pipeline.sh`` for ATSes that don't have a legacy
+``data/{ats}/main.py`` — scrapers that live only in jobhive.
+
+Reads ``ats-companies/{ats}.csv`` (the canonical tenant list — single
+source of truth, columns ``name,url``), scrapes each tenant via the
+appropriate jobhive class, dedupes, and writes a flat
+``data/{ats}/jobs.csv``.
+
+Usage:
+    python scripts/run_pipeline.py cornerstone
+    python scripts/run_pipeline.py icims --concurrency 6
+    python scripts/run_pipeline.py breezy --max-tenants 50
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import json
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+from jobhive.exceptions import CompanyNotFoundError
+from jobhive.models import Job
+from jobhive.scrapers import (
+    AmazonScraper,
+    AppleScraper,
+    ArbetsformedlingenScraper,
+    AshbyScraper,
+    AvatureScraper,
+    BambooHRScraper,
+    BreezyScraper,
+    BuiltInScraper,
+    BundesagenturScraper,
+    CornerstoneScraper,
+    EightfoldScraper,
+    EuresScraper,
+    GemScraper,
+    GetOnBrdScraper,
+    GoogleScraper,
+    GreenhouseScraper,
+    JazzHRScraper,
+    JobsChScraper,
+    JoinComScraper,
+    LeverScraper,
+    ManfredScraper,
+    MercorScraper,
+    MetaScraper,
+    OracleScraper,
+    PersonioScraper,
+    PhenomScraper,
+    PinpointScraper,
+    ProgramathorScraper,
+    RecruiteeScraper,
+    RecruiterboxScraper,
+    RemoteOKScraper,
+    RipplingScraper,
+    SmartRecruitersScraper,
+    SuccessFactorsScraper,
+    TaleoScraper,
+    TeamtailorScraper,
+    TeslaScraper,
+    TheHubScraper,
+    TikTokScraper,
+    UberScraper,
+    WantedScraper,
+    WellfoundScraper,
+    WeWorkRemotelyScraper,
+    WorkableScraper,
+    WorkdayScraper,
+    YCombinatorScraper,
+    iCIMSScraper,
+)
+
+
+def _slug_col(row: dict[str, Any]) -> str | None:
+    """Return the canonical ``slug`` column value if present and non-empty.
+
+    Introduced by the 2026-05 ``ats-companies/`` migration: the CSV now
+    carries an explicit ``slug`` column with the scraper/API identifier
+    (decoupled from ``url`` which is the user-facing canonical URL).
+    All slug-extractor helpers and lambdas below prefer this column
+    first, falling back to the legacy url/name parsing logic so files
+    that haven't been migrated yet still work.
+    """
+    slug = (row.get("slug") or "").strip()
+    return slug or None
+
+
+def _recruitee_slug(row: dict[str, Any]) -> str | None:
+    """Recruitee tenants live at ``{slug}.recruitee.com``. CSVs sometimes
+    store the human-readable name in the ``name`` column and the slug in
+    the URL — always parse the URL when present."""
+    if (slug := _slug_col(row)):
+        return slug.lower()
+    url = (row.get("url") or "").strip()
+    if url.startswith("http"):
+        m = re.match(r"https?://([a-z0-9][a-z0-9-]+)\.recruitee\.com", url, re.IGNORECASE)
+        if m:
+            return m.group(1).lower()
+    name = (row.get("name") or "").strip()
+    return name or None
+
+
+def _personio_slug(row: dict[str, Any]) -> str | None:
+    if (slug := _slug_col(row)):
+        return slug.lower()
+    url = (row.get("url") or "").strip()
+    if url.startswith("http"):
+        m = re.match(r"https?://([a-z0-9][a-z0-9-]+)\.jobs\.personio\.com",
+                     url, re.IGNORECASE)
+        if m:
+            return m.group(1).lower()
+    name = (row.get("name") or "").strip()
+    return name or None
+
+
+def _avature_slug(row: dict[str, Any]) -> str | None:
+    """Avature tenants live at ``{slug}.avature.net`` (or sometimes the
+    full careers URL). Extract the subdomain when a URL is present."""
+    if (slug := _slug_col(row)):
+        return slug.lower()
+    url = (row.get("url") or "").strip()
+    if url.startswith("http"):
+        m = re.match(r"https?://([a-z0-9][a-z0-9-]+)\.avature\.net",
+                     url, re.IGNORECASE)
+        if m:
+            return m.group(1).lower()
+    name = (row.get("name") or "").strip()
+    return name or None
+
+
+def _successfactors_slug(row: dict[str, Any]) -> str | None:
+    """SuccessFactors tenants are best addressed by their careers host.
+
+    The explicit ``slug`` column is useful for stable tenant identity, but it
+    is not necessarily a resolvable host. After the 2026-05 CSV migration rows
+    like ``slug=ace1950`` also carry ``url=https://ace1950.jobs2web.com``; the
+    scraper needs the latter to avoid guessing ``job.ace1950.com``.
+    """
+    url = (row.get("url") or "").strip()
+    if url:
+        return url.rstrip("/")
+    if (slug := _slug_col(row)):
+        return slug
+    return (row.get("name") or "").strip() or None
+
+
+def _rippling_slug(row: dict[str, Any]) -> str | None:
+    if (slug := _slug_col(row)):
+        return slug.lower()
+    url = (row.get("url") or "").strip()
+    if url.startswith("http"):
+        m = re.match(r"https?://ats\.rippling\.com/([a-z0-9][a-z0-9-]+)",
+                     url, re.IGNORECASE)
+        if m:
+            return m.group(1).lower()
+    name = (row.get("name") or "").strip()
+    return name or None
+
+
+def _workable_slug(row: dict[str, Any]) -> str | None:
+    # Workable tenants are case-sensitive in the URL but lowercased
+    # in the API; ``apply.workable.com`` is permissive. Preserve case
+    # from the slug column when present.
+    if (slug := _slug_col(row)):
+        return slug
+    url = (row.get("url") or "").strip()
+    if url.startswith("http"):
+        m = re.match(r"https?://apply\.workable\.com/([^/?#]+)",
+                     url, re.IGNORECASE)
+        if m:
+            return m.group(1)
+    name = (row.get("name") or "").strip()
+    return name or None
+
+
+def _lever_slug(row: dict[str, Any]) -> str | None:
+    if (slug := _slug_col(row)):
+        return slug.lower()
+    url = (row.get("url") or "").strip()
+    if url.startswith("http"):
+        m = re.match(r"https?://jobs\.lever\.co/([^/?#]+)", url, re.IGNORECASE)
+        if m:
+            return m.group(1).lower()
+    name = (row.get("name") or "").strip()
+    return name or None
+
+
+def _greenhouse_slug(row: dict[str, Any]) -> str | None:
+    if (slug := _slug_col(row)):
+        return slug.lower()
+    url = (row.get("url") or "").strip()
+    if url.startswith("http"):
+        m = re.match(
+            r"https?://(?:job-boards|boards)\.greenhouse\.io/([^/?#]+)",
+            url, re.IGNORECASE,
+        )
+        if m:
+            return m.group(1).lower()
+    name = (row.get("name") or "").strip()
+    return name or None
+
+
+def _ashby_slug(row: dict[str, Any]) -> str | None:
+    if (slug := _slug_col(row)):
+        return slug.lower()
+    url = (row.get("url") or "").strip()
+    if url.startswith("http"):
+        m = re.match(r"https?://jobs\.ashbyhq\.com/([^/?#]+)", url, re.IGNORECASE)
+        if m:
+            return m.group(1).lower()
+    name = (row.get("name") or "").strip()
+    return name or None
+
+
+def _oracle_slug(row: dict[str, Any]) -> str | None:
+    """Return the Oracle API origin plus site selector.
+
+    ``ats-companies/oracle.csv`` stores user-facing CandidateExperience URLs,
+    e.g. ``https://host/hcmUI/CandidateExperience/en/sites/CX_1``. The scraper
+    calls REST endpoints at the host root and needs the site number separately.
+    """
+    raw = (row.get("url") or "").strip()
+    if not raw:
+        return None
+    if not raw.startswith(("http://", "https://")):
+        return raw
+    parsed = urlparse(raw)
+    if not parsed.scheme or not parsed.netloc:
+        return raw
+    base = f"{parsed.scheme}://{parsed.netloc}"
+    site = _oracle_site_from_url(raw)
+    return f"{base}?site_number={site}" if site else base
+
+
+def _oracle_site_from_url(raw: str) -> str | None:
+    parsed = urlparse(raw)
+    query_site = parse_qs(parsed.query).get("site_number")
+    if query_site and query_site[0]:
+        return query_site[0]
+    match = re.search(r"/sites/([^/?#]+)", parsed.path)
+    if match:
+        return match.group(1)
+    return None
+
+
+def _icims_slug(row: dict[str, Any]) -> str | None:
+    """iCIMS rows can have a bare slug in `name`/`slug` or a
+    `careers-{slug}.icims.com` URL. Either form is accepted by the
+    scraper, but normalize to slug. Keep parsing the URL first when
+    present because some tenants use the `uscareers-` subdomain
+    variant — that information lives in the URL, not the slug column."""
+    url = (row.get("url") or "").strip()
+    if url:
+        m = re.search(r"//careers-([a-z0-9-]+)\.icims\.com", url)
+        if m:
+            return m.group(1)
+        m = re.search(r"//uscareers-([a-z0-9-]+)\.icims\.com", url)
+        if m:
+            # Pass the full URL so the scraper preserves the uscareers- prefix.
+            return url.split("?", 1)[0].rstrip("/")
+    if (slug := _slug_col(row)):
+        return slug
+    return (row.get("name") or "").strip() or None
+
+
+# Per-ATS config:
+# - scraper: the jobhive class
+# - slug: callable turning a CSV row into `company_slug`
+# - kwargs (optional): callable returning additional kwargs for the scraper
+#   (used by Phenom which needs `locale` and `country` per tenant)
+# - csv: tenant CSV path (relative to repo root; canonical location
+#   is ``ats-companies/{ats}.csv`` with columns ``name,url``)
+# - output: jobs CSV output path (per-ATS jobs dataset under ``{ats}/``)
+CONFIGS: dict[str, dict[str, Any]] = {
+    "cornerstone": {
+        "scraper": CornerstoneScraper,
+        # Scraper accepts either a bare slug OR the full career URL.
+        # Prefer the slug column post-migration.
+        "slug": lambda r: _slug_col(r) or r.get("url") or r.get("name"),
+        "csv": "ats-companies/cornerstone.csv",
+        "output": "cornerstone/jobs.csv",
+    },
+    "icims": {
+        "scraper": iCIMSScraper,
+        "slug": _icims_slug,
+        "csv": "ats-companies/icims.csv",
+        "output": "icims/jobs.csv",
+    },
+    "breezy": {
+        "scraper": BreezyScraper,
+        "slug": lambda r: _slug_col(r) or r.get("name"),
+        "csv": "ats-companies/breezy.csv",
+        "output": "breezy/jobs.csv",
+    },
+    "gem": {
+        # Gem boards live at ``jobs.gem.com/{slug}``. Post-migration the
+        # slug column has the value directly; legacy files store it in the
+        # last URL path component, which we extract as fallback.
+        "scraper": GemScraper,
+        "slug": lambda r: _slug_col(r) or (
+            (r.get("url") or "").rstrip("/").rsplit("/", 1)[-1]
+            if (r.get("url") or "").strip()
+            else (r.get("name") or "").strip()
+        ),
+        "csv": "ats-companies/gem.csv",
+        "output": "gem/jobs.csv",
+    },
+    "successfactors": {
+        "scraper": SuccessFactorsScraper,
+        "slug": _successfactors_slug,
+        "csv": "ats-companies/successfactors.csv",
+        "output": "successfactors/jobs.csv",
+    },
+    "taleo": {
+        "scraper": TaleoScraper,
+        # Taleo CSV stores bare URLs without scheme (the discovery flow
+        # captures slug=full URL). The scraper needs `https://` prefix.
+        "slug": lambda r: (
+            (r.get("url") or "").strip()
+            if (r.get("url") or "").startswith("http")
+            else f"https://{(r.get('url') or '').strip()}"
+            if r.get("url") else None
+        ),
+        "csv": "ats-companies/taleo.csv",
+        "output": "taleo/jobs.csv",
+    },
+    "oracle": {
+        "scraper": OracleScraper,
+        "slug": _oracle_slug,
+        "csv": "ats-companies/oracle.csv",
+        "output": "oracle/jobs.csv",
+    },
+    "phenom": {
+        "scraper": PhenomScraper,
+        "slug": lambda r: r.get("url"),
+        # Phenom needs per-tenant locale + country.
+        "kwargs": lambda r: {
+            "locale": r.get("locale") or "en_us",
+            "country": r.get("country") or "us",
+        },
+        "csv": "ats-companies/phenom.csv",
+        "output": "phenom/jobs.csv",
+    },
+    "pinpoint": {
+        "scraper": PinpointScraper,
+        "slug": lambda r: _slug_col(r) or r.get("name") or r.get("url"),
+        "csv": "ats-companies/pinpoint.csv",
+        "output": "pinpoint/jobs.csv",
+    },
+    "recruiterbox": {
+        "scraper": RecruiterboxScraper,
+        "slug": lambda r: _slug_col(r) or r.get("name") or r.get("url"),
+        "csv": "ats-companies/recruiterbox.csv",
+        "output": "recruiterbox/jobs.csv",
+    },
+    "workday": {
+        # Workday's slug is the FULL careers URL (the scraper parses the
+        # company/instance/site components). The CSV stores `url` directly.
+        "scraper": WorkdayScraper,
+        "slug": lambda r: (r.get("url") or "").strip() or None,
+        "csv": "ats-companies/workday.csv",
+        "output": "workday/jobs.csv",
+    },
+    "bamboohr": {
+        "scraper": BambooHRScraper,
+        "slug": lambda r: _slug_col(r) or (r.get("name") or "").strip() or None,
+        "csv": "ats-companies/bamboohr.csv",
+        "output": "bamboohr/jobs.csv",
+    },
+    "teamtailor": {
+        "scraper": TeamtailorScraper,
+        "slug": lambda r: _slug_col(r) or (r.get("name") or "").strip() or None,
+        "csv": "ats-companies/teamtailor.csv",
+        "output": "teamtailor/jobs.csv",
+    },
+    "jazzhr": {
+        "scraper": JazzHRScraper,
+        # JazzHR sites are Cloudflare-protected — the scraper auto-falls
+        # back to httpcloak under client_kind="auto".
+        "slug": lambda r: _slug_col(r) or (r.get("name") or "").strip() or None,
+        "csv": "ats-companies/jazzhr.csv",
+        "output": "jazzhr/jobs.csv",
+    },
+    "recruitee": {
+        "scraper": RecruiteeScraper,
+        # Recruitee CSVs mix human names ("5280 High School") with the
+        # actual subdomain ("5280highschool"). Always derive the slug
+        # from the URL when one is present.
+        "slug": _recruitee_slug,
+        "csv": "ats-companies/recruitee.csv",
+        "output": "recruitee/jobs.csv",
+    },
+    "ashby": {
+        "scraper": AshbyScraper,
+        "slug": _ashby_slug,
+        "csv": "ats-companies/ashby.csv",
+        "output": "ashby/jobs.csv",
+    },
+    "lever": {
+        "scraper": LeverScraper,
+        "slug": _lever_slug,
+        "csv": "ats-companies/lever.csv",
+        "output": "lever/jobs.csv",
+    },
+    "greenhouse": {
+        "scraper": GreenhouseScraper,
+        "slug": _greenhouse_slug,
+        "csv": "ats-companies/greenhouse.csv",
+        "output": "greenhouse/jobs.csv",
+    },
+    "workable": {
+        "scraper": WorkableScraper,
+        "slug": _workable_slug,
+        "csv": "ats-companies/workable.csv",
+        "output": "workable/jobs.csv",
+    },
+    "smartrecruiters": {
+        "scraper": SmartRecruitersScraper,
+        # SmartRecruiters slugs are case-sensitive (e.g. ``Dominos``,
+        # not ``dominos``). Both the legacy ``name`` column and the new
+        # ``slug`` column must preserve case — never call ``.lower()``
+        # on them. If the slug column got lowercased by accident, fall
+        # back to the name column which is canonically capitalized.
+        "slug": lambda r: _slug_col(r) or (r.get("name") or "").strip() or None,
+        "csv": "ats-companies/smartrecruiters.csv",
+        "output": "smartrecruiters/jobs.csv",
+    },
+    "personio": {
+        "scraper": PersonioScraper,
+        "slug": _personio_slug,
+        "csv": "ats-companies/personio.csv",
+        "output": "personio/jobs.csv",
+    },
+    "rippling": {
+        "scraper": RipplingScraper,
+        "slug": _rippling_slug,
+        "csv": "ats-companies/rippling.csv",
+        "output": "rippling/jobs.csv",
+    },
+    "avature": {
+        "scraper": AvatureScraper,
+        "slug": _avature_slug,
+        "csv": "ats-companies/avature.csv",
+        "output": "avature/jobs.csv",
+    },
+    "join_com": {
+        "scraper": JoinComScraper,
+        # Prefer the canonical slug column; legacy fallback derives it
+        # from the URL's last path component. The lowercased form
+        # matters because names in the CSV come from the sitemap with
+        # arbitrary casing and would 301-redirect on every probe.
+        "slug": lambda r: (
+            (_slug_col(r) or "").lower()
+            or (r.get("url") or "").rstrip("/").rsplit("/", 1)[-1].lower()
+            or None
+        ),
+        "csv": "ats-companies/join_com.csv",
+        "output": "join_com/jobs.csv",
+    },
+    "mercor": {
+        "scraper": MercorScraper,
+        # Mercor is a single-tenant scraper — slug is ignored.
+        "slug": lambda r: "mercor",
+        "csv": "ats-companies/mercor.csv",
+        "output": "mercor/jobs.csv",
+    },
+    # ---- Single-tenant big-tech scrapers (singleton mode) -----------------
+    # Each big-tech employer runs its own bespoke careers system. These
+    # scrapers ignore the slug (or use a fixed one) — wire them through
+    # the runner via ``singleton: True`` so we don't need a one-row CSV
+    # per company. Output goes to ``{ats}/jobs.csv``.
+    "amazon": {
+        "scraper": AmazonScraper, "singleton": True,
+        "output": "amazon/jobs.csv",
+    },
+    "apple": {
+        "scraper": AppleScraper, "singleton": True,
+        "output": "apple/jobs.csv",
+    },
+    "google": {
+        "scraper": GoogleScraper, "singleton": True,
+        "output": "google/jobs.csv",
+    },
+    "meta": {
+        "scraper": MetaScraper, "singleton": True,
+        "output": "meta/jobs.csv",
+    },
+    "tesla": {
+        "scraper": TeslaScraper, "singleton": True,
+        "output": "tesla/jobs.csv",
+    },
+    "tiktok": {
+        "scraper": TikTokScraper, "singleton": True,
+        "output": "tiktok/jobs.csv",
+    },
+    "uber": {
+        "scraper": UberScraper, "singleton": True,
+        "output": "uber/jobs.csv",
+    },
+    "bundesagentur": {
+        # German federal employment agency — official, public, ~1M+ jobs.
+        # Single-source aggregator; subdivides internally by berufsfeld
+        # (job category) to bypass the 10k pagination cap.
+        "scraper": BundesagenturScraper, "singleton": True,
+        "output": "bundesagentur/jobs.csv",
+    },
+    "arbetsformedlingen": {
+        # Sweden's federal employment service — public JSON API. ~46k
+        # active jobs, fanned out across 21 regions to bypass the 10k cap.
+        "scraper": ArbetsformedlingenScraper, "singleton": True,
+        "output": "arbetsformedlingen/jobs.csv",
+    },
+    "eures": {
+        # EU-wide aggregator across the 31 EURES countries. ~2.7M jobs;
+        # subdivided per-country, then by NUTS region / NACE sector if a
+        # country exceeds the 10k pagination cap.
+        "scraper": EuresScraper, "singleton": True,
+        "output": "eures/jobs.csv",
+    },
+    # Direct-posting providers from PR #15 — each is a single global
+    # endpoint (slug ignored). Pass any value (e.g. ``"any"``) when
+    # invoking the scraper; the runner uses ``singleton: True`` so no
+    # per-tenant CSV is required.
+    "builtin": {
+        # US tech jobs aggregator. ~3-6k live jobs depending on the day.
+        # Optional Firecrawl detail-page enrichment via env var.
+        "scraper": BuiltInScraper, "singleton": True,
+        "output": "builtin/jobs.csv",
+    },
+    "getonbrd": {
+        # LATAM tech jobs board. ~1k live.
+        "scraper": GetOnBrdScraper, "singleton": True,
+        "output": "getonbrd/jobs.csv",
+    },
+    "jobsch": {
+        # jobs.ch — Switzerland's largest direct-posting board. ~50k live.
+        "scraper": JobsChScraper, "singleton": True,
+        "output": "jobsch/jobs.csv",
+    },
+    "manfred": {
+        # Manfred — Spain / LATAM curated tech roles. ~40 live.
+        "scraper": ManfredScraper, "singleton": True,
+        "output": "manfred/jobs.csv",
+    },
+    "programathor": {
+        # Programathor — Brazilian dev jobs. ~3k live, opt-in proxy
+        # path for the bot-protected detail pages.
+        "scraper": ProgramathorScraper, "singleton": True,
+        "output": "programathor/jobs.csv",
+    },
+    "remoteok": {
+        # RemoteOK — remote-only listings, US-heavy. ~100 live.
+        "scraper": RemoteOKScraper, "singleton": True,
+        "output": "remoteok/jobs.csv",
+    },
+    "thehub": {
+        # The Hub — Nordic startups, ships lat/lon. ~1k live.
+        "scraper": TheHubScraper, "singleton": True,
+        "output": "thehub/jobs.csv",
+    },
+    "wanted": {
+        # Wanted — Korea + Japan tech roles. ~10k live.
+        "scraper": WantedScraper, "singleton": True,
+        "output": "wanted/jobs.csv",
+    },
+    "wellfound": {
+        # Wellfound (was AngelList Talent) — US startups. ~700 live;
+        # opt-in Firecrawl path because the API is auth-gated.
+        "scraper": WellfoundScraper, "singleton": True,
+        "output": "wellfound/jobs.csv",
+    },
+    "weworkremotely": {
+        # We Work Remotely — remote-only listings. ~500 live.
+        "scraper": WeWorkRemotelyScraper, "singleton": True,
+        "output": "weworkremotely/jobs.csv",
+    },
+    "ycombinator": {
+        # Y Combinator's Work at a Startup board. ~770 live.
+        "scraper": YCombinatorScraper, "singleton": True,
+        "output": "ycombinator/jobs.csv",
+    },
+    "eightfold": {
+        "scraper": EightfoldScraper,
+        # CSV has either a slug (most tenants → ``{slug}.eightfold.ai``) or a
+        # full custom-domain URL (``apply.careers.{co}.com``). Pass the slug
+        # column verbatim; for full URLs we extract the slug and let the
+        # ``base_url`` kwarg do the override.
+        "slug": lambda r: (
+            (r.get("slug") or r.get("url") or r.get("name") or "")
+            .strip()
+            .replace("https://", "")
+            .replace("http://", "")
+            .split("/")[0]
+            .split(".")[0]
+            or None
+        ),
+        "kwargs": lambda r: _eightfold_kwargs(r),
+        "csv": "ats-companies/eightfold.csv",
+        "output": "eightfold/jobs.csv",
+    },
+}
+
+
+def _eightfold_kwargs(row: dict[str, Any]) -> dict[str, Any]:
+    """Build Eightfold-specific overrides from a CSV row.
+
+    - ``url`` (when full https://...) → ``base_url`` override (custom domains).
+    - ``domain`` column → API ``domain`` parameter.
+    - Otherwise default to ``{slug}.eightfold.ai`` and ``{slug}.com``.
+    """
+    kw: dict[str, Any] = {}
+    raw_url = (row.get("url") or "").strip()
+    if raw_url.startswith("http"):
+        parsed = urlparse(raw_url)
+        if parsed.scheme and parsed.netloc:
+            kw["base_url"] = f"{parsed.scheme}://{parsed.netloc}"
+        else:
+            kw["base_url"] = raw_url.rstrip("/")
+    domain = (row.get("domain") or "").strip()
+    if domain:
+        kw["domain"] = domain
+    name = (row.get("name") or "").strip()
+    if name:
+        kw["company_name"] = name
+    return kw
+
+DATA_ROOT = Path(__file__).resolve().parent.parent  # → repo root
+
+JOB_CSV_FIELDS = [
+    "url", "title", "company", "ats_type", "ats_id", "location",
+    "is_remote", "salary_min", "salary_max", "salary_currency",
+    "salary_period", "salary_summary", "employment_type",
+    "department", "team", "description", "posted_at",
+    "requisition_id", "apply_url", "commitment", "raw",
+]
+
+
+def _job_to_row(job: Job) -> dict[str, Any]:
+    """Flatten a Job to CSV-friendly fields. ``raw`` is JSON-serialized."""
+    raw_json = ""
+    if job.raw:
+        try:
+            raw_json = json.dumps(job.raw, default=str, ensure_ascii=False)[:5000]
+        except (TypeError, ValueError):
+            raw_json = ""
+    return {
+        "url": str(job.url),
+        "title": job.title,
+        "company": job.company,
+        "ats_type": job.ats_type.value,
+        "ats_id": job.ats_id,
+        "location": job.location or "",
+        "is_remote": "" if job.is_remote is None else str(job.is_remote).lower(),
+        "salary_min": "" if job.salary_min is None else job.salary_min,
+        "salary_max": "" if job.salary_max is None else job.salary_max,
+        "salary_currency": job.salary_currency or "",
+        "salary_period": job.salary_period or "",
+        "salary_summary": job.salary_summary or "",
+        "employment_type": job.employment_type or "",
+        "department": job.department or "",
+        "team": job.team or "",
+        "description": (job.description or "")[:500].replace("\n", " "),
+        "posted_at": job.posted_at.isoformat() if job.posted_at else "",
+        "requisition_id": job.requisition_id or "",
+        "apply_url": str(job.apply_url) if job.apply_url else "",
+        "commitment": job.commitment or "",
+        "raw": raw_json,
+    }
+
+
+async def _run_scraper(scraper_cls, slug, kwargs=None, timeout=30) -> tuple[str, list[Job], str | None]:
+    """Run one scraper in a thread (most are sync). Returns (slug, jobs, error_or_None)."""
+    extra = kwargs or {}
+
+    def _run() -> list[Job]:
+        return scraper_cls(slug, timeout=timeout, **extra).fetch()
+
+    try:
+        jobs = await asyncio.to_thread(_run)
+        return slug, jobs, None
+    except CompanyNotFoundError:
+        return slug, [], "not_found"
+    except Exception as exc:
+        return slug, [], f"{type(exc).__name__}: {str(exc)[:120]}"
+
+
+async def run(ats: str, concurrency: int, max_tenants: int | None, timeout: float) -> int:
+    cfg = CONFIGS[ats]
+
+    targets: list[tuple[str, dict[str, Any]]] = []
+    if cfg.get("singleton"):
+        # Single-tenant scraper (big-tech bespoke careers). No CSV — call
+        # the scraper once with the ATS name as a placeholder slug; the
+        # scraper itself ignores it (each company has its own private API).
+        targets = [(ats, {})]
+    else:
+        csv_path = DATA_ROOT / cfg["csv"]
+        if not csv_path.exists():
+            print(f"[{ats}] No tenant CSV at {csv_path}; nothing to scrape.")
+            return 0
+        rows = list(csv.DictReader(csv_path.open()))
+        kwargs_factory = cfg.get("kwargs")
+        for r in rows:
+            slug = cfg["slug"](r)
+            if slug:
+                kw = kwargs_factory(r) if kwargs_factory else {}
+                targets.append((slug, kw))
+
+    if max_tenants:
+        targets = targets[:max_tenants]
+
+    print(f"[{ats}] Scraping {len(targets)} tenants (concurrency={concurrency}, timeout={timeout}s)")
+    sem = asyncio.Semaphore(concurrency)
+    counts = {"success": 0, "not_found": 0, "error": 0, "jobs": 0}
+
+    output_path = DATA_ROOT / cfg["output"]
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_output_path = output_path.with_name(f".{output_path.name}.tmp")
+    seen_keys: set[tuple[str, str]] = set()  # (company, ats_id) for cross-tenant dedup
+
+    t0 = time.time()
+    with tmp_output_path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=JOB_CSV_FIELDS)
+        writer.writeheader()
+
+        # ---- Streaming path: scrapers that would otherwise load >5 GB
+        # of Job objects into RAM expose a ``fetch_stream()`` async
+        # generator. We iterate it directly and write each job to disk
+        # as it arrives, keeping the in-flight footprint flat (~200 MB
+        # for the seen-set + a bounded asyncio.Queue) instead of
+        # accumulating the full corpus. EURES is the only such ATS
+        # today — its ~2.7 M-row pan-EU catalog would peak at ~10 GB
+        # RSS in legacy mode, exceeding the VPS RAM budget.
+        if cfg.get("singleton") and hasattr(cfg["scraper"], "fetch_stream"):
+            scraper = cfg["scraper"](ats, timeout=timeout)
+            try:
+                async for job in scraper.fetch_stream():
+                    writer.writerow(_job_to_row(job))
+                    counts["jobs"] += 1
+                    # Periodic flush so the file is consultable while
+                    # the long-running scrape is still in flight.
+                    if counts["jobs"] % 10_000 == 0:
+                        f.flush()
+                        elapsed = time.time() - t0
+                        print(
+                            f"  [{ats}] streamed {counts['jobs']:,} jobs in "
+                            f"{elapsed:.0f}s",
+                        )
+                counts["success"] = 1
+            except CompanyNotFoundError:
+                counts["not_found"] = 1
+            except Exception as exc:
+                counts["error"] = 1
+                print(f"  [{ats}] streaming failed: {type(exc).__name__}: "
+                      f"{str(exc)[:200]}")
+        else:
+            async def task(slug: str, kw: dict[str, Any]) -> None:
+                async with sem:
+                    _, jobs, err = await _run_scraper(cfg["scraper"], slug, kw, timeout)
+                if err == "not_found":
+                    counts["not_found"] += 1
+                    return
+                if err:
+                    counts["error"] += 1
+                    return
+                counts["success"] += 1
+                for job in jobs:
+                    key = (job.company, job.ats_id)
+                    if key in seen_keys:
+                        continue
+                    seen_keys.add(key)
+                    writer.writerow(_job_to_row(job))
+                    counts["jobs"] += 1
+
+            # Process tasks in batches and flush periodically
+            batch_size = 50
+            for i in range(0, len(targets), batch_size):
+                batch = targets[i:i + batch_size]
+                await asyncio.gather(*(task(s, kw) for s, kw in batch))
+                f.flush()
+                elapsed = time.time() - t0
+                print(
+                    f"  [{ats}] processed {min(i + batch_size, len(targets))}/{len(targets)} "
+                    f"tenants in {elapsed:.0f}s — "
+                    f"{counts['success']} OK, {counts['not_found']} not-found, "
+                    f"{counts['error']} errors, {counts['jobs']:,} jobs"
+                )
+
+    elapsed = time.time() - t0
+    print(
+        f"[{ats}] Done in {elapsed:.0f}s: {counts['jobs']:,} jobs from "
+        f"{counts['success']}/{len(targets)} tenants → {output_path}"
+    )
+
+    failure_threshold = max(1, (len(targets) + 1) // 2)
+    catastrophic_failure = (
+        bool(targets)
+        and counts["jobs"] == 0
+        and counts["error"] >= failure_threshold
+    )
+    if catastrophic_failure:
+        tmp_output_path.unlink(missing_ok=True)
+        if output_path.exists():
+            print(
+                f"[{ats}] ACTION keep_previous: scrape produced 0 jobs with "
+                f"{counts['error']}/{len(targets)} tenant errors; preserved "
+                f"{output_path} for the next publish."
+            )
+        else:
+            print(
+                f"[{ats}] ACTION retry: scrape produced 0 jobs with "
+                f"{counts['error']}/{len(targets)} tenant errors and no "
+                "previous jobs.csv exists."
+            )
+        return 1
+
+    tmp_output_path.replace(output_path)
+    if counts["error"] >= failure_threshold:
+        print(
+            f"[{ats}] ACTION investigate: scrape kept partial data but "
+            f"{counts['error']}/{len(targets)} tenants failed."
+        )
+        return 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("ats", choices=sorted(CONFIGS.keys()))
+    parser.add_argument("--concurrency", type=int, default=8)
+    parser.add_argument("--max-tenants", type=int, default=None)
+    parser.add_argument("--timeout", type=float, default=30.0)
+    args = parser.parse_args()
+    return asyncio.run(run(args.ats, args.concurrency, args.max_tenants, args.timeout))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/jobhive/scrapers/oracle.py
+++ b/src/jobhive/scrapers/oracle.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
 
 PAGE_LIMIT = 200
 SITE_RE = re.compile(r"site_number=([^&]+)")
+SITE_PATH_RE = re.compile(r"/sites/([^/?#]+)")
 DEFAULT_SITE = "CX_1"
 MAX_RETRIES = 3
 RETRY_BASE_DELAY = 1.5
@@ -85,6 +86,25 @@ _EMPLOYMENT_TYPE_PATTERNS = {
 }
 
 
+def _normalize_oracle_target(raw_url: str) -> tuple[str, str]:
+    """Return ``(host_root, site_number)`` for Oracle careers URLs.
+
+    The tenant CSV stores public CandidateExperience URLs such as
+    ``https://host/hcmUI/CandidateExperience/en/sites/CX_1``. Oracle's REST API
+    lives at the host root, while the site number belongs in the finder string.
+    Keep supporting the older ``https://host?site_number=CX_...`` form too.
+    """
+    match = SITE_RE.search(raw_url)
+    site = match.group(1) if match else DEFAULT_SITE
+    parsed = urlparse(raw_url)
+    if parsed.scheme and parsed.netloc:
+        path_site = SITE_PATH_RE.search(parsed.path)
+        if not match and path_site:
+            site = path_site.group(1)
+        return f"{parsed.scheme}://{parsed.netloc}".rstrip("/"), site
+    return raw_url.split("?", 1)[0].rstrip("/"), site
+
+
 @ScraperRegistry.register(ATSType.ORACLE)
 class OracleScraper(BaseScraper):
     """Oracle scraper — `company_slug` is the full careers URL.
@@ -99,10 +119,7 @@ class OracleScraper(BaseScraper):
         return asyncio.run(self._fetch_async())
 
     async def _fetch_async(self) -> list[Job]:
-        url = self.company_slug
-        match = SITE_RE.search(url)
-        site = match.group(1) if match else DEFAULT_SITE
-        base = url.split("?", 1)[0].rstrip("/")
+        base, site = _normalize_oracle_target(self.company_slug)
         if not base.startswith(("http://", "https://")):
             raise ScraperError(
                 f"Oracle slug must be a full URL (https://...oraclecloud.com), got {base!r}"

--- a/src/jobhive/storage/publisher.py
+++ b/src/jobhive/storage/publisher.py
@@ -164,6 +164,13 @@ class DatasetPublisher:
         """
         started = datetime.now(tz=UTC)
         files_uploaded: list[str] = []
+        manifest_key = f"{self._prefix}/manifest.json"
+        existing_manifest = _load_existing_manifest(self._r2, manifest_key)
+        _guard_suspicious_empty_job_slices(
+            source_dir=source_dir,
+            ats_csv_pattern=ats_csv_pattern,
+            existing_manifest=existing_manifest,
+        )
 
         # ExitStack owns every per-ATS CSV temp: Pass 1 streams each
         # enriched per-ATS slice into one of these, then Pass 3
@@ -1059,6 +1066,71 @@ def _sum_by_ats_companies_rows(manifest: dict[str, object]) -> int:
             if isinstance(rows, int):
                 total += rows
     return total
+
+
+def _guard_suspicious_empty_job_slices(
+    *,
+    source_dir: Path,
+    ats_csv_pattern: str,
+    existing_manifest: dict[str, object],
+) -> None:
+    """Block publishes that would replace known-good provider data with empty.
+
+    A header-only ``<ats>/jobs.csv`` is valid CSV, so the streaming publisher
+    can otherwise upload it and patch the manifest to ``rows: 0``. Treat that
+    as suspicious when the existing manifest proves the provider either had
+    jobs before or still has tenants in ``by_ats_companies``.
+    """
+    if os.getenv("JOBHIVE_ALLOW_EMPTY_PUBLISH"):
+        return
+
+    by_ats = existing_manifest.get("by_ats")
+    if not isinstance(by_ats, dict):
+        by_ats = {}
+    by_ats_companies = existing_manifest.get("by_ats_companies")
+    if not isinstance(by_ats_companies, dict):
+        by_ats_companies = {}
+
+    suspicious: list[str] = []
+    for ats in ATSType:
+        if ats is ATSType.CUSTOM:
+            continue
+        source_path = source_dir / ats_csv_pattern.format(ats=ats.value)
+        if not source_path.exists() or source_path.stat().st_size == 0:
+            continue
+        if _csv_data_row_count(source_path) != 0:
+            continue
+
+        previous_rows = _entry_rows(by_ats.get(ats.value))
+        company_rows = _entry_rows(by_ats_companies.get(ats.value))
+        if previous_rows > 0 or company_rows > 0:
+            suspicious.append(
+                f"{ats.value}: local jobs.csv has 0 rows; "
+                f"manifest previously had {previous_rows} jobs and "
+                f"{company_rows} companies. Suggested action: retry the "
+                "provider scrape or keep the previous published data."
+            )
+
+    if suspicious:
+        raise StorageError(
+            "Refusing to publish suspicious empty provider slices. "
+            "Set JOBHIVE_ALLOW_EMPTY_PUBLISH=1 only for intentional empty "
+            "providers.\n- "
+            + "\n- ".join(suspicious)
+        )
+
+
+def _entry_rows(entry: object) -> int:
+    if not isinstance(entry, dict):
+        return 0
+    rows = entry.get("rows")
+    return rows if isinstance(rows, int) and rows > 0 else 0
+
+
+def _csv_data_row_count(path: Path) -> int:
+    with path.open("rb") as f:
+        lines = sum(1 for _ in f)
+    return max(lines - 1, 0)
 
 
 def _load_existing_manifest(r2_client: R2Client, key: str) -> dict[str, object]:

--- a/src/jobhive/storage/publisher.py
+++ b/src/jobhive/storage/publisher.py
@@ -276,6 +276,7 @@ class DatasetPublisher:
                 },
                 all_entry=all_entry,
                 by_ats=per_ats_entries,
+                existing_manifest=existing_manifest,
             )
             files_uploaded.append(manifest_key)
 
@@ -477,11 +478,16 @@ class DatasetPublisher:
         stats_factory,
         all_entry: dict[str, object],
         by_ats: dict[ATSType, dict[str, object]],
+        existing_manifest: dict[str, object] | None = None,
     ) -> str:
         """Read existing manifest, replace jobs-related fields, preserve
         the companies block written by the CI."""
         key = f"{self._prefix}/manifest.json"
-        existing = _load_existing_manifest(self._r2, key)
+        existing = (
+            existing_manifest
+            if existing_manifest is not None
+            else _load_existing_manifest(self._r2, key)
+        )
 
         manifest: dict[str, object] = {**existing}
         manifest["version"] = "2.0"
@@ -1096,14 +1102,25 @@ def _guard_suspicious_empty_job_slices(
         if ats is ATSType.CUSTOM:
             continue
         source_path = source_dir / ats_csv_pattern.format(ats=ats.value)
-        if not source_path.exists() or source_path.stat().st_size == 0:
-            continue
-        if _csv_data_row_count(source_path) != 0:
+        if not source_path.exists():
             continue
 
         previous_rows = _entry_rows(by_ats.get(ats.value))
         company_rows = _entry_rows(by_ats_companies.get(ats.value))
-        if previous_rows > 0 or company_rows > 0:
+        has_prior_data = previous_rows > 0 or company_rows > 0
+        if source_path.stat().st_size == 0:
+            if has_prior_data:
+                suspicious.append(
+                    f"{ats.value}: local jobs.csv is 0 bytes; "
+                    f"manifest previously had {previous_rows} jobs and "
+                    f"{company_rows} companies. Suggested action: retry the "
+                    "provider scrape or keep the previous published data."
+                )
+            continue
+        if _csv_data_row_count(source_path) != 0:
+            continue
+
+        if has_prior_data:
             suspicious.append(
                 f"{ats.value}: local jobs.csv has 0 rows; "
                 f"manifest previously had {previous_rows} jobs and "

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -418,6 +418,58 @@ def test_publish_refuses_suspicious_empty_provider_slice(tmp_path, fake_r2) -> N
     assert "jobhive/v1/greenhouse/jobs.csv" not in fake_r2.uploads
 
 
+def test_publish_refuses_zero_byte_provider_slice_with_prior_manifest(
+    tmp_path, fake_r2
+) -> None:
+    gh_dir = tmp_path / "greenhouse"
+    gh_dir.mkdir()
+    (gh_dir / "jobs.csv").write_bytes(b"")
+    fake_r2.upload_bytes(
+        json.dumps(
+            {
+                "version": "2.0",
+                "by_ats": {"greenhouse": {"rows": 123, "size_bytes": 100}},
+                "by_ats_companies": {"greenhouse": {"rows": 5, "size_bytes": 50}},
+            }
+        ).encode("utf-8"),
+        "jobhive/v1/manifest.json",
+        content_type="application/json",
+    )
+
+    publisher = DatasetPublisher(fake_r2, write_parquet=True)
+    with pytest.raises(StorageError, match=r"local jobs\.csv is 0 bytes"):
+        publisher.publish_from_directory(tmp_path)
+    assert "jobhive/v1/greenhouse/jobs.csv" not in fake_r2.uploads
+
+
+def test_publish_reuses_manifest_loaded_for_empty_slice_guard(
+    ats_csv_dir, fake_r2
+) -> None:
+    fake_r2.upload_bytes(
+        json.dumps(
+            {
+                "version": "2.0",
+                "by_ats_companies": {"greenhouse": {"rows": 5}},
+            }
+        ).encode("utf-8"),
+        "jobhive/v1/manifest.json",
+        content_type="application/json",
+    )
+    calls = 0
+    real_get_bytes = fake_r2.get_bytes
+
+    def counted_get_bytes(key: str):
+        nonlocal calls
+        calls += 1
+        return real_get_bytes(key)
+
+    fake_r2.get_bytes = counted_get_bytes
+
+    DatasetPublisher(fake_r2, write_parquet=True).publish_from_directory(ats_csv_dir)
+
+    assert calls == 1
+
+
 def test_publish_without_pyarrow_raises(monkeypatch, fake_r2) -> None:
     """When write_parquet=True but pyarrow is missing, we fail fast."""
     import builtins

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -390,6 +390,34 @@ def test_publish_raises_when_no_csvs_present(tmp_path, fake_r2) -> None:
         publisher.publish_from_directory(tmp_path)
 
 
+def test_publish_refuses_suspicious_empty_provider_slice(tmp_path, fake_r2) -> None:
+    gh_dir = tmp_path / "greenhouse"
+    gh_dir.mkdir()
+    (gh_dir / "jobs.csv").write_text(
+        "url,title,company,ats_type,ats_id,location,is_remote,salary_min,"
+        "salary_max,salary_currency,salary_period,salary_summary,"
+        "employment_type,department,team,description,posted_at,"
+        "requisition_id,apply_url,commitment,raw\n",
+        encoding="utf-8",
+    )
+    fake_r2.upload_bytes(
+        json.dumps(
+            {
+                "version": "2.0",
+                "by_ats": {"greenhouse": {"rows": 123, "size_bytes": 100}},
+                "by_ats_companies": {"greenhouse": {"rows": 5, "size_bytes": 50}},
+            }
+        ).encode("utf-8"),
+        "jobhive/v1/manifest.json",
+        content_type="application/json",
+    )
+
+    publisher = DatasetPublisher(fake_r2, write_parquet=True)
+    with pytest.raises(StorageError, match="Refusing to publish suspicious empty"):
+        publisher.publish_from_directory(tmp_path)
+    assert "jobhive/v1/greenhouse/jobs.csv" not in fake_r2.uploads
+
+
 def test_publish_without_pyarrow_raises(monkeypatch, fake_r2) -> None:
     """When write_parquet=True but pyarrow is missing, we fail fast."""
     import builtins

--- a/tests/test_run_pipeline_guards.py
+++ b/tests/test_run_pipeline_guards.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import scripts.run_pipeline as runner
+from jobhive.models import ATSType, Job
+
+
+def test_provider_slug_normalizers_match_current_company_csv_shape() -> None:
+    sf_row = {
+        "name": "Ace1950",
+        "slug": "ace1950",
+        "url": "https://ace1950.jobs2web.com",
+    }
+    assert runner._successfactors_slug(sf_row) == "https://ace1950.jobs2web.com"
+
+    oracle_row = {
+        "name": "ABM US",
+        "slug": "eiqg",
+        "url": (
+            "https://eiqg.fa.us2.oraclecloud.com/"
+            "hcmUI/CandidateExperience/en/sites/CX_1"
+        ),
+    }
+    assert (
+        runner._oracle_slug(oracle_row)
+        == "https://eiqg.fa.us2.oraclecloud.com?site_number=CX_1"
+    )
+
+    eightfold_row = {
+        "name": "Amdocs",
+        "slug": "amdocs",
+        "url": "https://amdocs.eightfold.ai/careers",
+    }
+    assert runner._eightfold_kwargs(eightfold_row)["base_url"] == (
+        "https://amdocs.eightfold.ai"
+    )
+
+
+def test_catastrophic_failure_preserves_previous_jobs_csv(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "ats-companies").mkdir()
+    (tmp_path / "ats-companies" / "fake.csv").write_text(
+        "name,slug,url\nAcme,acme,https://example.com\n",
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / "fake"
+    out_dir.mkdir()
+    out_path = out_dir / "jobs.csv"
+    previous = "url,title,company,ats_type,ats_id\nhttps://old,Old,Acme,custom,1\n"
+    out_path.write_text(previous, encoding="utf-8")
+
+    class FailingScraper:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def fetch(self):
+            raise RuntimeError("down")
+
+    monkeypatch.setattr(runner, "DATA_ROOT", tmp_path)
+    monkeypatch.setitem(
+        runner.CONFIGS,
+        "fake",
+        {
+            "scraper": FailingScraper,
+            "slug": lambda r: r["slug"],
+            "csv": "ats-companies/fake.csv",
+            "output": "fake/jobs.csv",
+        },
+    )
+
+    rc = asyncio.run(runner.run("fake", concurrency=1, max_tenants=None, timeout=1))
+
+    assert rc == 1
+    assert out_path.read_text(encoding="utf-8") == previous
+    assert not (out_dir / ".jobs.csv.tmp").exists()
+
+
+def test_singleton_success_returns_zero_exit_code(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class SingletonScraper:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def fetch(self):
+            return [
+                Job(
+                    url="https://example.com/job/1",
+                    title="Engineer",
+                    company="Acme",
+                    ats_type=ATSType.CUSTOM,
+                    ats_id="1",
+                )
+            ]
+
+    monkeypatch.setattr(runner, "DATA_ROOT", tmp_path)
+    monkeypatch.setitem(
+        runner.CONFIGS,
+        "single",
+        {
+            "scraper": SingletonScraper,
+            "singleton": True,
+            "output": "single/jobs.csv",
+        },
+    )
+
+    rc = asyncio.run(runner.run("single", concurrency=1, max_tenants=None, timeout=1))
+
+    assert rc == 0
+    assert (tmp_path / "single" / "jobs.csv").exists()

--- a/tests/test_scrapers_extra.py
+++ b/tests/test_scrapers_extra.py
@@ -483,6 +483,22 @@ def test_oracle_extracts_site_number_from_query(httpx_mock) -> None:
     OracleScraper(f"{base}?site_number=CX_45002").fetch()
 
 
+def test_oracle_accepts_candidate_experience_site_url(httpx_mock) -> None:
+    base = "https://eeho.fa.us2.oraclecloud.com"
+    api = f"{base}/hcmRestApi/resources/latest/recruitingCEJobRequisitions"
+    httpx_mock.add_response(
+        url=(
+            f"{api}?onlyData=true"
+            f"&finder=findReqs%3BsiteNumber%3DCX_45002%2Climit%3D200%2Coffset%3D0"
+            f"&expand=requisitionList"
+        ),
+        json={"items": [{"TotalJobsCount": 0, "requisitionList": []}]},
+    )
+    OracleScraper(
+        f"{base}/hcmUI/CandidateExperience/en/sites/CX_45002"
+    ).fetch()
+
+
 def test_oracle_requires_full_url() -> None:
     with pytest.raises(ScraperError, match="full URL"):
         OracleScraper("eeho").fetch()

--- a/uv.lock
+++ b/uv.lock
@@ -320,6 +320,19 @@ wheels = [
 ]
 
 [[package]]
+name = "cloakbrowser"
+version = "0.3.28"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "playwright" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/f5/58ae30a4f8f64045a74d8c63df833878f637fa29b101c8f99c3973b8c17f/cloakbrowser-0.3.28.tar.gz", hash = "sha256:e8cc34fd4f434141d57a651b95b72787438c4bcd73396c3cfb499b5a95161c02", size = 5343502, upload-time = "2026-05-11T19:46:19.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/56/c2b788a6eeacc2fe21ce1a37b7b5c871322a15f965b205b22dbef618992a/cloakbrowser-0.3.28-py3-none-any.whl", hash = "sha256:a88b7c8b327959c7a84bf36e2f2d7f758ec1ba6da6f66cc6e261566f44a98c7e", size = 66947, upload-time = "2026-05-11T19:46:17.313Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -452,6 +465,63 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/3f/dbf99fb14bfeb88c28f16729215478c0e265cacd6dc22270c8f31bb6892f/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4", size = 196995, upload-time = "2026-04-27T13:37:15.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/0f/a91f143f356523ff682309732b175765a9bc2836fd7c081c2c67fedc1ad4/greenlet-3.5.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:8f1cc966c126639cd152fdaa52624d2655f492faa79e013fea161de3e6dda082", size = 284726, upload-time = "2026-04-27T12:20:51.402Z" },
+    { url = "https://files.pythonhosted.org/packages/95/82/800646c7ffc5dbabd75ddd2f6b519bb898c0c9c969e5d0473bfe5d20bcce/greenlet-3.5.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:362624e6a8e5bca3b8233e45eef33903a100e9539a2b995c364d595dbc4018b3", size = 604264, upload-time = "2026-04-27T12:52:39.494Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ac/354867c0bba812fc33b15bc55aedafedd0aee3c7dd91dfca22444157dc0c/greenlet-3.5.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5ecd83806b0f4c2f53b1018e0005cd82269ea01d42befc0368730028d850ed1c", size = 616099, upload-time = "2026-04-27T12:59:39.623Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ab/192090c4a5b30df148c22bf4b8895457d739a7c7c5a7b9c41e5dd7f537f2/greenlet-3.5.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa94cb2288681e3a11645958f1871d48ee9211bd2f66628fdace505927d6e564", size = 623976, upload-time = "2026-04-27T13:02:37.363Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b0/815bece7399e01cadb69014219eebd0042339875c59a59b0820a46ece356/greenlet-3.5.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0ff251e9a0279522e62f6176412869395a64ddf2b5c5f782ff609a8216a4e662", size = 615198, upload-time = "2026-04-27T12:25:25.928Z" },
+    { url = "https://files.pythonhosted.org/packages/24/11/05eb2b9b188c6df7d68a89c99134d644a7af616a40b9808e8e6ced315d5d/greenlet-3.5.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:64d6ac45f7271f48e45f67c95b54ef73534c52ec041fcda8edf520c6d811f4bc", size = 418379, upload-time = "2026-04-27T13:05:12.755Z" },
+    { url = "https://files.pythonhosted.org/packages/10/80/3b2c0a895d6698f6ddb31b07942ebfa982f3e30888bc5546a5b5990de8b2/greenlet-3.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6d874e79afd41a96e11ff4c5d0bc90a80973e476fda1c2c64985667397df432b", size = 1574927, upload-time = "2026-04-27T12:53:25.81Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0e/f354af514a4c61454dbc68e44d47544a5a4d6317e30b77ddfa3a09f4c5f3/greenlet-3.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0ed006e4b86c59de7467eb2601cd1b77b5a7d657d1ee55e30fe30d76451edba4", size = 1642683, upload-time = "2026-04-27T12:25:23.9Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/6a/87f38255201e993a1915265ebb80cd7c2c78b04a45744995abbf6b259fd8/greenlet-3.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:703cb211b820dbffbbc55a16bfc6e4583a6e6e990f33a119d2cc8b83211119c8", size = 238115, upload-time = "2026-04-27T12:21:48.845Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f8/450fe3c5938fa737ea4d22699772e6e34e8e24431a47bf4e8a1ceed4a98e/greenlet-3.5.0-cp311-cp311-win_arm64.whl", hash = "sha256:6c18dfb59c70f5a94acd271c72e90128c3c776e41e5f07767908c8c1b74ad339", size = 235017, upload-time = "2026-04-27T12:22:26.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e9/4eeadf8cb3403ac274245ba75f07844abc7fa5f6787583fc9156ba741e0f/greenlet-3.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:41353ec2ecedf7aa8f682753a41919f8718031a6edac46b8d3dc7ed9e1ceb136", size = 620610, upload-time = "2026-04-27T13:02:39.194Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ef/f913b3c0eb7d26d86a2401c5e1546c9d46b657efee724b06f6f4ac5d8824/greenlet-3.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:58c1c374fe2b3d852f9b6b11a7dff4c85404e51b9a596fd9e89cf904eb09866d", size = 422775, upload-time = "2026-04-27T13:05:14.261Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/4fb3a0805bd5165da5ebf858da7cc01cce8061674106d2cf5bdab32cbfde/greenlet-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8", size = 238840, upload-time = "2026-04-27T12:23:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cb/baa584cb00532126ffe12d9787db0a60c5a4f55c27bfe2666df5d4c30a32/greenlet-3.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:83ed9f27f1680b50e89f40f6df348a290ea234b249a4003d366663a12eab94f2", size = 235615, upload-time = "2026-04-27T12:21:38.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
+    { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/15/a643b4ecd09969e30b8a150d5919960caae0abe4f5af75ab040b1ab85e78/greenlet-3.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4964101b8585c144cbda5532b1aa644255126c08a265dae90c16e7a0e63aaa9d", size = 623234, upload-time = "2026-04-27T13:02:40.611Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
+    { url = "https://files.pythonhosted.org/packages/77/18/3b13d5ef1275b0ffaf933b05efa21408ac4ca95823c7411d79682e4fdcff/greenlet-3.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:7022615368890680e67b9965d33f5773aade330d5343bbe25560135aaa849eae", size = 425243, upload-time = "2026-04-27T13:05:15.689Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/b7/9c5c3d653bd4ff614277c049ac676422e2c557db47b4fe43e6313fc005dc/greenlet-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:47422135b1d308c14b2c6e758beedb1acd33bb91679f5670edf77bf46244722b", size = 235525, upload-time = "2026-04-27T12:23:12.308Z" },
+    { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/89/2dadb89793c37ee8b4c237857188293e9060dc085f19845c292e00f8e091/greenlet-3.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37", size = 668086, upload-time = "2026-04-27T13:02:42.314Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/75722be7e26a2af4cbd2dc35b0ed382dacf9394b7e75551f76ed1abe87f2/greenlet-3.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2", size = 470799, upload-time = "2026-04-27T13:05:17.094Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
+    { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/62/1c498375cee177b55d980c1db319f26470e5309e54698c8f8fc06c0fd539/greenlet-3.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988", size = 236862, upload-time = "2026-04-27T12:23:24.957Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5c/0602239503b124b70e39355cbdb39361ecfe65b87a5f2f63752c32f5286f/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce", size = 657015, upload-time = "2026-04-27T13:02:43.973Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/38/51/8699f865f125dc952384cb432b0f7138aa4d8f2969a7d12d0df5b94d054d/greenlet-3.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2", size = 488275, upload-time = "2026-04-27T13:05:18.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -551,17 +621,30 @@ all = [
     { name = "aiohttp" },
     { name = "beautifulsoup4" },
     { name = "boto3" },
+    { name = "cloakbrowser" },
     { name = "firecrawl-py" },
     { name = "html2text" },
     { name = "httpcloak" },
+    { name = "polars" },
     { name = "pyarrow" },
+    { name = "rapidfuzz" },
 ]
 dev = [
+    { name = "aiohttp" },
+    { name = "beautifulsoup4" },
+    { name = "boto3" },
+    { name = "cloakbrowser" },
+    { name = "firecrawl-py" },
+    { name = "html2text" },
+    { name = "httpcloak" },
     { name = "mypy" },
     { name = "pandas-stubs" },
+    { name = "polars" },
+    { name = "pyarrow" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-httpx" },
+    { name = "rapidfuzz" },
     { name = "ruff" },
     { name = "types-boto3" },
 ]
@@ -573,13 +656,31 @@ parquet = [
 ]
 publish = [
     { name = "boto3" },
+    { name = "polars" },
     { name = "pyarrow" },
+    { name = "rapidfuzz" },
 ]
 scrapers = [
     { name = "aiohttp" },
     { name = "beautifulsoup4" },
+    { name = "cloakbrowser" },
     { name = "html2text" },
     { name = "httpcloak" },
+]
+test = [
+    { name = "aiohttp" },
+    { name = "beautifulsoup4" },
+    { name = "boto3" },
+    { name = "cloakbrowser" },
+    { name = "firecrawl-py" },
+    { name = "html2text" },
+    { name = "httpcloak" },
+    { name = "polars" },
+    { name = "pyarrow" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-httpx" },
+    { name = "rapidfuzz" },
 ]
 
 [package.metadata]
@@ -587,24 +688,29 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'scrapers'", specifier = ">=3.9" },
     { name = "beautifulsoup4", marker = "extra == 'scrapers'", specifier = ">=4.12" },
     { name = "boto3", marker = "extra == 'publish'", specifier = ">=1.34" },
+    { name = "cloakbrowser", marker = "extra == 'scrapers'", specifier = ">=0.3" },
     { name = "firecrawl-py", marker = "extra == 'discovery'", specifier = ">=1.0" },
     { name = "html2text", marker = "extra == 'scrapers'", specifier = ">=2024.0" },
     { name = "httpcloak", marker = "extra == 'scrapers'", specifier = ">=1.6" },
     { name = "httpx", specifier = ">=0.27" },
+    { name = "jobhive-py", extras = ["all"], marker = "extra == 'test'" },
     { name = "jobhive-py", extras = ["scrapers", "parquet", "publish", "discovery"], marker = "extra == 'all'" },
+    { name = "jobhive-py", extras = ["test"], marker = "extra == 'dev'" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "pandas", specifier = ">=2.0" },
     { name = "pandas-stubs", marker = "extra == 'dev'" },
+    { name = "polars", marker = "extra == 'publish'", specifier = ">=0.20" },
     { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=15.0" },
     { name = "pyarrow", marker = "extra == 'publish'", specifier = ">=15.0" },
     { name = "pydantic", specifier = ">=2.6" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
-    { name = "pytest-httpx", marker = "extra == 'dev'", specifier = ">=0.30" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23" },
+    { name = "pytest-httpx", marker = "extra == 'test'", specifier = ">=0.30" },
+    { name = "rapidfuzz", marker = "extra == 'publish'", specifier = ">=3.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
     { name = "types-boto3", marker = "extra == 'dev'" },
 ]
-provides-extras = ["scrapers", "parquet", "publish", "discovery", "all", "dev"]
+provides-extras = ["scrapers", "parquet", "publish", "discovery", "all", "test", "dev"]
 
 [[package]]
 name = "librt"
@@ -1034,12 +1140,59 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.59.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/48/abab23f40643b4de8f2665816f0a1bf0994eeecda39d6d62f0f292b2ad01/playwright-1.59.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:bfc6940100b57423175c819ce2422ec5880d55fa2769987f62ab7a1f5fe6783e", size = 43156922, upload-time = "2026-04-29T08:11:08.921Z" },
+    { url = "https://files.pythonhosted.org/packages/08/71/5e4d98b2ce3641b4343623c6450ff33b9de1c979d12a957505e392338b07/playwright-1.59.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:af068143a0c045ec11608b67d6c42e58db7e9cf65a742dd21fddedc1a9802c47", size = 41947177, upload-time = "2026-04-29T08:11:12.867Z" },
+    { url = "https://files.pythonhosted.org/packages/80/91/fd219aa78ca03d37e93aaedaed4e224131e3090a9264f9bb773c8271d67e/playwright-1.59.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:4a4a2d4842b0e4120de3fa48636e4b69085a05b81d8a35ad4353f530ade72ed6", size = 43156922, upload-time = "2026-04-29T08:11:16.595Z" },
+    { url = "https://files.pythonhosted.org/packages/73/0c/1e513d37c5be07d12829ebce93dbfe7baee230084cb66966c423432799c4/playwright-1.59.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c5792aad9e22b91a09264b9edbc18553cf05ea5a39404d65dc19a012c6b2e51d", size = 47151793, upload-time = "2026-04-29T08:11:19.979Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2d/15f72288cb65d690134e18fefb9483cc4976f7579b580648c45e494481a7/playwright-1.59.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c881a19377d2b900af855fb525b5f22a27bf3cfbecba6d1edb36766d56cb100", size = 46877615, upload-time = "2026-04-29T08:11:23.863Z" },
+    { url = "https://files.pythonhosted.org/packages/72/a1/717ac5bc99f387c0f60def91271ea4262125c0815d764a5d1776a272275c/playwright-1.59.0-py3-none-win32.whl", hash = "sha256:6989c476be2b9cd3e24a18cc9dcf202e266fb3d91e3e5395cd668c54ea54b119", size = 37713698, upload-time = "2026-04-29T08:11:27.251Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a5/4e630ee05d8b46b840f943268e86d6063703e8dadb2d3eb405c7b9b2e48c/playwright-1.59.0-py3-none-win_amd64.whl", hash = "sha256:d5a5cc064b82ca92996080025710844e417f44df8fda9001102c28f44174171c", size = 37713704, upload-time = "2026-04-29T08:11:30.41Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0c/3ece41761ba13c8321009aefcaec7a016eb42799c42eef5e03ace7f2de5b/playwright-1.59.0-py3-none-win_arm64.whl", hash = "sha256:93581ad515728cadc8af39b288a5633ba6d36e7d72048e79d890ce01ea2156f9", size = 33956745, upload-time = "2026-04-29T08:11:34.738Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "polars"
+version = "1.40.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8c/bc9bc948058348ed43117cecc3007cd608f395915dae8a00974579a5dab1/polars-1.40.1.tar.gz", hash = "sha256:ab2694134b137596b5a59bfd7b4c54ebbc9b59f9403127f18e32d363777552e8", size = 733574, upload-time = "2026-04-22T19:15:55.507Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/91/74fc60d94488685a92ac9d49d7ec55f3e91fe9b77942a6235a5fa7f249c3/polars-1.40.1-py3-none-any.whl", hash = "sha256:c0f861219d1319cdea45c4ce4d30355a47176b8f98dcedf95ea8269f131b8abd", size = 828723, upload-time = "2026-04-22T19:14:25.452Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.40.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ba/26d40f039be9f552b5fd7365a621bdfc0f8e912ef77094ae4693491b0bae/polars_runtime_32-1.40.1.tar.gz", hash = "sha256:37f3065615d1bf90d03b5326222df4c5c1f8a5d33e50470aa588e3465e6eb814", size = 2935843, upload-time = "2026-04-22T19:15:57.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/46/22c8af5eed68ac2eeb556e0fa3ca8a7b798e984ceff4450888f3b5ac61fd/polars_runtime_32-1.40.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:b748ef652270cc49e9e69f99a035e0eb4d5f856d42bcd6ac4d9d80a40142aa1e", size = 52098755, upload-time = "2026-04-22T19:14:28.555Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3e/48599a38009ca60ff82a6f38c8a621ce3c0286aa7397c7d79e741bd9060e/polars_runtime_32-1.40.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d249b3743e05986060cec0a7aaa542d020df6c6b876e556023a310efd581f9be", size = 46367542, upload-time = "2026-04-22T19:14:32.433Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e9/384bc069367a1a36ee31c13782c178dbd039b2b873b772d4a0fc23a2373d/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5987b30e7aa1059d069498496e8dda35afd592b0ac3d46ed87e3ff8df1ad652c", size = 50252104, upload-time = "2026-04-22T19:14:35.945Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ef/7d57ceb0651af74194e97ed6583e148d352f03d696090221b8059cdfc90b/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d7f42a8b3f16fc66002cc0f6516f7dd7653396886ae0ed362ab95c0b3408b59", size = 56250788, upload-time = "2026-04-22T19:14:39.743Z" },
+    { url = "https://files.pythonhosted.org/packages/10/0f/e4b3ffc748827a14a474ec9c42e45c066050e440fec57e914091d9adda75/polars_runtime_32-1.40.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e5f7becc237a7ec9d9a10878dc8e54b73bbf4e2d94a2991c37d7a0b38590d8f9", size = 50432590, upload-time = "2026-04-22T19:14:43.388Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/0b/b8d95fbed869fa4caabe9c400e4210374913b376e925e96fdcfa9be6416b/polars_runtime_32-1.40.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:992d14cf191dde043d36fbdbc98a65e43fbc7e9a5024cecd45f838ac4988c1ee", size = 54155564, upload-time = "2026-04-22T19:14:47.239Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d9/d091d8fb5cbed5e9536adfed955c4c89987a4cc3b8e73ae4532402b91c74/polars_runtime_32-1.40.1-cp310-abi3-win_amd64.whl", hash = "sha256:f78bb2abd00101cbb23cc0cb068f7e36e081057a15d2ec2dde3dda280709f030", size = 51829755, upload-time = "2026-04-22T19:14:50.85Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ad/b33c3022a394f3eb55c3310597cec615412a8a33880055eee191d154a628/polars_runtime_32-1.40.1-cp310-abi3-win_arm64.whl", hash = "sha256:b5cbfaf6b085b420b4bfcbe24e8f665076d1cccfdb80c0484c02a023ce205537", size = 45822104, upload-time = "2026-04-22T19:14:54.192Z" },
 ]
 
 [[package]]
@@ -1309,6 +1462,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1378,6 +1543,85 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "rapidfuzz"
+version = "3.14.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/21/ef6157213316e85790041254259907eb722e00b03480256c0545d98acd33/rapidfuzz-3.14.5.tar.gz", hash = "sha256:ba10ac57884ce82112f7ed910b67e7fb6072d8ef2c06e30dc63c0f604a112e0e", size = 57901753, upload-time = "2026-04-07T11:16:31.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/f9/3c41a7be8855803f4f6c713b472226a98d31d41869d98f64f4ca790510d6/rapidfuzz-3.14.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e251126d48615e1f02b4a178f2cd0cd4f0332b8a019c01a2e10480f7552554b4", size = 1952372, upload-time = "2026-04-07T11:13:58.32Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/89/c2557e37531d03465193bff0ab9de70b468420a807d71a26a65100635459/rapidfuzz-3.14.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5ab449c9abd0d4e1f8145dce0798a4c822a1a1933d613c764a641bea88b8bdab", size = 1159782, upload-time = "2026-04-07T11:14:00.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b2/ffeeb7eca1a897d51b998f4c0ef0281696c3b06abcca4f88f9def708ffe1/rapidfuzz-3.14.5-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb2829fedd672dd7107267189dabe2bbe07972801d636014417c6861eb89e358", size = 1383677, upload-time = "2026-04-07T11:14:01.696Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d0/4539e42a2d596e068f7738f279638a4a74edd1fbb6f8594e2458058979c6/rapidfuzz-3.14.5-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d50e5861872935fece391351cbb5ba21d1bced277cf5e1143d207a0a35f1925", size = 3168906, upload-time = "2026-04-07T11:14:03.29Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/1c/3ec897eb9d8b05308aa8ef6ae4ed64b088ad521a3f9d8ff469e7e97bc2b0/rapidfuzz-3.14.5-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:7092a216728f80c960bd6b3807275d1ee318b168986bd5dc523349581d4890b8", size = 1478176, upload-time = "2026-04-07T11:14:04.94Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ba/970c03a12ce20a5399e22afe9f8932fd4cd1265b8a8461d0e63b00eb4eae/rapidfuzz-3.14.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9669753caef7fdc6529f6adcc5883ed98d65976445d9322e7dbdb6b697feee13", size = 2402441, upload-time = "2026-04-07T11:14:07.228Z" },
+    { url = "https://files.pythonhosted.org/packages/81/93/61d351cae60c1d0e21ba5ff1a1015ad045539ed215da9d6e302204ed887a/rapidfuzz-3.14.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:823b1b9d9230809d8edcc18872770764bfe8ef4357995e16744047c8ccf0e489", size = 2511628, upload-time = "2026-04-07T11:14:09.234Z" },
+    { url = "https://files.pythonhosted.org/packages/87/52/374d2d4f60fd98155142a869323aa221e30868cfa1f15171a0f64070c247/rapidfuzz-3.14.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f0b2af76b7e7060c09e1a0dfa9410eb19369cbe6164509bff2ef94094b54d2b6", size = 4275480, upload-time = "2026-04-07T11:14:11.332Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/04/82e7989bc9ec20a15b720a335c5cb6b0724bf6582013898f90a3280cfccd/rapidfuzz-3.14.5-cp311-cp311-win32.whl", hash = "sha256:c5801a89604c65ab4cc9e91b23bc4076d0ca80efd8c976fb63843d7879a85d7f", size = 1725627, upload-time = "2026-04-07T11:14:13.217Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b5/eca8ac5609bc9bcb02bb6ff87fa5983cc92b8772d66a431556ab8a8c178f/rapidfuzz-3.14.5-cp311-cp311-win_amd64.whl", hash = "sha256:d7ca16637c0ede8243f84074044bd0b2335a0341421f8227c85756de2d18c819", size = 1545977, upload-time = "2026-04-07T11:14:14.766Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/e1/dbf318de28f65fa2cdd0a9dfbdee380f8199eb83b19259bc4f8592551b4e/rapidfuzz-3.14.5-cp311-cp311-win_arm64.whl", hash = "sha256:8c90cdf8516d9057e502aa6003cea71cf5ec27cc44699ca52412b502a04761bb", size = 816827, upload-time = "2026-04-07T11:14:16.788Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/e3/574435c6aafb80254c191ef40d7aca2cb2bb97a095ec9395e9fa59ac307a/rapidfuzz-3.14.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0d3378f471ef440473a396ce2f8e97ee12f89a78b495540e0a5617bbfe895638", size = 1944601, upload-time = "2026-04-07T11:14:18.771Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/1f/fbad3102a255ecc112ce9a7e779bacab7fd14398217be8868dc9082ba363/rapidfuzz-3.14.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e910eebca9fd0eba245c0555e764597e8a0cccb673a92da2dc2397050725f48", size = 1164293, upload-time = "2026-04-07T11:14:20.534Z" },
+    { url = "https://files.pythonhosted.org/packages/88/37/a3eb7ff6121ed3a5f199a8c38cc86c8e481816f879cb0e0b738b078c9a7e/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01550fe5f60fd176aa66b7611289d46dc4aa4b1b904874c7b6d1d54e581c5ec1", size = 1371999, upload-time = "2026-04-07T11:14:22.63Z" },
+    { url = "https://files.pythonhosted.org/packages/79/72/97a9728c711c7c1b06e107d3f0623880fb4ef90e147ed13c551a1730e7cc/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:48bee0b91bebfaec41e1081e351000659ab7570cc4598d617aa04d5bf827f9e6", size = 3145715, upload-time = "2026-04-07T11:14:24.508Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/d5caabbea233ac90c286c87c260e49d7641467e87438a18d858e41c82e91/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:7e580cb04ad849ae9b786fa21383c6b994b6e6c1444ad1cb9f22392759d72741", size = 1456304, upload-time = "2026-04-07T11:14:26.515Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/a7/2d1a81250ac8c01a0100c026018e76f0e7a097ff63e4c553e02a6938c6fb/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:09d6c9ba091854f07817055d795d604179c12a8f308ba4c7d56f3719dfea1646", size = 2389089, upload-time = "2026-04-07T11:14:28.635Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0d/c47c3872203ae88e6506997c0b576ad731f5261daa25d559be09c9756658/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1e989f86113be66574113b9c7bdf4793f3f863d248e47d911b355e05ca6b6b10", size = 2493404, upload-time = "2026-04-07T11:14:30.577Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/2f/71e0a5a3130792146c8a200a2dd1e52aa16f7c1074012e17f2601eea9a90/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0ebd1a18e2e47bc0b292a07e6ed9c3642f8aaa672d12253885f599b50807a4f9", size = 4251709, upload-time = "2026-04-07T11:14:32.451Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/d39874901abacef325adb5b34ae416817c8486dfb4fb87c7a9b74ec5b072/rapidfuzz-3.14.5-cp312-cp312-win32.whl", hash = "sha256:9981d38a703b86f0e315a3cd229fd1906fe1d91c989ed121fb975b3c849f89f5", size = 1710069, upload-time = "2026-04-07T11:14:34.37Z" },
+    { url = "https://files.pythonhosted.org/packages/85/0b/f65572c53de8a1c704bda707f63a447b67bdbe95d7cdc70d18885e191df5/rapidfuzz-3.14.5-cp312-cp312-win_amd64.whl", hash = "sha256:d8375e3da319593389727c3187ccaf3e0e84199accc530866b8e0f2b79af05e9", size = 1540630, upload-time = "2026-04-07T11:14:36.287Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c3/143be3a578f989758cae516f3270d5cbb49783a7bfdf57cc27a670e00456/rapidfuzz-3.14.5-cp312-cp312-win_arm64.whl", hash = "sha256:478b59bb018a6780d73f33e38d0b3ec5e968a6c1ed42876b993dd456b7aa20e8", size = 813137, upload-time = "2026-04-07T11:14:38.289Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/252803f2010ba699618cdc048b6e1f7cc1f433c08b4a9a17579b92ab0142/rapidfuzz-3.14.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ebd8fd343bf8492a1e60bcb6dc99f90f74f65d98d8241a6b3e1fed225b76ecd6", size = 1940205, upload-time = "2026-04-07T11:14:40.319Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/59/b2afd98e41af9cd54554a4c1c423d84cdd60e6b1c0a09496f033b55f60ec/rapidfuzz-3.14.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6737b35d5af7479c5bf9710f7b17edd9d2c43128d974d25fb4ea653e42c64609", size = 1159639, upload-time = "2026-04-07T11:14:42.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/7aa7e62c4c516a7af322ed0c4f0774208b72d457d0cfec808bad0df12f4a/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b002c7994cc9f2bc9d9856f0fbaee6e8072c983873846c92f25cefba5b2a925f", size = 1367194, upload-time = "2026-04-07T11:14:44.25Z" },
+    { url = "https://files.pythonhosted.org/packages/90/79/2fc252a63bc91d3c3b234d0a3a6ad4ebc460037a23cdcdaf9285f986e6c9/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:17a34330cd2a538c1ce5d400b61ba358c5b72c654b928ff87b362e88f8b864c7", size = 3151805, upload-time = "2026-04-07T11:14:46.21Z" },
+    { url = "https://files.pythonhosted.org/packages/17/54/0c83508f2683ea70e2d05f8527eb07328acf7bb1e9d97a3bece5702378e7/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:95d937e74c1a7a1287dfb03b62a827be08ede10a155cf1af73bbf47f2b73ee6e", size = 1455667, upload-time = "2026-04-07T11:14:47.991Z" },
+    { url = "https://files.pythonhosted.org/packages/71/1b/070175e873177814d58850a01ebe80e20ae11e93eb4da894d563988660fa/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:46b92a9970dcc34f0096901c792644094cab49554ac3547f35e3aebbdf0a3610", size = 2388246, upload-time = "2026-04-07T11:14:50.098Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/dd/77caf7aaf9c2be050ad1f128d7c24ff0f59079aa62c5f62f9df41c0af45e/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e012177c8e8a8a0754ae0d6027d63042aa5ff036d9f40f07cb3466a6082e21b8", size = 2494333, upload-time = "2026-04-07T11:14:52.303Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/dd7e1f2aa31a8fbbfc16b0610af1d770ffaf1287490f3c8c5b1c52da264f/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a2ae6f53f99c9a0eca7a0afc5b4e45fc73bc1dd4ac74c00509031d76df80ed98", size = 4258579, upload-time = "2026-04-07T11:14:54.538Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0a/ac99e1ba347ba0e85e0bb60b74231d55fb93c0eff43f2920ccb413d0be08/rapidfuzz-3.14.5-cp313-cp313-win32.whl", hash = "sha256:4a60f0057231188e3bd30216f7b4e0f279b11fa4ec818bb6c1d9f014d1562fbc", size = 1709231, upload-time = "2026-04-07T11:14:56.524Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/cb/0e251d731b3166378644238e8f0cf9e89858c024e19f75ca9f7e3ae83fd5/rapidfuzz-3.14.5-cp313-cp313-win_amd64.whl", hash = "sha256:11bfc2ed8fbe4ab86bd516fadefab126f90e6dcadffa761739fcb304707dfd35", size = 1538519, upload-time = "2026-04-07T11:14:58.635Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6f/4548132acc947db6d5346a248e44a8b3a22d608ef30e770fb578caaf2d00/rapidfuzz-3.14.5-cp313-cp313-win_arm64.whl", hash = "sha256:b486b5218808f6f4dc471b114b1054e63553db69705c97da0271f47bd706aedd", size = 812628, upload-time = "2026-04-07T11:15:00.552Z" },
+    { url = "https://files.pythonhosted.org/packages/00/60/69b177577290c5eab892c6f75fe89c3aff3f9ae80298a78d9372b1cecb9a/rapidfuzz-3.14.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:39ef8658aaf67d51667e7bdaf7096f432333377d8302ac43c70b5df8a4cf89b8", size = 1970231, upload-time = "2026-04-07T11:15:02.603Z" },
+    { url = "https://files.pythonhosted.org/packages/48/38/2fd790052659cc4e2907b63c25433f0987864b445c1aeec1a302ef5ad948/rapidfuzz-3.14.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9ad37a0be705b544af6296da8edddc260d10a8ae5462530fc9991f66498bb1f9", size = 1194394, upload-time = "2026-04-07T11:15:04.572Z" },
+    { url = "https://files.pythonhosted.org/packages/80/f4/28430ad8472fc3536e8ebd51a864a226e979cfe924c6e3f83d111373aa74/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d45e06f60729e07d9b20c205f7e5cff90b6ef2584e852eecf46e045aea69627d", size = 1377051, upload-time = "2026-04-07T11:15:06.728Z" },
+    { url = "https://files.pythonhosted.org/packages/77/7e/9aeacabcfd1e77397968362e5b98fe14248b8307011136b17daf99752a8e/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e52da10236aa6212de71b9e170bace65b64b129c0dea7fc243d6c9ce976f5074", size = 3160565, upload-time = "2026-04-07T11:15:08.667Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f4/db4dd7be0cd2f2022117ac5407d905f435d60e48baaea313a567ad27e865/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:440d30faaf682ca496170a7f0cc5453ec942e3e079f0fd802c9a7f938dfb50a3", size = 1442113, upload-time = "2026-04-07T11:15:11.138Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/99/0e9f6aa57f3e32a767216f797e56dc96b720fcecfb9d8ee907ecc82f8d66/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:56227a61fd3d17b0cd9793132431f3a3d07c8654be96794ba9f89fe0fc8b2d09", size = 2396618, upload-time = "2026-04-07T11:15:13.154Z" },
+    { url = "https://files.pythonhosted.org/packages/60/94/44a78e39ffce17cbdd3e2b53b696acc751d5d153be0f499d052b07a4d904/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:2e83cd2e25bb4edd97b689d9979d9c3acccdaaf26ceac08212ceece202febcfa", size = 2478220, upload-time = "2026-04-07T11:15:15.193Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/df/454311469a09a507e9d784a35796742bec22e4cebe75551e2da4e0e290fd/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:af3b859726cd3374287e405e14b9634563c078c5531a4f62375508addebddad1", size = 4265027, upload-time = "2026-04-07T11:15:17.28Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/01/175465a9ab3e3b70ba669058372f009d1d49c1746e2dcd56b69df188d3a5/rapidfuzz-3.14.5-cp313-cp313t-win32.whl", hash = "sha256:8ce1d850b3c0178440efde9e884d98421b5e87ff925f364d6d79e23910d7593f", size = 1766814, upload-time = "2026-04-07T11:15:19.687Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a0/a9b84a47af06ebed94a1439eb2f02adebfb8628bcd30af1fe3e02f5ef56c/rapidfuzz-3.14.5-cp313-cp313t-win_amd64.whl", hash = "sha256:c84af70bcf34e99aee894e46a0f1ac77f17d0ef828179c387407642e2466d28a", size = 1582448, upload-time = "2026-04-07T11:15:21.98Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f1/5937800238b3f8248e70860d79f69ba8f73e764fff47e36bc9e2f26dbcc6/rapidfuzz-3.14.5-cp313-cp313t-win_arm64.whl", hash = "sha256:aac0ad28c686a5e72b81668b906c030ee28050b244544b8af68e12fb32543895", size = 832932, upload-time = "2026-04-07T11:15:24.358Z" },
+    { url = "https://files.pythonhosted.org/packages/81/41/aa3ffb3355e62e1bf91f6599b3092e866bc88487a07c524004943c7676df/rapidfuzz-3.14.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1a31cc6d7d03e7318a0974c038959c59e19c752b81115f2e9138b3331cd64d45", size = 1943327, upload-time = "2026-04-07T11:15:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e1/c2141f1840a41e07ad2db6f724945f8f8ff3065463899a22939152dd6e09/rapidfuzz-3.14.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0298d357e2bc59d572da4db0bc631009b6f8f6c9bc8c11e99a12b833f16b6575", size = 1161755, upload-time = "2026-04-07T11:15:28.659Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/07/66e753eeaa353161d1d331b7dd517bb349b0bacfebe8496d7b26be26f81f/rapidfuzz-3.14.5-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:59b3dba758661a318995655435c6ab20a04ade79fa51e75bc8dc107cac8df280", size = 1376571, upload-time = "2026-04-07T11:15:31.225Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/85/9535df0b78ba51f478c9ce7eb6d1f85535cc31fe356773b48fd9d3e563ca/rapidfuzz-3.14.5-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4900143d82071bdda533b00300c40b14b963ff826b3642cc463b6dd0f036585e", size = 3156468, upload-time = "2026-04-07T11:15:33.428Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ee/b667eb93bba6dc4e0de658edd778e1619dc4d6aab68fa5e5c7f075152735/rapidfuzz-3.14.5-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:feedf219672eef83ea6be6f3bb093bba396a8560fc75be85ba225f082903df0a", size = 1458311, upload-time = "2026-04-07T11:15:35.557Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ce/479074f5624364a48df3403c538797ef22d3ac49c19dc76c3f79fcdcc70c/rapidfuzz-3.14.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:419e4397a36e2665ec992d8d64c20ba4b2a42500c76ecadeca78a4f19cb9cc32", size = 2398228, upload-time = "2026-04-07T11:15:37.669Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/15/a8982f649150fffbdcd6f17565974501f6ab33b2795267bffbd4a7ba905b/rapidfuzz-3.14.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:97131ab2be39043054ee28d99e09efe316e6d53449b7e962dfcf3c2de8b2b246", size = 2497226, upload-time = "2026-04-07T11:15:39.857Z" },
+    { url = "https://files.pythonhosted.org/packages/19/52/5267c03ef6759831b7d4625a0c9c06e87baa2fae084b61ac9c388858317b/rapidfuzz-3.14.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:593c00dac4e30231c35bf3b4f1da8ec0998762e9e94425586a5d636fcd57f9d0", size = 4262283, upload-time = "2026-04-07T11:15:42.279Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c0/2579f343a97f5254c43bb5853baccc01488357dcb64a27bcb869b7888a4a/rapidfuzz-3.14.5-cp314-cp314-win32.whl", hash = "sha256:0084b687b02b4e569b46d8d6d4ad25659528e6081cd6d067ca453a69035f07e4", size = 1744614, upload-time = "2026-04-07T11:15:44.498Z" },
+    { url = "https://files.pythonhosted.org/packages/17/eb/8edfed1e80119dc9c35b11df4bc701eea85622ad681fff0263b6961d3224/rapidfuzz-3.14.5-cp314-cp314-win_amd64.whl", hash = "sha256:5dfa89d78f22cd773054caff44827b846161a29f2dcf7e78b8f90d086621e502", size = 1588971, upload-time = "2026-04-07T11:15:46.86Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/04/5676df93c85cfa57a3045d8047318df9f3cd58c7b8a99340dd95f874795e/rapidfuzz-3.14.5-cp314-cp314-win_arm64.whl", hash = "sha256:67f3f9d2b444268ab53e47d31bab89954888d23c04c6789f2c727e51fe4b1d13", size = 834985, upload-time = "2026-04-07T11:15:49.411Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/0d/4a8988cea658fe335048ddef8c876addff1b6daa3c9ca8ad65a5a2196e69/rapidfuzz-3.14.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:77eac0526899b3c3ad1454bb2b03cdb491d67358ec8ef0c9c48bd61b632b431d", size = 1972517, upload-time = "2026-04-07T11:15:51.819Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a3/f5cfd9965a9d9a9e32249159797c47b5d6299ea6d1629f9126b25f1c10a3/rapidfuzz-3.14.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b9c6bd754d11f6e78ac54e3d86b4b11dc1ba2f13e5fc958899574532897f5a99", size = 1196056, upload-time = "2026-04-07T11:15:54.292Z" },
+    { url = "https://files.pythonhosted.org/packages/64/07/561c2e40cfd10e6630a7b0ac5a2a813aef50d944bcd1f3d260319d659d5b/rapidfuzz-3.14.5-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:738c96944d076deeaff70e92b65696ab4f7ecb8081d7791c5403a3257dfaf8ff", size = 1374732, upload-time = "2026-04-07T11:15:56.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/39/123bb94fee40e2fb3b7c49b80827c7ef42d838e18def3fc2fef5a3cf817a/rapidfuzz-3.14.5-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4c1bca487a17fe4226b4ffb2d30e799d2b274d692cffa76bd0746f56235fca3", size = 3166902, upload-time = "2026-04-07T11:15:58.768Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0a/45716fafc9fd2e028cf20b5ac5bc704887081cd312f84edb0e325599414b/rapidfuzz-3.14.5-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:af6a90a4ed2a48fa1a2d17e9d824e6c7c950bea5bad0b707c77fd55751e6bfef", size = 1452130, upload-time = "2026-04-07T11:16:01.453Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/49/4e96c413114398481c0a5b0086af32c364a18613c9a2ea578d17c4bea4ee/rapidfuzz-3.14.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bf5018938208d4597b2e679a4f8cff9fd252f1df53583130ae56281a21801b64", size = 2396308, upload-time = "2026-04-07T11:16:03.588Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b7/49fea9fc6878d59bd259d01dd1972d9b86117992b1c66d9b16f0a65273c3/rapidfuzz-3.14.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c0919d1f89ddf91129906705723118ea09754171e4116f5a5dbc667c7bc9b261", size = 2488210, upload-time = "2026-04-07T11:16:05.871Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/44/a1f732b93ffacbdad077b7c801149549b2938e1bece6addb5ad85ed74df8/rapidfuzz-3.14.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:93d8da883a35116d6813432177f35e570db5b0a5e30ecb0cbd7cb39c815735df", size = 4270621, upload-time = "2026-04-07T11:16:08.483Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/ce/ff942d19fce5385054650bb71a58495ddda299d94661ccc4e6e7fa44868b/rapidfuzz-3.14.5-cp314-cp314t-win32.whl", hash = "sha256:0f23e37019ec07712d58976b1ab2b889f8649a7f7c2f626a2f34ea9139e79279", size = 1803950, upload-time = "2026-04-07T11:16:10.873Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/0f/9aafc63f9661222b819b391c187eed29fc90ad5935f9690e5ecc2d2047a4/rapidfuzz-3.14.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7d5ca9c7832e6879a707296d1463685f7c243a27846227044504741640caec66", size = 1632357, upload-time = "2026-04-07T11:16:13.1Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a6/51fc1b0e61e3326e1c68a61cfd0c6b3c34c843681c4b1eefbf0596f59162/rapidfuzz-3.14.5-cp314-cp314t-win_arm64.whl", hash = "sha256:3e91dcd2549b8f8d843f98ba03a17e01f3d8b72ce942adbbb6761bc58ffce813", size = 855409, upload-time = "2026-04-07T11:16:15.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/ee/e71853bf82846c5c2174b924b71d8e8099fb05ff87c958a720380b434ba3/rapidfuzz-3.14.5-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:578e6051f6d5e6200c259b47a103cf06bb875ab5814d17333fc0b5c290b22f4c", size = 1888603, upload-time = "2026-04-07T11:16:18.223Z" },
+    { url = "https://files.pythonhosted.org/packages/36/82/40f67b730f32be2ebad9f62add1571c754f52249254b2e88af094b907eee/rapidfuzz-3.14.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fbf1b8bb2695415b347f3727da1addca2acb82c9b97ac86bebf8b1bead1eb12d", size = 1120599, upload-time = "2026-04-07T11:16:20.682Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/9f/a3635cc4ec8fc6e14b46e7db1f7f8763d8c4bef33dcc124eea2e6cb2c8f3/rapidfuzz-3.14.5-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f4a8f5cc84c7ad6bffa0e9947b33eb343ad66e6b53e94fe54378a5508c5ed53", size = 1348524, upload-time = "2026-04-07T11:16:23.451Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1b/2b229520f0b48464cfcd7aa758f74551d12c9bc4ab544022a60210aab064/rapidfuzz-3.14.5-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:97c6d85283629646fa87acc22c66b30ea9d4de7f6fdf887daa2e30fa041829b5", size = 3099302, upload-time = "2026-04-07T11:16:25.858Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b5/363906b1064fc6fe611783a61764927bbd91919aaaabe8cba82151ca93ef/rapidfuzz-3.14.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:dfef96543ced67d9513a422755db422ae1dc34dade0a1485e0b43e7342ed3ebf", size = 1509889, upload-time = "2026-04-07T11:16:28.487Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- normalize Oracle CandidateExperience URLs, SuccessFactors public hosts, and Eightfold base URLs used by the cron runner
- make provider job output writes atomic and preserve the previous `jobs.csv` on catastrophic zero-job failures
- add a publisher guard that refuses suspicious empty provider slices when the manifest shows prior jobs or tenants
- update `uv.lock`

## Root Cause
The runner opened `<provider>/jobs.csv` for writing before the scrape completed. When a provider had a systemic failure, the existing good file was replaced by a header-only CSV. The publisher then treated that CSV as valid and pushed a zero-row artifact to Storage.

## Validation
- Real provider probes after branching from `origin/main`:
  - `eightfold`: 3/3 tenants returned jobs (`158`, `1443`, `652`)
  - `oracle`: 3/3 tenants returned jobs (`2023`, `27`, `70`)
  - `successfactors`: 2/3 tenants returned jobs (`60`, `68`), 1/3 returned a clean empty result with no error
- `uv run --extra dev --extra publish --extra scrapers pytest tests/test_run_pipeline_guards.py tests/test_successfactors.py tests/test_eightfold.py tests/test_scrapers_extra.py::test_oracle_with_default_site tests/test_scrapers_extra.py::test_oracle_extracts_site_number_from_query tests/test_scrapers_extra.py::test_oracle_accepts_candidate_experience_site_url tests/test_scrapers_extra.py::test_oracle_requires_full_url tests/test_publisher.py -q`
- Result: `141 passed in 3.43s`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops zero-job publishes from cron by making scrapes atomic and adding a guard that blocks suspicious empty provider outputs. Also normalizes Oracle, SuccessFactors, and Eightfold inputs and adds a generic per-ATS pipeline runner.

- New Features
  - Add `scripts/run_pipeline.py` to run per-ATS scrapes, stream large providers, control concurrency, and write via temp files.
  - Normalize provider inputs: Oracle CandidateExperience URLs → `base?site_number=...`; SuccessFactors uses public host URL; Eightfold sets `base_url`/`domain` from CSV.
  - Oracle scraper now accepts CandidateExperience site paths and extracts `site_number`.
  - Publisher guard blocks empty `<ats>/jobs.csv` when the manifest shows prior jobs or companies; override with `JOBHIVE_ALLOW_EMPTY_PUBLISH=1`.

- Bug Fixes
  - Preserve the previous `jobs.csv` on zero-job, high-error runs instead of replacing it with a header-only file.
  - Close the tenant CSV handle in the runner and reuse the already-loaded manifest in the publisher to avoid a redundant R2 read.

<sup>Written for commit f95c4fb5440efb346b2056a9125db46e193ff45b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents zero-job publishes from cron by making scrape output writes atomic (`tmp` → rename), detecting catastrophic failures before overwriting a good `jobs.csv`, and adding a publisher-side guard that raises `StorageError` when a provider's local slice has 0 rows but the manifest shows prior jobs or tenants.

- **`scripts/run_pipeline.py`** — new generic ATS pipeline runner with per-provider slug normalizers for Oracle (CandidateExperience paths), SuccessFactors (public host URL), and Eightfold (custom-domain `base_url`); atomic writes and catastrophic-failure detection.
- **`src/jobhive/storage/publisher.py`** — `_guard_suspicious_empty_job_slices` loaded before the ExitStack block so it fails fast with no partial uploads; `JOBHIVE_ALLOW_EMPTY_PUBLISH=1` escape hatch for intentional empty providers.
- **`src/jobhive/scrapers/oracle.py`** — `_normalize_oracle_target` now accepts `/hcmUI/CandidateExperience/…/sites/CX_N` paths in addition to the existing `?site_number=` form.

<h3>Confidence Score: 4/5</h3>

The change is safe to merge. The atomic-write and guard mechanics are straightforward, well-tested, and fail closed — a misconfiguration raises an error rather than silently publishing bad data.

The core guard logic, Oracle normalization, and catastrophic-failure detection are all covered by new tests and follow predictable paths. The only findings are a missing context manager on a file open in the pipeline runner and a redundant R2 read per publish run in the publisher — neither affects correctness.

No files require special attention. The two minor suggestions in `scripts/run_pipeline.py` and `src/jobhive/storage/publisher.py` are quality improvements, not blockers.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/run_pipeline.py | New generic pipeline runner: atomic temp-file writes, catastrophic-failure detection, per-ATS slug normalization. Minor unclosed file handle on the tenant CSV read. |
| src/jobhive/scrapers/oracle.py | Adds `_normalize_oracle_target` to accept CandidateExperience site-path URLs in addition to the existing `?site_number=` query-string form. Logic is correct and well-tested. |
| src/jobhive/storage/publisher.py | Adds publisher-side guard that blocks suspicious empty-provider publishes. Loads the existing manifest twice per run (once for the guard, once inside `_patch_and_upload_manifest`). |
| tests/test_run_pipeline_guards.py | New tests covering catastrophic-failure preservation, singleton success path, and slug normalizer shapes. Good coverage of the critical guard behavior. |
| tests/test_publisher.py | Adds `test_publish_refuses_suspicious_empty_provider_slice` verifying the guard raises and no files are uploaded. Assertion is meaningful. |
| tests/test_scrapers_extra.py | Adds Oracle tests for default site, query-string site_number, CandidateExperience site-path URL, and bare-slug rejection. All target the new normalization logic. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
scripts/run_pipeline.py:711
The tenant CSV file opened here is never explicitly closed. In CPython the reference count drops to zero immediately and the handle is released, but under PyPy or if `csv.DictReader` raises mid-iteration the file object can linger until GC. Use a context manager to make the lifetime explicit.

```suggestion
        with csv_path.open(newline="") as fh:
            rows = list(csv.DictReader(fh))
```

### Issue 2 of 2
src/jobhive/storage/publisher.py:167-168
**Redundant R2 read per publish run**

`_load_existing_manifest` is called here (new, for the guard) and again inside `_patch_and_upload_manifest` (pre-existing). Every publish therefore incurs two round-trips to R2 for the same object. The calls are close enough in time that consistency shouldn't be an issue in practice, but passing `existing_manifest` into `_patch_and_upload_manifest` (or caching it on the instance) would halve the network cost and make it trivially clear that both callers see the same snapshot.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add cron scrape guards for empty provide..."](https://github.com/kalil0321/ats-scrapers/commit/4618f9ab6b6f59996d20d7616c8754c4ef963b97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31974339)</sub>

<!-- /greptile_comment -->