### PR TITLE
[codex] Fix Recruiterbox company entries

### DIFF
--- a/ats-companies/recruiterbox.csv
+++ b/ats-companies/recruiterbox.csv
@@ -1,251 +1,246 @@
 name,slug,url
-1lattice,1lattice,https://1lattice.recruiterbox.com
-2workonline1,2workonline1,https://2workonline1.recruiterbox.com
-accfb,accfb,https://accfb.recruiterbox.com
-adgistics,adgistics,https://adgistics.recruiterbox.com
-adidevtechnologies,adidevtechnologies,https://adidevtechnologies.recruiterbox.com
-advsol,advsol,https://advsol.recruiterbox.com
-aerosonic,aerosonic,https://aerosonic.recruiterbox.com
-aeworks,aeworks,https://aeworks.recruiterbox.com
-agila,agila,https://agila.recruiterbox.com
-aixialgroup,aixialgroup,https://aixialgroup.recruiterbox.com
-ajc,ajc,https://ajc.recruiterbox.com
-ajob,ajob,https://ajob.recruiterbox.com
-aliceandolivia,aliceandolivia,https://aliceandolivia.recruiterbox.com
+Lattice Technologies Pvt Ltd,1lattice,https://1lattice.recruiterbox.com
+2 WorkOnline,2workonline1,https://2workonline1.recruiterbox.com
+Alameda County Community Food Bank,accfb,https://accfb.recruiterbox.com
+Adgistics Ltd.,adgistics,https://adgistics.recruiterbox.com
+Adidev Technologies Inc,adidevtechnologies,https://adidevtechnologies.recruiterbox.com
+Advanced Solutions International,advsol,https://advsol.recruiterbox.com
+Aerosonic,aerosonic,https://aerosonic.recruiterbox.com
+AE Works,aeworks,https://aeworks.recruiterbox.com
+Agila Documents Clearing Services LLC,agila,https://agila.recruiterbox.com
+Aixial Group,aixialgroup,https://aixialgroup.recruiterbox.com
+American Jewish Committee,ajc,https://ajc.recruiterbox.com
+Ajob,ajob,https://ajob.recruiterbox.com
+ALICE + OLIVIA,aliceandolivia,https://aliceandolivia.recruiterbox.com
 alignable,alignable,https://alignable.hire.trakstar.com
-alleghanyhealth,alleghanyhealth,https://alleghanyhealth.recruiterbox.com
-allendigital,allendigital,https://allendigital.recruiterbox.com
-alphasights,alphasights,https://alphasights.recruiterbox.com
-alvine,alvine,https://alvine.recruiterbox.com
-americanuniversity,americanuniversity,https://americanuniversity.recruiterbox.com
-anchorfree,anchorfree,https://anchorfree.recruiterbox.com
-anduin,anduin,https://anduin.recruiterbox.com
-aprco,aprco,https://aprco.recruiterbox.com
-aquilasw,aquilasw,https://aquilasw.recruiterbox.com
-ardentlearninginc,ardentlearninginc,https://ardentlearninginc.recruiterbox.com
-ascellatech,ascellatech,https://ascellatech.recruiterbox.com
-athlete,athlete,https://athlete.recruiterbox.com
-avaaz,avaaz,https://avaaz.recruiterbox.com
-avaenergy,avaenergy,https://avaenergy.recruiterbox.com
-avisbudgetpaylessrd,avisbudgetpaylessrd,https://avisbudgetpaylessrd.recruiterbox.com
-babbellonian,babbellonian,https://babbellonian.recruiterbox.com
-bennington,bennington,https://bennington.recruiterbox.com
-bionews,bionews,https://bionews.recruiterbox.com
-bookmyshow,bookmyshow,https://bookmyshow.recruiterbox.com
-bracinternational,bracinternational,https://bracinternational.recruiterbox.com
-brudis,brudis,https://brudis.recruiterbox.com
-bsglaw,bsglaw,https://bsglaw.recruiterbox.com
-cactusshoppi,cactusshoppi,https://cactusshoppi.recruiterbox.com
-caixamagica,caixamagica,https://caixamagica.recruiterbox.com
-cambridgecomputer,cambridgecomputer,https://cambridgecomputer.recruiterbox.com
+Alleghany Health,alleghanyhealth,https://alleghanyhealth.recruiterbox.com
+Allen Online,allendigital,https://allendigital.recruiterbox.com
+AlphaSights,alphasights,https://alphasights.recruiterbox.com
+Alvine,alvine,https://alvine.recruiterbox.com
+American University In the Emirates (AUE),americanuniversity,https://americanuniversity.recruiterbox.com
+Anchorfree,anchorfree,https://anchorfree.recruiterbox.com
+Anduin Transactions,anduin,https://anduin.recruiterbox.com
+Advertising Production Resources,aprco,https://aprco.recruiterbox.com
+Aquila Software Group,aquilasw,https://aquilasw.recruiterbox.com
+"Ardent Learning, Inc.",ardentlearninginc,https://ardentlearninginc.recruiterbox.com
+"Ascella Technologies, Inc.",ascellatech,https://ascellatech.recruiterbox.com
+Athlete Lab,athlete,https://athlete.recruiterbox.com
+Avaaz,avaaz,https://avaaz.recruiterbox.com
+Ava Community Energy,avaenergy,https://avaenergy.recruiterbox.com
+Servicolt,avisbudgetpaylessrd,https://avisbudgetpaylessrd.recruiterbox.com
+Babbel,babbellonian,https://babbellonian.recruiterbox.com
+Bennington College,bennington,https://bennington.recruiterbox.com
+"Bionews, Inc.",bionews,https://bionews.recruiterbox.com
+BookMyShow,bookmyshow,https://bookmyshow.recruiterbox.com
+BRAC INTERNATIONAL,bracinternational,https://bracinternational.recruiterbox.com
+"Brudis & Associates, Inc.",brudis,https://brudis.recruiterbox.com
+Berman Sobin Gross LLP,bsglaw,https://bsglaw.recruiterbox.com
+CARE S.A. (Cactus shoppi),cactusshoppi,https://cactusshoppi.recruiterbox.com
+Caixa Mágica Software,caixamagica,https://caixamagica.recruiterbox.com
+"Cambridge Computer Services, Inc",cambridgecomputer,https://cambridgecomputer.recruiterbox.com
 cambrio,cambrio,https://cambrio.recruiterbox.com
