### PR TITLE
[codex] Ignore local todo files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,8 @@ urls.md
 CONTINUOUS_DISCOVERY_GUIDE.md
 DISCOVERY_ENHANCEMENTS.md
 XANALYSIS.md
+/todo.md
+/todo.*.md
 
 # Per-ATS operator dirs (company CSVs + jobs.csv outputs)
 amazon/


### PR DESCRIPTION
## Summary
- Ignore root-level local todo note files via `/todo.md` and `/todo.*.md`.

## Validation
- Not run; .gitignore-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore root-level local todo notes to prevent accidental commits. Adds `/todo.md` and `/todo.*.md` patterns to `.gitignore`.

<sup>Written for commit f3278725bf261376a0a3a776cf2218f9a2ba922d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds two gitignore patterns to prevent accidental commits of root-level personal todo note files.

- Adds `/todo.md` to ignore a root-level `todo.md` file.
- Adds `/todo.*.md` to ignore root-level files matching `todo.*.md` (e.g., `todo.work.md`). Both patterns are correctly anchored with `/` so they only apply at the repository root, not in subdirectories.

<h3>Confidence Score: 5/5</h3>

A minimal, targeted gitignore update with no functional code changes — safe to merge.

The change adds two well-formed, root-anchored gitignore patterns. There is nothing to break and no code paths affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .gitignore | Adds `/todo.md` and `/todo.*.md` patterns to ignore root-level personal todo notes |

</details>

<sub>Reviews (1): Last reviewed commit: ["Ignore local todo files"](https://github.com/kalil0321/ats-scrapers/commit/f3278725bf261376a0a3a776cf2218f9a2ba922d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31976348)</sub>

<!-- /greptile_comment -->