### PR TITLE
Fix Taleo company entries

### DIFF
--- a/ats-companies/taleo.csv
+++ b/ats-companies/taleo.csv
@@ -1,115 +1,111 @@
 name,slug,url
-ACDY28,ACDY28,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=ACDY28&cws=1
-ACMEBRIC,ACMEBRIC,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=ACMEBRIC&cws=1
-ACTIONLINK,ACTIONLINK,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=ACTIONLINK&cws=1
-ADELPHI,ADELPHI,https://phf.tbe.taleo.net/phf02/ats/careers/v2/searchResults?org=ADELPHI&cws=39
-AGIOS,AGIOS,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=AGIOS&cws=1
-AMERINC,AMERINC,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=AMERINC&cws=1
-ARKASTAT2,ARKASTAT2,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=ARKASTAT2&cws=64
-ASPENGOV,ASPENGOV,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=ASPENGOV&cws=1
-ATLGA,ATLGA,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=ATLGA&cws=1
-AURORA,AURORA,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=AURORA&cws=1
-BAA9G6,BAA9G6,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=BAA9G6&cws=1
-BASESOLU,BASESOLU,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=BASESOLU&cws=1
-BIA,BIA,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=BIA&cws=1
-BSHHOME,BSHHOME,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=BSHHOME&cws=1
-BUTTLLC2,BUTTLLC2,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=BUTTLLC2&cws=1
-C2PORTFOLIO,C2PORTFOLIO,https://phh.tbe.taleo.net/phh02/ats/careers/v2/searchResults?org=C2PORTFOLIO&cws=38
-CAMBRIDGEMA,CAMBRIDGEMA,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=CAMBRIDGEMA&cws=37
-CAREUSA,CAREUSA,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=CAREUSA&cws=52
-CARLCORP2,CARLCORP2,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=CARLCORP2&cws=1
-CELESTAR,CELESTAR,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=CELESTAR&cws=1
-CITYBURNABY,CITYBURNABY,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CITYBURNABY&cws=1
-CITYOFKA,CITYOFKA,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CITYOFKA&cws=1
-CNLLTD,CNLLTD,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CNLLTD&cws=1
-COMACOUN,COMACOUN,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=COMACOUN&cws=1
-COMPREHENSIVEPS,COMPREHENSIVEPS,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=COMPREHENSIVEPS&cws=1
-COSC,COSC,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=COSC&cws=1
-CPOFNYS,CPOFNYS,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=CPOFNYS&cws=1
-CRCS,CRCS,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CRCS&cws=1
-CUSTOMONLINE,CUSTOMONLINE,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=CUSTOMONLINE&cws=1
-CUSTOMONLINE,CUSTOMONLINE,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=CUSTOMONLINE&cws=37
-CYDE,CYDE,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=CYDE&cws=1
-DCSCORP,DCSCORP,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=DCSCORP&cws=1
-DNQV4N,DNQV4N,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=DNQV4N&cws=37
-DSB,DSB,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=DSB&cws=1
-ECCO,ECCO,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=ECCO&cws=1
-ERT,ERT,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=ERT&cws=1
-EXPERITEC,EXPERITEC,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=EXPERITEC&cws=1
-FHB,FHB,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=FHB&cws=38
-GATEWAYVENT,GATEWAYVENT,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=GATEWAYVENT&cws=1
-GEMINIIND,GEMINIIND,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=GEMINIIND&cws=1
-GRANITEROCK,GRANITEROCK,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=GRANITEROCK&cws=41
-GRANTTHORNTON,GRANTTHORNTON,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=GRANTTHORNTON&cws=1
-GROUPEMONTPETIT,GROUPEMONTPETIT,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=GROUPEMONTPETIT&cws=37
-HGAC,HGAC,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=HGAC&cws=1
-HKFQUN,HKFQUN,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=HKFQUN&cws=1
-ICANN,ICANN,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=ICANN&cws=1
-IDRC,IDRC,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=IDRC&cws=1
-IESCORG,IESCORG,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=IESCORG&cws=1
-INFOGATEWAYS,INFOGATEWAYS,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=INFOGATEWAYS&cws=1
-INSTITUTEDA,INSTITUTEDA,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=INSTITUTEDA&cws=1
-INVENSENSE,INVENSENSE,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=INVENSENSE&cws=1
-INVXIS,INVXIS,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=INVXIS&cws=1
-ITS,ITS,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=ITS&cws=1
-KHOV,KHOV,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=KHOV&cws=1
-KLOHNCRIPPEN,KLOHNCRIPPEN,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=KLOHNCRIPPEN&cws=1
-LEISURESPORTS,LEISURESPORTS,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=LEISURESPORTS&cws=1
-MILCORP,MILCORP,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=MILCORP&cws=1
-MRA,MRA,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=MRA&cws=1
-MSFOCA,MSFOCA,https://lde.tbe.taleo.net/lde01/ats/careers/v2/searchResults?org=MSFOCA&cws=1
-N2FGE8,N2FGE8,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=N2FGE8&cws=1
-NBF1199,NBF1199,https://phf.tbe.taleo.net/phf03/ats/careers/v2/searchResults?org=NBF1199&cws=1
-NETGINC,NETGINC,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=NETGINC&cws=37
-NETWSECU,NETWSECU,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=NETWSECU&cws=1
-NEWJERSH2,NEWJERSH2,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=NEWJERSH2&cws=1
-NFINDY,NFINDY,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=NFINDY&cws=37
-NUAXINNO,NUAXINNO,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=NUAXINNO&cws=1
-OAKSCHRISTIAN,OAKSCHRISTIAN,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=OAKSCHRISTIAN&cws=1
-ORBIS,ORBIS,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=ORBIS&cws=1
-OSOURCE,OSOURCE,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=OSOURCE&cws=1
-PFS,PFS,https://phf.tbe.taleo.net/phf01/ats/careers/v2/searchResults?org=PFS&cws=1
-PHILADELPHIACORP,PHILADELPHIACORP,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=PHILADELPHIACORP&cws=1
-PHXIND,PHXIND,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=PHXIND&cws=1
-PLUSONE,PLUSONE,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=PLUSONE&cws=1
-POWERENGINEERS,POWERENGINEERS,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=POWERENGINEERS&cws=44
-PROSUM,PROSUM,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=PROSUM&cws=1
-Q8Z9AA,Q8Z9AA,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=Q8Z9AA&cws=1
-R8GHJR,R8GHJR,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=R8GHJR&cws=1
-RADIPART,RADIPART,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=RADIPART&cws=1
-SAINTELIZABETH,SAINTELIZABETH,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=SAINTELIZABETH&cws=1
-STG_CAREUSA,STG_CAREUSA,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=STG_CAREUSA&cws=1
-STG_CITCO,STG_CITCO,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=STG_CITCO&cws=1
-STG_PCG,STG_PCG,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=STG_PCG&cws=1
-STJOSHAM,STJOSHAM,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=STJOSHAM&cws=1
-TCHC,TCHC,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=TCHC&cws=45
-TELRIDE,TELRIDE,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=TELRIDE&cws=1
-TERPSYS,TERPSYS,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=TERPSYS&cws=1
-THDA2,THDA2,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=THDA2&cws=1
-THESOUTP,THESOUTP,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=THESOUTP&cws=1
-TIDETRANS,TIDETRANS,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=TIDETRANS&cws=40
-TILLAMOOKCREAMERY,TILLAMOOKCREAMERY,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=TILLAMOOKCREAMERY&cws=1
-TPC,TPC,https://phh.tbe.taleo.net/phh02/ats/careers/v2/searchResults?org=TPC&cws=1
-TRQS8M,TRQS8M,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=TRQS8M&cws=1
-VALOROUS,VALOROUS,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=VALOROUS&cws=1
-VBGOV,VBGOV,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=VBGOV&cws=1
-VPH,VPH,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=VPH&cws=41
-WESTVAN,WESTVAN,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=WESTVAN&cws=1
-XNZ8Q7,XNZ8Q7,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=XNZ8Q7&cws=1
-YKHC,YKHC,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=YKHC&cws=41
-YMCAUSA,YMCAUSA,https://phf.tbe.taleo.net/phf01/ats/careers/v2/searchResults?org=YMCAUSA&cws=1
-phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=FREEHOUS&cws=39,freehous,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchresults?org=freehous&cws=39
-phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=MEDIACOMCC&cws=46,mediacomcc,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchresults?org=mediacomcc&cws=46
-phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=UH9TY5&cws=41,uh9ty5,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchresults?org=uh9ty5&cws=41
-phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=CLINIPACE&cws=41,clinipace,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchresults?org=clinipace&cws=41
-phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=GRANDSIERRARESORT&cws=54,grandsierraresort,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchresults?org=grandsierraresort&cws=54
-phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=WWCI&cws=40,WWCI,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=WWCI&cws=40
-phf.tbe.taleo.net/phf01/ats/careers/v2/searchResults?org=JSHR6E&cws=63,jshr6e,https://phf.tbe.taleo.net/phf01/ats/careers/v2/searchresults?org=jshr6e&cws=63
-phf.tbe.taleo.net/phf02/ats/careers/v2/searchResults?org=COSTCO&cws=41,COSTCO,https://phf.tbe.taleo.net/phf02/ats/careers/v2/searchResults?org=COSTCO&cws=41
-phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=EMPITODA&cws=37,empitoda,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchresults?org=empitoda&cws=37
-phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=GRANITEROCK&cws=42,graniterock,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchresults?org=graniterock&cws=42
-phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=UT62VN&cws=37,ut62vn,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchresults?org=ut62vn&cws=37
-phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=ARTESIA&cws=40,artesia,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchresults?org=artesia&cws=40
-phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=CONSERVATION&cws=39,conservation,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchresults?org=conservation&cws=39
-phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=DCSCORP2&cws=37,dcscorp2,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchresults?org=dcscorp2&cws=37
-phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=PCG&cws=47,pcg,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchresults?org=pcg&cws=47
+"HX5, LLC",https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=ACDY28&cws=1,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=ACDY28&cws=1
+ACME Brick Company,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=ACMEBRIC&cws=1,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=ACMEBRIC&cws=1
+ActionLink,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=ACTIONLINK&cws=1,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=ACTIONLINK&cws=1
+Adelphi University,https://phf.tbe.taleo.net/phf02/ats/careers/v2/searchResults?org=ADELPHI&cws=39,https://phf.tbe.taleo.net/phf02/ats/careers/v2/searchResults?org=ADELPHI&cws=39
+Agios Pharmaceuticals Inc,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=AGIOS&cws=1,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=AGIOS&cws=1
+AmeriHealth Caritas,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=AMERINC&cws=1,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=AMERINC&cws=1
+Arkansas State University Three Rivers,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=ARKASTAT2&cws=64,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=ARKASTAT2&cws=64
+City of Aspen,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=ASPENGOV&cws=1,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=ASPENGOV&cws=1
+City of Atlanta,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=ATLGA&cws=1,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=ATLGA&cws=1
+Aurora Flight Sciences,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=AURORA&cws=1,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=AURORA&cws=1
+KGHM International Ltd,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=BAA9G6&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=BAA9G6&cws=1
+"Base-2 Solutions, LLC",https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=BASESOLU&cws=1,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=BASESOLU&cws=1
+"Boeing Intelligence & Analytics, Inc. (BIA)",https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=BIA&cws=1,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=BIA&cws=1
+BSH Home Appliances Corporation,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=BSHHOME&cws=1,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=BSHHOME&cws=1
+Butterball,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=BUTTLLC2&cws=1,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=BUTTLLC2&cws=1
+"C2 Essentials, Inc",https://phh.tbe.taleo.net/phh02/ats/careers/v2/searchResults?org=C2PORTFOLIO&cws=38,https://phh.tbe.taleo.net/phh02/ats/careers/v2/searchResults?org=C2PORTFOLIO&cws=38
+City of Cambridge MA,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=CAMBRIDGEMA&cws=37,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=CAMBRIDGEMA&cws=37
+CARE USA,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=CAREUSA&cws=52,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=CAREUSA&cws=52
+Carley Corporation,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=CARLCORP2&cws=1,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=CARLCORP2&cws=1
+Celestar,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=CELESTAR&cws=1,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=CELESTAR&cws=1
+City of Burnaby,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CITYBURNABY&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CITYBURNABY&cws=1
+City of Kawartha Lakes,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CITYOFKA&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CITYOFKA&cws=1
+Canadian Nuclear Laboratories,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CNLLTD&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CNLLTD&cws=1
+Memorial Health System of Southwest Oklahoma,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=COMACOUN&cws=1,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=COMACOUN&cws=1
+"CPS Solutions, LLC",https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=COMPREHENSIVEPS&cws=1,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=COMPREHENSIVEPS&cws=1
+City of St. Catharines,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=COSC&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=COSC&cws=1
+CP Unlimited,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=CPOFNYS&cws=1,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=CPOFNYS&cws=1
+Canadian Red Cross,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CRCS&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CRCS&cws=1
+Custom Online,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=CUSTOMONLINE&cws=1,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=CUSTOMONLINE&cws=1
+Custom Online,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=CUSTOMONLINE&cws=37,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=CUSTOMONLINE&cws=37
+"Cydecor, Inc",https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=CYDE&cws=1,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=CYDE&cws=1
+DCS Corporation,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=DCSCORP&cws=1,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=DCSCORP&cws=1
+National Capital Commission,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=DNQV4N&cws=37,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=DNQV4N&cws=37
+Dah Sing Bank,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=DSB&cws=1,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=DSB&cws=1
+"Ecco USA, Inc.",https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=ECCO&cws=1,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=ECCO&cws=1
+ERT,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=ERT&cws=1,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=ERT&cws=1
+Experitec,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=EXPERITEC&cws=1,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=EXPERITEC&cws=1
+First Hawaiian Bank,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=FHB&cws=38,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=FHB&cws=38
+"Three Saints Bay, LLC",https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=GATEWAYVENT&cws=1,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=GATEWAYVENT&cws=1
+Gemini Industries Inc.,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=GEMINIIND&cws=1,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=GEMINIIND&cws=1
+Graniterock,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=GRANITEROCK&cws=41,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=GRANITEROCK&cws=41
+Doane Grant Thornton,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=GRANTTHORNTON&cws=1,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=GRANTTHORNTON&cws=1
+Groupe Montpetit Ressources Humaines Inc,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=GROUPEMONTPETIT&cws=37,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=GROUPEMONTPETIT&cws=37
+H-GAC,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=HGAC&cws=1,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=HGAC&cws=1
+Apex IT,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=HKFQUN&cws=1,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=HKFQUN&cws=1
+ICANN,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=ICANN&cws=1,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=ICANN&cws=1
+International Development Research Centre (IDRC),https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=IDRC&cws=1,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=IDRC&cws=1
+IESC,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=IESCORG&cws=1,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=IESCORG&cws=1
+Information Gateways Inc,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=INFOGATEWAYS&cws=1,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=INFOGATEWAYS&cws=1
+Institute for Defense Analyses,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=INSTITUTEDA&cws=1,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=INSTITUTEDA&cws=1
+"INVENSENSE, INC.",https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=INVENSENSE&cws=1,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=INVENSENSE&cws=1
+RealmOne,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=INVXIS&cws=1,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=INVXIS&cws=1
+Sierra-Cedar,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=ITS&cws=1,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=ITS&cws=1
+"K. Hovnanian Companies, LLC",https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=KHOV&cws=1,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=KHOV&cws=1
+Klohn Crippen Berger,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=KLOHNCRIPPEN&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=KLOHNCRIPPEN&cws=1
+"Leisure Sports, Inc.",https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=LEISURESPORTS&cws=1,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=LEISURESPORTS&cws=1
+The MIL Corporation,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=MILCORP&cws=1,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=MILCORP&cws=1
+MRA,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=MRA&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=MRA&cws=1
+Artsen zonder Grenzen,https://lde.tbe.taleo.net/lde01/ats/careers/v2/searchResults?org=MSFOCA&cws=1,https://lde.tbe.taleo.net/lde01/ats/careers/v2/searchResults?org=MSFOCA&cws=1
+Lakeshore Technical College,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=N2FGE8&cws=1,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=N2FGE8&cws=1
+1199SEIU Funds,https://phf.tbe.taleo.net/phf03/ats/careers/v2/searchResults?org=NBF1199&cws=1,https://phf.tbe.taleo.net/phf03/ats/careers/v2/searchResults?org=NBF1199&cws=1
+Arlo,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=NETGINC&cws=37,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=NETGINC&cws=37
+"Network Security Systems Plus, INC.",https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=NETWSECU&cws=1,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=NETWSECU&cws=1
+New Jersey Housing and Mortgage Finance Agency,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=NEWJERSH2&cws=1,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=NEWJERSH2&cws=1
+"Nurses and More, Inc.",https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=NFINDY&cws=37,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=NFINDY&cws=37
+NuAxis Innovations,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=NUAXINNO&cws=1,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=NUAXINNO&cws=1
+Oaks Christian School,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=OAKSCHRISTIAN&cws=1,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=OAKSCHRISTIAN&cws=1
+ORBIS Inc,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=ORBIS&cws=1,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=ORBIS&cws=1
+"OUTSOURCE Consulting Services, Inc.",https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=OSOURCE&cws=1,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=OSOURCE&cws=1
+"Potawatomi Federal Solutions, LLC",https://phf.tbe.taleo.net/phf01/ats/careers/v2/searchResults?org=PFS&cws=1,https://phf.tbe.taleo.net/phf01/ats/careers/v2/searchResults?org=PFS&cws=1
+Philadelphia Corporation for Aging,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=PHILADELPHIACORP&cws=1,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=PHILADELPHIACORP&cws=1
+Phoenix Industrial,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=PHXIND&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=PHXIND&cws=1
+POWER Engineers,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=POWERENGINEERS&cws=44,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=POWERENGINEERS&cws=44
+Prosum Technology Services,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=PROSUM&cws=1,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=PROSUM&cws=1
+City of New Westminster,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=Q8Z9AA&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=Q8Z9AA&cws=1
+"ATCO Communications Services, LLC",https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=R8GHJR&cws=1,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=R8GHJR&cws=1
+Radiology Partners,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=RADIPART&cws=1,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=RADIPART&cws=1
+SE Health,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=SAINTELIZABETH&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=SAINTELIZABETH&cws=1
+St. Joseph's Healthcare Hamilton,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=STJOSHAM&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=STJOSHAM&cws=1
+Toronto Community Housing Corporation,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=TCHC&cws=45,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=TCHC&cws=45
+"TSG Ski & Golf, LLC",https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=TELRIDE&cws=1,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=TELRIDE&cws=1
+TerpSys,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=TERPSYS&cws=1,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=TERPSYS&cws=1
+Tennessee Housing Development Agency,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=THDA2&cws=1,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=THDA2&cws=1
+The Southeast Permanente Medical Group,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=THESOUTP&cws=1,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=THESOUTP&cws=1
+Tidewater,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=TIDETRANS&cws=40,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=TIDETRANS&cws=40
+Tillamook County Creamery Association,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=TILLAMOOKCREAMERY&cws=1,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=TILLAMOOKCREAMERY&cws=1
+Portland Clinic,https://phh.tbe.taleo.net/phh02/ats/careers/v2/searchResults?org=TPC&cws=1,https://phh.tbe.taleo.net/phh02/ats/careers/v2/searchResults?org=TPC&cws=1
+City of Richmond,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=TRQS8M&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=TRQS8M&cws=1
+"Valorous, Inc.",https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=VALOROUS&cws=1,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=VALOROUS&cws=1
+City of Virginia Beach,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=VBGOV&cws=1,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=VBGOV&cws=1
+Valley Presbyterian Hospital,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=VPH&cws=41,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=VPH&cws=41
+West Vancouver,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=WESTVAN&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=WESTVAN&cws=1
+City of Delta,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=XNZ8Q7&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=XNZ8Q7&cws=1
+Yukon-Kuskokwim Health Corporation,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=YKHC&cws=41,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=YKHC&cws=41
+YMCA of the USA,https://phf.tbe.taleo.net/phf01/ats/careers/v2/searchResults?org=YMCAUSA&cws=1,https://phf.tbe.taleo.net/phf01/ats/careers/v2/searchResults?org=YMCAUSA&cws=1
+Freedom House,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=FREEHOUS&cws=39,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=FREEHOUS&cws=39
+Mediacom Communications Corporation,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=MEDIACOMCC&cws=46,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=MEDIACOMCC&cws=46
+Pinellas Suncoast Transit Authority,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=UH9TY5&cws=41,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=UH9TY5&cws=41
+Caidya,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=CLINIPACE&cws=41,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=CLINIPACE&cws=41
+Meruelo Group,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=GRANDSIERRARESORT&cws=54,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=GRANDSIERRARESORT&cws=54
+WTTW/Chicago PBS and WFMT/Chicago Classical,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=WWCI&cws=40,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=WWCI&cws=40
+Crane NXT,https://phf.tbe.taleo.net/phf01/ats/careers/v2/searchResults?org=JSHR6E&cws=63,https://phf.tbe.taleo.net/phf01/ats/careers/v2/searchResults?org=JSHR6E&cws=63
+Costco,https://phf.tbe.taleo.net/phf02/ats/careers/v2/searchResults?org=COSTCO&cws=41,https://phf.tbe.taleo.net/phf02/ats/careers/v2/searchResults?org=COSTCO&cws=41
+Empire Today,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=EMPITODA&cws=37,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=EMPITODA&cws=37
+Graniterock,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=GRANITEROCK&cws=42,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=GRANITEROCK&cws=42
+"M. J. Electric, LLC",https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=UT62VN&cws=37,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=UT62VN&cws=37
+City of Artesia,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=ARTESIA&cws=40,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=ARTESIA&cws=40
+Conservation International,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=CONSERVATION&cws=39,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=CONSERVATION&cws=39
+DCS Corporation,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=DCSCORP2&cws=37,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=DCSCORP2&cws=37
+Pinellas County Government,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=PCG&cws=47,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=PCG&cws=47