-caribbeancatalyst,caribbeancatalyst,https://caribbeancatalyst.recruiterbox.com
-cashfree,cashfree,https://cashfree.recruiterbox.com
-cassaday,cassaday,https://cassaday.recruiterbox.com
-celtra,celtra,https://celtra.recruiterbox.com
+CaribbeanCatalyst,caribbeancatalyst,https://caribbeancatalyst.recruiterbox.com
+Cassaday & Company,cassaday,https://cassaday.recruiterbox.com
+"Celtra, Inc.",celtra,https://celtra.recruiterbox.com
 chartcube,chartcube,https://chartcube.hire.trakstar.com
-cheesecakelabs,cheesecakelabs,https://cheesecakelabs.recruiterbox.com
-chilindo,chilindo,https://chilindo.recruiterbox.com
-classe365,classe365,https://classe365.recruiterbox.com
-cleanreturns,cleanreturns,https://cleanreturns.recruiterbox.com
-climateactioncampaign,climateactioncampaign,https://climateactioncampaign.recruiterbox.com
-cmruni,cmruni,https://cmruni.recruiterbox.com
-codehs,codehs,https://codehs.recruiterbox.com
-commsignia,commsignia,https://commsignia.recruiterbox.com
-conyersga,conyersga,https://conyersga.recruiterbox.com
-creliohealth,creliohealth,https://creliohealth.recruiterbox.com
+Cheesecake Labs,cheesecakelabs,https://cheesecakelabs.recruiterbox.com
+Chilindo,chilindo,https://chilindo.recruiterbox.com
+Classe365,classe365,https://classe365.recruiterbox.com
+Cleanreturns,cleanreturns,https://cleanreturns.recruiterbox.com
+Climate Action Campaign,climateactioncampaign,https://climateactioncampaign.recruiterbox.com
+CMR University,cmruni,https://cmruni.recruiterbox.com
+Commsignia,commsignia,https://commsignia.recruiterbox.com
+"City of Conyers, GA",conyersga,https://conyersga.recruiterbox.com
+CrelioHealth,creliohealth,https://creliohealth.recruiterbox.com
 crowdhouse,crowdhouse,https://crowdhouse.hire.trakstar.com
-crystalknows,crystalknows,https://crystalknows.recruiterbox.com
-datawords,datawords,https://datawords.recruiterbox.com
-decathlonchina,decathlonchina,https://decathlonchina.recruiterbox.com
-dekoit,dekoit,https://dekoit.recruiterbox.com
-dito,dito,https://dito.recruiterbox.com
-dlelectric,dlelectric,https://dlelectric.recruiterbox.com
-dncapital,dncapital,https://dncapital.recruiterbox.com
-doyouconvert,doyouconvert,https://doyouconvert.recruiterbox.com
-dream11,dream11,https://dream11.recruiterbox.com
-dreamclinic84937,dreamclinic84937,https://dreamclinic84937.recruiterbox.com
-dripcapital,dripcapital,https://dripcapital.recruiterbox.com
+Crystal Knows,crystalknows,https://crystalknows.recruiterbox.com
+Datawords,datawords,https://datawords.recruiterbox.com
+Decathlon China,decathlonchina,https://decathlonchina.recruiterbox.com
+Dekoit,dekoit,https://dekoit.recruiterbox.com
+Dito,dito,https://dito.recruiterbox.com
+D&L Electric,dlelectric,https://dlelectric.recruiterbox.com
+DN Capital,dncapital,https://dncapital.recruiterbox.com
+doyouconvert.com,doyouconvert,https://doyouconvert.recruiterbox.com
+Dream11 Inc.,dream11,https://dream11.recruiterbox.com
+Dreamclinic Massage & Acupuncture,dreamclinic84937,https://dreamclinic84937.recruiterbox.com
+Drip Capital,dripcapital,https://dripcapital.recruiterbox.com
 driveai,driveai,https://driveai.hire.trakstar.com
