### PR TITLE
[codex] add separate provider descriptions

### DIFF
--- a/provider-description-matrix.md
+++ b/provider-description-matrix.md
@@ -1,0 +1,56 @@
+# Provider Description Matrix
+
+This table covers the 47 providers configured in `scripts/run_pipeline.py`.
+`API/feed` means the data comes from a machine-readable endpoint such as JSON,
+XML, RSS, GraphQL, or a markdown endpoint. `HTML` means the scraper parses a
+page/rendered page rather than a structured job payload.
+
+| Provider | Has description? | Is description 2 steps? | Job fetch: API / HTML? | Description: API / HTML? |
+|---|---:|---:|---|---|
+| `amazon` | Yes | No | API | API |
+| `apple` | Yes | No | API | API |
+| `arbetsformedlingen` | Yes | No | API | API |
+| `ashby` | Yes | No | API | API |
+| `avature` | Yes | Yes | HTML | HTML |
+| `bamboohr` | Yes | Yes | HTML | API |
+| `breezy` | Yes | Yes | API | HTML |
+| `builtin` | Yes | No | HTML | HTML |
+| `bundesagentur` | Yes | Yes | API | API |
+| `cornerstone` | Yes | No | API/feed + HTML bootstrap | API/feed |
+| `eightfold` | Yes | Yes | API | API |
+| `eures` | Yes | No | API/feed | API/feed |
+| `gem` | Yes | Yes | API/feed | API/feed |
+| `getonbrd` | Yes | No | API/feed | API/feed |
+| `google` | Yes | Yes | HTML | HTML |
+| `greenhouse` | Yes | No | API/feed | API/feed |
+| `icims` | Yes | Yes | HTML | HTML |
+| `jazzhr` | Yes | Yes | HTML | HTML |
+| `jobsch` | Yes | Yes | API | HTML |
+| `join_com` | Yes | Yes | HTML | HTML |
+| `lever` | Yes | No | API | API |
+| `manfred` | Yes | Yes | API/feed | API/feed |
+| `mercor` | Yes | No | API/feed | API/feed |
+| `meta` | Yes | Yes | HTML / browser | HTML |
+| `oracle` | Yes | Yes | API/feed | API/feed |
+| `personio` | Yes | Yes | API | HTML |
+| `phenom` | Yes | No | API/feed + HTML bootstrap | API/feed |
+| `pinpoint` | Yes | No | API/feed | API/feed |
+| `programathor` | Yes | Yes | HTML | HTML |
+| `recruitee` | Yes | No | API/feed | API/feed |
+| `recruiterbox` | Yes | No | API/feed | API/feed |
+| `remoteok` | Yes | No | API/feed | API/feed |
+| `rippling` | Yes | Yes | API/feed | API/feed |
+| `smartrecruiters` | Yes | Yes | API/feed | API/feed |
+| `successfactors` | Yes | No | API/feed (RSS/XML) | API/feed (RSS/XML) |
+| `taleo` | Yes | Yes | HTML | HTML |
+| `teamtailor` | Yes | No | API/feed (RSS/XML) | API/feed (RSS/XML) |
+| `tesla` | Yes | Yes | API/feed / browser | API/feed |
+| `thehub` | Yes | No | API/feed | API/feed |
+| `tiktok` | Yes | No | API/feed | API/feed |
+| `uber` | Yes | No | API/feed | API/feed |
+| `wanted` | Yes | Yes | API/feed | API/feed |
+| `wellfound` | Yes | Yes | HTML / Firecrawl | HTML / Firecrawl |
+| `weworkremotely` | Yes | No | API/feed (RSS/XML) | API/feed (RSS/XML) |
+| `workable` | Yes | Yes | API/feed | API/feed (Markdown) |
+| `workday` | Yes | Yes | API/feed | API/feed |
+| `ycombinator` | Yes | No | API/feed | API/feed |

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -22,7 +22,9 @@ import asyncio
 import csv
 import json
 import re
+import sqlite3
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
@@ -79,6 +81,7 @@ from jobhive.scrapers import (
     YCombinatorScraper,
     iCIMSScraper,
 )
+from jobhive.scrapers.base import BaseScraper
 
 
 def _slug_col(row: dict[str, Any]) -> str | None:
@@ -645,6 +648,154 @@ JOB_CSV_FIELDS = [
 ]
 
 
+class DescriptionCache:
+    """Disk-backed description cache built from the previous jobs CSV."""
+
+    def __init__(self) -> None:
+        self.conn: sqlite3.Connection | None = None
+        with tempfile.NamedTemporaryFile(
+            prefix="jobhive-description-cache-",
+            suffix=".sqlite3",
+            delete=False,
+        ) as tmp:
+            self.path = Path(tmp.name)
+        try:
+            self.conn = sqlite3.connect(self.path)
+            self.conn.execute("PRAGMA journal_mode=OFF")
+            self.conn.execute("PRAGMA synchronous=OFF")
+            self.conn.execute("PRAGMA temp_store=MEMORY")
+            self.conn.execute(
+                """
+                CREATE TABLE descriptions (
+                    kind TEXT NOT NULL,
+                    cache_key TEXT NOT NULL,
+                    description TEXT NOT NULL,
+                    PRIMARY KEY (kind, cache_key)
+                )
+                """
+            )
+        except Exception:
+            if self.conn is not None:
+                self.conn.close()
+            self.path.unlink(missing_ok=True)
+            raise
+        self.count = 0
+
+    def close(self) -> None:
+        if self.conn is not None:
+            self.conn.close()
+            self.conn = None
+        self.path.unlink(missing_ok=True)
+
+    def load_csv(self, path: Path) -> None:
+        if not path.exists():
+            return
+
+        batch: list[tuple[str, str, str]] = []
+        try:
+            with path.open(newline="") as fh:
+                for row in csv.DictReader(fh):
+                    description = (row.get("description") or "").strip()
+                    if not description:
+                        continue
+                    for key in _row_description_keys(row):
+                        batch.append((*key, description))
+                    if len(batch) >= 2_000:
+                        self._insert_many(batch)
+                        batch.clear()
+                if batch:
+                    self._insert_many(batch)
+        except (OSError, csv.Error, sqlite3.Error):
+            self.conn.execute("DELETE FROM descriptions")
+            self.conn.commit()
+        self.count = self.conn.execute(
+            "SELECT COUNT(*) FROM descriptions"
+        ).fetchone()[0]
+
+    def _insert_many(self, rows: list[tuple[str, str, str]]) -> int:
+        cur = self.conn.executemany(
+            """
+            INSERT OR IGNORE INTO descriptions (kind, cache_key, description)
+            VALUES (?, ?, ?)
+            """,
+            rows,
+        )
+        self.conn.commit()
+        return cur.rowcount
+
+    def get(self, job: Job) -> str | None:
+        for kind, key in _description_keys(job):
+            row = self.conn.execute(
+                """
+                SELECT description FROM descriptions
+                WHERE kind = ? AND cache_key = ?
+                """,
+                (kind, key),
+            ).fetchone()
+            if row:
+                return row[0]
+        return None
+
+    def set(self, job: Job, description: str) -> None:
+        rows = [(*key, description) for key in _description_keys(job)]
+        if rows:
+            self.count += self._insert_many(rows)
+
+
+def _description_keys(job: Job) -> list[tuple[str, str]]:
+    keys: list[tuple[str, str]] = []
+    company = (job.company or "").strip()
+    ats_id = (job.ats_id or "").strip()
+    if company and ats_id:
+        keys.append(("company_ats_id", f"{company}\0{ats_id}"))
+    url = str(job.url).strip()
+    if url:
+        keys.append(("url", url))
+    return keys
+
+
+def _row_description_keys(row: dict[str, str]) -> list[tuple[str, str]]:
+    keys: list[tuple[str, str]] = []
+    company = (row.get("company") or "").strip()
+    ats_id = (row.get("ats_id") or "").strip()
+    if company and ats_id:
+        keys.append(("company_ats_id", f"{company}\0{ats_id}"))
+    url = (row.get("url") or "").strip()
+    if url:
+        keys.append(("url", url))
+    return keys
+
+
+def _load_description_cache(path: Path) -> DescriptionCache:
+    cache = DescriptionCache()
+    cache.load_csv(path)
+    return cache
+
+
+def _cached_description(job: Job, cache: DescriptionCache) -> str | None:
+    return cache.get(job)
+
+
+async def _ensure_description(
+    scraper: BaseScraper,
+    job: Job,
+    cache: DescriptionCache,
+) -> None:
+    cached = _cached_description(job, cache)
+    if cached:
+        job.description = cached
+        return
+    if job.description:
+        return
+    get_description = getattr(scraper, "get_description", None)
+    if get_description is None:
+        return
+    description = await asyncio.to_thread(get_description, job)
+    if description:
+        job.description = description[:25_000]
+        cache.set(job, job.description)
+
+
 def _job_to_row(job: Job) -> dict[str, Any]:
     """Flatten a Job to CSV-friendly fields. ``raw`` is JSON-serialized."""
     raw_json = ""
@@ -669,7 +820,7 @@ def _job_to_row(job: Job) -> dict[str, Any]:
         "employment_type": job.employment_type or "",
         "department": job.department or "",
         "team": job.team or "",
-        "description": (job.description or "")[:500].replace("\n", " "),
+        "description": (job.description or "")[:25_000].replace("\n", " "),
         "posted_at": job.posted_at.isoformat() if job.posted_at else "",
         "requisition_id": job.requisition_id or "",
         "apply_url": str(job.apply_url) if job.apply_url else "",
@@ -678,20 +829,29 @@ def _job_to_row(job: Job) -> dict[str, Any]:
     }
 
 
-async def _run_scraper(scraper_cls, slug, kwargs=None, timeout=30) -> tuple[str, list[Job], str | None]:
-    """Run one scraper in a thread (most are sync). Returns (slug, jobs, error_or_None)."""
+async def _run_scraper(
+    scraper_cls,
+    slug,
+    kwargs=None,
+    timeout=30,
+    *,
+    include_descriptions: bool = True,
+) -> tuple[str, BaseScraper | None, list[Job], str | None]:
+    """Run one scraper in a thread (most are sync)."""
     extra = kwargs or {}
 
-    def _run() -> list[Job]:
-        return scraper_cls(slug, timeout=timeout, **extra).fetch()
+    def _run() -> tuple[BaseScraper, list[Job]]:
+        scraper = scraper_cls(slug, timeout=timeout, **extra)
+        scraper.include_descriptions = include_descriptions
+        return scraper, scraper.fetch()
 
     try:
-        jobs = await asyncio.to_thread(_run)
-        return slug, jobs, None
+        scraper, jobs = await asyncio.to_thread(_run)
+        return slug, scraper, jobs, None
     except CompanyNotFoundError:
-        return slug, [], "not_found"
+        return slug, None, [], "not_found"
     except Exception as exc:
-        return slug, [], f"{type(exc).__name__}: {str(exc)[:120]}"
+        return slug, None, [], f"{type(exc).__name__}: {str(exc)[:120]}"
 
 
 async def run(ats: str, concurrency: int, max_tenants: int | None, timeout: float) -> int:
