### PR TITLE
[codex] Fix Eightfold company entries

### DIFF
--- a/ats-companies/eightfold.csv
+++ b/ats-companies/eightfold.csv
@@ -4,8 +4,8 @@ Arcadis,arcadis,https://arcadis.eightfold.ai/careers
 Boston Scientific,bostonscientific,https://bostonscientific.eightfold.ai/careers
 Citi,citi,https://citi.eightfold.ai/careers
 Coca-Cola Europacific Partners,ccep,https://ccep.eightfold.ai/careers
-Corteva,corteva,https://corteva.eightfold.ai/careers
-DSM,dsm,https://dsm.eightfold.ai/careers
+Corteva Agriscience,corteva,https://corteva.eightfold.ai/careers
+dsm-firmenich,dsm,https://dsm.eightfold.ai/careers
 Dexcom,dexcom,https://dexcom.eightfold.ai/careers
 Dolby,dolby,https://dolby.eightfold.ai/careers
 Eaton,eaton,https://eaton.eightfold.ai/careers
@@ -13,21 +13,21 @@ Ericsson,ericsson,https://ericsson.eightfold.ai/careers
 Estée Lauder Companies,elcompanies,https://elcompanies.eightfold.ai/careers
 Ford,ford,https://ford.eightfold.ai/careers
 Fortive,fortive,https://fortive.eightfold.ai/careers
-Government of Puerto Rico,puertoricogov,https://puertoricogov.eightfold.ai/careers
-Grupo Bimbo,grupobimbo,https://grupobimbo.eightfold.ai/careers
+OATRH,puertoricogov,https://puertoricogov.eightfold.ai/careers
+Bimbo Bakeries USA,grupobimbo,https://grupobimbo.eightfold.ai/careers
 Hasbro,hasbro,https://hasbro.eightfold.ai/careers
 Kraft Heinz,kraftheinz,https://kraftheinz.eightfold.ai/careers
 Lam Research,lamresearch,https://lamresearch.eightfold.ai/careers
 MercadoLibre,mercadolibre,https://mercadolibre.eightfold.ai/careers
-Micron,micron,https://micron.eightfold.ai/careers
+Micron Technology,micron,https://micron.eightfold.ai/careers
 Microsoft,microsoft,https://microsoft.eightfold.ai/careers
-Modern Technology Solutions,mtsi-va,https://mtsi-va.eightfold.ai/careers
+Modern Technology Solutions Inc,mtsi-va,https://mtsi-va.eightfold.ai/careers
 Morgan Stanley,morganstanley,https://morganstanley.eightfold.ai/careers
-NTT Data,nttdata,https://nttdata.eightfold.ai/careers
+NTT DATA,nttdata,https://nttdata.eightfold.ai/careers
 Northrop Grumman,ngc,https://ngc.eightfold.ai/careers
-Nvidia,nvidia,https://nvidia.eightfold.ai/careers
+NVIDIA Corporation,nvidia,https://nvidia.eightfold.ai/careers
 PayPal,paypal,https://paypal.eightfold.ai/careers
-Ptc,ptc,https://ptc.eightfold.ai/careers
+PTC,ptc,https://ptc.eightfold.ai/careers
 Qualcomm,qualcomm,https://qualcomm.eightfold.ai/careers
 Ralliant,ralliant,https://ralliant.eightfold.ai/careers
 Starbucks,starbucks,https://starbucks.eightfold.ai/careers
@@ -39,9 +39,9 @@ UKG,ukg,https://ukg.eightfold.ai/careers
 Vialto Partners,vialto,https://vialto.eightfold.ai/careers
 Vodafone,vodafone,https://vodafone.eightfold.ai/careers
 Whirlpool,whirlpool,https://whirlpool.eightfold.ai/careers
-appliedmaterials,appliedmaterials,https://appliedmaterials.eightfold.ai/careers
-caci,caci,https://caci.eightfold.ai/careers
-kering,kering,https://kering.eightfold.ai/careers
-slb,slb,https://slb.eightfold.ai/careers
-softtek,softtek,https://softtek.eightfold.ai/careers
-telekom-growthhub,telekom-growthhub,https://telekom-growthhub.eightfold.ai/careers
+Applied Materials,appliedmaterials,https://appliedmaterials.eightfold.ai/careers
+CACI,caci,https://caci.eightfold.ai/careers
+Kering,kering,https://kering.eightfold.ai/careers
+SLB,slb,https://slb.eightfold.ai/careers
+Softtek,softtek,https://softtek.eightfold.ai/careers
+Deutsche Telekom,telekom-growthhub,https://telekom-growthhub.eightfold.ai/careers


### PR DESCRIPTION
## Summary

- Updates Eightfold display names from public Eightfold career page titles.
- Keeps this PR scoped to `ats-companies/eightfold.csv`.

## Validation

- Eightfold audit: 46 input rows checked against `{slug}.eightfold.ai/api/pcsx/search` and public careers pages.
- All 46 rows returned API 200 and public page 200.
- Final CSV sanity check: 46 rows, 0 duplicate slugs, 0 duplicate URLs, 0 missing fields, 0 URL/slug mismatches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed incorrect company display names for Eightfold entries in `ats-companies/eightfold.csv` to match titles on public careers pages. Slugs and URLs are unchanged.

- **Bug Fixes**
  - Updated 15 display names (e.g., "Corteva Agriscience", "dsm-firmenich", "Bimbo Bakeries USA", "NVIDIA Corporation", "Applied Materials", "CACI", "SLB", "Deutsche Telekom").
  - Scope limited to `ats-companies/eightfold.csv`.
  - Validation: audited all 46 rows against `{slug}.eightfold.ai/api/pcsx/search` and public careers pages (all 200); CSV checks passed (no duplicates, no missing fields).

<sup>Written for commit 47f2de4a4245447723a48ef9fc68209ae344f80a. Summary will update on new commits. <a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/145?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