-dyversemarketing,dyversemarketing,https://dyversemarketing.recruiterbox.com
+Dyverse,dyversemarketing,https://dyversemarketing.recruiterbox.com
 eagleandfox,eagleandfox,https://eagleandfox.hire.trakstar.com
-eagletechva,eagletechva,https://eagletechva.recruiterbox.com
-easebuzz,easebuzz,https://easebuzz.recruiterbox.com
-ecmenergy,ecmenergy,https://ecmenergy.recruiterbox.com
-egovernments,egovernments,https://egovernments.recruiterbox.com
-egsllp,egsllp,https://egsllp.recruiterbox.com
-elliottlewis,elliottlewis,https://elliottlewis.recruiterbox.com
-enterpriseknowledge,enterpriseknowledge,https://enterpriseknowledge.recruiterbox.com
-eridanis,eridanis,https://eridanis.recruiterbox.com
-exotel,exotel,https://exotel.recruiterbox.com
-fairyland,fairyland,https://fairyland.recruiterbox.com
-fbcrogers,fbcrogers,https://fbcrogers.recruiterbox.com
-fcmh,fcmh,https://fcmh.recruiterbox.com
-finario,finario,https://finario.recruiterbox.com
-firespring,firespring,https://firespring.recruiterbox.com
-fitfyles,fitfyles,https://fitfyles.recruiterbox.com
-foodoraitalia,foodoraitalia,https://foodoraitalia.recruiterbox.com
-footballradar,footballradar,https://footballradar.recruiterbox.com
-forgeperform,forgeperform,https://forgeperform.recruiterbox.com
-forthright,forthright,https://forthright.recruiterbox.com
-freestonepg,freestonepg,https://freestonepg.recruiterbox.com
-frontlinems,frontlinems,https://frontlinems.recruiterbox.com
-gestionline,gestionline,https://gestionline.recruiterbox.com
-grassrootsvoter,grassrootsvoter,https://grassrootsvoter.recruiterbox.com
-gutblick,gutblick,https://gutblick.recruiterbox.com
-hackerearthjobs,hackerearthjobs,https://hackerearthjobs.recruiterbox.com
-halecohosp,halecohosp,https://halecohosp.recruiterbox.com
-happycog,happycog,https://happycog.recruiterbox.com
-happyfox,happyfox,https://happyfox.recruiterbox.com
-headlinemedia,headlinemedia,https://headlinemedia.recruiterbox.com
-healthix,healthix,https://healthix.recruiterbox.com
+"Eagle Technologies, Inc.",eagletechva,https://eagletechva.recruiterbox.com
+Easebuzz Pvt Ltd,easebuzz,https://easebuzz.recruiterbox.com
+ECM Energy Services,ecmenergy,https://ecmenergy.recruiterbox.com
+eGovernments Foundation,egovernments,https://egovernments.recruiterbox.com
+Ellenoff Grossman and Schole LLP,egsllp,https://egsllp.recruiterbox.com
+Elliott-Lewis | Sautter Crane | AA Duckett,elliottlewis,https://elliottlewis.recruiterbox.com
+Enterprise Knowledge LLC,enterpriseknowledge,https://enterpriseknowledge.recruiterbox.com
+Eridanis,eridanis,https://eridanis.recruiterbox.com
+Exotel Techcom Pvt Ltd,exotel,https://exotel.recruiterbox.com
+Oakland Children's Fairyland,fairyland,https://fairyland.recruiterbox.com
+First Baptist Church of Rogers,fbcrogers,https://fbcrogers.recruiterbox.com
+Franklin County Memorial Hospital,fcmh,https://fcmh.recruiterbox.com
+Finario,finario,https://finario.recruiterbox.com
+Firespring,firespring,https://firespring.recruiterbox.com
+Fitfyles LLP,fitfyles,https://fitfyles.recruiterbox.com
+Foodora Italia,foodoraitalia,https://foodoraitalia.recruiterbox.com
+Football Radar,footballradar,https://footballradar.recruiterbox.com
+Forge Performance Group,forgeperform,https://forgeperform.recruiterbox.com
+Forthright Staffing By Dion,forthright,https://forthright.recruiterbox.com
+Freestone Property Group,freestonepg,https://freestonepg.recruiterbox.com
+Frontline Managed Services,frontlinems,https://frontlinems.recruiterbox.com
+Gestionline,gestionline,https://gestionline.recruiterbox.com
+Grassroots Voter Outreach,grassrootsvoter,https://grassrootsvoter.recruiterbox.com
+Gutblick,gutblick,https://gutblick.recruiterbox.com
+HackerEarth,hackerearthjobs,https://hackerearthjobs.recruiterbox.com
+Hale County Hospital,halecohosp,https://halecohosp.recruiterbox.com
+Happy Cog,happycog,https://happycog.recruiterbox.com
+HappyFox,happyfox,https://happyfox.recruiterbox.com
+Headline Media,headlinemedia,https://headlinemedia.recruiterbox.com
+Healthix,healthix,https://healthix.recruiterbox.com
 helpshift,helpshift,https://helpshift.hire.trakstar.com