### PR DESCRIPTION
## Summary
- replace opaque Taleo tenant codes with verified company display names where the live pages exposed JSON-LD, page detail text, or logo/title evidence
- normalize Taleo `slug` values to the full scraper URL and restore case-sensitive `searchResults`/`org` URLs that were returning empty listings
- remove broken/non-production Taleo tenants that returned 500s or staging content

## Validation
- audited 114 original Taleo rows against live Taleo career pages and one sample detail page when jobs were present
- final CSV sanity: 110 rows, no missing fields, no duplicate slug/url values, no URL-shaped display names
- final live check: 110/110 URLs returned expected Taleo career content; 90 listings had jobs; 794 listing jobs detected

CSV-only change, so no unit tests were added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned and fixed Taleo company entries in `taleo.csv` to use verified company names and working URLs. This restores valid listings and removes broken tenants.

- **Bug Fixes**
  - Replaced tenant codes with verified company display names from JSON-LD or on-page signals.
  - Normalized `slug` values to the full scraper URL and corrected case-sensitive `searchResults`/`org` params to avoid empty results.
  - Removed tenants returning 500s or serving staging content.

<sup>Written for commit b7cd904ebd6d8b2e3cae383b46294d3822e7ad6d. Summary will update on new commits. <a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/146?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

