### PR TITLE
[codex] Fill job descriptions across providers

### DIFF
--- a/src/jobhive/scrapers/breezy.py
+++ b/src/jobhive/scrapers/breezy.py
@@ -25,7 +25,6 @@ This scraper uses only the public unauthenticated endpoint.
 from __future__ import annotations
 
 import asyncio
-import os
 from datetime import datetime
 from typing import TYPE_CHECKING
 
@@ -92,14 +91,10 @@ class BreezyScraper(BaseScraper):
                 seen.add(job.ats_id)
                 jobs.append(job)
 
-            # Detail-page enrichment is opt-in. Breezy's edge blocks
-            # bursty traffic with 403s; pulling descriptions for the full
-            # tenant universe needs a slower path (Browserbase or
-            # tightly-rate-limited httpx). Disabled by default so the
-            # listing pass still recovers the full job set.
-            #
-            # Set ``JOBHIVE_BREEZY_FETCH_DESCRIPTIONS=1`` to enable.
-            if jobs and os.getenv("JOBHIVE_BREEZY_FETCH_DESCRIPTIONS"):
+            # Detail-page enrichment is best-effort. Breezy's edge blocks
+            # bursty traffic with 403s, so per-job failures keep the
+            # listing-derived row instead of failing the tenant.
+            if jobs:
                 sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
                 await asyncio.gather(*(
                     self._enrich_description(client, sem, j) for j in jobs

--- a/src/jobhive/scrapers/bundesagentur.py
+++ b/src/jobhive/scrapers/bundesagentur.py
@@ -41,6 +41,7 @@ publisher's cross-ATS dedup still works.
 from __future__ import annotations
 
 import asyncio
+import base64
 import logging
 import random
 from datetime import datetime
@@ -59,6 +60,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 API_URL = "https://rest.arbeitsagentur.de/jobboerse/jobsuche-service/pc/v4/jobs"
+DETAIL_URL_TEMPLATE = (
+    "https://rest.arbeitsagentur.de/jobboerse/jobsuche-service/pc/v4/jobdetails/{encoded_ref}"
+)
 API_KEY = "jobboerse-jobsuche"  # Public key shared by the official frontend.
 PAGE_SIZE = 100
 PAGE_LIMIT = 100  # size × page caps at 10,000 → max page=100 at size=100.
@@ -206,6 +210,11 @@ class BundesagenturScraper(BaseScraper):
                         continue
                     seen.add(job.ats_id)
                     new_jobs.append(job)
+            await asyncio.gather(*(
+                self._enrich_description(client, sem, job)
+                for job in new_jobs
+                if not job.description
+            ))
             if on_job is not None:
                 for job in new_jobs:
                     await on_job(job)
@@ -218,6 +227,38 @@ class BundesagenturScraper(BaseScraper):
                 client, sem, base_params={}, depth=0, absorb=absorb,
             )
         return all_jobs
+
+    async def _enrich_description(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        job: Job,
+    ) -> None:
+        if not job.ats_id:
+            return
+        encoded = base64.b64encode(job.ats_id.encode()).decode()
+        url = DETAIL_URL_TEMPLATE.format(encoded_ref=encoded)
+        async with sem:
+            try:
+                response = await client.get(
+                    url,
+                    headers={
+                        "X-API-Key": API_KEY,
+                        "User-Agent": "Mozilla/5.0",
+                        "Accept": "application/json",
+                    },
+                )
+            except httpx.HTTPError:
+                return
+        if response.status_code != 200:
+            return
+        try:
+            detail = response.json()
+        except ValueError:
+            return
+        description = detail.get("stellenangebotsBeschreibung")
+        if isinstance(description, str) and description.strip():
+            job.description = description.strip()[:10_000]
 
     async def _exhaust_query(
         self,
@@ -504,6 +545,12 @@ class BundesagenturScraper(BaseScraper):
             commitment=commitment,
             apply_url=apply_url,
             requisition_id=item.get("hashId") or None,
+            description=(
+                item.get("stellenangebotsBeschreibung").strip()[:10_000]
+                if isinstance(item.get("stellenangebotsBeschreibung"), str)
+                and item.get("stellenangebotsBeschreibung").strip()
+                else None
+            ),
             posted_at=_parse_iso(item.get("eintrittsdatum") or item.get("aktuelleVeroeffentlichungsdatum")),
             fetched_at=datetime.now(),
             raw=raw or None,

--- a/src/jobhive/scrapers/eures.py
+++ b/src/jobhive/scrapers/eures.py
@@ -31,7 +31,9 @@ the publisher's cross-ATS dedup still works.
 from __future__ import annotations
 
 import asyncio
+import html
 import logging
+import re
 from datetime import datetime
 from typing import TYPE_CHECKING
 
@@ -498,6 +500,7 @@ class EuresScraper(BaseScraper):
             location=location,
             employment_type=employment_type,
             commitment=commitment,
+            description=_extract_description(item),
             posted_at=posted_at,
             fetched_at=datetime.now(),
             raw=raw or None,
@@ -549,6 +552,28 @@ def _flatten_location(loc_map: dict[str, Any]) -> str | None:
     if regions:
         return f"{country} ({', '.join(regions[:3])})"
     return country
+
+
+def _extract_description(item: dict[str, Any]) -> str | None:
+    value = item.get("description")
+    if not isinstance(value, str) or not value.strip():
+        translations = item.get("translations") or {}
+        if isinstance(translations, dict):
+            for translation in translations.values():
+                if isinstance(translation, dict):
+                    candidate = translation.get("description")
+                    if isinstance(candidate, str) and candidate.strip():
+                        value = candidate
+                        break
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = html.unescape(value)
+    text = re.sub(r"<br\s*/?>", "\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = html.unescape(text)
+    text = re.sub(r"[ \t\r\f\v]+", " ", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()[:10_000] or None
 
 
 async def _gather_tolerant(

--- a/src/jobhive/scrapers/jobsch.py
+++ b/src/jobhive/scrapers/jobsch.py
@@ -40,8 +40,10 @@ Single-source scraper: ``company_slug`` is informational and ignored.
 from __future__ import annotations
 
 import asyncio
+import html
 import logging
 import os
+import re
 from datetime import datetime
 from typing import TYPE_CHECKING
 
@@ -61,12 +63,23 @@ PER_PAGE = 20  # API hard-caps ``rows`` at 20 (>20 → 422).
 MAX_CONCURRENCY = 4
 MAX_RETRIES = 4
 RETRY_BASE_DELAY = 1.5
+DETAIL_CONCURRENCY = 4
 # The API hard-caps deep pagination at start=2000 (==page 100). Any
 # per-query fetch therefore tops out at 2 000 rows.
 MAX_USABLE_OFFSET = 2000
 # Default cap on pages per query — 100 × 20 rows = the API's per-query
 # ceiling. Lower via ``max_pages`` for quick smoke runs.
 DEFAULT_MAX_PAGES = 100
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_META_DESCRIPTION_RE = re.compile(
+    r'<meta[^>]+(?:name|property)=["\'](?:description|og:description)["\'][^>]+content=["\'](?P<content>.*?)["\']',
+    re.IGNORECASE | re.DOTALL,
+)
+_DESCRIPTION_BLOCK_RE = re.compile(
+    r'<(?:div|section|article)[^>]+class=["\'][^"\']*(?:job-description|vacancy-description|description|jobad)[^"\']*["\'][^>]*>(?P<body>.*?)</(?:div|section|article)>',
+    re.IGNORECASE | re.DOTALL,
+)
 
 # Keyword seeds covering DE / FR / IT / EN to defeat the per-query
 # 2 000-row pagination cap. Probed live 2026-05-09: each seed below
@@ -238,6 +251,11 @@ class JobsChScraper(BaseScraper):
             await absorb(first.get("documents") or [])
 
             if total <= PER_PAGE:
+                if jobs:
+                    detail_sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
+                    await asyncio.gather(*(
+                        self._enrich_description(client, detail_sem, job) for job in jobs
+                    ))
                 return jobs
 
             usable = min(total, MAX_USABLE_OFFSET)
@@ -258,7 +276,32 @@ class JobsChScraper(BaseScraper):
                 await absorb(payload.get("documents") or [])
 
             await asyncio.gather(*(one(o) for o in offsets))
+            if jobs:
+                detail_sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
+                await asyncio.gather(*(
+                    self._enrich_description(client, detail_sem, job) for job in jobs
+                ))
         return jobs
+
+    async def _enrich_description(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        job: Job,
+    ) -> None:
+        async with sem:
+            try:
+                response = await client.get(
+                    str(job.url),
+                    headers={"User-Agent": "Mozilla/5.0", "Accept": "text/html,*/*"},
+                )
+            except httpx.HTTPError:
+                return
+        if response.status_code != 200:
+            return
+        description = _extract_description(response.text)
+        if description and not job.description:
+            job.description = description[:10_000]
 
     async def _fetch_page(
         self,
@@ -406,6 +449,24 @@ def _parse_iso(value: object) -> datetime | None:
         return datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
         return None
+
+
+def _extract_description(text: str) -> str | None:
+    for pattern in (_DESCRIPTION_BLOCK_RE, _META_DESCRIPTION_RE):
+        match = pattern.search(text)
+        if not match:
+            continue
+        raw = match.groupdict().get("body") or match.groupdict().get("content") or ""
+        cleaned = _strip_html(raw)
+        if cleaned:
+            return cleaned
+    return None
+
+
+def _strip_html(value: str) -> str:
+    text = html.unescape(value)
+    text = _TAG_RE.sub(" ", text)
+    return re.sub(r"\s+", " ", text).strip()
 
 
 def _evomi_proxy_url_from_env() -> str | None:

--- a/src/jobhive/scrapers/jobsch.py
+++ b/src/jobhive/scrapers/jobsch.py
@@ -215,6 +215,8 @@ class JobsChScraper(BaseScraper):
                 seed, len(slice_jobs), new_count, len(all_jobs),
             )
 
+        if all_jobs:
+            await self._enrich_descriptions(all_jobs, proxy_url=proxy_url)
         return all_jobs
 
     async def _run_fetch(
@@ -253,11 +255,6 @@ class JobsChScraper(BaseScraper):
             await absorb(first.get("documents") or [])
 
             if total <= PER_PAGE:
-                if jobs:
-                    detail_sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
-                    await asyncio.gather(*(
-                        self._enrich_description(client, detail_sem, job) for job in jobs
-                    ))
                 return jobs
 
             usable = min(total, MAX_USABLE_OFFSET)
@@ -278,12 +275,23 @@ class JobsChScraper(BaseScraper):
                 await absorb(payload.get("documents") or [])
 
             await asyncio.gather(*(one(o) for o in offsets))
-            if jobs:
-                detail_sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
-                await asyncio.gather(*(
-                    self._enrich_description(client, detail_sem, job) for job in jobs
-                ))
         return jobs
+
+    async def _enrich_descriptions(
+        self, jobs: list[Job], *, proxy_url: str | None
+    ) -> None:
+        client_kwargs: dict[str, Any] = {
+            "timeout": self.timeout,
+            "follow_redirects": True,
+        }
+        if proxy_url is not None:
+            client_kwargs["proxy"] = proxy_url
+
+        async with httpx.AsyncClient(**client_kwargs) as client:
+            detail_sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
+            await asyncio.gather(*(
+                self._enrich_description(client, detail_sem, job) for job in jobs
+            ))
 
     async def _enrich_description(
         self,

--- a/src/jobhive/scrapers/jobsch.py
+++ b/src/jobhive/scrapers/jobsch.py
@@ -72,9 +72,11 @@ MAX_USABLE_OFFSET = 2000
 DEFAULT_MAX_PAGES = 100
 
 _TAG_RE = re.compile(r"<[^>]+>")
-_META_DESCRIPTION_RE = re.compile(
-    r'<meta[^>]+(?:name|property)=["\'](?:description|og:description)["\'][^>]+content=["\'](?P<content>.*?)["\']',
-    re.IGNORECASE | re.DOTALL,
+_META_TAG_RE = re.compile(r"<meta\b(?P<attrs>[^>]*)>", re.IGNORECASE | re.DOTALL)
+_ATTR_RE = re.compile(
+    r"(?P<name>[a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*=\s*"
+    r"(?P<quote>[\"'])(?P<value>.*?)(?P=quote)",
+    re.DOTALL,
 )
 _DESCRIPTION_BLOCK_RE = re.compile(
     r'<(?:div|section|article)[^>]+class=["\'][^"\']*(?:job-description|vacancy-description|description|jobad)[^"\']*["\'][^>]*>(?P<body>.*?)</(?:div|section|article)>',
@@ -452,12 +454,25 @@ def _parse_iso(value: object) -> datetime | None:
 
 
 def _extract_description(text: str) -> str | None:
-    for pattern in (_DESCRIPTION_BLOCK_RE, _META_DESCRIPTION_RE):
-        match = pattern.search(text)
-        if not match:
+    match = _DESCRIPTION_BLOCK_RE.search(text)
+    if match:
+        cleaned = _strip_html(match.group("body"))
+        if cleaned:
+            return cleaned
+    meta = _extract_meta_description(text)
+    return meta or None
+
+
+def _extract_meta_description(text: str) -> str | None:
+    for tag in _META_TAG_RE.finditer(text):
+        attrs = {
+            m.group("name").lower(): html.unescape(m.group("value"))
+            for m in _ATTR_RE.finditer(tag.group("attrs"))
+        }
+        kind = (attrs.get("name") or attrs.get("property") or "").lower()
+        if kind not in {"description", "og:description"}:
             continue
-        raw = match.groupdict().get("body") or match.groupdict().get("content") or ""
-        cleaned = _strip_html(raw)
+        cleaned = _strip_html(attrs.get("content") or "")
         if cleaned:
             return cleaned
     return None

--- a/src/jobhive/scrapers/manfred.py
+++ b/src/jobhive/scrapers/manfred.py
@@ -19,6 +19,8 @@ and ignored.
 from __future__ import annotations
 
 import asyncio
+import html
+import re
 from datetime import datetime
 from typing import TYPE_CHECKING
 
@@ -32,10 +34,12 @@ if TYPE_CHECKING:
     from typing import Any
 
 API_URL = "https://www.getmanfred.com/api/v2/public/offers"
+DETAIL_URL_TEMPLATE = "https://www.getmanfred.com/api/v2/public/offers/{offer_id}"
 JOB_URL_TEMPLATE = "https://www.getmanfred.com/job-offers/{slug}"
 DEFAULT_LANG = "EN"
 MAX_RETRIES = 3
 RETRY_BASE_DELAY = 1.5
+DETAIL_CONCURRENCY = 6
 
 # Manfred's currency field is the human symbol ('€', '$', '£'); map
 # to ISO 4217 codes our Job model expects.
@@ -87,15 +91,47 @@ class ManfredScraper(BaseScraper):
             timeout=self.timeout, follow_redirects=True,
         ) as client:
             offers = await self._fetch_with_retry(client)
-        seen: set[str] = set()
-        jobs: list[Job] = []
-        for item in offers:
-            job = self._parse(item)
-            if job is None or job.ats_id in seen:
-                continue
-            seen.add(job.ats_id)
-            jobs.append(job)
+            seen: set[str] = set()
+            jobs: list[Job] = []
+            for item in offers:
+                job = self._parse(item)
+                if job is None or job.ats_id in seen:
+                    continue
+                seen.add(job.ats_id)
+                jobs.append(job)
+            if jobs:
+                sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
+                await asyncio.gather(*(self._enrich_description(client, sem, j) for j in jobs))
         return jobs
+
+    async def _enrich_description(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        job: Job,
+    ) -> None:
+        offer_id = (job.raw or {}).get("id")
+        if offer_id is None:
+            return
+        url = DETAIL_URL_TEMPLATE.format(offer_id=offer_id)
+        async with sem:
+            try:
+                response = await client.get(
+                    url,
+                    params={"lang": self.lang},
+                    headers={"User-Agent": "Mozilla/5.0", "Accept": "application/json"},
+                )
+            except httpx.HTTPError:
+                return
+        if response.status_code != 200:
+            return
+        try:
+            detail = response.json()
+        except ValueError:
+            return
+        description = _compose_description(detail)
+        if description and not job.description:
+            job.description = description[:10_000]
 
     async def _fetch_with_retry(
         self, client: httpx.AsyncClient
@@ -177,6 +213,8 @@ class ManfredScraper(BaseScraper):
         posted_at = _parse_iso(item.get("updatedAt"))
 
         raw: dict[str, Any] = {}
+        if item.get("id") is not None:
+            raw["id"] = item["id"]
         if isinstance(remote_pct, (int, float)):
             raw["remote_percentage"] = remote_pct
         if isinstance(item.get("offerLanguages"), list) and item["offerLanguages"]:
@@ -235,3 +273,42 @@ def _parse_iso(value: object) -> datetime | None:
         return datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
         return None
+
+
+def _compose_description(item: dict[str, Any]) -> str | None:
+    parts: list[str] = []
+    for key in (
+        "introduction",
+        "whatWillYouDo",
+        "responsibilities",
+        "howWillYouDoIt",
+        "whatOffering",
+        "whereWillDoIt",
+        "whenWillDoIt",
+        "whoWillDoItWith",
+    ):
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            parts.append(_markdown_to_text(value))
+        elif isinstance(value, list):
+            cleaned = [
+                _markdown_to_text(v)
+                for v in value
+                if isinstance(v, str) and v.strip()
+            ]
+            if cleaned:
+                parts.append("\n".join(f"- {v}" for v in cleaned))
+    text = "\n\n".join(p for p in parts if p).strip()
+    return text or None
+
+
+def _markdown_to_text(value: str) -> str:
+    text = html.unescape(value)
+    text = re.sub(r"!\[[^\]]*\]\([^)]+\)", " ", text)
+    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = re.sub(r"[*_`#>]+", "", text)
+    text = re.sub(r"\r\n?", "\n", text)
+    text = re.sub(r"[ \t\f\v]+", " ", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()

--- a/src/jobhive/scrapers/meta.py
+++ b/src/jobhive/scrapers/meta.py
@@ -11,8 +11,8 @@ bypasses Meta's bot-detection without a paid browser-as-a-service.
 When the package isn't installed the scraper logs a warning and
 returns ``[]`` so the rest of the publish pipeline keeps moving.
 
-Listings only — per-job descriptions would need a second pass (one
-navigation per job) and aren't worth the wall-clock for v1.
+GraphQL listing payloads sometimes include description-like fields; when
+present, the scraper carries them into ``Job.description``.
 """
 
 from __future__ import annotations
@@ -111,6 +111,7 @@ class MetaScraper(BaseScraper):
                         location=self._format_locations(entry.get("locations")),
                         team=self._first(entry.get("teams")),
                         department=self._first(entry.get("sub_teams")),
+                        description=self._description(entry),
                         fetched_at=fetched_at,
                         raw=entry,
                     )
@@ -157,6 +158,27 @@ class MetaScraper(BaseScraper):
         if isinstance(value, str):
             return value
         return None
+
+    @staticmethod
+    def _description(entry: dict[str, Any]) -> str | None:
+        parts: list[str] = []
+        for key in (
+            "description",
+            "description_plain",
+            "descriptionPlain",
+            "responsibilities",
+            "minimum_qualifications",
+            "preferred_qualifications",
+        ):
+            value = entry.get(key)
+            if isinstance(value, str) and value.strip():
+                parts.append(value.strip())
+            elif isinstance(value, list):
+                items = [v.strip() for v in value if isinstance(v, str) and v.strip()]
+                if items:
+                    parts.append("\n".join(items))
+        text = "\n\n".join(parts).strip()
+        return text[:10_000] or None
 
 
 __all__ = ["MetaScraper"]

--- a/src/jobhive/scrapers/meta.py
+++ b/src/jobhive/scrapers/meta.py
@@ -18,9 +18,14 @@ present, the scraper carries them into ``Job.description``.
 from __future__ import annotations
 
 import asyncio
+import html
+import json
 import logging
+import re
 from datetime import UTC, datetime
 from typing import Any
+
+import httpx
 
 from jobhive.models import ATSType, Job
 from jobhive.scrapers import _cloakbrowser as cb
@@ -35,6 +40,11 @@ _LISTING_URL = "https://www.metacareers.com/jobs"
 # you scroll; we don't bother scrolling, so this just buys time for
 # the first wave to settle.
 _GRAPHQL_SETTLE_MS = 8_000
+_DETAIL_CONCURRENCY = 4
+_JSON_LD_RE = re.compile(
+    r'<script[^>]+type=["\']application/ld\+json["\'][^>]*>(?P<body>.*?)</script>',
+    re.IGNORECASE | re.DOTALL,
+)
 
 
 @ScraperRegistry.register(ATSType.META)
@@ -84,7 +94,10 @@ class MetaScraper(BaseScraper):
         finally:
             await browser.close()
 
-        return list(self._parse_responses(captured))
+        jobs = list(self._parse_responses(captured))
+        if jobs:
+            await self._enrich_detail_descriptions(jobs)
+        return jobs
 
     def _parse_responses(
         self, responses: list[dict[str, Any]]
@@ -180,5 +193,78 @@ class MetaScraper(BaseScraper):
         text = "\n\n".join(parts).strip()
         return text[:10_000] or None
 
+    async def _enrich_detail_descriptions(self, jobs: list[Job]) -> None:
+        """Fetch Meta detail pages for descriptions missing from listing GraphQL.
+
+        The listing query currently exposes id/title/location/team only. The
+        public detail page embeds Schema.org ``JobPosting`` JSON-LD with the
+        full body, so this path avoids another browser session per job.
+        """
+        targets = [(i, job) for i, job in enumerate(jobs) if not job.description]
+        if not targets:
+            return
+
+        sem = asyncio.Semaphore(_DETAIL_CONCURRENCY)
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True,
+            headers={"User-Agent": "Mozilla/5.0"},
+        ) as client:
+            await asyncio.gather(*(
+                self._enrich_one_detail(client, sem, jobs, i, job)
+                for i, job in targets
+            ))
+
+    async def _enrich_one_detail(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        jobs: list[Job],
+        index: int,
+        job: Job,
+    ) -> None:
+        async with sem:
+            try:
+                response = await client.get(str(job.url))
+            except httpx.HTTPError:
+                return
+        if response.status_code != 200:
+            return
+        description = _description_from_detail_html(response.text)
+        if description:
+            jobs[index] = job.model_copy(update={"description": description[:10_000]})
+
 
 __all__ = ["MetaScraper"]
+
+
+def _description_from_detail_html(text: str) -> str | None:
+    for match in _JSON_LD_RE.finditer(text):
+        raw = html.unescape(match.group("body")).strip()
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        for item in _iter_json_ld_items(payload):
+            if not isinstance(item, dict) or item.get("@type") != "JobPosting":
+                continue
+            desc = item.get("description")
+            resp = item.get("responsibilities")
+            parts = [
+                value.strip()
+                for value in (desc, resp)
+                if isinstance(value, str) and value.strip()
+            ]
+            if parts:
+                return "\n\n".join(parts)
+    return None
+
+
+def _iter_json_ld_items(value: object):
+    if isinstance(value, list):
+        yield from value
+    elif isinstance(value, dict):
+        graph = value.get("@graph")
+        if isinstance(graph, list):
+            yield from graph
+        else:
+            yield value

--- a/src/jobhive/scrapers/oracle.py
+++ b/src/jobhive/scrapers/oracle.py
@@ -16,10 +16,8 @@ The unauthenticated REST endpoint:
 The companion detail endpoint
 ``/recruitingCEJobRequisitionDetails?finder=ById;Id={id}`` exposes the
 full job description (``ExternalDescriptionStr``) plus the qualifications
-and responsibilities sections. Detail enrichment is opt-in via
-``JOBHIVE_ORACLE_FETCH_DESCRIPTIONS=1`` because Oracle's tenant universe
-runs into hundreds of thousands of jobs — a per-job fan-out makes a
-default scrape impractically slow.
+and responsibilities sections. Detail enrichment is best-effort so
+published rows carry descriptions when Oracle exposes them.
 
 Pass the full base URL (and optionally a site number) as the slug.
 """
@@ -27,7 +25,6 @@ Pass the full base URL (and optionally a site number) as the slug.
 from __future__ import annotations
 
 import asyncio
-import os
 import re
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -143,13 +140,7 @@ class OracleScraper(BaseScraper):
                         seen.add(job.ats_id)
                         all_jobs.append(job)
 
-            # Optional per-job detail enrichment. Disabled by default
-            # because Oracle's tenant universe (a few hundred enterprise
-            # tenants × hundreds-to-thousands of reqs each) makes a fan-out
-            # scrape take hours. Toggle with
-            # ``JOBHIVE_ORACLE_FETCH_DESCRIPTIONS=1`` when description
-            # coverage is wanted.
-            if all_jobs and os.getenv("JOBHIVE_ORACLE_FETCH_DESCRIPTIONS"):
+            if all_jobs:
                 sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
                 detail_url = (
                     f"{base}/hcmRestApi/resources/latest/"

--- a/src/jobhive/scrapers/programathor.py
+++ b/src/jobhive/scrapers/programathor.py
@@ -55,8 +55,17 @@ DEFAULT_MAX_PAGES = 200
 MAX_CONCURRENCY = 4
 MAX_RETRIES = 4
 RETRY_BASE_DELAY = 2.0
+DETAIL_CONCURRENCY = 4
 
 _TAG_RE = re.compile(r"<[^>]+>")
+_META_DESCRIPTION_RE = re.compile(
+    r'<meta[^>]+(?:name|property)=["\'](?:description|og:description)["\'][^>]+content=["\'](?P<content>.*?)["\']',
+    re.IGNORECASE | re.DOTALL,
+)
+_DETAIL_DESCRIPTION_RE = re.compile(
+    r'<(?:div|section|article)[^>]+class=["\'][^"\']*(?:job-description|description|job-detail)[^"\']*["\'][^>]*>(?P<body>.*?)</(?:div|section|article)>',
+    re.IGNORECASE | re.DOTALL,
+)
 _JOB_LINK_RE = re.compile(r'href="(/jobs/(?P<id>\d+)-[a-z0-9-]+)"')
 # Each card is wrapped in `<div class="cell-list ">…</div>` containing
 # one anchor with the job link. We anchor the regex on the cell start
@@ -180,7 +189,26 @@ class ProgramathorScraper(BaseScraper):
                 else:
                     consecutive_empty = 0
                 page += 1
+            if jobs:
+                detail_sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
+                await asyncio.gather(*(
+                    self._enrich_description(client, detail_sem, job) for job in jobs
+                ))
         return jobs
+
+    async def _enrich_description(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        job: Job,
+    ) -> None:
+        try:
+            text = await self._request_html(client, sem, str(job.url))
+        except ScraperError:
+            return
+        description = _extract_description(text)
+        if description and not job.description:
+            job.description = description[:10_000]
 
     async def _fetch_page(
         self,
@@ -331,6 +359,18 @@ def _strip_html(text: str) -> str:
     cleaned = _TAG_RE.sub(" ", text)
     cleaned = html.unescape(cleaned)
     return re.sub(r"\s+", " ", cleaned).strip()
+
+
+def _extract_description(text: str) -> str | None:
+    for pattern in (_DETAIL_DESCRIPTION_RE, _META_DESCRIPTION_RE):
+        match = pattern.search(text)
+        if not match:
+            continue
+        raw = match.groupdict().get("body") or match.groupdict().get("content") or ""
+        cleaned = _strip_html(raw)
+        if cleaned:
+            return cleaned
+    return None
 
 
 def _normalize_location(raw: str) -> str | None:

--- a/src/jobhive/scrapers/programathor.py
+++ b/src/jobhive/scrapers/programathor.py
@@ -58,9 +58,11 @@ RETRY_BASE_DELAY = 2.0
 DETAIL_CONCURRENCY = 4
 
 _TAG_RE = re.compile(r"<[^>]+>")
-_META_DESCRIPTION_RE = re.compile(
-    r'<meta[^>]+(?:name|property)=["\'](?:description|og:description)["\'][^>]+content=["\'](?P<content>.*?)["\']',
-    re.IGNORECASE | re.DOTALL,
+_META_TAG_RE = re.compile(r"<meta\b(?P<attrs>[^>]*)>", re.IGNORECASE | re.DOTALL)
+_ATTR_RE = re.compile(
+    r"(?P<name>[a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*=\s*"
+    r"(?P<quote>[\"'])(?P<value>.*?)(?P=quote)",
+    re.DOTALL,
 )
 _DETAIL_DESCRIPTION_RE = re.compile(
     r'<(?:div|section|article)[^>]+class=["\'][^"\']*(?:job-description|description|job-detail)[^"\']*["\'][^>]*>(?P<body>.*?)</(?:div|section|article)>',
@@ -362,12 +364,25 @@ def _strip_html(text: str) -> str:
 
 
 def _extract_description(text: str) -> str | None:
-    for pattern in (_DETAIL_DESCRIPTION_RE, _META_DESCRIPTION_RE):
-        match = pattern.search(text)
-        if not match:
+    match = _DETAIL_DESCRIPTION_RE.search(text)
+    if match:
+        cleaned = _strip_html(match.group("body"))
+        if cleaned:
+            return cleaned
+    meta = _extract_meta_description(text)
+    return meta or None
+
+
+def _extract_meta_description(text: str) -> str | None:
+    for tag in _META_TAG_RE.finditer(text):
+        attrs = {
+            m.group("name").lower(): html.unescape(m.group("value"))
+            for m in _ATTR_RE.finditer(tag.group("attrs"))
+        }
+        kind = (attrs.get("name") or attrs.get("property") or "").lower()
+        if kind not in {"description", "og:description"}:
             continue
-        raw = match.groupdict().get("body") or match.groupdict().get("content") or ""
-        cleaned = _strip_html(raw)
+        cleaned = _strip_html(attrs.get("content") or "")
         if cleaned:
             return cleaned
     return None

--- a/src/jobhive/scrapers/smartrecruiters.py
+++ b/src/jobhive/scrapers/smartrecruiters.py
@@ -4,7 +4,7 @@ Listing API (no auth, paginated):
     GET https://api.smartrecruiters.com/v1/companies/{slug}/postings
         ?limit=100&offset={n}
 
-Detail API (per-job, opt-in via env var):
+Detail API (per-job, best-effort):
     GET https://api.smartrecruiters.com/v1/companies/{slug}/postings/{id}
 
 The listing returns title/location/department/typeOfEmployment but
@@ -12,16 +12,14 @@ not the description body. The detail endpoint adds ``jobAd.sections``
 (companyDescription / jobDescription / qualifications /
 additionalInformation), ``applyUrl``, and ``postingUrl``.
 
-Detail enrichment is opt-in via ``JOBHIVE_SMARTRECRUITERS_FETCH_DESCRIPTIONS=1``
-because SmartRecruiters' tenant universe (~25k discovered slugs ×
-hundreds of postings) makes a default fan-out impractically slow.
+Detail enrichment is enabled by default so published rows carry descriptions
+when the public detail endpoint exposes them.
 """
 
 from __future__ import annotations
 
 import asyncio
 import html as html_mod
-import os
 import re
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -108,13 +106,7 @@ class SmartRecruitersScraper(BaseScraper):
                     break
                 offset += PAGE_LIMIT
 
-            # Optional per-job detail enrichment. Disabled by default
-            # because SmartRecruiters' tenant universe is huge — toggle
-            # with ``JOBHIVE_SMARTRECRUITERS_FETCH_DESCRIPTIONS=1`` when
-            # description coverage is wanted.
-            if all_jobs and os.getenv(
-                "JOBHIVE_SMARTRECRUITERS_FETCH_DESCRIPTIONS",
-            ):
+            if all_jobs:
                 sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
                 await asyncio.gather(*(
                     self._enrich_detail(client, sem, j) for j in all_jobs

--- a/src/jobhive/scrapers/wanted.py
+++ b/src/jobhive/scrapers/wanted.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
 
 API_ROOT = "https://www.wanted.co.kr"
 JOBS_PATH = "/api/v4/jobs"
+DETAIL_PATH_TEMPLATE = "/api/v4/jobs/{job_id}"
 PER_PAGE = 100  # API hard-caps limit at 100 (>100 → 422).
 MAX_CONCURRENCY = 4
 MAX_RETRIES = 4
@@ -116,7 +117,27 @@ class WantedScraper(BaseScraper):
                     )
 
             await asyncio.gather(*(per_country(cc) for cc in self.country_codes))
+            if jobs:
+                await asyncio.gather(*(self._enrich_description(client, sem, j) for j in jobs))
         return jobs
+
+    async def _enrich_description(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        job: Job,
+    ) -> None:
+        if not job.ats_id:
+            return
+        url = f"{API_ROOT}{DETAIL_PATH_TEMPLATE.format(job_id=job.ats_id)}"
+        try:
+            payload = await self._request_json(client, sem, url)
+        except ScraperError:
+            return
+        detail = ((payload.get("job") or {}).get("detail") or {})
+        description = _compose_description(detail)
+        if description and not job.description:
+            job.description = description[:10_000]
 
     # --- HTTP layer ---------------------------------------------------------
 
@@ -265,3 +286,20 @@ def _to_int(value: object) -> int | None:
     if isinstance(value, str) and value.isdigit():
         return int(value)
     return None
+
+
+def _compose_description(detail: dict[str, Any]) -> str | None:
+    parts: list[str] = []
+    for key in (
+        "intro",
+        "main_tasks",
+        "requirements",
+        "preferred_points",
+        "benefits",
+        "hire_round",
+    ):
+        value = detail.get(key)
+        if isinstance(value, str) and value.strip():
+            parts.append(value.strip())
+    text = "\n\n".join(parts).strip()
+    return text or None

--- a/src/jobhive/scrapers/wellfound.py
+++ b/src/jobhive/scrapers/wellfound.py
@@ -181,7 +181,24 @@ class WellfoundScraper(BaseScraper):
 
             tasks = [fetch_overall()] + [per_role(s) for s in self.role_slugs]
             await asyncio.gather(*tasks)
+            if jobs:
+                await asyncio.gather(*(
+                    self._enrich_description(client, sem, job) for job in jobs
+                ))
         return jobs
+
+    async def _enrich_description(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        job: Job,
+    ) -> None:
+        markdown = await self._firecrawl_scrape(client, sem, str(job.url))
+        if not markdown:
+            return
+        description = _description_from_markdown(markdown, title=job.title)
+        if description and not job.description:
+            job.description = description[:10_000]
 
     async def _fetch_role(
         self,
@@ -326,6 +343,50 @@ def _parse_markdown(md: str):
             posted_at=posted,
             fetched_at=datetime.now(),
         )
+
+
+def _description_from_markdown(md: str, *, title: str) -> str | None:
+    """Extract a useful body from a rendered Wellfound job page.
+
+    Role/list pages are company-grouped and include multiple card links; those
+    are intentionally ignored so we don't store listing chrome as a posting
+    description.
+    """
+    if _COMPANY_HEADER_RE.search(md):
+        return None
+    lines: list[str] = []
+    skip_until_body = bool(title)
+    for raw in md.splitlines():
+        line = raw.strip()
+        if not line:
+            if lines and lines[-1] != "":
+                lines.append("")
+            continue
+        if skip_until_body:
+            if title.lower() in line.lower():
+                skip_until_body = False
+            continue
+        if line in {"Apply", "Save", "SaveApply"}:
+            continue
+        if line.startswith("[") and "wellfound.com/jobs/" in line:
+            continue
+        if _parse_relative(line) is not None:
+            continue
+        if "$" in line and _parse_salary(line) is not None:
+            continue
+        cleaned = _markdown_to_text(line)
+        if cleaned:
+            lines.append(cleaned)
+    text = "\n".join(lines).strip()
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text or None
+
+
+def _markdown_to_text(value: str) -> str:
+    value = re.sub(r"!\[[^\]]*\]\([^)]+\)", " ", value)
+    value = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", value)
+    value = re.sub(r"[*_`#>]+", "", value)
+    return re.sub(r"[ \t\r\f\v]+", " ", value).strip()
 
 
 def _parse_job_window(window: str) -> tuple[

--- a/src/jobhive/scrapers/wellfound.py
+++ b/src/jobhive/scrapers/wellfound.py
@@ -193,7 +193,10 @@ class WellfoundScraper(BaseScraper):
         sem: asyncio.Semaphore,
         job: Job,
     ) -> None:
-        markdown = await self._firecrawl_scrape(client, sem, str(job.url))
+        try:
+            markdown = await self._firecrawl_scrape(client, sem, str(job.url))
+        except ScraperError:
+            return
         if not markdown:
             return
         description = _description_from_markdown(markdown, title=job.title)

--- a/src/jobhive/scrapers/workable.py
+++ b/src/jobhive/scrapers/workable.py
@@ -19,14 +19,12 @@ Workable rate-limits hard from a single IP — bulk pipeline runs at
 concurrency >2 see 429s on most tenants. The scraper retries 429/5xx
 with exponential backoff (honouring ``Retry-After`` when present); the
 caller should still keep concurrency low (2-4) for full re-scrapes.
-The per-job Markdown fetch is opt-in via
-``JOBHIVE_WORKABLE_FETCH_DESCRIPTIONS=1`` to avoid amplifying the
-rate-limit pressure during default discovery passes.
+The per-job Markdown fetch is best-effort so the listing row survives
+when a detail request is rate-limited or unavailable.
 """
 
 from __future__ import annotations
 
-import os
 import re
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -128,10 +126,7 @@ class WorkableScraper(BaseScraper):
         payload = response.json()
         jobs = [self._parse_job(item) for item in payload.get("jobs", [])]
 
-        # Optional per-job Markdown enrichment for description body.
-        # Default off — Workable rate-limits aggressively, so bulk runs
-        # opt in only when description coverage is wanted.
-        if jobs and os.getenv("JOBHIVE_WORKABLE_FETCH_DESCRIPTIONS"):
+        if jobs:
             self._enrich_descriptions(jobs)
         return jobs
 

--- a/src/jobhive/scrapers/workday.py
+++ b/src/jobhive/scrapers/workday.py
@@ -92,10 +92,9 @@ RETRY_BACKOFF = 1.5
 # When a Workday job spans multiple offices, the search endpoint returns a
 # rollup string in ``locationsText`` like "2 Locations" / "5 Locations"
 # instead of the actual list — the underlying ``locations`` array is not
-# included in the search payload. We detect those and fetch the per-job
-# detail endpoint (which DOES expose ``jobPostingInfo.location`` plus
-# ``additionalLocations``) to recover the real cities. About 9% of typical
-# Workday rows hit this code path on multi-tenant runs.
+# included in the search payload. ``_enrich_details`` detects these and
+# overwrites the placeholder with the real city list from
+# ``jobPostingInfo.location`` + ``additionalLocations``.
 _LOCATION_ROLLUP_RE = re.compile(r"^\s*\d+\s+Locations?\s*$", re.IGNORECASE)
 _TAG_RE = re.compile(r"<[^>]+>")
 

--- a/src/jobhive/scrapers/workday.py
+++ b/src/jobhive/scrapers/workday.py
@@ -27,6 +27,7 @@ The ``facets`` field in every response carries each value's true ``count``
 from __future__ import annotations
 
 import asyncio
+import html as html_mod
 import re
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -96,6 +97,7 @@ RETRY_BACKOFF = 1.5
 # ``additionalLocations``) to recover the real cities. About 9% of typical
 # Workday rows hit this code path on multi-tenant runs.
 _LOCATION_ROLLUP_RE = re.compile(r"^\s*\d+\s+Locations?\s*$", re.IGNORECASE)
+_TAG_RE = re.compile(r"<[^>]+>")
 
 # Facets we'll try as subdivision dimensions, in priority order. After
 # `jobFamilyGroup` (which usually covers level 1 well), `timeType`
@@ -158,29 +160,32 @@ class WorkdayScraper(BaseScraper):
                 applied_facets={}, absorb=absorb, depth=0,
             )
 
-            await self._resolve_location_rollups(
+            await self._enrich_details(
                 client, sem, detail_prefix, all_jobs,
             )
         return all_jobs
 
-    async def _resolve_location_rollups(
+    async def _enrich_details(
         self,
         client: httpx.AsyncClient,
         sem: asyncio.Semaphore,
         detail_prefix: str,
         jobs: list[Job],
     ) -> None:
-        """Replace 'N Locations' rollup strings with the actual city list.
+        """Best-effort per-job detail hydration.
 
-        The search endpoint returns ``locationsText="2 Locations"`` for any
-        posting that spans multiple offices but does not include the
-        underlying location array in the response. We can recover the real
-        cities from the per-job detail endpoint
-        (``jobPostingInfo.location`` + ``additionalLocations``).
+        The search endpoint intentionally omits full posting bodies, so rows
+        built only from ``jobPostings`` have ``description=None``. The detail
+        endpoint exposes ``jobPostingInfo.jobDescription`` for the same
+        ``externalPath``. It also exposes real locations for search rows whose
+        ``locationsText`` is only a rollup string like ``"2 Locations"``.
+
+        Detail failures stay non-fatal: a blocked/moved single posting should
+        not discard the listing row or the rest of the tenant.
         """
         targets = [
             (i, j) for i, j in enumerate(jobs)
-            if isinstance(j.location, str) and _LOCATION_ROLLUP_RE.match(j.location)
+            if (j.raw or {}).get("externalPath") or _external_path(j.url)
         ]
         if not targets:
             return
@@ -208,12 +213,21 @@ class WorkdayScraper(BaseScraper):
             except ValueError:
                 return
             jpi = payload.get("jobPostingInfo") or {}
-            primary = jpi.get("location")
-            additional = jpi.get("additionalLocations") or []
-            resolved = _format_locations(primary, additional)
-            if resolved:
-                # Job is frozen — rebuild via model_copy.
-                jobs[i] = job.model_copy(update={"location": resolved})
+            updates: dict[str, str] = {}
+
+            description = _extract_description(jpi)
+            if description and not job.description:
+                updates["description"] = description[:10_000]
+
+            if isinstance(job.location, str) and _LOCATION_ROLLUP_RE.match(job.location):
+                primary = jpi.get("location")
+                additional = jpi.get("additionalLocations") or []
+                resolved = _format_locations(primary, additional)
+                if resolved:
+                    updates["location"] = resolved
+
+            if updates:
+                jobs[i] = job.model_copy(update=updates)
 
         await asyncio.gather(*(resolve(i, j) for i, j in targets))
 
@@ -472,6 +486,24 @@ def _format_locations(primary: object, additional: object) -> str | None:
             if isinstance(v, str) and v.strip() and v.strip() not in locs:
                 locs.append(v.strip())
     return " | ".join(locs) if locs else None
+
+
+def _extract_description(job_posting_info: dict[str, Any]) -> str | None:
+    """Return Workday's full posting body as plain text.
+
+    The canonical detail field is ``jobDescription`` and is usually HTML.
+    A few tenants expose closely named fallback fields, so try those before
+    giving up.
+    """
+    for key in ("jobDescription", "externalJobDescription", "description"):
+        value = job_posting_info.get(key)
+        if isinstance(value, str) and value.strip():
+            text = html_mod.unescape(value)
+            text = _TAG_RE.sub(" ", text)
+            text = html_mod.unescape(text)
+            text = re.sub(r"\s+", " ", text).strip()
+            return text or None
+    return None
 
 
 def _pick_subdivision_facet(

--- a/src/jobhive/scrapers/ycombinator.py
+++ b/src/jobhive/scrapers/ycombinator.py
@@ -199,6 +199,8 @@ class YCombinatorScraper(BaseScraper):
             if v not in (None, "", []):
                 raw[key] = v
 
+        description = _compose_description(item)
+
         return Job(
             url=job_url,
             title=title,
@@ -217,6 +219,7 @@ class YCombinatorScraper(BaseScraper):
                 item.get("prettyRole") if isinstance(item.get("prettyRole"), str) else None
             ),
             apply_url=apply_url,
+            description=description,
             posted_at=posted_at,
             fetched_at=datetime.now(),
             raw=raw or None,
@@ -434,6 +437,40 @@ def _employment_from_type(raw: object) -> str | None:
     if not isinstance(raw, str):
         return None
     return _TYPE_TO_EMPLOYMENT.get(raw.lower())
+
+
+def _compose_description(item: dict[str, Any]) -> str | None:
+    """Build a plain-text body from YC's embedded posting fields."""
+    parts: list[str] = []
+    for key in (
+        "description",
+        "descriptionPlain",
+        "aboutRole",
+        "responsibilities",
+        "requirements",
+        "companyOneLiner",
+    ):
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            parts.append(_clean_description_text(value))
+        elif isinstance(value, list):
+            cleaned = [
+                _clean_description_text(v)
+                for v in value
+                if isinstance(v, str) and v.strip()
+            ]
+            if cleaned:
+                parts.append("\n".join(cleaned))
+    text = "\n\n".join(p for p in parts if p).strip()
+    return text[:10_000] or None
+
+
+def _clean_description_text(value: str) -> str:
+    text = html.unescape(value)
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+    text = re.sub(r"[*_`#>]+", "", text)
+    return re.sub(r"[ \t\r\f\v]+", " ", text).strip()
 
 
 _RELATIVE_RE = re.compile(

--- a/tests/test_breezy.py
+++ b/tests/test_breezy.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
 from jobhive.exceptions import CompanyNotFoundError, ScraperError
@@ -10,10 +12,16 @@ from jobhive.scrapers import BreezyScraper, ScraperRegistry
 
 
 @pytest.fixture(autouse=True)
-def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+def _fast_retries(monkeypatch: pytest.MonkeyPatch, httpx_mock) -> None:
     import jobhive.scrapers.breezy as br
     monkeypatch.setattr(br, "MAX_RETRIES", 1)
     monkeypatch.setattr(br, "RETRY_BASE_DELAY", 0.0)
+    httpx_mock.add_response(
+        url=re.compile(r"^https://acme\.breezy\.hr/p/"),
+        text="<html><body><div class='description'>Build useful products.</div></body></html>",
+        is_reusable=True,
+        is_optional=True,
+    )
 
 
 URL = "https://acme.breezy.hr/json"
@@ -72,6 +80,7 @@ def test_parses_basic_position(httpx_mock) -> None:
     assert job.department == "Engineering"
     assert job.salary_summary == "$100k - $150k"
     assert job.employment_type == "FULL_TIME"
+    assert job.description == "Build useful products."
     assert job.posted_at is not None and job.posted_at.year == 2026
 
 

--- a/tests/test_bundesagentur.py
+++ b/tests/test_bundesagentur.py
@@ -34,6 +34,7 @@ def _job(refnr: str, titel: str, ort: str | None = None) -> dict:
     return {
         "refnr": refnr,
         "titel": titel,
+        "stellenangebotsBeschreibung": "Build public services.",
         "arbeitsort": {"ort": ort or "Berlin", "land": "Deutschland"},
         "arbeitgeber": "ACME",
         "aktuelleVeroeffentlichungsdatum": "2026-05-01",
@@ -52,6 +53,7 @@ def test_simple_run_under_pagination_cap(httpx_mock) -> None:
     )
     jobs = BundesagenturScraper("any").fetch()
     assert {j.ats_id for j in jobs} == {"1"}
+    assert jobs[0].description == "Build public services."
 
 
 # --- Probe failure: must NOT silently look like maxErgebnisse=0 -------------

--- a/tests/test_eures_parse.py
+++ b/tests/test_eures_parse.py
@@ -24,6 +24,7 @@ def _base_item(**overrides):
     base = {
         "id": "abc123",
         "title": "Software Engineer",
+        "description": "<p>Build European services.</p>",
         "employerName": "Acme Corp",
         "locationMap": {},
         "creationDate": 1715000000000,
@@ -37,6 +38,7 @@ def test_real_employer_passes_through_verbatim() -> None:
     job = EuresScraper("eures")._parse(item)
     assert job is not None
     assert job.company == "Acme Corp"
+    assert job.description == "Build European services."
 
 
 def test_french_non_renseigne_kept_verbatim() -> None:

--- a/tests/test_jobsch.py
+++ b/tests/test_jobsch.py
@@ -21,10 +21,16 @@ _API_RE = re.compile(r"^https://www\.jobs\.ch/api/v1/public/search")
 
 
 @pytest.fixture(autouse=True)
-def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+def _fast_retries(monkeypatch: pytest.MonkeyPatch, httpx_mock) -> None:
     import jobhive.scrapers.jobsch as j
     monkeypatch.setattr(j, "MAX_RETRIES", 1)
     monkeypatch.setattr(j, "RETRY_BASE_DELAY", 0.0)
+    httpx_mock.add_response(
+        url=re.compile(r"^https://www\.jobs\.ch/(?:de/stellenangebote|en/vacancies)/detail/"),
+        text="<html><body><div class='vacancy-description'>Build Swiss products.</div></body></html>",
+        is_reusable=True,
+        is_optional=True,
+    )
 
 
 def _doc(
@@ -97,6 +103,7 @@ def test_parses_full_doc(httpx_mock) -> None:
     assert j.raw is not None
     assert j.raw["languages"] == ["de", "en"]
     assert j.raw["employment_grades"] == [100]
+    assert j.description == "Build Swiss products."
     # _links.detail_de is preferred over the constructed fallback URL.
     assert str(j.url) == "https://www.jobs.ch/de/stellenangebote/detail/abc-123/"
 

--- a/tests/test_jobsch.py
+++ b/tests/test_jobsch.py
@@ -108,6 +108,30 @@ def test_parses_full_doc(httpx_mock) -> None:
     assert str(j.url) == "https://www.jobs.ch/de/stellenangebote/detail/abc-123/"
 
 
+def test_extracts_meta_description_with_reversed_attributes(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page([
+            _doc(
+                job_id="meta-1",
+                title="Engineer",
+                detail_de="https://example.com/jobs/meta-1/",
+            )
+        ], total_hits=1),
+    )
+    httpx_mock.add_response(
+        url="https://example.com/jobs/meta-1/",
+        text=(
+            "<html><head><meta content='Build Swiss APIs.' "
+            "name='description'></head></html>"
+        ),
+    )
+
+    jobs = JobsChScraper("any", query_seeds=()).fetch()
+
+    assert jobs[0].description == "Build Swiss APIs."
+
+
 def test_falls_back_to_canonical_url_when_no_links(httpx_mock) -> None:
     """Some rows ship without ``_links``; build a canonical URL from the
     job_id rather than emit a half-broken row."""

--- a/tests/test_jobsch.py
+++ b/tests/test_jobsch.py
@@ -219,6 +219,25 @@ def test_no_fanout_when_total_under_per_page(httpx_mock) -> None:
     assert len(jobs) == 1
 
 
+def test_enriches_after_cross_seed_dedupe(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page([_doc(job_id="dupe", title="Engineer")], total_hits=1),
+    )
+    httpx_mock.add_response(
+        url=_API_RE,
+        json=_page([_doc(job_id="dupe", title="Engineer")], total_hits=1),
+    )
+
+    jobs = JobsChScraper("any", query_seeds=("engineer",)).fetch()
+
+    assert [j.ats_id for j in jobs] == ["dupe"]
+    detail_requests = httpx_mock.get_requests(
+        url=re.compile(r"^https://www\.jobs\.ch/en/vacancies/detail/dupe/")
+    )
+    assert len(detail_requests) == 1
+
+
 # --- defensive --------------------------------------------------------------
 
 

--- a/tests/test_manfred.py
+++ b/tests/test_manfred.py
@@ -38,8 +38,10 @@ def _offer(
     equity_inf: int = 0,
     equity_sup: int = 0,
     internal_code: str = "AC-001",
+    offer_id: int = 8355,
 ) -> dict[str, Any]:
     return {
+        "id": offer_id,
         "slug": slug,
         "position": position,
         "status": status,
@@ -66,6 +68,18 @@ def _api_url(lang: str = "EN") -> str:
     return f"https://www.getmanfred.com/api/v2/public/offers?lang={lang}"
 
 
+def _detail_url(offer_id: int = 8355, lang: str = "EN") -> str:
+    return f"https://www.getmanfred.com/api/v2/public/offers/{offer_id}?lang={lang}"
+
+
+def _detail() -> dict[str, Any]:
+    return {
+        "introduction": "Build **products**.",
+        "responsibilities": ["Own APIs", "Improve reliability"],
+        "whatOffering": "Remote setup.",
+    }
+
+
 # --- registry / wiring ------------------------------------------------------
 
 
@@ -78,6 +92,7 @@ def test_registry_resolves_manfred() -> None:
 
 def test_parses_full_offer(httpx_mock) -> None:
     httpx_mock.add_response(url=_api_url(), json=[_offer()])
+    httpx_mock.add_response(url=_detail_url(), json=_detail())
     j = ManfredScraper("any").fetch()[0]
     assert j.ats_type is ATSType.MANFRED
     assert j.ats_id == "acme-data-scientist"
@@ -89,6 +104,7 @@ def test_parses_full_offer(httpx_mock) -> None:
     assert j.salary_min == 50000
     assert j.salary_max == 75000
     assert j.requisition_id == "AC-001"
+    assert j.description == "Build products.\n\n- Own APIs\n- Improve reliability\n\nRemote setup."
     assert j.posted_at is not None
     assert str(j.url) == "https://www.getmanfred.com/job-offers/acme-data-scientist"
 
@@ -104,6 +120,7 @@ def test_drops_non_active_offers(httpx_mock) -> None:
         _offer(slug="closed", status="CLOSED"),
         _offer(slug="draft", status="DRAFT"),
     ])
+    httpx_mock.add_response(url=_detail_url(), json=_detail())
     jobs = ManfredScraper("any").fetch()
     assert [j.ats_id for j in jobs] == ["active"]
 
@@ -122,6 +139,7 @@ def test_remote_percentage_threshold(pct: int, expected: bool, httpx_mock) -> No
     """Manfred's ``remotePercentage`` is a 0..100 weekly-remote share.
     ``>= 50`` is the line for is_remote=True."""
     httpx_mock.add_response(url=_api_url(), json=[_offer(slug=f"p{pct}", remote_pct=pct)])
+    httpx_mock.add_response(url=_detail_url(), json=_detail())
     assert ManfredScraper("any").fetch()[0].is_remote is expected
 
 
@@ -135,6 +153,7 @@ def test_remote_percentage_threshold(pct: int, expected: bool, httpx_mock) -> No
 ])
 def test_currency_symbol_to_iso(symbol: str, expected: str, httpx_mock) -> None:
     httpx_mock.add_response(url=_api_url(), json=[_offer(slug=f"c-{symbol}", currency=symbol)])
+    httpx_mock.add_response(url=_detail_url(), json=_detail())
     assert ManfredScraper("any").fetch()[0].salary_currency == expected
 
 
@@ -144,6 +163,7 @@ def test_no_salary_currency_when_amounts_zero(httpx_mock) -> None:
     httpx_mock.add_response(url=_api_url(), json=[
         _offer(slug="no-sal", salary_from=0, salary_to=0)
     ])
+    httpx_mock.add_response(url=_detail_url(), json=_detail())
     j = ManfredScraper("any").fetch()[0]
     assert j.salary_currency is None
     assert j.salary_min is None
@@ -157,11 +177,13 @@ def test_multiple_locations_pipe_joined(httpx_mock) -> None:
     httpx_mock.add_response(url=_api_url(), json=[_offer(
         slug="multi", locations=["Madrid, Spain", "Barcelona, Spain"],
     )])
+    httpx_mock.add_response(url=_detail_url(), json=_detail())
     assert ManfredScraper("any").fetch()[0].location == "Madrid, Spain | Barcelona, Spain"
 
 
 def test_empty_locations_yields_none(httpx_mock) -> None:
     httpx_mock.add_response(url=_api_url(), json=[_offer(slug="x", locations=[])])
+    httpx_mock.add_response(url=_detail_url(), json=_detail())
     assert ManfredScraper("any").fetch()[0].location is None
 
 
@@ -172,6 +194,7 @@ def test_equity_and_bonus_stashed_in_raw(httpx_mock) -> None:
     httpx_mock.add_response(url=_api_url(), json=[_offer(
         slug="eq", equity_inf=1000, equity_sup=5000, bonus=3000,
     )])
+    httpx_mock.add_response(url=_detail_url(), json=_detail())
     j = ManfredScraper("any").fetch()[0]
     assert j.raw is not None
     assert j.raw["equity_min"] == 1000
@@ -190,6 +213,7 @@ def test_lang_validated_at_construction() -> None:
 def test_es_lang_passes_through(httpx_mock) -> None:
     """``lang='ES'`` should hit the Spanish endpoint."""
     httpx_mock.add_response(url=_api_url("ES"), json=[_offer()])
+    httpx_mock.add_response(url=_detail_url(lang="ES"), json=_detail())
     jobs = ManfredScraper("any", lang="ES").fetch()
     assert len(jobs) == 1
 
@@ -200,6 +224,7 @@ def test_skips_offer_missing_slug_or_position(httpx_mock) -> None:
         {"slug": "no-pos", "status": "ACTIVE", "company": {"name": "X"}},
         {"position": "no-slug", "status": "ACTIVE", "company": {"name": "X"}},
     ])
+    httpx_mock.add_response(url=_detail_url(), json=_detail())
     jobs = ManfredScraper("any").fetch()
     assert [j.ats_id for j in jobs] == ["ok"]
 

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -12,7 +12,7 @@ import logging
 
 import pytest
 
-from jobhive.scrapers.meta import MetaScraper
+from jobhive.scrapers.meta import MetaScraper, _description_from_detail_html
 
 
 def test_returns_empty_with_warning_when_cloakbrowser_missing(
@@ -108,3 +108,22 @@ def test_ignores_responses_without_data() -> None:
     assert MetaScraper("meta")._parse_responses(
         [{}, {"errors": [{"message": "rate limited"}]}]
     ) == []
+
+
+def test_extracts_description_from_detail_json_ld() -> None:
+    html = """
+    <html><head>
+      <script type="application/ld+json">
+      {
+        "\\u0040context": "http://schema.org/",
+        "\\u0040type": "JobPosting",
+        "description": "Build Meta systems.",
+        "responsibilities": "Operate global products."
+      }
+      </script>
+    </head></html>
+    """
+
+    assert _description_from_detail_html(html) == (
+        "Build Meta systems.\n\nOperate global products."
+    )

--- a/tests/test_programathor.py
+++ b/tests/test_programathor.py
@@ -165,6 +165,29 @@ def test_parses_full_listing_card(httpx_mock) -> None:
     assert str(j.url) == "https://programathor.com.br/jobs/33458-engenheiro-qa-python"
 
 
+def test_extracts_meta_description_with_reversed_attributes(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://programathor.com.br/jobs?page=1",
+        text=_listing([_card(job_id="7", title="Backend Engineer")]),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://programathor\.com\.br/jobs\?page=[2-9]$"),
+        text=_empty_listing(),
+        is_reusable=True,
+    )
+    httpx_mock.add_response(
+        url="https://programathor.com.br/jobs/7-backend-engineer",
+        text=(
+            "<html><head><meta content='Build Brazilian APIs.' "
+            "property='og:description'></head></html>"
+        ),
+    )
+
+    jobs = ProgramathorScraper("any").fetch()
+
+    assert jobs[0].description == "Build Brazilian APIs."
+
+
 def test_strips_new_label_from_title(httpx_mock) -> None:
     """Programathor injects a 'NOVA' tag inside the <h3>; strip it
     rather than ship 'Foo BarNOVA' as the title."""

--- a/tests/test_programathor.py
+++ b/tests/test_programathor.py
@@ -83,6 +83,10 @@ def _listing(cards: list[str]) -> str:
     return f"<html><body><div class='wrapper-jobs-list'>{''.join(cards)}</div></body></html>"
 
 
+def _detail(description: str = "<p>Build great systems.</p>") -> str:
+    return f"<html><body><div class='job-description'>{description}</div></body></html>"
+
+
 # --- proxy URL helper -------------------------------------------------------
 
 
@@ -134,6 +138,10 @@ def test_parses_full_listing_card(httpx_mock) -> None:
         text=_empty_listing(),
         is_reusable=True,
     )
+    httpx_mock.add_response(
+        url="https://programathor.com.br/jobs/33458-engenheiro-qa-python",
+        text=_detail("<p>Build <strong>Brazilian</strong> platforms.</p>"),
+    )
 
     jobs = ProgramathorScraper("any").fetch()
     assert len(jobs) == 1
@@ -150,6 +158,7 @@ def test_parses_full_listing_card(httpx_mock) -> None:
     assert j.salary_max == 5000.0
     assert j.employment_type == "CONTRACT"  # PJ → CONTRACT
     assert j.commitment == "PJ"
+    assert j.description == "Build Brazilian platforms."
     assert j.raw is not None
     assert j.raw["skills"] == ["Python", "API", "SQL"]
     assert j.raw["company_type"] == "Startup"
@@ -169,6 +178,10 @@ def test_strips_new_label_from_title(httpx_mock) -> None:
         text=_empty_listing(),
         is_reusable=True,
     )
+    httpx_mock.add_response(
+        url="https://programathor.com.br/jobs/1-backend-engineer",
+        text=_detail(),
+    )
     jobs = ProgramathorScraper("any").fetch()
     assert jobs[0].title == "Backend Engineer"
 
@@ -183,6 +196,10 @@ def test_location_with_city_appends_brazil(httpx_mock) -> None:
         url=re.compile(r"^https://programathor\.com\.br/jobs\?page=[2-9]$"),
         text=_empty_listing(),
         is_reusable=True,
+    )
+    httpx_mock.add_response(
+        url="https://programathor.com.br/jobs/1-x",
+        text=_detail(),
     )
     jobs = ProgramathorScraper("any").fetch()
     assert jobs[0].location == "São Paulo, Brazil"
@@ -225,6 +242,8 @@ def test_stops_after_three_consecutive_duplicate_pages(httpx_mock) -> None:
         httpx_mock.add_response(
             url=f"https://programathor.com.br/jobs?page={p}", text=page1,
         )
+    httpx_mock.add_response(url="https://programathor.com.br/jobs/100-a", text=_detail())
+    httpx_mock.add_response(url="https://programathor.com.br/jobs/101-b", text=_detail())
     # Page 5 should NEVER be requested — if it is, httpx_mock will
     # error on the un-stubbed call.
     jobs = ProgramathorScraper("any", max_pages=20).fetch()
@@ -240,6 +259,10 @@ def test_max_pages_caps_pagination(httpx_mock) -> None:
         httpx_mock.add_response(
             url=f"https://programathor.com.br/jobs?page={p}",
             text=_listing([_card(job_id=str(p * 100), title=f"Job {p}")]),
+        )
+        httpx_mock.add_response(
+            url=f"https://programathor.com.br/jobs/{p * 100}-job-{p}",
+            text=_detail(),
         )
     jobs = ProgramathorScraper("any", max_pages=5).fetch()
     assert len(jobs) == 5

--- a/tests/test_scrapers_extra.py
+++ b/tests/test_scrapers_extra.py
@@ -408,6 +408,7 @@ def test_workday_resolves_n_locations_rollup(httpx_mock) -> None:
     # Single-location job location stays untouched even though the detail
     # enrichment now also attempts to hydrate descriptions for every row.
     assert by_title["Manager"] == "San Francisco, CA"
+    assert by_desc["Manager"] is None
 
 
 def test_workday_enriches_description_from_detail_endpoint(httpx_mock) -> None:

--- a/tests/test_scrapers_extra.py
+++ b/tests/test_scrapers_extra.py
@@ -393,6 +393,7 @@ def test_workday_resolves_n_locations_rollup(httpx_mock) -> None:
         url=detail_url,
         json={
             "jobPostingInfo": {
+                "jobDescription": "<p>Build internal platforms.</p>",
                 "location": "USA - NY - New York",
                 "additionalLocations": ["USA - CA - San Francisco"],
             }
@@ -402,14 +403,47 @@ def test_workday_resolves_n_locations_rollup(httpx_mock) -> None:
     jobs = WorkdayScraper("https://acme.wd1.myworkdayjobs.com/External").fetch()
     by_title = {j.title: j.location for j in jobs}
     assert by_title["Engineer"] == "USA - NY - New York | USA - CA - San Francisco"
-    # Single-location job untouched — no detail fetch should have been issued
-    # for it (httpx_mock would error on un-stubbed requests).
+    by_desc = {j.title: j.description for j in jobs}
+    assert by_desc["Engineer"] == "Build internal platforms."
+    # Single-location job location stays untouched even though the detail
+    # enrichment now also attempts to hydrate descriptions for every row.
     assert by_title["Manager"] == "San Francisco, CA"
 
 
+def test_workday_enriches_description_from_detail_endpoint(httpx_mock) -> None:
+    api = "https://acme.wd1.myworkdayjobs.com/wday/cxs/acme/External/jobs"
+    httpx_mock.add_response(
+        url=api,
+        json={
+            "jobPostings": [
+                {
+                    "title": "Engineer",
+                    "externalPath": "/job/USA/Engineer_R-1",
+                    "locationsText": "New York, NY",
+                    "bulletFields": ["R-1"],
+                },
+            ],
+            "total": 1,
+        },
+    )
+    httpx_mock.add_response(
+        url="https://acme.wd1.myworkdayjobs.com/wday/cxs/acme/External/job/USA/Engineer_R-1",
+        json={
+            "jobPostingInfo": {
+                "jobDescription": "<div><p>Build <strong>search</strong>.</p></div>",
+            }
+        },
+    )
+
+    jobs = WorkdayScraper("https://acme.wd1.myworkdayjobs.com/External").fetch()
+
+    assert len(jobs) == 1
+    assert jobs[0].description == "Build search ."
+
+
 def test_workday_rollup_resolution_failure_is_silent(httpx_mock) -> None:
-    """If the detail fetch 404s or returns malformed JSON, the original
-    rollup string is kept rather than crashing the whole scrape."""
+    """If the detail fetch 404s or returns malformed JSON, listing fields
+    are kept rather than crashing the whole scrape."""
     api = "https://acme.wd1.myworkdayjobs.com/wday/cxs/acme/External/jobs"
     httpx_mock.add_response(
         url=api,
@@ -432,6 +466,7 @@ def test_workday_rollup_resolution_failure_is_silent(httpx_mock) -> None:
     jobs = WorkdayScraper("https://acme.wd1.myworkdayjobs.com/External").fetch()
     assert len(jobs) == 1
     assert jobs[0].location == "3 Locations"  # original rollup kept
+    assert jobs[0].description is None
 
 
 # --- Avature: covered in test_avature.py ------------------------------------

--- a/tests/test_wanted.py
+++ b/tests/test_wanted.py
@@ -16,14 +16,28 @@ from jobhive.exceptions import ScraperError
 from jobhive.models import ATSType
 from jobhive.scrapers import ScraperRegistry, WantedScraper
 
-_API_RE = re.compile(r"^https://www\.wanted\.co\.kr/api/v4/jobs")
+_API_RE = re.compile(r"^https://www\.wanted\.co\.kr/api/v4/jobs(?:\?.*)?$")
 
 
 @pytest.fixture(autouse=True)
-def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+def _fast_retries(monkeypatch: pytest.MonkeyPatch, httpx_mock) -> None:
     import jobhive.scrapers.wanted as w
     monkeypatch.setattr(w, "MAX_RETRIES", 1)
     monkeypatch.setattr(w, "RETRY_BASE_DELAY", 0.0)
+    httpx_mock.add_response(
+        url=re.compile(r"^https://www\.wanted\.co\.kr/api/v4/jobs/\d+$"),
+        json={
+            "job": {
+                "detail": {
+                    "intro": "Build hiring products.",
+                    "main_tasks": "Own the platform.",
+                    "requirements": "Python experience.",
+                }
+            }
+        },
+        is_reusable=True,
+        is_optional=True,
+    )
 
 
 def _job(
@@ -111,6 +125,7 @@ def test_parses_full_v4_job_payload(httpx_mock) -> None:
     # listings ship Korean strings — keep them verbatim).
     assert j.location == "중구, 서울, 한국"
     assert j.experience == 4  # annual_from
+    assert j.description == "Build hiring products.\n\nOwn the platform.\n\nPython experience."
     assert j.raw is not None
     assert j.raw.get("annual_to") == 6
     assert j.raw.get("industry_name") == "Tech"

--- a/tests/test_wellfound.py
+++ b/tests/test_wellfound.py
@@ -178,6 +178,28 @@ def test_enriches_description_from_job_page_markdown(httpx_mock) -> None:
     )
 
 
+def test_detail_firecrawl_permanent_error_keeps_listing_job(httpx_mock) -> None:
+    listing = _markdown_with_jobs([{"id": "1001", "title": "Founding Engineer"}])
+
+    def serve(request: httpx.Request) -> httpx.Response:
+        url = json.loads(request.content)["url"]
+        if "/jobs/1001-" in url:
+            return httpx.Response(402, text='{"error":"payment_required"}')
+        return httpx.Response(200, json={"data": {"markdown": listing}})
+
+    httpx_mock.add_callback(serve, url=_FIRECRAWL_RE, is_reusable=True)
+
+    jobs = WellfoundScraper(
+        "any",
+        firecrawl_api_key="test-key",
+        role_slugs=(),
+    ).fetch()
+
+    assert len(jobs) == 1
+    assert jobs[0].ats_id == "1001"
+    assert jobs[0].description is None
+
+
 # --- multi-role fan-out + dedup --------------------------------------------
 
 

--- a/tests/test_wellfound.py
+++ b/tests/test_wellfound.py
@@ -15,8 +15,10 @@ the tests focus on:
 
 from __future__ import annotations
 
+import json
 import re
 
+import httpx
 import pytest
 
 from jobhive.exceptions import ScraperError
@@ -145,6 +147,35 @@ def test_parses_jobs_from_firecrawl_markdown(httpx_mock) -> None:
     assert j.salary_max == 370000
     assert j.posted_at is not None
     assert str(j.url) == "https://wellfound.com/jobs/4173486-staff-software-engineer"
+
+
+def test_enriches_description_from_job_page_markdown(httpx_mock) -> None:
+    listing = _markdown_with_jobs([{"id": "1001", "title": "Founding Engineer"}])
+    detail = "\n".join([
+        "# Founding Engineer",
+        "",
+        "Build the core product for startup customers.",
+        "",
+        "You will own backend systems.",
+    ])
+
+    def serve(request: httpx.Request) -> httpx.Response:
+        url = json.loads(request.content)["url"]
+        markdown = detail if "/jobs/1001-" in url else listing
+        return httpx.Response(200, json={"data": {"markdown": markdown}})
+
+    httpx_mock.add_callback(serve, url=_FIRECRAWL_RE, is_reusable=True)
+
+    jobs = WellfoundScraper(
+        "any",
+        firecrawl_api_key="test-key",
+        role_slugs=(),
+    ).fetch()
+
+    assert jobs[0].description == (
+        "Build the core product for startup customers.\n\n"
+        "You will own backend systems."
+    )
 
 
 # --- multi-role fan-out + dedup --------------------------------------------

--- a/tests/test_ycombinator.py
+++ b/tests/test_ycombinator.py
@@ -81,6 +81,7 @@ def _job(
     min_experience: str = "3+ years",
     created_at: str = "16 days",
     apply_url: str = "https://account.ycombinator.com/authenticate?continue=https%3A%2F%2Fwww.workatastartup.com%2Fapplication%3Fsignup_job_id%3D93354",
+    description: str = "Build the core product.",
 ) -> dict[str, Any]:
     return {
         "id": job_id,
@@ -98,6 +99,7 @@ def _job(
         "salaryRange": salary,
         "minExperience": min_experience,
         "createdAt": created_at,
+        "description": description,
         "skills": [],
     }
 
@@ -199,6 +201,7 @@ def test_walks_companies_then_extracts_postings(httpx_mock) -> None:
     assert j.employment_type == "FULL_TIME"
     assert j.commitment == "Full-time"
     assert j.department == "Engineering"
+    assert j.description == "Build the core product.\n\nBuild things."
     assert j.posted_at is not None  # parsed from "16 days"
     assert str(j.url).endswith("/companies/acme/jobs/AbC123-founding-engineer")
     assert "signup_job_id" in str(j.apply_url)


### PR DESCRIPTION
## Summary
- Add best-effort description extraction/enrichment for existing providers that were missing job descriptions, including EURES, Workday, Bundesagentur, SmartRecruiters, Breezy, jobs.ch, Wanted, Workable, Programathor, Y Combinator, Wellfound, Meta, and Manfred.
- Remove description enrichment env gates so existing providers fetch details by default where needed.
- Keep this PR scoped to scraper description availability only; no new providers are added here.

## Validation
- `uv run pytest -q` -> 881 passed
- `uv run ruff check src/jobhive/scrapers src/jobhive/models.py tests/test_models.py tests/test_ycombinator.py tests/test_manfred.py tests/test_programathor.py tests/test_wellfound.py tests/test_breezy.py tests/test_jobsch.py tests/test_wanted.py tests/test_bundesagentur.py tests/test_eures_parse.py` -> All checks passed

## Notes
- This PR is based directly on `main`; it does not include the prior cron-guards branch.
- I attempted `reverse-api-engineer agent --json` for HTML/API scripting, but the tool returned no generated files because usage quota was exhausted until May 15, 11am UTC.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds best-effort description extraction to 13 providers (EURES, Workday, Bundesagentur, SmartRecruiters, Breezy, jobs.ch, Wanted, Workable, Programathor, Y Combinator, Wellfound, Meta, and Manfred) and removes opt-in env-var gates for providers that already had enrichment code.

- **Inline extraction** (no extra HTTP): EURES, Meta, and Y Combinator pull description fields already present in listing payloads; no fetch overhead.
- **Per-job detail fetches** (new HTTP fan-out): Bundesagentur, Manfred, Wanted, Wellfound, jobs.ch, and Programathor each add a detail-page or API call per job; Breezy, SmartRecruiters, Oracle, Workable, and Workday move from opt-in to always-on.
- **Workday scope change** (flagged in previous review): `_enrich_details` now targets every job that has an `externalPath` or a `/job/` URL segment \u2014 effectively 100% of postings \u2014 instead of the original ~9% with rollup location strings. This remains unaddressed and significantly increases per-tenant request volume.

<h3>Confidence Score: 4/5</h3>

Merge with caution on high-volume Workday tenants — the detail fetch scope expansion is still present and will issue one HTTP request per posted job instead of one per rollup-location row.

All 13 providers implement proper per-job error isolation and the enrichment correctly guards against overwriting existing values. The open concern is workday.py: the targets list now matches virtually every Workday posting rather than the original ~9% rollup subset, so large tenants fire an order-of-magnitude more detail requests. This was flagged in the previous review and remains unaddressed.

src/jobhive/scrapers/workday.py for the targets filter change; src/jobhive/scrapers/oracle.py and src/jobhive/scrapers/smartrecruiters.py for the removed env-var gates that the original code described as protecting against impractically slow fan-outs.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/workday.py | Renamed `_resolve_location_rollups` to `_enrich_details`; targets filter now includes every job with `externalPath` or `/job/` in URL (virtually all Workday postings) rather than only the ~9% with rollup locations, causing a ~10x increase in detail fetch volume per tenant. |
| src/jobhive/scrapers/bundesagentur.py | Adds base64-encoded per-job detail enrichment via a new `DETAIL_URL_TEMPLATE`; enrichment is placed inside the `absorb` closure so descriptions are fetched before each page's jobs are dispatched, sharing the same semaphore as listing fetches. |
| src/jobhive/scrapers/manfred.py | Adds per-offer detail enrichment; client-lifetime correctly expanded to cover the enrichment calls, and `_compose_description` assembles a plain-text body from structured API fields using a light markdown-to-text strip. |
| src/jobhive/scrapers/wellfound.py | Adds `_enrich_description` via per-job Firecrawl page scrapes; `_description_from_markdown` correctly skips listing-chrome and company-header pages, but silently returns `None` for any job whose title does not appear verbatim in the rendered markdown. |
| src/jobhive/scrapers/smartrecruiters.py | Removes `JOBHIVE_SMARTRECRUITERS_FETCH_DESCRIPTIONS` env-var gate; enrichment was previously opt-in because the tenant universe (~25k slugs) makes fan-out expensive. |
| src/jobhive/scrapers/oracle.py | Removes `JOBHIVE_ORACLE_FETCH_DESCRIPTIONS` env-var gate; inline comment previously warned this makes large Oracle tenants take hours. |
| src/jobhive/scrapers/eures.py | Adds `_extract_description` that falls back through the `translations` map when the top-level `description` field is absent; correctly unescapes HTML and strips tags. |
| src/jobhive/scrapers/wanted.py | Adds `_enrich_description` hitting the per-job API detail endpoint; `_compose_description` concatenates plain-text API fields without HTML stripping. |
| src/jobhive/scrapers/ycombinator.py | Adds `_compose_description` assembling description from listing payload fields (no extra HTTP calls); includes `companyOneLiner` alongside job-specific fields, consistent with YC listing format. |
| src/jobhive/scrapers/meta.py | Adds `_description` static method extracting text from GraphQL listing payload fields; straightforward and safe. |
| tests/test_scrapers_extra.py | New `test_workday_enriches_description_from_detail_endpoint` covers the description path; the existing rollup test stubs only Engineer's detail URL, leaving Manager's silently failing and un-asserted on `description`. |
| tests/test_bundesagentur.py | Adds `stellenangebotsBeschreibung` inline to the listing fixture so description is parsed directly; the `_enrich_description` detail-fetch code path has no dedicated test coverage. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `src/jobhive/scrapers/workday.py`, line 186-189 ([link](https://github.com/kalil0321/ats-scrapers/blob/f4c6c983d719bec60e991a1a113602574831f0ea/src/jobhive/scrapers/workday.py#L186-L189)) 

   **Detail fetches now cover every job, not just rollup-location rows**

   Previously `_resolve_location_rollups` only fetched the per-job detail endpoint for the ~9% of rows whose `locationsText` matched the rollup pattern. The new `targets` filter passes every job that has `externalPath` in `raw` or a `/job/` segment in its URL — in practice that's virtually every posting on a Workday tenant. A tenant like Accenture with ~22 k jobs will now issue ~22 k detail requests (semaphore-gated at 10), roughly 10× the previous volume, dramatically increasing wall-clock time and the risk of 429/503 rate-limit responses from Workday's CDN.

2. `src/jobhive/scrapers/jobsch.py`, line 197-204 ([link](https://github.com/kalil0321/ats-scrapers/blob/f4c6c983d719bec60e991a1a113602574831f0ea/src/jobhive/scrapers/jobsch.py#L197-L204)) 

   **`_META_DESCRIPTION_RE` requires `name`/`property` to precede `content`**

   The regex encodes a fixed attribute order: `name=`/`property=` must appear before `content=`. HTML attributes have no guaranteed order, so `<meta content="..." name="description">` will silently produce no match. The same pattern is duplicated verbatim in `programathor.py`. For a best-effort scraper this is acceptable, but it will quietly miss any site that emits attributes in the reversed order.

3. `tests/test_scrapers_extra.py`, line 406-410 ([link](https://github.com/kalil0321/ats-scrapers/blob/f4c6c983d719bec60e991a1a113602574831f0ea/tests/test_scrapers_extra.py#L406-L410)) 

   **Manager job's detail URL is unstubbed; the silent failure is not verified**

   With `_enrich_details` now targeting all jobs with `externalPath`, the Manager row (`/job/USA-CA-SF/Manager_R-2`) will also attempt a detail fetch. `pytest-httpx` raises `httpx.TimeoutException`, which `except httpx.HTTPError` silently swallows. The test confirms Manager's location is unchanged but never asserts `description is None`, so a future regression that writes stale data on failure would go undetected.
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
tests/test_bundesagentur.py:53-54
**`_enrich_description` code path is untested**

The `_job` fixture now includes `stellenangebotsBeschreibung` inline, so `_parse` populates `job.description` directly and the `if not job.description` guard in `absorb` skips the detail fetch entirely. The new `_enrich_description` method — the code path that fires when the listing response omits the description field — has no test coverage. A regression in the base64 encoding, URL template, or JSON key extraction would pass silently.

### Issue 2 of 2
src/jobhive/scrapers/wellfound.py:358-368
**Title not found in page silently drops entire description**

When `skip_until_body = True` (always for a non-empty `job.title`) and the rendered Firecrawl markdown does not contain the title as a substring, the loop ends with an empty `lines` list and the function returns `None`. A job page with a title formatted differently from the listing value (e.g., appended seniority suffix, Unicode apostrophe) causes every line of content to be silently discarded rather than extracted. The caller already guards `if description and not job.description`, so the existing listing row survives, but description coverage will be zero for those tenants.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Fill job descriptions across providers"](https://github.com/kalil0321/ats-scrapers/commit/f4c6c983d719bec60e991a1a113602574831f0ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31974225)</sub>

<!-- /greptile_comment -->