-hertzdollarthriftyrd,hertzdollarthriftyrd,https://hertzdollarthriftyrd.recruiterbox.com
-holloway,holloway,https://holloway.recruiterbox.com
+Andel Star,hertzdollarthriftyrd,https://hertzdollarthriftyrd.recruiterbox.com
+"Holloway Sportswear, Inc.",holloway,https://holloway.recruiterbox.com
 home,home,https://home.recruiterbox.com
-hudsonsfurniturecareers,hudsonsfurniturecareers,https://hudsonsfurniturecareers.recruiterbox.com
-humach,humach,https://humach.recruiterbox.com
-imagicle,imagicle,https://imagicle.recruiterbox.com
-imiclimatecontrol,imiclimatecontrol,https://imiclimatecontrol.recruiterbox.com
-imicriticalengineering,imicriticalengineering,https://imicriticalengineering.recruiterbox.com
-imsi,imsi,https://imsi.recruiterbox.com
-industryft,industryft,https://industryft.recruiterbox.com
-ineventapp,ineventapp,https://ineventapp.recruiterbox.com
-infracloud,infracloud,https://infracloud.recruiterbox.com
-inorison,inorison,https://inorison.recruiterbox.com
-inspiredteachingschool,inspiredteachingschool,https://inspiredteachingschool.recruiterbox.com
-intergaming,intergaming,https://intergaming.recruiterbox.com
-interglobalhomes,interglobalhomes,https://interglobalhomes.recruiterbox.com
-internationaltradeinstitute,internationaltradeinstitute,https://internationaltradeinstitute.recruiterbox.com
-irishealthclinical,irishealthclinical,https://irishealthclinical.recruiterbox.com
-jenni,jenni,https://jenni.recruiterbox.com
-k2partnering,k2partnering,https://k2partnering.recruiterbox.com
-kingsmill,kingsmill,https://kingsmill.recruiterbox.com
-klbgroup1,klbgroup1,https://klbgroup1.recruiterbox.com
-kyosk,kyosk,https://kyosk.recruiterbox.com
-ladybird,ladybird,https://ladybird.recruiterbox.com
-lakepointe,lakepointe,https://lakepointe.recruiterbox.com
+Hudson's Furniture,hudsonsfurniturecareers,https://hudsonsfurniturecareers.recruiterbox.com
+"Humach, LLC",humach,https://humach.recruiterbox.com
+Imagicle,imagicle,https://imagicle.recruiterbox.com
+IMI Climate Control,imiclimatecontrol,https://imiclimatecontrol.recruiterbox.com
+IMI Process Automation,imicriticalengineering,https://imicriticalengineering.recruiterbox.com
+Imsi,imsi,https://imsi.recruiterbox.com
+Industry FInTech,industryft,https://industryft.recruiterbox.com
+InEvent,ineventapp,https://ineventapp.recruiterbox.com
+InfraCloud Technologies,infracloud,https://infracloud.recruiterbox.com
+Inorison Technologies,inorison,https://inorison.recruiterbox.com
+Inspired Teaching Demonstration School,inspiredteachingschool,https://inspiredteachingschool.recruiterbox.com
+Intergaming Ltd.,intergaming,https://intergaming.recruiterbox.com
+INTERGLOBAL HOMES,interglobalhomes,https://interglobalhomes.recruiterbox.com
+International Trade Institute,internationaltradeinstitute,https://internationaltradeinstitute.recruiterbox.com
+Iris Telehealth for Providers,irishealthclinical,https://irishealthclinical.recruiterbox.com
+Jenni Icard,jenni,https://jenni.recruiterbox.com
+K2 Partnering Solutions,k2partnering,https://k2partnering.recruiterbox.com
+Kingsmill Resort,kingsmill,https://kingsmill.recruiterbox.com
+KLB Group,klbgroup1,https://klbgroup1.recruiterbox.com
+Kyosk Digital Services,kyosk,https://kyosk.recruiterbox.com
+Ladybird Web Solution Pvt Ltd,ladybird,https://ladybird.recruiterbox.com
+Lakepointe Church,lakepointe,https://lakepointe.recruiterbox.com
 lambda3,lambda3,https://lambda3.recruiterbox.com