@@ -727,112 +887,127 @@ async def run(ats: str, concurrency: int, max_tenants: int | None, timeout: floa
     output_path = DATA_ROOT / cfg["output"]
     output_path.parent.mkdir(parents=True, exist_ok=True)
     tmp_output_path = output_path.with_name(f".{output_path.name}.tmp")
+    uses_streaming = bool(cfg.get("singleton") and hasattr(cfg["scraper"], "fetch_stream"))
+    description_cache = _load_description_cache(output_path)
+    if description_cache.count:
+        print(f"[{ats}] Loaded {description_cache.count:,} cached description keys")
     seen_keys: set[tuple[str, str]] = set()  # (company, ats_id) for cross-tenant dedup
 
     t0 = time.time()
-    with tmp_output_path.open("w", newline="") as f:
-        writer = csv.DictWriter(f, fieldnames=JOB_CSV_FIELDS)
-        writer.writeheader()
+    try:
+        with tmp_output_path.open("w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=JOB_CSV_FIELDS)
+            writer.writeheader()
 
-        # ---- Streaming path: scrapers that would otherwise load >5 GB
-        # of Job objects into RAM expose a ``fetch_stream()`` async
-        # generator. We iterate it directly and write each job to disk
-        # as it arrives, keeping the in-flight footprint flat (~200 MB
-        # for the seen-set + a bounded asyncio.Queue) instead of
-        # accumulating the full corpus. EURES is the only such ATS
-        # today — its ~2.7 M-row pan-EU catalog would peak at ~10 GB
-        # RSS in legacy mode, exceeding the VPS RAM budget.
-        if cfg.get("singleton") and hasattr(cfg["scraper"], "fetch_stream"):
-            scraper = cfg["scraper"](ats, timeout=timeout)
-            try:
-                async for job in scraper.fetch_stream():
-                    writer.writerow(_job_to_row(job))
-                    counts["jobs"] += 1
-                    # Periodic flush so the file is consultable while
-                    # the long-running scrape is still in flight.
-                    if counts["jobs"] % 10_000 == 0:
-                        f.flush()
-                        elapsed = time.time() - t0
-                        print(
-                            f"  [{ats}] streamed {counts['jobs']:,} jobs in "
-                            f"{elapsed:.0f}s",
+            # ---- Streaming path: scrapers that would otherwise load >5 GB
+            # of Job objects into RAM expose a ``fetch_stream()`` async
+            # generator. We iterate it directly and write each job to disk
+            # as it arrives, keeping the in-flight footprint flat (~200 MB
+            # for the seen-set + a bounded asyncio.Queue) instead of
+            # accumulating the full corpus. EURES is the only such ATS
+            # today — its ~2.7 M-row pan-EU catalog would peak at ~10 GB
+            # RSS in legacy mode, exceeding the VPS RAM budget.
+            if uses_streaming:
+                scraper = cfg["scraper"](ats, timeout=timeout)
+                try:
+                    async for job in scraper.fetch_stream():
+                        await _ensure_description(scraper, job, description_cache)
+                        writer.writerow(_job_to_row(job))
+                        counts["jobs"] += 1
+                        # Periodic flush so the file is consultable while
+                        # the long-running scrape is still in flight.
+                        if counts["jobs"] % 10_000 == 0:
+                            f.flush()
+                            elapsed = time.time() - t0
+                            print(
+                                f"  [{ats}] streamed {counts['jobs']:,} jobs in "
+                                f"{elapsed:.0f}s",
+                            )
+                    counts["success"] = 1
+                except CompanyNotFoundError:
+                    counts["not_found"] = 1
+                except Exception as exc:
+                    counts["error"] = 1
+                    print(f"  [{ats}] streaming failed: {type(exc).__name__}: "
+                          f"{str(exc)[:200]}")
+            else:
+                async def task(slug: str, kw: dict[str, Any]) -> None:
+                    async with sem:
+                        _, scraper, jobs, err = await _run_scraper(
+                            cfg["scraper"],
+                            slug,
+                            kw,
+                            timeout,
                         )
-                counts["success"] = 1
-            except CompanyNotFoundError:
-                counts["not_found"] = 1
-            except Exception as exc:
-                counts["error"] = 1
-                print(f"  [{ats}] streaming failed: {type(exc).__name__}: "
-                      f"{str(exc)[:200]}")
-        else:
-            async def task(slug: str, kw: dict[str, Any]) -> None:
-                async with sem:
-                    _, jobs, err = await _run_scraper(cfg["scraper"], slug, kw, timeout)
-                if err == "not_found":
-                    counts["not_found"] += 1
-                    return
-                if err:
-                    counts["error"] += 1
-                    return
-                counts["success"] += 1
-                for job in jobs:
-                    key = (job.company, job.ats_id)
-                    if key in seen_keys:
-                        continue
-                    seen_keys.add(key)
-                    writer.writerow(_job_to_row(job))
-                    counts["jobs"] += 1
+                    if err == "not_found":
+                        counts["not_found"] += 1
+                        return
+                    if err:
+                        counts["error"] += 1
+                        return
+                    counts["success"] += 1
+                    for job in jobs:
+                        key = (job.company, job.ats_id)
+                        if key in seen_keys:
+                            continue
+                        seen_keys.add(key)
+                        if scraper is not None:
+                            await _ensure_description(scraper, job, description_cache)
+                        writer.writerow(_job_to_row(job))
+                        counts["jobs"] += 1
 
-            # Process tasks in batches and flush periodically
-            batch_size = 50
-            for i in range(0, len(targets), batch_size):
-                batch = targets[i:i + batch_size]
-                await asyncio.gather(*(task(s, kw) for s, kw in batch))
-                f.flush()
-                elapsed = time.time() - t0
-                print(
-                    f"  [{ats}] processed {min(i + batch_size, len(targets))}/{len(targets)} "
-                    f"tenants in {elapsed:.0f}s — "
-                    f"{counts['success']} OK, {counts['not_found']} not-found, "
-                    f"{counts['error']} errors, {counts['jobs']:,} jobs"
-                )
+                # Process tasks in batches and flush periodically
+                batch_size = 50
+                for i in range(0, len(targets), batch_size):
+                    batch = targets[i:i + batch_size]
+                    await asyncio.gather(*(task(s, kw) for s, kw in batch))
+                    f.flush()
+                    elapsed = time.time() - t0
+                    print(
+                        f"  [{ats}] processed {min(i + batch_size, len(targets))}/{len(targets)} "
+                        f"tenants in {elapsed:.0f}s — "
+                        f"{counts['success']} OK, {counts['not_found']} not-found, "
+                        f"{counts['error']} errors, {counts['jobs']:,} jobs"
+                    )
 
-    elapsed = time.time() - t0
-    print(
-        f"[{ats}] Done in {elapsed:.0f}s: {counts['jobs']:,} jobs from "
-        f"{counts['success']}/{len(targets)} tenants → {output_path}"
-    )
-
-    failure_threshold = max(1, (len(targets) + 1) // 2)
-    catastrophic_failure = (
-        bool(targets)
-        and counts["jobs"] == 0
-        and counts["error"] >= failure_threshold
-    )
-    if catastrophic_failure:
-        tmp_output_path.unlink(missing_ok=True)
-        if output_path.exists():
-            print(
-                f"[{ats}] ACTION keep_previous: scrape produced 0 jobs with "
-                f"{counts['error']}/{len(targets)} tenant errors; preserved "
-                f"{output_path} for the next publish."
-            )
-        else:
-            print(
-                f"[{ats}] ACTION retry: scrape produced 0 jobs with "
-                f"{counts['error']}/{len(targets)} tenant errors and no "
-                "previous jobs.csv exists."
-            )
-        return 1
-
-    tmp_output_path.replace(output_path)
-    if counts["error"] >= failure_threshold:
+        elapsed = time.time() - t0
         print(
-            f"[{ats}] ACTION investigate: scrape kept partial data but "
-            f"{counts['error']}/{len(targets)} tenants failed."
+            f"[{ats}] Done in {elapsed:.0f}s: {counts['jobs']:,} jobs from "
+            f"{counts['success']}/{len(targets)} tenants → {output_path}"
         )
-        return 1
-    return 0
+
+        failure_threshold = max(1, (len(targets) + 1) // 2)
+        catastrophic_failure = (
+            bool(targets)
+            and counts["jobs"] == 0
+            and counts["error"] >= failure_threshold
+        )
+        if catastrophic_failure:
+            tmp_output_path.unlink(missing_ok=True)
+            if output_path.exists():
+                print(
+                    f"[{ats}] ACTION keep_previous: scrape produced 0 jobs with "
+                    f"{counts['error']}/{len(targets)} tenant errors; preserved "
+                    f"{output_path} for the next publish."
+                )
+            else:
+                print(
+                    f"[{ats}] ACTION retry: scrape produced 0 jobs with "
+                    f"{counts['error']}/{len(targets)} tenant errors and no "
+                    "previous jobs.csv exists."
+                )
+            return 1
+
+        tmp_output_path.replace(output_path)
+        if counts["error"] >= failure_threshold:
+            print(
+                f"[{ats}] ACTION investigate: scrape kept partial data but "
+                f"{counts['error']}/{len(targets)} tenants failed."
+            )
+            return 1
+        return 0
+    finally:
+        description_cache.close()
 
 
 def main() -> int:

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -768,7 +768,11 @@ def _row_description_keys(row: dict[str, str]) -> list[tuple[str, str]]:
 
 def _load_description_cache(path: Path) -> DescriptionCache:
     cache = DescriptionCache()
-    cache.load_csv(path)
+    try:
+        cache.load_csv(path)
+    except Exception:
+        cache.close()
+        raise
     return cache
 
 
@@ -787,10 +791,14 @@ async def _ensure_description(
         return
     if job.description:
         return
-    get_description = getattr(scraper, "get_description", None)
-    if get_description is None:
+    try:
+        description = await asyncio.to_thread(scraper.get_description, job)
+    except Exception as exc:
+        print(
+            "  description fetch failed for "
+            f"{job.url}: {type(exc).__name__}: {str(exc)[:200]}"
+        )
         return
-    description = await asyncio.to_thread(get_description, job)
     if description:
         job.description = description[:25_000]
         cache.set(job, job.description)

--- a/src/jobhive/models.py
+++ b/src/jobhive/models.py
@@ -441,7 +441,7 @@ class Job(BaseModel):
         default=None,
         description=(
             "Plain-text job description. HTML and markdown are "
-            "stripped to text. Truncated to ~10kB when the source "
+            "stripped to text. Truncated to ~25k chars when the source "
             "exceeds it."
         ),
     )

--- a/src/jobhive/scrapers/avature.py
+++ b/src/jobhive/scrapers/avature.py
@@ -141,6 +141,24 @@ class AvatureScraper(BaseScraper):
     def fetch(self) -> list[Job]:
         return asyncio.run(self._fetch_async())
 
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        copy = job.model_copy()
+
+        async def run() -> str | None:
+            async with httpx.AsyncClient(
+                timeout=self.timeout, follow_redirects=True,
+            ) as client:
+                sem = asyncio.Semaphore(1)
+                await self._enrich_with_detail(client, sem, copy)
+            if not copy.description:
+                sem = asyncio.Semaphore(1)
+                await self._enrich_with_detail_via_httpcloak(sem, copy)
+            return copy.description
+
+        return asyncio.run(run())
+
     async def _fetch_async(self) -> list[Job]:
         base = self._resolve_base_url()
         company = _company_from_base(base) or self.company_slug
@@ -796,7 +814,7 @@ def _apply_detail_to_job(
     # Description.
     if description and not job.description:
         # Cap at ~12kB to avoid Pydantic warnings on extreme outliers.
-        job.description = description[:12_000]
+        job.description = description[:25_000]
 
 
 def _company_from_base(base: str) -> str | None:

--- a/src/jobhive/scrapers/avature.py
+++ b/src/jobhive/scrapers/avature.py
@@ -277,11 +277,12 @@ class AvatureScraper(BaseScraper):
         # Same TLS fingerprint for detail enrichment so we don't lose
         # the descriptions we just unlocked. Best-effort — a single
         # detail failure must not throw away the listing row.
-        sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
-        await asyncio.gather(*(
-            self._enrich_with_detail_via_httpcloak(sem, job)
-            for job in all_jobs
-        ))
+        if self.include_descriptions:
+            sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
+            await asyncio.gather(*(
+                self._enrich_with_detail_via_httpcloak(sem, job)
+                for job in all_jobs
+            ))
         return all_jobs
 
     def _fetch_page_via_httpcloak_sync(self, base: str, offset: int) -> str:
@@ -457,33 +458,34 @@ class AvatureScraper(BaseScraper):
                     if len(page_jobs) < PAGE_SIZE:
                         break
 
-                # Detail pages — small parallel batch on extra tabs.
-                bb_detail_concurrency = 4
-                sem = asyncio.Semaphore(bb_detail_concurrency)
-                tabs = [await ctx.new_page() for _ in range(bb_detail_concurrency)]
-                tab_q: asyncio.Queue = asyncio.Queue()
-                for t in tabs:
-                    tab_q.put_nowait(t)
+                if self.include_descriptions:
+                    # Detail pages — small parallel batch on extra tabs.
+                    bb_detail_concurrency = 4
+                    sem = asyncio.Semaphore(bb_detail_concurrency)
+                    tabs = [await ctx.new_page() for _ in range(bb_detail_concurrency)]
+                    tab_q: asyncio.Queue = asyncio.Queue()
+                    for t in tabs:
+                        tab_q.put_nowait(t)
 
-                async def enrich(job: Job) -> None:
-                    async with sem:
-                        tab = await tab_q.get()
-                        try:
+                    async def enrich(job: Job) -> None:
+                        async with sem:
+                            tab = await tab_q.get()
                             try:
-                                await tab.goto(
-                                    str(job.url),
-                                    wait_until="domcontentloaded",
-                                    timeout=30_000,
-                                )
-                            except Exception:
-                                return
-                            html = await tab.content()
-                            fields, description = _parse_detail(html)
-                            _apply_detail_to_job(job, fields, description)
-                        finally:
-                            tab_q.put_nowait(tab)
+                                try:
+                                    await tab.goto(
+                                        str(job.url),
+                                        wait_until="domcontentloaded",
+                                        timeout=30_000,
+                                    )
+                                except Exception:
+                                    return
+                                html = await tab.content()
+                                fields, description = _parse_detail(html)
+                                _apply_detail_to_job(job, fields, description)
+                            finally:
+                                tab_q.put_nowait(tab)
 
-                await asyncio.gather(*(enrich(j) for j in all_jobs))
+                    await asyncio.gather(*(enrich(j) for j in all_jobs))
             finally:
                 await browser.close()
         return all_jobs

--- a/src/jobhive/scrapers/bamboohr.py
+++ b/src/jobhive/scrapers/bamboohr.py
@@ -125,6 +125,22 @@ class BambooHRScraper(BaseScraper):
     def fetch(self) -> list[Job]:
         return asyncio.run(self._fetch_async())
 
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        copy = job.model_copy()
+
+        async def run() -> str | None:
+            async with httpx.AsyncClient(
+                timeout=self.timeout,
+                follow_redirects=True,
+            ) as client:
+                sem = asyncio.Semaphore(1)
+                await self._enrich_one(client, sem, copy)
+            return copy.description
+
+        return asyncio.run(run())
+
     async def _fetch_async(self) -> list[Job]:
         async with httpx.AsyncClient(
             timeout=self.timeout,
@@ -296,8 +312,8 @@ def _apply_opening_to_job(job: Job, opening: dict) -> None:
     desc_html = opening.get("description")
     if isinstance(desc_html, str) and desc_html.strip():
         # ``description`` is HTML on BambooHR's side. Strip tags for
-        # plain-text storage; cap at 10kB to match the Job schema doc.
-        job.description = _strip_tags(desc_html)[:10_000] or None
+        # plain-text storage; cap at 25k chars to match the Job schema doc.
+        job.description = _strip_tags(desc_html)[:25_000] or None
 
     emp_label = opening.get("employmentStatusLabel")
     if isinstance(emp_label, str) and emp_label.strip():

--- a/src/jobhive/scrapers/bamboohr.py
+++ b/src/jobhive/scrapers/bamboohr.py
@@ -152,7 +152,7 @@ class BambooHRScraper(BaseScraper):
         ) as client:
             html = await self._fetch_widget(client)
             jobs = self._parse_widget(html)
-            if jobs:
+            if self.include_descriptions and jobs:
                 await self._enrich_from_detail_api(client, jobs)
             return jobs
 

--- a/src/jobhive/scrapers/base.py
+++ b/src/jobhive/scrapers/base.py
@@ -46,6 +46,30 @@ class BaseScraper(ABC):
     def fetch(self) -> list[Job]:
         """Return all currently active jobs for this company."""
 
+    def get_description(self, job: Job) -> str | None:
+        """Fetch or return the best-known description for one job.
+
+        The default implementation is correct for providers whose listing
+        payload already includes the full description. Providers that need a
+        per-job detail request override this method.
+        """
+        return job.description
+
+    def enrich_descriptions(self, jobs: list[Job]) -> list[Job]:
+        """Fill missing descriptions in ``jobs`` when the provider supports it.
+
+        The default path calls :meth:`get_description` one job at a time.
+        High-volume providers can override this with a batched/concurrent
+        implementation while keeping the public API stable.
+        """
+        for job in jobs:
+            if job.description:
+                continue
+            description = self.get_description(job)
+            if description:
+                job.description = description[:25_000]
+        return jobs
+
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.company_slug!r})"
 

--- a/src/jobhive/scrapers/base.py
+++ b/src/jobhive/scrapers/base.py
@@ -41,6 +41,7 @@ class BaseScraper(ABC):
     def __init__(self, company_slug: str, *, timeout: float = 30.0) -> None:
         self.company_slug = company_slug
         self.timeout = timeout
+        self.include_descriptions = True
 
     @abstractmethod
     def fetch(self) -> list[Job]:

--- a/src/jobhive/scrapers/breezy.py
+++ b/src/jobhive/scrapers/breezy.py
@@ -67,6 +67,21 @@ class BreezyScraper(BaseScraper):
     def fetch(self) -> list[Job]:
         return asyncio.run(self._fetch_async())
 
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        copy = job.model_copy()
+
+        async def run() -> str | None:
+            async with httpx.AsyncClient(
+                timeout=self.timeout, follow_redirects=False,
+            ) as client:
+                sem = asyncio.Semaphore(1)
+                await self._enrich_description(client, sem, copy)
+            return copy.description
+
+        return asyncio.run(run())
+
     async def _fetch_async(self) -> list[Job]:
         # ``follow_redirects=False`` on the client default — the JSON
         # listing endpoint must NOT follow redirects so we can detect
@@ -120,7 +135,7 @@ class BreezyScraper(BaseScraper):
             return
         description = _extract_description(response.text)
         if description:
-            job.description = description[:12_000]
+            job.description = description[:25_000]
 
     async def _fetch_with_retry(
         self, client: httpx.AsyncClient

--- a/src/jobhive/scrapers/breezy.py
+++ b/src/jobhive/scrapers/breezy.py
@@ -109,7 +109,7 @@ class BreezyScraper(BaseScraper):
             # Detail-page enrichment is best-effort. Breezy's edge blocks
             # bursty traffic with 403s, so per-job failures keep the
             # listing-derived row instead of failing the tenant.
-            if jobs:
+            if self.include_descriptions and jobs:
                 sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
                 await asyncio.gather(*(
                     self._enrich_description(client, sem, j) for j in jobs

--- a/src/jobhive/scrapers/bundesagentur.py
+++ b/src/jobhive/scrapers/bundesagentur.py
@@ -223,11 +223,12 @@ class BundesagenturScraper(BaseScraper):
                         continue
                     seen.add(job.ats_id)
                     new_jobs.append(job)
-            await asyncio.gather(*(
-                self._enrich_description(client, sem, job)
-                for job in new_jobs
-                if not job.description
-            ))
+            if self.include_descriptions:
+                await asyncio.gather(*(
+                    self._enrich_description(client, sem, job)
+                    for job in new_jobs
+                    if not job.description
+                ))
             if on_job is not None:
                 for job in new_jobs:
                     await on_job(job)

--- a/src/jobhive/scrapers/bundesagentur.py
+++ b/src/jobhive/scrapers/bundesagentur.py
@@ -129,6 +129,19 @@ class BundesagenturScraper(BaseScraper):
         from cron contexts that write straight to disk."""
         return asyncio.run(self._fetch_async())
 
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        copy = job.model_copy()
+
+        async def run() -> str | None:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                sem = asyncio.Semaphore(1)
+                await self._enrich_description(client, sem, copy)
+            return copy.description
+
+        return asyncio.run(run())
+
     async def fetch_stream(self) -> AsyncGenerator[Job, None]:
         """Stream jobs as they're parsed.
 
@@ -258,7 +271,7 @@ class BundesagenturScraper(BaseScraper):
             return
         description = detail.get("stellenangebotsBeschreibung")
         if isinstance(description, str) and description.strip():
-            job.description = description.strip()[:10_000]
+            job.description = description.strip()[:25_000]
 
     async def _exhaust_query(
         self,
@@ -546,7 +559,7 @@ class BundesagenturScraper(BaseScraper):
             apply_url=apply_url,
             requisition_id=item.get("hashId") or None,
             description=(
-                item.get("stellenangebotsBeschreibung").strip()[:10_000]
+                item.get("stellenangebotsBeschreibung").strip()[:25_000]
                 if isinstance(item.get("stellenangebotsBeschreibung"), str)
                 and item.get("stellenangebotsBeschreibung").strip()
                 else None

--- a/src/jobhive/scrapers/cornerstone.py
+++ b/src/jobhive/scrapers/cornerstone.py
@@ -311,7 +311,7 @@ def _clean_description(value: object) -> str | None:
         return None
     if cleaned.lower() in _PLACEHOLDER_DESCRIPTIONS:
         return None
-    return cleaned[:10_000]
+    return cleaned[:25_000]
 
 
 def _parse_iso(value: object) -> datetime | None:

--- a/src/jobhive/scrapers/eightfold.py
+++ b/src/jobhive/scrapers/eightfold.py
@@ -92,6 +92,23 @@ class EightfoldScraper(BaseScraper):
     def fetch(self) -> list[Job]:
         return asyncio.run(self._fetch_async())
 
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        copy = job.model_copy()
+
+        async def run() -> str | None:
+            async with httpx.AsyncClient(
+                timeout=self.timeout,
+                follow_redirects=True,
+                headers={"User-Agent": "Mozilla/5.0"},
+            ) as client:
+                sem = asyncio.Semaphore(1)
+                await self._enrich_position_details(client, sem, copy)
+            return copy.description
+
+        return asyncio.run(run())
+
     # --- async pipeline -------------------------------------------------
 
     async def _fetch_async(self) -> list[Job]:
@@ -198,7 +215,7 @@ class EightfoldScraper(BaseScraper):
         data = payload.get("data") or {}
         desc_html = data.get("jobDescription")
         if isinstance(desc_html, str) and desc_html.strip() and not job.description:
-            job.description = _strip_html(desc_html)[:12_000] or None
+            job.description = _strip_html(desc_html)[:25_000] or None
 
     async def _fetch_page_httpx(
         self, client: httpx.AsyncClient, *, start: int

--- a/src/jobhive/scrapers/eightfold.py
+++ b/src/jobhive/scrapers/eightfold.py
@@ -167,7 +167,7 @@ class EightfoldScraper(BaseScraper):
             # higher request volume well; the search calls were ~10
             # pages × 12 concurrency, the detail pass is per-job but
             # still fits inside the same WAF budget.
-            if all_jobs:
+            if self.include_descriptions and all_jobs:
                 detail_sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
                 await asyncio.gather(*(
                     self._enrich_position_details(client, detail_sem, j)

--- a/src/jobhive/scrapers/eures.py
+++ b/src/jobhive/scrapers/eures.py
@@ -573,7 +573,7 @@ def _extract_description(item: dict[str, Any]) -> str | None:
     text = html.unescape(text)
     text = re.sub(r"[ \t\r\f\v]+", " ", text)
     text = re.sub(r"\n{3,}", "\n\n", text)
-    return text.strip()[:10_000] or None
+    return text.strip()[:25_000] or None
 
 
 async def _gather_tolerant(

--- a/src/jobhive/scrapers/gem.py
+++ b/src/jobhive/scrapers/gem.py
@@ -144,7 +144,7 @@ class GemScraper(BaseScraper):
         ) as client:
             postings = await self._fetch_list(client)
             jobs = [self._parse_job(item) for item in postings]
-            if jobs:
+            if self.include_descriptions and jobs:
                 await self._enrich_with_details(client, jobs, postings)
             return jobs
 

--- a/src/jobhive/scrapers/gem.py
+++ b/src/jobhive/scrapers/gem.py
@@ -123,6 +123,21 @@ class GemScraper(BaseScraper):
     def fetch(self) -> list[Job]:
         return asyncio.run(self._fetch_async())
 
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        copy = job.model_copy()
+        posting = {"extId": job.ats_id}
+
+        async def run() -> str | None:
+            async with httpx.AsyncClient(
+                timeout=self.timeout, follow_redirects=True,
+            ) as client:
+                await self._enrich_with_details(client, [copy], [posting])
+            return copy.description
+
+        return asyncio.run(run())
+
     async def _fetch_async(self) -> list[Job]:
         async with httpx.AsyncClient(
             timeout=self.timeout, follow_redirects=True,
@@ -274,7 +289,7 @@ def _apply_detail_to_job(job: Job, detail: dict[str, Any]) -> None:
     """
     desc_html = detail.get("descriptionHtml")
     if isinstance(desc_html, str) and desc_html.strip():
-        job.description = _strip_html(desc_html)[:12_000] or None
+        job.description = _strip_html(desc_html)[:25_000] or None
 
     # Posted date — Gem ships ``firstPublishedTsSec`` (epoch seconds) and
     # ``startDateTs`` (epoch seconds, *future* go-live). Prefer the

--- a/src/jobhive/scrapers/getonbrd.py
+++ b/src/jobhive/scrapers/getonbrd.py
@@ -384,9 +384,9 @@ def _concat_descriptions(attrs: dict[str, Any]) -> str:
 
 def _strip_html(text: str) -> str:
     """Strip tags + entities + collapse whitespace, then truncate so the
-    canonical schema's ~10kB description budget isn't blown by long
+    canonical schema's ~25k chars description budget isn't blown by long
     HTML-formatted bodies."""
     cleaned = _TAG_RE.sub(" ", text)
     cleaned = html.unescape(cleaned)
     cleaned = re.sub(r"\s+", " ", cleaned).strip()
-    return cleaned[:10_000]
+    return cleaned[:25_000]

--- a/src/jobhive/scrapers/google.py
+++ b/src/jobhive/scrapers/google.py
@@ -108,7 +108,7 @@ class GoogleScraper(BaseScraper):
 
             # Per-job detail enrichment: pull description, location, team
             # from each job's HTML detail page. Best-effort.
-            if all_jobs:
+            if self.include_descriptions and all_jobs:
                 sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
                 await asyncio.gather(*(
                     self._enrich_detail(client, sem, j) for j in all_jobs

--- a/src/jobhive/scrapers/google.py
+++ b/src/jobhive/scrapers/google.py
@@ -74,6 +74,21 @@ class GoogleScraper(BaseScraper):
     def fetch(self) -> list[Job]:
         return asyncio.run(self._fetch_async())
 
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        copy = job.model_copy()
+
+        async def run() -> str | None:
+            async with httpx.AsyncClient(
+                timeout=self.timeout, follow_redirects=True,
+            ) as client:
+                sem = asyncio.Semaphore(1)
+                await self._enrich_detail(client, sem, copy)
+            return copy.description
+
+        return asyncio.run(run())
+
     async def _fetch_async(self) -> list[Job]:
         seen: set[str] = set()
         all_jobs: list[Job] = []
@@ -211,7 +226,7 @@ def _apply_detail_to_job(job: Job, html: str) -> None:
     # Description — prefer the wider h3 container; fall back to meta.
     description = _extract_full_description(html)
     if description and not job.description:
-        job.description = description[:10_000]
+        job.description = description[:25_000]
 
     # Location + team chips.
     for chip in _CHIP_RE.finditer(html):

--- a/src/jobhive/scrapers/greenhouse.py
+++ b/src/jobhive/scrapers/greenhouse.py
@@ -165,7 +165,7 @@ def _clean_description(value: object) -> str | None:
     text = html_mod.unescape(value)
     text = _TAG_RE.sub(" ", text)
     text = re.sub(r"\s+", " ", text).strip()
-    return text[:10_000] or None
+    return text[:25_000] or None
 
 
 def _parse_iso(value: object) -> datetime | None:

--- a/src/jobhive/scrapers/icims.py
+++ b/src/jobhive/scrapers/icims.py
@@ -147,6 +147,21 @@ class iCIMSScraper(BaseScraper):  # noqa: N801  matches public iCIMS branding
     def fetch(self) -> list[Job]:
         return asyncio.run(self._fetch_async())
 
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        copy = job.model_copy()
+
+        async def run() -> str | None:
+            async with httpx.AsyncClient(
+                timeout=self.timeout, follow_redirects=True,
+            ) as client:
+                sem = asyncio.Semaphore(1)
+                await self._enrich_detail(client, sem, copy)
+            return copy.description
+
+        return asyncio.run(run())
+
     async def _fetch_async(self) -> list[Job]:
         seen: set[str] = set()
         all_jobs: list[Job] = []
@@ -315,7 +330,7 @@ def _apply_jsonld_to_job(job: Job, html_text: str) -> None:
     if not job.description:
         desc_html = posting.get("description")
         if isinstance(desc_html, str) and desc_html.strip():
-            job.description = _strip(desc_html)[:10_000] or None
+            job.description = _strip(desc_html)[:25_000] or None
 
     emp_raw = posting.get("employmentType")
     if isinstance(emp_raw, str):

--- a/src/jobhive/scrapers/icims.py
+++ b/src/jobhive/scrapers/icims.py
@@ -181,7 +181,7 @@ class iCIMSScraper(BaseScraper):  # noqa: N801  matches public iCIMS branding
             # Detail enrichment: pull schema.org JSON-LD from each job's
             # iframe page. Best-effort — failures keep the listing-derived
             # row.
-            if all_jobs:
+            if self.include_descriptions and all_jobs:
                 sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
                 await asyncio.gather(*(
                     self._enrich_detail(client, sem, j) for j in all_jobs

--- a/src/jobhive/scrapers/jazzhr.py
+++ b/src/jobhive/scrapers/jazzhr.py
@@ -173,7 +173,7 @@ class JazzHRScraper(BaseScraper):
 
         # Detail enrichment via JSON-LD on each job's detail page.
         # Best-effort: errors fall through silently.
-        if jobs:
+        if self.include_descriptions and jobs:
             async with httpx.AsyncClient(
                 timeout=self.timeout, follow_redirects=True,
             ) as client:

--- a/src/jobhive/scrapers/jazzhr.py
+++ b/src/jobhive/scrapers/jazzhr.py
@@ -134,6 +134,21 @@ class JazzHRScraper(BaseScraper):
     def fetch(self) -> list[Job]:
         return asyncio.run(self._fetch_async())
 
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        copy = job.model_copy()
+
+        async def run() -> str | None:
+            async with httpx.AsyncClient(
+                timeout=self.timeout, follow_redirects=True,
+            ) as client:
+                sem = asyncio.Semaphore(1)
+                await self._enrich_detail(client, sem, copy)
+            return copy.description
+
+        return asyncio.run(run())
+
     async def _fetch_async(self) -> list[Job]:
         if self.client_kind == "httpcloak":
             html_text = await asyncio.to_thread(self._fetch_via_httpcloak_sync)
@@ -347,13 +362,13 @@ def _apply_jsonld_to_job(job: Job, html_text: str) -> None:
         if not job.description:
             fallback = _description_from_html(html_text)
             if fallback:
-                job.description = fallback[:10_000]
+                job.description = fallback[:25_000]
         return
 
     if not job.description:
         desc_html = posting.get("description")
         if isinstance(desc_html, str) and desc_html.strip():
-            job.description = _strip_tags(desc_html)[:10_000] or None
+            job.description = _strip_tags(desc_html)[:25_000] or None
 
     emp_raw = posting.get("employmentType")
     if isinstance(emp_raw, str):

--- a/src/jobhive/scrapers/jobsch.py
+++ b/src/jobhive/scrapers/jobsch.py
@@ -235,7 +235,7 @@ class JobsChScraper(BaseScraper):
                 seed, len(slice_jobs), new_count, len(all_jobs),
             )
 
-        if all_jobs:
+        if self.include_descriptions and all_jobs:
             await self._enrich_descriptions(all_jobs, proxy_url=proxy_url)
         return all_jobs
 

--- a/src/jobhive/scrapers/jobsch.py
+++ b/src/jobhive/scrapers/jobsch.py
@@ -144,6 +144,26 @@ class JobsChScraper(BaseScraper):
     def fetch(self) -> list[Job]:
         return asyncio.run(self._fetch_async())
 
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        copy = job.model_copy()
+        proxy_url = _evomi_proxy_url_from_env()
+
+        async def run() -> str | None:
+            client_kwargs: dict[str, Any] = {
+                "timeout": self.timeout,
+                "follow_redirects": True,
+            }
+            if proxy_url is not None:
+                client_kwargs["proxy"] = proxy_url
+            async with httpx.AsyncClient(**client_kwargs) as client:
+                sem = asyncio.Semaphore(1)
+                await self._enrich_description(client, sem, copy)
+            return copy.description
+
+        return asyncio.run(run())
+
     async def _fetch_async(self) -> list[Job]:
         # Probe IP routing on the empty query: if the datacenter IP is
         # 403-blocked, the same probe-then-proxy escalation runs once,
@@ -311,7 +331,7 @@ class JobsChScraper(BaseScraper):
             return
         description = _extract_description(response.text)
         if description and not job.description:
-            job.description = description[:10_000]
+            job.description = description[:25_000]
 
     async def _fetch_page(
         self,

--- a/src/jobhive/scrapers/join_com.py
+++ b/src/jobhive/scrapers/join_com.py
@@ -96,7 +96,7 @@ class JoinComScraper(BaseScraper):
                     break
                 page += 1
 
-            if all_jobs:
+            if self.include_descriptions and all_jobs:
                 self._enrich_with_details(client, all_jobs)
         return all_jobs
 

--- a/src/jobhive/scrapers/join_com.py
+++ b/src/jobhive/scrapers/join_com.py
@@ -100,6 +100,13 @@ class JoinComScraper(BaseScraper):
                 self._enrich_with_details(client, all_jobs)
         return all_jobs
 
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        copy = job.model_copy()
+        self._enrich_with_detail(copy)
+        return copy.description
+
     def _enrich_with_details(
         self, client: httpx.Client, jobs: list[Job],
     ) -> None:
@@ -128,6 +135,21 @@ class JoinComScraper(BaseScraper):
 
         with ThreadPoolExecutor(max_workers=DETAIL_CONCURRENCY) as pool:
             list(pool.map(fetch_one, jobs))
+
+    def _enrich_with_detail(self, job: Job) -> None:
+        try:
+            with httpx.Client(
+                timeout=self.timeout, follow_redirects=True,
+            ) as detail_client:
+                response = detail_client.get(
+                    str(job.url),
+                    headers={"User-Agent": "Mozilla/5.0"},
+                )
+        except httpx.HTTPError:
+            return
+        if response.status_code != 200:
+            return
+        _apply_jsonld_to_job(job, response.text)
 
     def _resolve_company_id(self, client: httpx.Client) -> str:
         try:
@@ -237,7 +259,7 @@ def _apply_jsonld_to_job(job: Job, html_text: str) -> None:
     if not job.description:
         desc = posting.get("description")
         if isinstance(desc, str) and desc.strip():
-            job.description = _strip_double_encoded(desc)[:10_000] or None
+            job.description = _strip_double_encoded(desc)[:25_000] or None
 
     emp = posting.get("employmentType")
     if isinstance(emp, str) and not job.employment_type:

--- a/src/jobhive/scrapers/lever.py
+++ b/src/jobhive/scrapers/lever.py
@@ -148,10 +148,10 @@ class LeverScraper(BaseScraper):
                     break
 
         # Description: ``descriptionPlain`` is the canonical body. Cap
-        # at 10kB; the schema field allows up to that.
+        # at 25k chars; the schema field allows up to that.
         description = item.get("descriptionPlain") or item.get("description")
         description = (
-            description.strip()[:10_000] or None
+            description.strip()[:25_000] or None
             if isinstance(description, str)
             else None
         )

--- a/src/jobhive/scrapers/manfred.py
+++ b/src/jobhive/scrapers/manfred.py
@@ -86,6 +86,21 @@ class ManfredScraper(BaseScraper):
     def fetch(self) -> list[Job]:
         return asyncio.run(self._fetch_async())
 
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        copy = job.model_copy()
+
+        async def run() -> str | None:
+            async with httpx.AsyncClient(
+                timeout=self.timeout, follow_redirects=True,
+            ) as client:
+                sem = asyncio.Semaphore(1)
+                await self._enrich_description(client, sem, copy)
+            return copy.description
+
+        return asyncio.run(run())
+
     async def _fetch_async(self) -> list[Job]:
         async with httpx.AsyncClient(
             timeout=self.timeout, follow_redirects=True,
@@ -131,7 +146,7 @@ class ManfredScraper(BaseScraper):
             return
         description = _compose_description(detail)
         if description and not job.description:
-            job.description = description[:10_000]
+            job.description = description[:25_000]
 
     async def _fetch_with_retry(
         self, client: httpx.AsyncClient

--- a/src/jobhive/scrapers/manfred.py
+++ b/src/jobhive/scrapers/manfred.py
@@ -114,7 +114,7 @@ class ManfredScraper(BaseScraper):
                     continue
                 seen.add(job.ats_id)
                 jobs.append(job)
-            if jobs:
+            if self.include_descriptions and jobs:
                 sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
                 await asyncio.gather(*(self._enrich_description(client, sem, j) for j in jobs))
         return jobs

--- a/src/jobhive/scrapers/mercor.py
+++ b/src/jobhive/scrapers/mercor.py
@@ -173,7 +173,7 @@ def _parse_listing(item: dict[str, Any]) -> Job | None:
     salary_summary = _build_salary_summary(rate_min, rate_max, pay_freq)
 
     raw_desc = item.get("description")
-    description = raw_desc.strip()[:10_000] or None if isinstance(raw_desc, str) else None
+    description = raw_desc.strip()[:25_000] or None if isinstance(raw_desc, str) else None
 
     raw: dict[str, Any] = {}
     for k in ("commitment", "category", "skills", "tags",

--- a/src/jobhive/scrapers/meta.py
+++ b/src/jobhive/scrapers/meta.py
@@ -106,7 +106,7 @@ class MetaScraper(BaseScraper):
             await browser.close()
 
         jobs = list(self._parse_responses(captured))
-        if jobs:
+        if self.include_descriptions and jobs:
             await self._enrich_detail_descriptions(jobs)
         return jobs
 

--- a/src/jobhive/scrapers/meta.py
+++ b/src/jobhive/scrapers/meta.py
@@ -59,6 +59,17 @@ class MetaScraper(BaseScraper):
             return []
         return asyncio.run(self._fetch_via_cloakbrowser())
 
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        jobs = [job.model_copy()]
+
+        async def run() -> str | None:
+            await self._enrich_detail_descriptions(jobs)
+            return jobs[0].description
+
+        return asyncio.run(run())
+
     async def _fetch_via_cloakbrowser(self) -> list[Job]:
         from cloakbrowser import launch_async
 
@@ -191,7 +202,7 @@ class MetaScraper(BaseScraper):
                 if items:
                     parts.append("\n".join(items))
         text = "\n\n".join(parts).strip()
-        return text[:10_000] or None
+        return text[:25_000] or None
 
     async def _enrich_detail_descriptions(self, jobs: list[Job]) -> None:
         """Fetch Meta detail pages for descriptions missing from listing GraphQL.
@@ -231,7 +242,7 @@ class MetaScraper(BaseScraper):
             return
         description = _description_from_detail_html(response.text)
         if description:
-            jobs[index] = job.model_copy(update={"description": description[:10_000]})
+            jobs[index] = job.model_copy(update={"description": description[:25_000]})
 
 
 __all__ = ["MetaScraper"]

--- a/src/jobhive/scrapers/oracle.py
+++ b/src/jobhive/scrapers/oracle.py
@@ -179,7 +179,7 @@ class OracleScraper(BaseScraper):
                         seen.add(job.ats_id)
                         all_jobs.append(job)
 
-            if all_jobs:
+            if self.include_descriptions and all_jobs:
                 sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
                 detail_url = (
                     f"{base}/hcmRestApi/resources/latest/"

--- a/src/jobhive/scrapers/oracle.py
+++ b/src/jobhive/scrapers/oracle.py
@@ -115,6 +115,28 @@ class OracleScraper(BaseScraper):
     def fetch(self) -> list[Job]:
         return asyncio.run(self._fetch_async())
 
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        copy = job.model_copy()
+        base, _site = _normalize_oracle_target(self.company_slug)
+        if not base.startswith(("http://", "https://")):
+            return None
+        detail_url = (
+            f"{base}/hcmRestApi/resources/latest/"
+            "recruitingCEJobRequisitionDetails"
+        )
+
+        async def run() -> str | None:
+            async with httpx.AsyncClient(
+                timeout=self.timeout, follow_redirects=True,
+            ) as client:
+                sem = asyncio.Semaphore(1)
+                await self._enrich_detail(client, sem, detail_url, copy)
+            return copy.description
+
+        return asyncio.run(run())
+
     async def _fetch_async(self) -> list[Job]:
         base, site = _normalize_oracle_target(self.company_slug)
         if not base.startswith(("http://", "https://")):
@@ -200,7 +222,7 @@ class OracleScraper(BaseScraper):
 
         # Concatenate the three external sections — description /
         # qualifications / responsibilities — into a single plain-text
-        # body, capped at 10kB.
+        # body, capped at 25k chars.
         parts: list[str] = []
         for key in (
             "ExternalDescriptionStr",
@@ -211,7 +233,7 @@ class OracleScraper(BaseScraper):
             if isinstance(v, str) and v.strip():
                 parts.append(_strip_html(v))
         if parts:
-            job.description = "\n\n".join(parts)[:10_000]
+            job.description = "\n\n".join(parts)[:25_000]
 
     async def _fetch_with_retry(
         self,
@@ -275,7 +297,7 @@ class OracleScraper(BaseScraper):
         # ``ExternalDescriptionStr`` when enabled.
         short_desc = item.get("ShortDescriptionStr")
         description = (
-            _strip_html(short_desc)[:10_000]
+            _strip_html(short_desc)[:25_000]
             if isinstance(short_desc, str) and short_desc.strip()
             else None
         )

--- a/src/jobhive/scrapers/personio.py
+++ b/src/jobhive/scrapers/personio.py
@@ -94,7 +94,8 @@ class PersonioScraper(BaseScraper):
                     jobs = [self._parse_job(item, base) for item in items]
                     break
             if jobs:
-                self._enrich_descriptions(jobs)
+                if self.include_descriptions:
+                    self._enrich_descriptions(jobs)
                 return jobs
         if last_error:
             raise CompanyNotFoundError(

--- a/src/jobhive/scrapers/personio.py
+++ b/src/jobhive/scrapers/personio.py
@@ -102,28 +102,32 @@ class PersonioScraper(BaseScraper):
             ) from last_error
         return []
 
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        try:
+            with httpx.Client(
+                timeout=self.timeout, follow_redirects=True,
+            ) as client:
+                response = client.get(
+                    str(job.url),
+                    headers={"User-Agent": "Mozilla/5.0"},
+                )
+        except httpx.HTTPError:
+            return None
+        if response.status_code != 200:
+            return None
+        description = _extract_description(response.text)
+        return description[:25_000] if description else None
+
     def _enrich_descriptions(self, jobs: list[Job]) -> None:
         """Fan out per-job HTML fetches; pull the description body out
         of the ``page_jobDescription`` block. ``httpx.Client`` is not
         thread-safe so we use short-lived per-thread clients."""
-        timeout = self.timeout
-
         def fetch_one(job: Job) -> None:
-            try:
-                with httpx.Client(
-                    timeout=timeout, follow_redirects=True,
-                ) as client:
-                    response = client.get(
-                        str(job.url),
-                        headers={"User-Agent": "Mozilla/5.0"},
-                    )
-            except httpx.HTTPError:
-                return
-            if response.status_code != 200:
-                return
-            description = _extract_description(response.text)
+            description = self.get_description(job)
             if description:
-                job.description = description[:10_000]
+                job.description = description
 
         with ThreadPoolExecutor(max_workers=DETAIL_CONCURRENCY) as pool:
             list(pool.map(fetch_one, jobs))

--- a/src/jobhive/scrapers/phenom.py
+++ b/src/jobhive/scrapers/phenom.py
@@ -401,7 +401,7 @@ def _clean_description(value: object) -> str | None:
     cleaned = re.sub(r"\s+", " ", cleaned).strip()
     if not cleaned:
         return None
-    return cleaned[:10_000]
+    return cleaned[:25_000]
 
 
 def _parse_iso(value: object) -> datetime | None:

--- a/src/jobhive/scrapers/pinpoint.py
+++ b/src/jobhive/scrapers/pinpoint.py
@@ -37,7 +37,7 @@ MAX_RETRIES = 3
 RETRY_BASE_DELAY = 1.5
 HTML_TAG_RE = re.compile(r"<[^>]+>")
 WHITESPACE_RE = re.compile(r"\s+")
-MAX_DESCRIPTION_LEN = 10_000
+MAX_DESCRIPTION_LEN = 25_000
 
 # Pinpoint sometimes prefixes the employment-type code with the
 # contract status (``permanent_full_time``, ``permanent_part_time``,

--- a/src/jobhive/scrapers/programathor.py
+++ b/src/jobhive/scrapers/programathor.py
@@ -148,6 +148,26 @@ class ProgramathorScraper(BaseScraper):
     def fetch(self) -> list[Job]:
         return asyncio.run(self._fetch_async())
 
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        copy = job.model_copy()
+
+        async def run() -> str | None:
+            client_kwargs: dict[str, Any] = {
+                "timeout": self.timeout,
+                "follow_redirects": True,
+            }
+            if self.proxy_url:
+                client_kwargs["proxy"] = self.proxy_url
+                client_kwargs["verify"] = False
+            async with httpx.AsyncClient(**client_kwargs) as client:
+                sem = asyncio.Semaphore(1)
+                await self._enrich_description(client, sem, copy)
+            return copy.description
+
+        return asyncio.run(run())
+
     async def _fetch_async(self) -> list[Job]:
         seen_ids: set[str] = set()
         jobs: list[Job] = []
@@ -210,7 +230,7 @@ class ProgramathorScraper(BaseScraper):
             return
         description = _extract_description(text)
         if description and not job.description:
-            job.description = description[:10_000]
+            job.description = description[:25_000]
 
     async def _fetch_page(
         self,

--- a/src/jobhive/scrapers/programathor.py
+++ b/src/jobhive/scrapers/programathor.py
@@ -211,7 +211,7 @@ class ProgramathorScraper(BaseScraper):
                 else:
                     consecutive_empty = 0
                 page += 1
-            if jobs:
+            if self.include_descriptions and jobs:
                 detail_sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
                 await asyncio.gather(*(
                     self._enrich_description(client, detail_sem, job) for job in jobs

--- a/src/jobhive/scrapers/recruitee.py
+++ b/src/jobhive/scrapers/recruitee.py
@@ -192,7 +192,7 @@ def _compose_description(offer: dict[str, Any]) -> str | None:
                 parts.append(cleaned)
     if not parts:
         return None
-    return "\n\n".join(parts)[:10_000]
+    return "\n\n".join(parts)[:25_000]
 
 
 def _fallback_url(slug: str, offer: dict[str, Any]) -> str:

--- a/src/jobhive/scrapers/recruiterbox.py
+++ b/src/jobhive/scrapers/recruiterbox.py
@@ -40,7 +40,7 @@ MAX_RETRIES = 3
 RETRY_BASE_DELAY = 1.5
 HTML_TAG_RE = re.compile(r"<[^>]+>")
 WHITESPACE_RE = re.compile(r"\s+")
-MAX_DESCRIPTION_LEN = 10_000
+MAX_DESCRIPTION_LEN = 25_000
 
 _TYPE_MAP = {
     "full_time": "FULL_TIME",

--- a/src/jobhive/scrapers/remoteok.py
+++ b/src/jobhive/scrapers/remoteok.py
@@ -218,11 +218,11 @@ def _iso_to_dt(value: object) -> datetime | None:
 
 def _clean_description(value: object) -> str | None:
     """Strip Remote OK's anti-bot reminder line + HTML, collapse whitespace,
-    and truncate to the canonical ~10kB budget."""
+    and truncate to the canonical ~25k chars budget."""
     if not isinstance(value, str) or not value.strip():
         return None
     text = html.unescape(value)
     text = _ANTIBOT_RE.sub("", text)
     text = _TAG_RE.sub(" ", text)
     text = re.sub(r"\s+", " ", text).strip()
-    return text[:10_000] or None
+    return text[:25_000] or None

--- a/src/jobhive/scrapers/rippling.py
+++ b/src/jobhive/scrapers/rippling.py
@@ -64,6 +64,21 @@ class RipplingScraper(BaseScraper):
     def fetch(self) -> list[Job]:
         return asyncio.run(self._fetch_async())
 
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        copy = job.model_copy()
+
+        async def run() -> str | None:
+            async with httpx.AsyncClient(
+                timeout=self.timeout, follow_redirects=True,
+            ) as client:
+                sem = asyncio.Semaphore(1)
+                await self._enrich_detail(client, sem, copy)
+            return copy.description
+
+        return asyncio.run(run())
+
     async def _fetch_async(self) -> list[Job]:
         url = API_TEMPLATE.format(slug=self.company_slug)
         async with httpx.AsyncClient(
@@ -188,7 +203,7 @@ def _apply_detail_to_job(job: Job, detail: dict[str, Any]) -> None:
             if isinstance(html, str) and html.strip():
                 parts.append(_strip_html(html))
         if parts:
-            job.description = "\n\n".join(parts)[:10_000]
+            job.description = "\n\n".join(parts)[:25_000]
 
     emp = detail.get("employmentType")
     if isinstance(emp, dict):

--- a/src/jobhive/scrapers/rippling.py
+++ b/src/jobhive/scrapers/rippling.py
@@ -111,7 +111,7 @@ class RipplingScraper(BaseScraper):
                 items = []
             jobs = [self._parse_job(item) for item in items]
 
-            if jobs:
+            if self.include_descriptions and jobs:
                 sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
                 await asyncio.gather(*(
                     self._enrich_detail(client, sem, j) for j in jobs

--- a/src/jobhive/scrapers/smartrecruiters.py
+++ b/src/jobhive/scrapers/smartrecruiters.py
@@ -74,6 +74,21 @@ class SmartRecruitersScraper(BaseScraper):
     def fetch(self) -> list[Job]:
         return asyncio.run(self._fetch_async())
 
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        copy = job.model_copy()
+
+        async def run() -> str | None:
+            async with httpx.AsyncClient(
+                timeout=self.timeout, follow_redirects=True,
+            ) as client:
+                sem = asyncio.Semaphore(1)
+                await self._enrich_detail(client, sem, copy)
+            return copy.description
+
+        return asyncio.run(run())
+
     async def _fetch_async(self) -> list[Job]:
         url = API_TEMPLATE.format(slug=self.company_slug)
         all_jobs: list[Job] = []
@@ -214,7 +229,7 @@ def _apply_detail_to_job(job: Job, detail: dict[str, Any]) -> None:
     ``companyDescription`` / ``jobDescription`` / ``qualifications`` /
     ``additionalInformation`` — each carrying ``title`` + HTML
     ``text``). We concatenate the four sections' plain text into a
-    single body, capped at 10kB, with the actual job description
+    single body, capped at 25k chars, with the actual job description
     first so consumers see the most relevant content if truncated.
     """
     if not job.description:
@@ -233,7 +248,7 @@ def _apply_detail_to_job(job: Job, detail: dict[str, Any]) -> None:
                     if isinstance(text, str) and text.strip():
                         parts.append(_strip_html(text))
             if parts:
-                job.description = "\n\n".join(parts)[:10_000]
+                job.description = "\n\n".join(parts)[:25_000]
 
     if not job.apply_url:
         apply_url = detail.get("applyUrl")

--- a/src/jobhive/scrapers/smartrecruiters.py
+++ b/src/jobhive/scrapers/smartrecruiters.py
@@ -121,7 +121,7 @@ class SmartRecruitersScraper(BaseScraper):
                     break
                 offset += PAGE_LIMIT
 
-            if all_jobs:
+            if self.include_descriptions and all_jobs:
                 sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
                 await asyncio.gather(*(
                     self._enrich_detail(client, sem, j) for j in all_jobs

--- a/src/jobhive/scrapers/successfactors.py
+++ b/src/jobhive/scrapers/successfactors.py
@@ -295,7 +295,7 @@ def _clean_description(value: object) -> str | None:
     text = html.unescape(value)
     text = _TAG_RE.sub(" ", text)
     text = re.sub(r"\s+", " ", text).strip()
-    return text[:10_000] or None
+    return text[:25_000] or None
 
 
 def _parse_pubdate(value: object) -> datetime | None:

--- a/src/jobhive/scrapers/taleo.py
+++ b/src/jobhive/scrapers/taleo.py
@@ -97,6 +97,21 @@ class TaleoScraper(BaseScraper):
     def fetch(self) -> list[Job]:
         return asyncio.run(self._fetch_async())
 
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        copy = job.model_copy()
+
+        async def run() -> str | None:
+            async with httpx.AsyncClient(
+                timeout=self.timeout, follow_redirects=True,
+            ) as client:
+                sem = asyncio.Semaphore(1)
+                await self._enrich_detail(client, sem, copy)
+            return copy.description
+
+        return asyncio.run(run())
+
     async def _fetch_async(self) -> list[Job]:
         url = self._validate_url(self.company_slug)
         async with httpx.AsyncClient(
@@ -231,7 +246,7 @@ def _apply_jsonld_to_job(job: Job, html_text: str) -> None:
 
     desc = posting.get("description")
     if isinstance(desc, str) and desc.strip() and not job.description:
-        job.description = _strip_jsonld_html(desc)[:10_000] or None
+        job.description = _strip_jsonld_html(desc)[:25_000] or None
 
     emp = posting.get("employmentType")
     if isinstance(emp, str) and not job.employment_type:

--- a/src/jobhive/scrapers/taleo.py
+++ b/src/jobhive/scrapers/taleo.py
@@ -119,7 +119,7 @@ class TaleoScraper(BaseScraper):
         ) as client:
             html_text = await self._fetch_with_retry(client, url)
             jobs = self._parse_listing(html_text, base_url=url)
-            if jobs:
+            if self.include_descriptions and jobs:
                 sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
                 await asyncio.gather(*(
                     self._enrich_detail(client, sem, j) for j in jobs

--- a/src/jobhive/scrapers/teamtailor.py
+++ b/src/jobhive/scrapers/teamtailor.py
@@ -165,7 +165,7 @@ class TeamtailorScraper(BaseScraper):
         text = re.sub(r"\s+", " ", text).strip()
         if not text:
             return None
-        return text[:10_000]
+        return text[:25_000]
 
 
 def _format_location(item: ET.Element) -> str | None:

--- a/src/jobhive/scrapers/tesla.py
+++ b/src/jobhive/scrapers/tesla.py
@@ -77,6 +77,35 @@ class TeslaScraper(BaseScraper):
             return []
         return asyncio.run(self._fetch_via_cloakbrowser())
 
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        if not job.ats_id or not cb.is_enabled():
+            return None
+
+        async def run() -> str | None:
+            from cloakbrowser import launch_async
+
+            proxy = cb.evomi_proxy_from_env()
+            browser = await launch_async(
+                headless=True, humanize=True, proxy=proxy,
+            )
+            try:
+                page = await browser.new_page()
+                await page.goto(
+                    f"{_BASE_URL}{_CAREERS_HOME}",
+                    wait_until="domcontentloaded",
+                    timeout=60_000,
+                )
+                await asyncio.sleep(_INITIAL_SETTLE_S)
+                details = await self._fetch_details(page, [job.ats_id])
+            finally:
+                await browser.close()
+            detail = details.get(job.ats_id)
+            return _format_description(detail) if detail else None
+
+        return asyncio.run(run())
+
     async def _fetch_via_cloakbrowser(self) -> list[Job]:
         from cloakbrowser import launch_async
 

--- a/src/jobhive/scrapers/tesla.py
+++ b/src/jobhive/scrapers/tesla.py
@@ -164,14 +164,15 @@ class TeslaScraper(BaseScraper):
             # this step every Tesla row ships with an empty
             # ``description`` (violates the
             # always-include-descriptions invariant).
-            ids = [j.ats_id for j in jobs]
-            details = await self._fetch_details(page, ids)
-            for j in jobs:
-                d = details.get(j.ats_id)
-                if d:
-                    j.description = _format_description(d) or None
-                    if not j.department:
-                        j.department = d.get("department") or None
+            if self.include_descriptions:
+                ids = [j.ats_id for j in jobs]
+                details = await self._fetch_details(page, ids)
+                for j in jobs:
+                    d = details.get(j.ats_id)
+                    if d:
+                        j.description = _format_description(d) or None
+                        if not j.department:
+                            j.department = d.get("department") or None
         finally:
             await browser.close()
 

--- a/src/jobhive/scrapers/thehub.py
+++ b/src/jobhive/scrapers/thehub.py
@@ -268,7 +268,7 @@ def _clean_description(value: object) -> str | None:
     text = html.unescape(value)
     text = _TAG_RE.sub(" ", text)
     text = re.sub(r"\s+", " ", text).strip()
-    return text[:10_000] or None
+    return text[:25_000] or None
 
 
 def _parse_iso(value: object) -> datetime | None:

--- a/src/jobhive/scrapers/tiktok.py
+++ b/src/jobhive/scrapers/tiktok.py
@@ -154,7 +154,7 @@ class TikTokScraper(BaseScraper):
 
 
 def _compose_description(*sources: object) -> str | None:
-    """Concatenate description-like fields and cap at 10kB.
+    """Concatenate description-like fields and cap at 25k chars.
 
     The body sometimes contains repeated whitespace from the API; we
     collapse runs of blank lines to keep storage tight.
@@ -167,7 +167,7 @@ def _compose_description(*sources: object) -> str | None:
         return None
     text = "\n\n".join(parts)
     text = re.sub(r"\n{3,}", "\n\n", text).strip()
-    return text[:10_000] or None
+    return text[:25_000] or None
 
 
 def _extract_label(value: object) -> str | None:

--- a/src/jobhive/scrapers/uber.py
+++ b/src/jobhive/scrapers/uber.py
@@ -161,10 +161,10 @@ class UberScraper(BaseScraper):
         elif isinstance(first_loc, str):
             location = first_loc
 
-        # Description is markdown — kept verbatim, capped at 10kB.
+        # Description is markdown — kept verbatim, capped at 25k chars.
         description_raw = item.get("description")
         description = (
-            description_raw.strip()[:10_000] or None
+            description_raw.strip()[:25_000] or None
             if isinstance(description_raw, str)
             else None
         )

--- a/src/jobhive/scrapers/usajobs.py
+++ b/src/jobhive/scrapers/usajobs.py
@@ -44,7 +44,7 @@ ENV_USER_AGENT = "USAJOBS_USER_AGENT"  # Optional override; defaults to email be
 DEFAULT_USER_AGENT = "stapply-ai (open-source jobs dataset)"
 HTML_TAG_RE = re.compile(r"<[^>]+>")
 WHITESPACE_RE = re.compile(r"\s+")
-MAX_DESCRIPTION_LEN = 10_000
+MAX_DESCRIPTION_LEN = 25_000
 
 _TYPE_MAP = {
     "full-time": "FULL_TIME",

--- a/src/jobhive/scrapers/wanted.py
+++ b/src/jobhive/scrapers/wanted.py
@@ -132,7 +132,7 @@ class WantedScraper(BaseScraper):
                     )
 
             await asyncio.gather(*(per_country(cc) for cc in self.country_codes))
-            if jobs:
+            if self.include_descriptions and jobs:
                 await asyncio.gather(*(self._enrich_description(client, sem, j) for j in jobs))
         return jobs
 

--- a/src/jobhive/scrapers/wanted.py
+++ b/src/jobhive/scrapers/wanted.py
@@ -76,6 +76,21 @@ class WantedScraper(BaseScraper):
     def fetch(self) -> list[Job]:
         return asyncio.run(self._fetch_async())
 
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        copy = job.model_copy()
+
+        async def run() -> str | None:
+            async with httpx.AsyncClient(
+                timeout=self.timeout, follow_redirects=True,
+            ) as client:
+                sem = asyncio.Semaphore(1)
+                await self._enrich_description(client, sem, copy)
+            return copy.description
+
+        return asyncio.run(run())
+
     async def _fetch_async(self) -> list[Job]:
         seen: set[str] = set()
         jobs: list[Job] = []
@@ -137,7 +152,7 @@ class WantedScraper(BaseScraper):
         detail = ((payload.get("job") or {}).get("detail") or {})
         description = _compose_description(detail)
         if description and not job.description:
-            job.description = description[:10_000]
+            job.description = description[:25_000]
 
     # --- HTTP layer ---------------------------------------------------------
 

--- a/src/jobhive/scrapers/welcometothejungle.py
+++ b/src/jobhive/scrapers/welcometothejungle.py
@@ -305,8 +305,8 @@ def _compose_description(hit: dict[str, object]) -> str | None:
     full = "\n\n".join(parts).strip()
     if not full:
         return None
-    # Cap at ~10kB as documented in the Job model
-    return full[:10_000]
+    # Cap at ~25k chars as documented in the Job model
+    return full[:25_000]
 
 
 def _parse_iso(value: object) -> datetime | None:

--- a/src/jobhive/scrapers/wellfound.py
+++ b/src/jobhive/scrapers/wellfound.py
@@ -156,9 +156,7 @@ class WellfoundScraper(BaseScraper):
         if job.description:
             return job.description
         if not self.firecrawl_api_key:
-            raise ScraperError(
-                "Wellfound requires a Firecrawl API key to fetch descriptions."
-            )
+            return None
         copy = job.model_copy()
 
         async def run() -> str | None:

--- a/src/jobhive/scrapers/wellfound.py
+++ b/src/jobhive/scrapers/wellfound.py
@@ -198,7 +198,7 @@ class WellfoundScraper(BaseScraper):
 
             tasks = [fetch_overall()] + [per_role(s) for s in self.role_slugs]
             await asyncio.gather(*tasks)
-            if jobs:
+            if self.include_descriptions and jobs:
                 await asyncio.gather(*(
                     self._enrich_description(client, sem, job) for job in jobs
                 ))

--- a/src/jobhive/scrapers/wellfound.py
+++ b/src/jobhive/scrapers/wellfound.py
@@ -152,6 +152,23 @@ class WellfoundScraper(BaseScraper):
             )
         return asyncio.run(self._fetch_async())
 
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        if not self.firecrawl_api_key:
+            raise ScraperError(
+                "Wellfound requires a Firecrawl API key to fetch descriptions."
+            )
+        copy = job.model_copy()
+
+        async def run() -> str | None:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                sem = asyncio.Semaphore(1)
+                await self._enrich_description(client, sem, copy)
+            return copy.description
+
+        return asyncio.run(run())
+
     async def _fetch_async(self) -> list[Job]:
         seen: set[str] = set()
         jobs: list[Job] = []
@@ -201,7 +218,7 @@ class WellfoundScraper(BaseScraper):
             return
         description = _description_from_markdown(markdown, title=job.title)
         if description and not job.description:
-            job.description = description[:10_000]
+            job.description = description[:25_000]
 
     async def _fetch_role(
         self,

--- a/src/jobhive/scrapers/weworkremotely.py
+++ b/src/jobhive/scrapers/weworkremotely.py
@@ -255,7 +255,7 @@ def _clean_description(value: object) -> str | None:
     text = html.unescape(value)
     text = _TAG_RE.sub(" ", text)
     text = re.sub(r"\s+", " ", text).strip()
-    return text[:10_000] or None
+    return text[:25_000] or None
 
 
 def _parse_pubdate(value: object) -> datetime | None:

--- a/src/jobhive/scrapers/workable.py
+++ b/src/jobhive/scrapers/workable.py
@@ -130,28 +130,34 @@ class WorkableScraper(BaseScraper):
             self._enrich_descriptions(jobs)
         return jobs
 
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        if not job.ats_id:
+            return None
+        url = MARKDOWN_TEMPLATE.format(slug=self.company_slug, shortcode=job.ats_id)
+        try:
+            with httpx.Client(timeout=self.timeout, follow_redirects=True) as client:
+                response = client.get(
+                    url,
+                    headers={"User-Agent": USER_AGENT, "Accept": "text/markdown"},
+                )
+        except httpx.HTTPError:
+            return None
+        if response.status_code != 200:
+            return None
+        text = response.text.strip()
+        return text[:25_000] if text else None
+
     def _enrich_descriptions(self, jobs: list[Job]) -> None:
         """Pull the Markdown body for each job from
         ``/{slug}/jobs/view/{shortcode}.md``. Runs in a thread pool with
         a low cap (4) so we stay below the per-tenant rate limit."""
-        slug = self.company_slug
-        timeout = self.timeout
 
         def fetch_one(job: Job) -> None:
-            url = MARKDOWN_TEMPLATE.format(slug=slug, shortcode=job.ats_id)
-            try:
-                with httpx.Client(timeout=timeout, follow_redirects=True) as c:
-                    resp = c.get(
-                        url,
-                        headers={"User-Agent": USER_AGENT, "Accept": "text/markdown"},
-                    )
-            except httpx.HTTPError:
-                return
-            if resp.status_code != 200:
-                return
-            text = resp.text.strip()
-            if text and not job.description:
-                job.description = text[:10_000]
+            description = self.get_description(job)
+            if description and not job.description:
+                job.description = description
 
         with ThreadPoolExecutor(max_workers=DETAIL_CONCURRENCY) as pool:
             list(pool.map(fetch_one, jobs))

--- a/src/jobhive/scrapers/workable.py
+++ b/src/jobhive/scrapers/workable.py
@@ -126,7 +126,7 @@ class WorkableScraper(BaseScraper):
         payload = response.json()
         jobs = [self._parse_job(item) for item in payload.get("jobs", [])]
 
-        if jobs:
+        if self.include_descriptions and jobs:
             self._enrich_descriptions(jobs)
         return jobs
 

--- a/src/jobhive/scrapers/workday.py
+++ b/src/jobhive/scrapers/workday.py
@@ -131,6 +131,28 @@ class WorkdayScraper(BaseScraper):
 
         return asyncio.run(self._fetch_async(api, base, company, detail_prefix))
 
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        match = URL_PATTERN.match(self.company_slug.rstrip("/"))
+        if not match:
+            return None
+        company = match.group("company")
+        instance = match.group("instance")
+        site = match.group("site")
+        detail_prefix = f"https://{company}.{instance}.myworkdayjobs.com/wday/cxs/{company}/{site}"
+        jobs = [job.model_copy()]
+
+        async def run() -> str | None:
+            async with httpx.AsyncClient(
+                timeout=self.timeout, follow_redirects=True,
+            ) as client:
+                sem = asyncio.Semaphore(1)
+                await self._enrich_details(client, sem, detail_prefix, jobs)
+            return jobs[0].description
+
+        return asyncio.run(run())
+
     async def _fetch_async(
         self,
         api: str,
@@ -216,7 +238,7 @@ class WorkdayScraper(BaseScraper):
 
             description = _extract_description(jpi)
             if description and not job.description:
-                updates["description"] = description[:10_000]
+                updates["description"] = description[:25_000]
 
             if isinstance(job.location, str) and _LOCATION_ROLLUP_RE.match(job.location):
                 primary = jpi.get("location")

--- a/src/jobhive/scrapers/workday.py
+++ b/src/jobhive/scrapers/workday.py
@@ -181,9 +181,10 @@ class WorkdayScraper(BaseScraper):
                 applied_facets={}, absorb=absorb, depth=0,
             )
 
-            await self._enrich_details(
-                client, sem, detail_prefix, all_jobs,
-            )
+            if self.include_descriptions:
+                await self._enrich_details(
+                    client, sem, detail_prefix, all_jobs,
+                )
         return all_jobs
 
     async def _enrich_details(

--- a/src/jobhive/scrapers/ycombinator.py
+++ b/src/jobhive/scrapers/ycombinator.py
@@ -462,7 +462,7 @@ def _compose_description(item: dict[str, Any]) -> str | None:
             if cleaned:
                 parts.append("\n".join(cleaned))
     text = "\n\n".join(p for p in parts if p).strip()
-    return text[:10_000] or None
+    return text[:25_000] or None
 
 
 def _clean_description_text(value: str) -> str:

--- a/tests/test_bamboohr.py
+++ b/tests/test_bamboohr.py
@@ -396,7 +396,7 @@ def test_description_failure_keeps_listing_row(httpx_mock) -> None:
 
 def test_description_is_truncated(httpx_mock) -> None:
     """Long descriptions are capped — both at the Pydantic field-level cap
-    (10kB) and our scraper-side cap (12kB) — so memory stays bounded."""
+    (25k chars) and our scraper-side cap (12kB) — so memory stays bounded."""
     huge = "Lorem ipsum dolor sit amet. " * 800  # ~22kB
     httpx_mock.add_response(url=WIDGET_URL, text=_widget_html([
         {"id": 1, "name": "Eng", "jobs": [{"id": 100, "title": "X", "location": "Y"}]},
@@ -407,4 +407,4 @@ def test_description_is_truncated(httpx_mock) -> None:
     )
     job = BambooHRScraper("acme").fetch()[0]
     assert job.description is not None
-    assert len(job.description) <= 10_000
+    assert len(job.description) <= 25_000

--- a/tests/test_description_api.py
+++ b/tests/test_description_api.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
+from jobhive.models import ATSType, Job
+from jobhive.scrapers import BreezyScraper, SmartRecruitersScraper, WorkableScraper
+from jobhive.scrapers.base import BaseScraper, ScraperRegistry
+
+TWO_STEP_PROVIDERS = {
+    ATSType.AVATURE,
+    ATSType.BAMBOOHR,
+    ATSType.BREEZY,
+    ATSType.BUNDESAGENTUR,
+    ATSType.EIGHTFOLD,
+    ATSType.GEM,
+    ATSType.GOOGLE,
+    ATSType.ICIMS,
+    ATSType.JAZZHR,
+    ATSType.JOBSCH,
+    ATSType.JOIN_COM,
+    ATSType.MANFRED,
+    ATSType.META,
+    ATSType.ORACLE,
+    ATSType.PERSONIO,
+    ATSType.PROGRAMATHOR,
+    ATSType.RIPPLING,
+    ATSType.SMARTRECRUITERS,
+    ATSType.TALEO,
+    ATSType.TESLA,
+    ATSType.WANTED,
+    ATSType.WELLFOUND,
+    ATSType.WORKABLE,
+    ATSType.WORKDAY,
+}
+
+
+def _job(
+    *,
+    ats_type: ATSType,
+    ats_id: str = "job-1",
+    url: str = "https://example.com/jobs/job-1",
+    description: str | None = None,
+) -> Job:
+    return Job(
+        url=url,
+        title="Engineer",
+        company="Acme",
+        ats_type=ats_type,
+        ats_id=ats_id,
+        description=description,
+        fetched_at=datetime.now(),
+    )
+
+
+def test_two_step_providers_override_get_description() -> None:
+    missing = [
+        ats.value
+        for ats in sorted(TWO_STEP_PROVIDERS, key=lambda item: item.value)
+        if ScraperRegistry.get(ats).get_description is BaseScraper.get_description
+    ]
+
+    assert missing == []
+
+
+def test_base_get_description_returns_existing_description() -> None:
+    class DummyScraper(BaseScraper):
+        ats = ATSType.CUSTOM
+
+        def fetch(self) -> list[Job]:
+            return []
+
+    job = _job(ats_type=ATSType.CUSTOM, description="Already known.")
+
+    assert DummyScraper("dummy").get_description(job) == "Already known."
+
+
+def test_base_enrich_descriptions_uses_get_description() -> None:
+    class DummyScraper(BaseScraper):
+        ats = ATSType.CUSTOM
+
+        def fetch(self) -> list[Job]:
+            return []
+
+        def get_description(self, job: Job) -> str | None:
+            return f"Description for {job.ats_id}"
+
+    job = _job(ats_type=ATSType.CUSTOM, description=None)
+
+    DummyScraper("dummy").enrich_descriptions([job])
+
+    assert job.description == "Description for job-1"
+
+
+def test_workable_get_description_fetches_markdown(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://apply.workable.com/acme/jobs/view/ABC123.md",
+        text="# Engineer\n\nBuild useful products.",
+    )
+    job = _job(
+        ats_type=ATSType.WORKABLE,
+        ats_id="ABC123",
+        url="https://apply.workable.com/acme/j/ABC123",
+    )
+
+    description = WorkableScraper("acme").get_description(job)
+
+    assert description == "# Engineer\n\nBuild useful products."
+    assert job.description is None
+
+
+def test_smartrecruiters_get_description_fetches_detail_api(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://api.smartrecruiters.com/v1/companies/acme/postings/123",
+        json={
+            "jobAd": {
+                "sections": {
+                    "jobDescription": {"text": "<p>Build APIs.</p>"},
+                    "qualifications": {"text": "<p>Write tests.</p>"},
+                }
+            }
+        },
+    )
+    job = _job(
+        ats_type=ATSType.SMARTRECRUITERS,
+        ats_id="123",
+        url="https://jobs.smartrecruiters.com/acme/123",
+    )
+
+    description = SmartRecruitersScraper("acme").get_description(job)
+
+    assert description == "Build APIs.\n\nWrite tests."
+    assert job.description is None
+
+
+def test_breezy_get_description_fetches_detail_html(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=re.compile(r"^https://acme\.breezy\.hr/p/123"),
+        text="<html><body><div class='description'>Build hiring tools.</div></body></html>",
+    )
+    job = _job(
+        ats_type=ATSType.BREEZY,
+        ats_id="123",
+        url="https://acme.breezy.hr/p/123-engineer",
+    )
+
+    description = BreezyScraper("acme").get_description(job)
+
+    assert description == "Build hiring tools."
+    assert job.description is None

--- a/tests/test_mercor.py
+++ b/tests/test_mercor.py
@@ -239,7 +239,7 @@ def test_description_truncated_to_10kb(httpx_mock) -> None:
     ]})
     jobs = MercorScraper("any").fetch()
     assert jobs[0].description is not None
-    assert len(jobs[0].description) <= 10_000
+    assert len(jobs[0].description) <= 25_000
 
 
 def test_description_none_when_empty(httpx_mock) -> None:

--- a/tests/test_phenom.py
+++ b/tests/test_phenom.py
@@ -299,7 +299,7 @@ def test_description_strips_html_and_truncates(httpx_mock) -> None:
     jobs = PhenomScraper(BASE).fetch()
     assert jobs[0].description is not None
     assert "<p>" not in jobs[0].description
-    assert len(jobs[0].description) <= 10_000
+    assert len(jobs[0].description) <= 25_000
 
 
 def test_url_is_full_when_relative(httpx_mock) -> None:

--- a/tests/test_run_pipeline_guards.py
+++ b/tests/test_run_pipeline_guards.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import csv
 
 import pytest
 
@@ -112,3 +113,344 @@ def test_singleton_success_returns_zero_exit_code(
 
     assert rc == 0
     assert (tmp_path / "single" / "jobs.csv").exists()
+
+
+def test_pipeline_reuses_previous_description_without_refetching(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "ats-companies").mkdir()
+    (tmp_path / "ats-companies" / "fake.csv").write_text(
+        "name,slug,url\nAcme,acme,https://example.com\n",
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / "fake"
+    out_dir.mkdir()
+    out_path = out_dir / "jobs.csv"
+    cached_description = "cached " + ("x" * 700)
+    out_path.write_text(
+        (
+            "url,title,company,ats_type,ats_id,description\n"
+            f"https://example.com/jobs/1,Old,Acme,custom,1,{cached_description}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    class CachedScraper:
+        def __init__(self, *_args, **_kwargs) -> None:
+            self.include_descriptions = True
+
+        def fetch(self):
+            assert self.include_descriptions is True
+            return [
+                Job(
+                    url="https://example.com/jobs/1",
+                    title="Engineer",
+                    company="Acme",
+                    ats_type=ATSType.CUSTOM,
+                    ats_id="1",
+                )
+            ]
+
+        def get_description(self, _job):
+            raise AssertionError("cached jobs should not refetch descriptions")
+
+    monkeypatch.setattr(runner, "DATA_ROOT", tmp_path)
+    monkeypatch.setitem(
+        runner.CONFIGS,
+        "fake",
+        {
+            "scraper": CachedScraper,
+            "slug": lambda r: r["slug"],
+            "csv": "ats-companies/fake.csv",
+            "output": "fake/jobs.csv",
+        },
+    )
+
+    rc = asyncio.run(runner.run("fake", concurrency=1, max_tenants=None, timeout=1))
+
+    assert rc == 0
+    rows = list(csv.DictReader(out_path.open(newline="")))
+    assert rows[0]["description"] == cached_description
+
+
+def test_pipeline_fetches_missing_description_after_cache_lookup(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "ats-companies").mkdir()
+    (tmp_path / "ats-companies" / "fake.csv").write_text(
+        "name,slug,url\nAcme,acme,https://example.com\n",
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / "fake"
+    out_dir.mkdir()
+    out_path = out_dir / "jobs.csv"
+    out_path.write_text(
+        (
+            "url,title,company,ats_type,ats_id,description\n"
+            "https://example.com/jobs/old,Old,Acme,custom,old,previous\n"
+        ),
+        encoding="utf-8",
+    )
+
+    class MissingScraper:
+        calls = 0
+
+        def __init__(self, *_args, **_kwargs) -> None:
+            self.include_descriptions = True
+
+        def fetch(self):
+            assert self.include_descriptions is True
+            return [
+                Job(
+                    url="https://example.com/jobs/2",
+                    title="Engineer",
+                    company="Acme",
+                    ats_type=ATSType.CUSTOM,
+                    ats_id="2",
+                )
+            ]
+
+        def get_description(self, job):
+            self.__class__.calls += 1
+            return f"fresh description for {job.ats_id}"
+
+    monkeypatch.setattr(runner, "DATA_ROOT", tmp_path)
+    monkeypatch.setitem(
+        runner.CONFIGS,
+        "fake",
+        {
+            "scraper": MissingScraper,
+            "slug": lambda r: r["slug"],
+            "csv": "ats-companies/fake.csv",
+            "output": "fake/jobs.csv",
+        },
+    )
+
+    rc = asyncio.run(runner.run("fake", concurrency=1, max_tenants=None, timeout=1))
+
+    assert rc == 0
+    rows = list(csv.DictReader(out_path.open(newline="")))
+    assert rows[0]["description"] == "fresh description for 2"
+    assert MissingScraper.calls == 1
+
+
+def test_pipeline_writes_full_description_instead_of_preview(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    long_description = "d" * 700
+
+    class FullDescriptionScraper:
+        def __init__(self, *_args, **_kwargs) -> None:
+            self.include_descriptions = True
+
+        def fetch(self):
+            assert self.include_descriptions is True
+            return [
+                Job(
+                    url="https://example.com/jobs/1",
+                    title="Engineer",
+                    company="Acme",
+                    ats_type=ATSType.CUSTOM,
+                    ats_id="1",
+                    description=long_description,
+                )
+            ]
+
+    monkeypatch.setattr(runner, "DATA_ROOT", tmp_path)
+    monkeypatch.setitem(
+        runner.CONFIGS,
+        "single",
+        {
+            "scraper": FullDescriptionScraper,
+            "singleton": True,
+            "output": "single/jobs.csv",
+        },
+    )
+
+    rc = asyncio.run(runner.run("single", concurrency=1, max_tenants=None, timeout=1))
+
+    assert rc == 0
+    rows = list(csv.DictReader((tmp_path / "single" / "jobs.csv").open(newline="")))
+    assert rows[0]["description"] == long_description
+
+
+def test_description_cache_loads_previous_csv_on_disk(tmp_path) -> None:
+    path = tmp_path / "jobs.csv"
+    path.write_text(
+        "url,title,company,ats_type,ats_id,description\n"
+        "https://example.com/jobs/1,Old,Acme,custom,1,cached\n",
+        encoding="utf-8",
+    )
+    cache = runner._load_description_cache(path)
+    try:
+        job = Job(
+            url="https://example.com/jobs/1",
+            title="Engineer",
+            company="Acme",
+            ats_type=ATSType.CUSTOM,
+            ats_id="1",
+        )
+
+        assert cache.get(job) == "cached"
+        assert cache.count == 2
+    finally:
+        cache.close()
+
+
+def test_description_cache_count_ignores_duplicate_keys(tmp_path) -> None:
+    path = tmp_path / "jobs.csv"
+    path.write_text(
+        "url,title,company,ats_type,ats_id,description\n"
+        "https://example.com/jobs/1,Old,Acme,custom,1,cached\n",
+        encoding="utf-8",
+    )
+    cache = runner._load_description_cache(path)
+    try:
+        job = Job(
+            url="https://example.com/jobs/1",
+            title="Engineer",
+            company="Acme",
+            ats_type=ATSType.CUSTOM,
+            ats_id="1",
+        )
+
+        cache.set(job, "cached")
+
+        assert cache.count == 2
+    finally:
+        cache.close()
+
+
+def test_description_cache_unlinks_temp_file_when_init_fails(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_path = tmp_path / "cache.sqlite3"
+
+    class FakeTempFile:
+        name = str(cache_path)
+
+        def __enter__(self):
+            cache_path.touch()
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    def fail_connect(_path):
+        raise OSError("sqlite unavailable")
+
+    monkeypatch.setattr(runner.tempfile, "NamedTemporaryFile", lambda **_kw: FakeTempFile())
+    monkeypatch.setattr(runner.sqlite3, "connect", fail_connect)
+
+    with pytest.raises(OSError):
+        runner.DescriptionCache()
+
+    assert not cache_path.exists()
+
+
+def test_pipeline_closes_description_cache_on_propagating_error(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "ats-companies").mkdir()
+    (tmp_path / "ats-companies" / "fake.csv").write_text(
+        "name,slug,url\nAcme,acme,https://example.com\n",
+        encoding="utf-8",
+    )
+
+    class FakeCache:
+        count = 0
+        closed = False
+
+        def get(self, _job):
+            return None
+
+        def set(self, _job, _description):
+            pass
+
+        def close(self):
+            self.closed = True
+
+    cache = FakeCache()
+
+    class ExplodingScraper:
+        def __init__(self, *_args, **_kwargs) -> None:
+            self.include_descriptions = True
+
+        def fetch(self):
+            return [
+                Job(
+                    url="https://example.com/jobs/1",
+                    title="Engineer",
+                    company="Acme",
+                    ats_type=ATSType.CUSTOM,
+                    ats_id="1",
+                    description="known",
+                )
+            ]
+
+    def explode_row(_job):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(runner, "DATA_ROOT", tmp_path)
+    monkeypatch.setattr(runner, "_load_description_cache", lambda _path: cache)
+    monkeypatch.setattr(runner, "_job_to_row", explode_row)
+    monkeypatch.setitem(
+        runner.CONFIGS,
+        "fake",
+        {
+            "scraper": ExplodingScraper,
+            "slug": lambda r: r["slug"],
+            "csv": "ats-companies/fake.csv",
+            "output": "fake/jobs.csv",
+        },
+    )
+
+    with pytest.raises(OSError):
+        asyncio.run(runner.run("fake", concurrency=1, max_tenants=None, timeout=1))
+
+    assert cache.closed is True
+
+
+def test_streaming_pipeline_reuses_sqlite_description_cache(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    out_dir = tmp_path / "stream"
+    out_dir.mkdir()
+    out_path = out_dir / "jobs.csv"
+    out_path.write_text(
+        (
+            "url,title,company,ats_type,ats_id,description\n"
+            "https://example.com/jobs/1,Old,Acme,custom,1,cached\n"
+        ),
+        encoding="utf-8",
+    )
+
+    class StreamingScraper:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        async def fetch_stream(self):
+            yield Job(
+                url="https://example.com/jobs/1",
+                title="Engineer",
+                company="Acme",
+                ats_type=ATSType.CUSTOM,
+                ats_id="1",
+            )
+
+    monkeypatch.setattr(runner, "DATA_ROOT", tmp_path)
+    monkeypatch.setitem(
+        runner.CONFIGS,
+        "stream",
+        {
+            "scraper": StreamingScraper,
+            "singleton": True,
+            "output": "stream/jobs.csv",
+        },
+    )
+
+    rc = asyncio.run(runner.run("stream", concurrency=1, max_tenants=None, timeout=1))
+
+    assert rc == 0
+    rows = list(csv.DictReader(out_path.open(newline="")))
+    assert rows[0]["description"] == "cached"

--- a/tests/test_run_pipeline_guards.py
+++ b/tests/test_run_pipeline_guards.py
@@ -234,6 +234,60 @@ def test_pipeline_fetches_missing_description_after_cache_lookup(
     assert MissingScraper.calls == 1
 
 
+def test_pipeline_keeps_job_when_description_fetch_raises(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "ats-companies").mkdir()
+    (tmp_path / "ats-companies" / "fake.csv").write_text(
+        "name,slug,url\nAcme,acme,https://example.com\n",
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / "fake"
+    out_dir.mkdir()
+    out_path = out_dir / "jobs.csv"
+    out_path.write_text(
+        "url,title,company,ats_type,ats_id,description\n",
+        encoding="utf-8",
+    )
+
+    class RaisingDescriptionScraper:
+        def __init__(self, *_args, **_kwargs) -> None:
+            self.include_descriptions = True
+
+        def fetch(self):
+            return [
+                Job(
+                    url="https://example.com/jobs/2",
+                    title="Engineer",
+                    company="Acme",
+                    ats_type=ATSType.CUSTOM,
+                    ats_id="2",
+                )
+            ]
+
+        def get_description(self, _job):
+            raise RuntimeError("detail API unavailable")
+
+    monkeypatch.setattr(runner, "DATA_ROOT", tmp_path)
+    monkeypatch.setitem(
+        runner.CONFIGS,
+        "fake",
+        {
+            "scraper": RaisingDescriptionScraper,
+            "slug": lambda r: r["slug"],
+            "csv": "ats-companies/fake.csv",
+            "output": "fake/jobs.csv",
+        },
+    )
+
+    rc = asyncio.run(runner.run("fake", concurrency=1, max_tenants=None, timeout=1))
+
+    assert rc == 0
+    rows = list(csv.DictReader(out_path.open(newline="")))
+    assert rows[0]["ats_id"] == "2"
+    assert rows[0]["description"] == ""
+
+
 def test_pipeline_writes_full_description_instead_of_preview(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -319,6 +373,30 @@ def test_description_cache_count_ignores_duplicate_keys(tmp_path) -> None:
         assert cache.count == 2
     finally:
         cache.close()
+
+
+def test_load_description_cache_closes_when_load_csv_fails(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    created = []
+
+    class FakeCache:
+        def __init__(self) -> None:
+            self.closed = False
+            created.append(self)
+
+        def load_csv(self, _path) -> None:
+            raise RuntimeError("bad csv")
+
+        def close(self) -> None:
+            self.closed = True
+
+    monkeypatch.setattr(runner, "DescriptionCache", FakeCache)
+
+    with pytest.raises(RuntimeError, match="bad csv"):
+        runner._load_description_cache(tmp_path / "jobs.csv")
+
+    assert created[0].closed is True
 
 
 def test_description_cache_unlinks_temp_file_when_init_fails(

--- a/tests/test_successfactors.py
+++ b/tests/test_successfactors.py
@@ -159,7 +159,7 @@ def test_description_truncated_to_10kb(httpx_mock) -> None:
     httpx_mock.add_response(url=FEED_URL, text=_rss([_item(description=huge_desc)]))
     jobs = SuccessFactorsScraper("job.acme.com").fetch()
     assert jobs[0].description is not None
-    assert len(jobs[0].description) <= 10_000
+    assert len(jobs[0].description) <= 25_000
 
 
 # --- Error handling ---------------------------------------------------------

--- a/tests/test_teamtailor.py
+++ b/tests/test_teamtailor.py
@@ -187,7 +187,7 @@ def test_description_truncated_to_10kb(httpx_mock) -> None:
     httpx_mock.add_response(url=RSS_URL, text=_rss([_item(description=huge_escaped)]))
     jobs = TeamtailorScraper("acme").fetch()
     assert jobs[0].description is not None
-    assert len(jobs[0].description) <= 10_000
+    assert len(jobs[0].description) <= 25_000
 
 
 def test_description_none_when_empty(httpx_mock) -> None:

--- a/tests/test_wellfound.py
+++ b/tests/test_wellfound.py
@@ -22,7 +22,7 @@ import httpx
 import pytest
 
 from jobhive.exceptions import ScraperError
-from jobhive.models import ATSType
+from jobhive.models import ATSType, Job
 from jobhive.scrapers import ScraperRegistry, WellfoundScraper
 from jobhive.scrapers.wellfound import (
     DEFAULT_ROLE_SLUGS,
@@ -96,6 +96,21 @@ def test_raises_without_firecrawl_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
     with pytest.raises(ScraperError, match="Firecrawl"):
         WellfoundScraper("any").fetch()
+
+
+def test_get_description_without_firecrawl_key_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+    job = Job(
+        url="https://wellfound.com/jobs/1",
+        title="Engineer",
+        company="Acme",
+        ats_type=ATSType.WELLFOUND,
+        ats_id="1",
+    )
+
+    assert WellfoundScraper("any").get_description(job) is None
 
 
 def test_uses_env_var_when_no_constructor_arg(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What changed

- Added `BaseScraper.get_description(job)` and `BaseScraper.enrich_descriptions(jobs)` as the shared architecture for fetching one job description separately.
- Added `get_description` overrides for the providers whose descriptions require a second step.
- Increased description truncation from 10k/12k chars to 25k chars across description paths.
- Added a provider description matrix covering the 47 configured pipeline providers.
- Added tests for the base API plus representative API/HTML second-step providers.

## Why

Some providers return job listings without complete descriptions, so consumers need a stable SDK-level method to fetch a single job description separately. This PR introduces that architecture without changing the pipeline behavior yet.

## Follow-up

Pipeline integration is intentionally left out of this PR. The next PR should update the pipeline to reuse existing descriptions from prior CSVs and call `get_description` only when needed.

## Validation

- `uv run --extra dev --extra scrapers ruff check .`
- `uv run --extra dev --extra scrapers pytest -q` (`899 passed`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a stable SDK API to fetch per-provider job descriptions and wires it into the pipeline with a disk-backed SQLite cache that reuses prior descriptions and fetches only when missing. Hardens enrichment to avoid batch crashes, supports streaming scrapers, and stores full descriptions up to 25k chars.

- **New Features**
  - Added `BaseScraper.get_description(job)` and `BaseScraper.enrich_descriptions(jobs)`; two-step providers now implement `get_description` and honor an `include_descriptions` flag.
  - Pipeline uses a temp SQLite `DescriptionCache` (keys: `company+ats_id`, `url`) for both batch and streaming; `_ensure_description` fills only missing descriptions and updates the cache.
  - Raised truncation to 25k chars across scrapers and the CSV writer; CSV now stores the full description (no preview). Added a provider description matrix.

- **Bug Fixes**
  - `_ensure_description` now catches `get_description` errors and continues; switched to direct `scraper.get_description` access.
  - `WellfoundScraper.get_description` returns `None` when the API key is missing to match other providers.
  - `_load_description_cache` closes/unlinks the SQLite temp file on failures; the cache is always closed in a `finally`.

<sup>Written for commit c9c50924b570d8b0124ba72664106fcbf1d0b373. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `BaseScraper.get_description` and `enrich_descriptions` as a stable SDK API for fetching individual job descriptions, wires a SQLite-backed `DescriptionCache` into the pipeline to reuse descriptions from the previous CSV, and raises the description truncation cap from 10–12k to 25k chars across all scrapers. Pipeline behavior is intentionally unchanged — `include_descriptions` still defaults to `True` so existing fetch paths are unaffected.

- **New base API**: `get_description` defaults to returning the existing description; 24 two-step providers override it with provider-specific HTTP/browser logic. `enrich_descriptions` iterates and fills missing descriptions one at a time.
- **Description cache**: `DescriptionCache` loads the prior output CSV into a temp SQLite file at pipeline start, keyed by `(company, ats_id)` and URL; `_ensure_description` checks the cache before calling `get_description`, and `cache.close()` is guaranteed via `finally`.
- **Truncation increase**: All per-scraper caps and the CSV output field updated from 10–12k to 25k chars.

<h3>Confidence Score: 3/5</h3>

Safe to merge after addressing the Wellfound get_description exception and the _load_description_cache resource-leak edge case.

WellfoundScraper.get_description raises ScraperError when the Firecrawl API key is absent, while every other provider returns None. _ensure_description in the pipeline does not catch exceptions from get_description, so if Wellfound's description enrichment inside fetch() fails silently and leaves jobs without descriptions, the subsequent call to get_description propagates a ScraperError through asyncio.to_thread into the task coroutine and then into asyncio.gather, aborting the entire batch for that ATS without incrementing the error counter.

src/jobhive/scrapers/wellfound.py (get_description raises instead of returning None) and scripts/run_pipeline.py (_ensure_description and _load_description_cache).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/run_pipeline.py | Adds DescriptionCache (SQLite-backed), _ensure_description, and wires both into the streaming and batch pipeline paths; has an unhandled exception risk when get_description raises, and a minor resource-leak edge case in _load_description_cache. |
| src/jobhive/scrapers/base.py | Adds get_description (default: return existing description) and enrich_descriptions (iterate and fill via get_description) as the new stable SDK surface; clean and well-documented. |
| src/jobhive/scrapers/wellfound.py | get_description raises ScraperError for missing API key, inconsistent with every other override which returns None; this can propagate as an unhandled exception through the pipeline's asyncio.gather. |
| src/jobhive/scrapers/workable.py | _enrich_descriptions refactored to delegate to get_description; include_descriptions guard added; description cap raised to 25k. |
| src/jobhive/scrapers/personio.py | get_description extracted from the inline fetch_one closure; _enrich_descriptions now delegates to it; logic is equivalent and cap raised to 25k. |
| src/jobhive/scrapers/avature.py | get_description added with both httpx and httpcloak fallback paths mirroring fetch(); include_descriptions guards added to skip detail enrichment when not needed. |
| src/jobhive/scrapers/tesla.py | get_description launches a fresh CloakBrowser session for a single job; include_descriptions guard added to fetch(); department enrichment is correctly skipped when descriptions are off. |
| tests/test_description_api.py | New tests covering the base API contract, two-step provider registry check, and representative API/HTML providers (Workable, SmartRecruiters, Breezy); well-structured and mutually independent. |
| tests/test_run_pipeline_guards.py | Comprehensive new pipeline integration tests covering cache reuse, missing-description fetch, full-description pass-through, cache count, temp-file cleanup on init failure, cache close on propagating error, and streaming cache reuse. |
| src/jobhive/scrapers/workday.py | get_description re-parses the company slug URL to build the detail prefix and enriches a single-element list; clean and consistent with the fetch path. |
| src/jobhive/models.py | Description field docstring updated to reflect 25k char cap; one-line change. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
scripts/run_pipeline.py:793-796
**Unhandled exception from `get_description` can crash pipeline batch**

`WellfoundScraper.get_description` raises `ScraperError` when `firecrawl_api_key` is not set, rather than returning `None`. If Wellfound's `_enrich_description` (called inside `fetch()`) fails silently on an auth error and leaves jobs without descriptions, the subsequent call to `get_description` via `asyncio.to_thread` here will raise, propagate through the `task` coroutine, and surface in `asyncio.gather`, aborting the entire batch. No other `get_description` override raises, so this is an inconsistency that the call site doesn't defend against.

### Issue 2 of 4
src/jobhive/scrapers/wellfound.py:155-161
Every other `get_description` override returns `None` when the prerequisite for a second fetch is missing (e.g., Tesla returns `None` when `cb.is_enabled()` is False, Oracle returns `None` for an invalid slug). Raising here is the only exception and means an unconfigured API key would propagate a `ScraperError` through `asyncio.to_thread` in `_ensure_description`, bypassing the pipeline's normal error accounting and crashing the in-flight batch.

```suggestion
    def get_description(self, job: Job) -> str | None:
        if job.description:
            return job.description
        if not self.firecrawl_api_key:
            return None
```

### Issue 3 of 4
scripts/run_pipeline.py:790-793
Since `BaseScraper` now always defines `get_description`, the `getattr` / `None` guard can never be `True`. Using `getattr` with a fallback implies the attribute might be absent, which is misleading for anyone reading this code later. A direct attribute access is clearer.

```suggestion
    description = await asyncio.to_thread(scraper.get_description, job)
```

### Issue 4 of 4
scripts/run_pipeline.py:769-772
`_load_description_cache` creates the `DescriptionCache` (opens a temp SQLite file) and then calls `load_csv`. If `load_csv` raises — for example, if the `except`-block's recovery `DELETE FROM descriptions` itself hits a `sqlite3.Error` — the local `cache` object goes out of scope with its connection and temp file open, since the `try/finally` in `run()` only guards the code after this line. Wrapping both steps keeps resource-ownership consistent.

```suggestion
def _load_description_cache(path: Path) -> DescriptionCache:
    cache = DescriptionCache()
    try:
        cache.load_csv(path)
    except Exception:
        cache.close()
        raise
    return cache
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["\[codex\] reuse cached pipeline descriptio..."](https://github.com/kalil0321/ats-scrapers/commit/bb3c2112b44527f6a5f209719b483965524b21d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32029730)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->