-leamseducation,leamseducation,https://leamseducation.recruiterbox.com
-lespetitsriens,lespetitsriens,https://lespetitsriens.recruiterbox.com
-lmnarchitects,lmnarchitects,https://lmnarchitects.recruiterbox.com
-lnwadvisors,lnwadvisors,https://lnwadvisors.recruiterbox.com
-lodestar,lodestar,https://lodestar.recruiterbox.com
-loginext,loginext,https://loginext.recruiterbox.com
-lummo,lummo,https://lummo.recruiterbox.com
-lutheranworld,lutheranworld,https://lutheranworld.recruiterbox.com
-maalthahb,maalthahb,https://maalthahb.recruiterbox.com
+LEAMS Education Services (Gamma Holdings LLC.),leamseducation,https://leamseducation.recruiterbox.com
+Les Petits Riens | Spullenhulp,lespetitsriens,https://lespetitsriens.recruiterbox.com
+LMN,lmnarchitects,https://lmnarchitects.recruiterbox.com
+Laird Norton Wetherby,lnwadvisors,https://lnwadvisors.recruiterbox.com
+"Lodestar Consulting, Inc.",lodestar,https://lodestar.recruiterbox.com
+LogiNext,loginext,https://loginext.recruiterbox.com
+Lummo (Formerly Bukukas),lummo,https://lummo.recruiterbox.com
+The Lutheran World Federation,lutheranworld,https://lutheranworld.recruiterbox.com
+MAİSON DE MAA KOZMETİK SANAYİ VE DIŞ TİCARET LİMİT,maalthahb,https://maalthahb.recruiterbox.com
 madebymany,madebymany,https://madebymany.hire.trakstar.com
-medibuddy,medibuddy,https://medibuddy.recruiterbox.com
-mekari,mekari,https://mekari.recruiterbox.com
-mercana,mercana,https://mercana.recruiterbox.com
-mercycorps69469,mercycorps69469,https://mercycorps69469.recruiterbox.com
-mgmtp,mgmtp,https://mgmtp.recruiterbox.com
-midea,midea,https://midea.recruiterbox.com
-mindgames,mindgames,https://mindgames.recruiterbox.com
-mkearney,mkearney,https://mkearney.recruiterbox.com
-mmlafleur,mmlafleur,https://mmlafleur.recruiterbox.com
-moengage,moengage,https://moengage.recruiterbox.com
+MediBuddy,medibuddy,https://medibuddy.recruiterbox.com
+Mekari (PT. Mid Solusi Nusantara),mekari,https://mekari.recruiterbox.com
+Mercana,mercana,https://mercana.recruiterbox.com
+Mercycorps69469,mercycorps69469,https://mercycorps69469.recruiterbox.com
+mgm technology partners,mgmtp,https://mgmtp.recruiterbox.com
+Midea,midea,https://midea.recruiterbox.com
+Mind Games,mindgames,https://mindgames.recruiterbox.com
+Clean Power Finance,mkearney,https://mkearney.recruiterbox.com
+M.M. LaFleur,mmlafleur,https://mmlafleur.recruiterbox.com
+MoEngage Inc,moengage,https://moengage.recruiterbox.com
 mordorintelligence,mordorintelligence,https://mordorintelligence.recruiterbox.com
-mpowerdirect,mpowerdirect,https://mpowerdirect.recruiterbox.com
-myagro,myagro,https://myagro.recruiterbox.com
+MPower Direct,mpowerdirect,https://mpowerdirect.recruiterbox.com
+myAgro Farms,myagro,https://myagro.recruiterbox.com
 naseba,naseba,https://naseba.recruiterbox.com
-native,native,https://native.recruiterbox.com
+Native,native,https://native.recruiterbox.com
 nebb,nebb,https://nebb.recruiterbox.com
-nemetschek,nemetschek,https://nemetschek.recruiterbox.com
-neopollard,neopollard,https://neopollard.recruiterbox.com
-neptuneio,neptuneio,https://neptuneio.recruiterbox.com
-newat,newat,https://newat.recruiterbox.com
-nmdas,nmdas,https://nmdas.recruiterbox.com
-npca,npca,https://npca.recruiterbox.com
-ocient,ocient,https://ocient.recruiterbox.com
-olark,olark,https://olark.recruiterbox.com
-oneilinteractive,oneilinteractive,https://oneilinteractive.recruiterbox.com
-perblue,perblue,https://perblue.recruiterbox.com
-perfectaudience,perfectaudience,https://perfectaudience.recruiterbox.com
-petrodiff,petrodiff,https://petrodiff.recruiterbox.com
-pfchangsrd,pfchangsrd,https://pfchangsrd.recruiterbox.com
-planate,planate,https://planate.recruiterbox.com
-planetbeauty,planetbeauty,https://planetbeauty.recruiterbox.com
-prodoor,prodoor,https://prodoor.recruiterbox.com
-propertymasters,propertymasters,https://propertymasters.recruiterbox.com
-proveng,proveng,https://proveng.recruiterbox.com
+Nemetschek OOD Bulgaria,nemetschek,https://nemetschek.recruiterbox.com
+NeoPollard Interactive,neopollard,https://neopollard.recruiterbox.com
+"Neptune.io, Inc.",neptuneio,https://neptuneio.recruiterbox.com
+New Age Technologies,newat,https://newat.recruiterbox.com
+New Mexico Admin Office of the District Attorneys,nmdas,https://nmdas.recruiterbox.com
+National Parks Conservation Association,npca,https://npca.recruiterbox.com
+Ocient Inc.,ocient,https://ocient.recruiterbox.com
+ONeil Interactive,oneilinteractive,https://oneilinteractive.recruiterbox.com
+PerBlue,perblue,https://perblue.recruiterbox.com
+Perfect Audience,perfectaudience,https://perfectaudience.recruiterbox.com
+Certas Energy Luxembourg sàrl,petrodiff,https://petrodiff.recruiterbox.com
+P. F. Chang´s,pfchangsrd,https://pfchangsrd.recruiterbox.com
+Planate Management Group,planate,https://planate.recruiterbox.com
+Planet Beauty,planetbeauty,https://planetbeauty.recruiterbox.com
+Sentinel Dock & Door Solutions,prodoor,https://prodoor.recruiterbox.com
+Property Masters,propertymasters,https://propertymasters.recruiterbox.com
+Providence Engineering,proveng,https://proveng.recruiterbox.com
 psyoptions,psyoptions,https://psyoptions.recruiterbox.com
-purecars,purecars,https://purecars.recruiterbox.com
-quartus,quartus,https://quartus.recruiterbox.com
+Purecars,purecars,https://purecars.recruiterbox.com
+Quartus Engineering,quartus,https://quartus.recruiterbox.com
 redbranch,redbranch,https://redbranch.hire.trakstar.com
-registrarcorp,registrarcorp,https://registrarcorp.recruiterbox.com
-relevatehealth,relevatehealth,https://relevatehealth.recruiterbox.com
-renewalcarolinas,renewalcarolinas,https://renewalcarolinas.recruiterbox.com
-reps2,reps2,https://reps2.recruiterbox.com
-revampedsecurityjobs,revampedsecurityjobs,https://revampedsecurityjobs.recruiterbox.com
-rhodeswolfe,rhodeswolfe,https://rhodeswolfe.recruiterbox.com
-richelieu,richelieu,https://richelieu.recruiterbox.com
-rigidtactical,rigidtactical,https://rigidtactical.recruiterbox.com
+Registrar Corp,registrarcorp,https://registrarcorp.recruiterbox.com
+Relevate Health,relevatehealth,https://relevatehealth.recruiterbox.com
+Renewal by Andersen,renewalcarolinas,https://renewalcarolinas.recruiterbox.com
+REPS & Co.,reps2,https://reps2.recruiterbox.com
+Revamped Home Security,revampedsecurityjobs,https://revampedsecurityjobs.recruiterbox.com
+Rhodes Wolfe,rhodeswolfe,https://rhodeswolfe.recruiterbox.com
+Richelieu Hardware,richelieu,https://richelieu.recruiterbox.com
+Rigid Tactical,rigidtactical,https://rigidtactical.recruiterbox.com
 rivalfox,rivalfox,https://rivalfox.hire.trakstar.com
 rollbar,rollbar,https://rollbar.hire.trakstar.com
-sajenaturalwellnessoffice,sajenaturalwellnessoffice,https://sajenaturalwellnessoffice.recruiterbox.com
-sajenaturalwellnessretail,sajenaturalwellnessretail,https://sajenaturalwellnessretail.recruiterbox.com
-scishis,scishis,https://scishis.recruiterbox.com
-scopicsoftware,scopicsoftware,https://scopicsoftware.recruiterbox.com
-selerix,selerix,https://selerix.recruiterbox.com
-sensedia,sensedia,https://sensedia.recruiterbox.com
-shantirecruitment,shantirecruitment,https://shantirecruitment.recruiterbox.com
+Saje Natural Wellness,sajenaturalwellnessoffice,https://sajenaturalwellnessoffice.recruiterbox.com
+Saje Natural Wellness | Retail,sajenaturalwellnessretail,https://sajenaturalwellnessretail.recruiterbox.com
+SCIS-HIS,scishis,https://scishis.recruiterbox.com
+Selerix,selerix,https://selerix.recruiterbox.com
+Sensedia,sensedia,https://sensedia.recruiterbox.com
+Shanti Recruitment Agency Co. Ltd Mauritius,shantirecruitment,https://shantirecruitment.recruiterbox.com
 sharechat,sharechat,https://sharechat.recruiterbox.com
-sigmabit,sigmabit,https://sigmabit.recruiterbox.com
-simpleenergy,simpleenergy,https://simpleenergy.recruiterbox.com
-smarttechnologies,smarttechnologies,https://smarttechnologies.recruiterbox.com
-smoketest,smoketest,https://smoketest.recruiterbox.com
-solarient,solarient,https://solarient.recruiterbox.com
-stealthstartup,stealthstartup,https://stealthstartup.recruiterbox.com
-stopnetservices,stopnetservices,https://stopnetservices.recruiterbox.com
-strategicsolutions,strategicsolutions,https://strategicsolutions.recruiterbox.com
-synergenhealth,synergenhealth,https://synergenhealth.recruiterbox.com
-systemone,systemone,https://systemone.recruiterbox.com
-takecareinsurance,takecareinsurance,https://takecareinsurance.recruiterbox.com
-tallyweijl,tallyweijl,https://tallyweijl.recruiterbox.com
-tangoanalytics,tangoanalytics,https://tangoanalytics.recruiterbox.com
-tapmango,tapmango,https://tapmango.recruiterbox.com
-tenthpin,tenthpin,https://tenthpin.recruiterbox.com
-terrapower,terrapower,https://terrapower.recruiterbox.com
-testbook,testbook,https://testbook.recruiterbox.com
-testdouble,testdouble,https://testdouble.recruiterbox.com
+Sigmabit,sigmabit,https://sigmabit.recruiterbox.com
+Simple Energy,simpleenergy,https://simpleenergy.recruiterbox.com
+SMART Technologies,smarttechnologies,https://smarttechnologies.recruiterbox.com
+Smoke,smoketest,https://smoketest.recruiterbox.com
+"Solari Enterprises, Inc.",solarient,https://solarient.recruiterbox.com
+Stealth Startup,stealthstartup,https://stealthstartup.recruiterbox.com
+Stop Net Services,stopnetservices,https://stopnetservices.recruiterbox.com
+SSG,strategicsolutions,https://strategicsolutions.recruiterbox.com
+Synergenhealth,synergenhealth,https://synergenhealth.recruiterbox.com
+"SystemOne, LLC",systemone,https://systemone.recruiterbox.com
+"TakeCare Insurance Company, Inc.",takecareinsurance,https://takecareinsurance.recruiterbox.com
+Tally Weijl,tallyweijl,https://tallyweijl.recruiterbox.com
+Tango,tangoanalytics,https://tangoanalytics.recruiterbox.com
+TapMango,tapmango,https://tapmango.recruiterbox.com
+Tenthpin,tenthpin,https://tenthpin.recruiterbox.com
+TerraPower,terrapower,https://terrapower.recruiterbox.com
+Test Double,testdouble,https://testdouble.recruiterbox.com
 testhuset,testhuset,https://testhuset.recruiterbox.com
-thalle,thalle,https://thalle.recruiterbox.com
-thebushschool,thebushschool,https://thebushschool.recruiterbox.com
-therap,therap,https://therap.recruiterbox.com
-timessquarenyc,timessquarenyc,https://timessquarenyc.recruiterbox.com
-togetherall,togetherall,https://togetherall.recruiterbox.com
-tokkalabs,tokkalabs,https://tokkalabs.recruiterbox.com
-tookitaki78808,tookitaki78808,https://tookitaki78808.recruiterbox.com
-trakstar,trakstar,https://trakstar.recruiterbox.com
-trickleup,trickleup,https://trickleup.recruiterbox.com
-trustingsocial,trustingsocial,https://trustingsocial.recruiterbox.com
-twonice,twonice,https://twonice.recruiterbox.com
-ugrowthfund,ugrowthfund,https://ugrowthfund.recruiterbox.com
-ukcourtesans,ukcourtesans,https://ukcourtesans.recruiterbox.com
-vegasolutions,vegasolutions,https://vegasolutions.recruiterbox.com
-veritaspress,veritaspress,https://veritaspress.recruiterbox.com
-viaconseil,viaconseil,https://viaconseil.recruiterbox.com
-vikingcruises,vikingcruises,https://vikingcruises.recruiterbox.com
-wandoo,wandoo,https://wandoo.recruiterbox.com
-watttime,watttime,https://watttime.recruiterbox.com
-wcccoe,wcccoe,https://wcccoe.recruiterbox.com
-wearebarbarian,wearebarbarian,https://wearebarbarian.recruiterbox.com
-weworkindia,weworkindia,https://weworkindia.recruiterbox.com
-whatfix101,whatfix101,https://whatfix101.recruiterbox.com
-windrosestaffing,windrosestaffing,https://windrosestaffing.recruiterbox.com
-wiredybpradio,wiredybpradio,https://wiredybpradio.recruiterbox.com
-witekio,witekio,https://witekio.recruiterbox.com
-wolframresearch,wolframresearch,https://wolframresearch.recruiterbox.com
-workforcesource,workforcesource,https://workforcesource.recruiterbox.com
-worksuites,worksuites,https://worksuites.recruiterbox.com
-wtrs,wtrs,https://wtrs.recruiterbox.com
-xideral,xideral,https://xideral.recruiterbox.com
-xstelecom,xstelecom,https://xstelecom.recruiterbox.com
-yeledvyalda,yeledvyalda,https://yeledvyalda.recruiterbox.com
-zeitview,zeitview,https://zeitview.recruiterbox.com
-zendesk,zendesk,https://zendesk.recruiterbox.com
-ziplr,ziplr,https://ziplr.recruiterbox.com
-zwillgen,zwillgen,https://zwillgen.recruiterbox.com
-zycron,zycron,https://zycron.recruiterbox.com
+Thalle Construction Company,thalle,https://thalle.recruiterbox.com
+The Bush School,thebushschool,https://thebushschool.recruiterbox.com
+Therap (BD) Ltd.,therap,https://therap.recruiterbox.com
+Times Square Alliance,timessquarenyc,https://timessquarenyc.recruiterbox.com
+Togetherall,togetherall,https://togetherall.recruiterbox.com
+Tokka Labs,tokkalabs,https://tokkalabs.recruiterbox.com
+Tookitaki Holding PTE LTD,tookitaki78808,https://tookitaki78808.recruiterbox.com
+Trakstar,trakstar,https://trakstar.recruiterbox.com
+Trickle Up,trickleup,https://trickleup.recruiterbox.com
+Trusting Social & Kompato AI,trustingsocial,https://trustingsocial.recruiterbox.com
+#twiceasnice Recruiting,twonice,https://twonice.recruiterbox.com
+University Growth Fund,ugrowthfund,https://ugrowthfund.recruiterbox.com
+UK Courtesans,ukcourtesans,https://ukcourtesans.recruiterbox.com
+Tokka Labs,vegasolutions,https://vegasolutions.recruiterbox.com
+Veritas Press,veritaspress,https://veritaspress.recruiterbox.com
+Viaconseil,viaconseil,https://viaconseil.recruiterbox.com
+Viking Cruises US,vikingcruises,https://vikingcruises.recruiterbox.com
+Wandoo Finance Group,wandoo,https://wandoo.recruiterbox.com
+WattTime,watttime,https://watttime.recruiterbox.com
+World Council of Churches,wcccoe,https://wcccoe.recruiterbox.com
+Barbarian,wearebarbarian,https://wearebarbarian.recruiterbox.com
+WeWork India,weworkindia,https://weworkindia.recruiterbox.com
+Whatfix,whatfix101,https://whatfix101.recruiterbox.com
+Windrose Staffing,windrosestaffing,https://windrosestaffing.recruiterbox.com
+Wired YBP Radio,wiredybpradio,https://wiredybpradio.recruiterbox.com
+Witekio,witekio,https://witekio.recruiterbox.com
+Wolfram,wolframresearch,https://wolframresearch.recruiterbox.com
+Workforce Source,workforcesource,https://workforcesource.recruiterbox.com
+Lucid Private Offices,worksuites,https://worksuites.recruiterbox.com
+Western Turnpike Rescue Squad,wtrs,https://wtrs.recruiterbox.com
+Xideral,xideral,https://xideral.recruiterbox.com
+XS Telecom,xstelecom,https://xstelecom.recruiterbox.com
+Yeled v'Yalda,yeledvyalda,https://yeledvyalda.recruiterbox.com
+Zeitview,zeitview,https://zeitview.recruiterbox.com
+Zendesk,zendesk,https://zendesk.recruiterbox.com
+Ziplr Technology Private Limited,ziplr,https://ziplr.recruiterbox.com
+ZwillGen,zwillgen,https://zwillgen.recruiterbox.com
+Zycron,zycron,https://zycron.recruiterbox.com


### PR DESCRIPTION
## Summary

- Updates Recruiterbox/Trakstar display names from public careers page headings/titles.
- Removes rows whose public careers URL returns 404 content.
- Keeps this PR scoped to `ats-companies/recruiterbox.csv`.

## Validation

- Recruiterbox audit: 250 input rows checked against `jsapi.recruiterbox.com/v1/openings?client_name={slug}` and public careers URLs.
- All 250 rows returned API JSON; 5 public careers URLs returned 404 and were removed.
- Final CSV sanity check: 245 rows, 0 duplicate slugs, 0 duplicate URLs, 0 missing fields, 0 URL/slug pattern mismatches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized Recruiterbox/Trakstar company names and removed dead entries in `ats-companies/recruiterbox.csv` to improve data accuracy.

- **Bug Fixes**
  - Updated display names to match public careers page headers/titles.
  - Removed 5 rows whose public careers URLs returned 404; CSV now has 245 rows.
  - Validated 250 slugs against `jsapi.recruiterbox.com/v1/openings?client_name={slug}`; all responded. Final CSV: no duplicate slugs/URLs and no missing fields.

<sup>Written for commit 24343f4aaff107d72c5d332df44a515b7eb50c76. Summary will update on new commits. <a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/144?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

