### PR TITLE
Fix Avature company entries

### DIFF
--- a/ats-companies/avature.csv
+++ b/ats-companies/avature.csv
@@ -1,89 +1,66 @@
 name,slug,url
-A2Milkkf,a2milkkf,https://a2milkkf.avature.net/careers/SearchJobs
-Ally,ally,https://ally.avature.net/careers/SearchJobs
-Astellas,astellas,https://astellas.avature.net/careers/SearchJobs
+The a2 Milk Company,a2milkkf,https://a2milkkf.avature.net/careers/SearchJobs
+Ally Financial,ally,https://ally.avature.net/careers/SearchJobs
+Astellas Pharma Inc.,astellas,https://astellas.avature.net/careers/SearchJobs
 Bloomberg,bloomberg,https://bloomberg.avature.net/careers/SearchJobs
-Bradyplus,bradyplus,https://bradyplus.avature.net/careers/SearchJobs
-Bupaanz,bupaanz,https://bupaanz.avature.net/careers/SearchJobs
-Cbreglobal,cbreglobal,https://cbreglobal.avature.net/careers/SearchJobs
-Cdcn,cdcn,https://cdcn.avature.net/careers/SearchJobs
-Cyclecarriage,cyclecarriage,https://cyclecarriage.avature.net/careers/SearchJobs
-Deloittepng,deloittepng,https://deloittepng.avature.net/careers/SearchJobs
+CBRE,cbreglobal,https://cbreglobal.avature.net/careers/SearchJobs
+Consumer Direct Care Network,cdcn,https://cdcn.avature.net/careers/SearchJobs
+Cycle & Carriage,cyclecarriage,https://cyclecarriage.avature.net/careers/SearchJobs
+Deloitte PNG,deloittepng,https://deloittepng.avature.net/careers/SearchJobs
 Delta,delta,https://delta.avature.net/careers/SearchJobs
-Dhlconsulting,dhlconsulting,https://dhlconsulting.avature.net/careers/SearchJobs
-Fonterrakf,fonterrakf,https://fonterrakf.avature.net/careers/SearchJobs
-Fortress,fortress,https://fortress.avature.net/careers/SearchJobs
-Gpshospitality,gpshospitality,https://gpshospitality.avature.net/careers/SearchJobs
-Justicejobs,justicejobs,https://justicejobs.avature.net/careers/SearchJobs
-Kpmgireland,kpmgireland,https://kpmgireland.avature.net/careers/SearchJobs
+DHL Consulting,dhlconsulting,https://dhlconsulting.avature.net/careers/SearchJobs
+Fonterra,fonterrakf,https://fonterrakf.avature.net/careers/SearchJobs
+GPS Hospitality,gpshospitality,https://gpshospitality.avature.net/careers/SearchJobs
+Ministry of Justice,justicejobs,https://justicejobs.avature.net/careers/SearchJobs
+KPMG Ireland,kpmgireland,https://kpmgireland.avature.net/careers/SearchJobs
 Maximus,maximus,https://maximus.avature.net/careers/SearchJobs
-Mhcta,mhcta,https://mhcta.avature.net/careers/SearchJobs
-Missionpethealth,missionpethealth,https://missionpethealth.avature.net/careers/SearchJobs
+Murphy-Hoffman Company,mhcta,https://mhcta.avature.net/careers/SearchJobs
 Monadelphous,monadelphous,https://monadelphous.avature.net/careers/SearchJobs
-Nva,nva,https://nva.avature.net/careers/SearchJobs
-One800Flowers,one800flowers,https://one800flowers.avature.net/careers/SearchJobs
-Onecall,onecall,https://onecall.avature.net/careers/SearchJobs
-Optavise,optavise,https://optavise.avature.net/careers/SearchJobs
-Plantemoran,plantemoran,https://plantemoran.avature.net/careers/SearchJobs
-Radpartners,radpartners,https://radpartners.avature.net/careers/SearchJobs
-Resourcebank,resourcebank,https://resourcebank.avature.net/careers/SearchJobs
-Sandbox2Uskpmg,sandbox2uskpmg,https://sandbox2uskpmg.avature.net/careers/SearchJobs
-Sandbox4Uskpmg,sandbox4uskpmg,https://sandbox4uskpmg.avature.net/careers/SearchJobs
-Stagingunifi,stagingunifi,https://stagingunifi.avature.net/careers/SearchJobs
+NVA,nva,https://nva.avature.net/careers/SearchJobs
+One Call,onecall,https://onecall.avature.net/careers/SearchJobs
+Radiology Partners,radpartners,https://radpartners.avature.net/careers/SearchJobs
+ResourceBank,resourcebank,https://resourcebank.avature.net/careers/SearchJobs
 Synopsys,synopsys,https://synopsys.avature.net/careers/SearchJobs
-Tescoinsuranceandmoneyservices,tescoinsuranceandmoneyservices,https://tescoinsuranceandmoneyservices.avature.net/careers/SearchJobs
-Uclahealth,uclahealth,https://uclahealth.avature.net/careers/SearchJobs
+Tesco Bank,tescoinsuranceandmoneyservices,https://tescoinsuranceandmoneyservices.avature.net/careers/SearchJobs
+UCLA Health,uclahealth,https://uclahealth.avature.net/careers/SearchJobs
 Unifi,unifi,https://unifi.avature.net/careers/SearchJobs
-Uskpmgats,uskpmgats,https://uskpmgats.avature.net/careers/SearchJobs
-Voutiqueintegrations,voutiqueintegrations,https://voutiqueintegrations.avature.net/careers/SearchJobs
-Walmartsourcingeu,walmartsourcingeu,https://walmartsourcingeu.avature.net/careers/SearchJobs
-Wilsonhcg,wilsonhcg,https://wilsonhcg.avature.net/careers/SearchJobs
 Xerox,xerox,https://xerox.avature.net/careers/SearchJobs
-adeccorecruiting,adeccorecruiting,https://adeccorecruiting.avature.net/careers/SearchJobs
-advocateaurorahealth,advocateaurorahealth,https://advocateaurorahealth.avature.net/careers/SearchJobs
-amspsr,amspsr,https://amspsr.avature.net/careers/SearchJobs
-amswh,amswh,https://amswh.avature.net/careers/SearchJobs
-avanade,avanade,https://avanade.avature.net/careers/SearchJobs
-berenberg,berenberg,https://berenberg.avature.net/careers/SearchJobs
-bmcrecruit,bmcrecruit,https://bmcrecruit.avature.net/careers/SearchJobs
-boozallen,boozallen,https://boozallen.avature.net/careers/SearchJobs
-broadinstitute,broadinstitute,https://broadinstitute.avature.net/careers/SearchJobs
-deloittebe,deloittebe,https://deloittebe.avature.net/careers/SearchJobs
-deloittecm,deloittecm,https://deloittecm.avature.net/careers/SearchJobs
-deloitteus,deloitteus,https://deloitteus.avature.net/careers/SearchJobs
-dfiretailgroup,dfiretailgroup,https://dfiretailgroup.avature.net/careers/SearchJobs
-ea,ea,https://ea.avature.net/careers/SearchJobs
+Adecco Recruiting,adeccorecruiting,https://adeccorecruiting.avature.net/careers/SearchJobs
+Advocate Health,advocateaurorahealth,https://advocateaurorahealth.avature.net/careers/SearchJobs
+AMS PSR,amspsr,https://amspsr.avature.net/careers/SearchJobs
+William Hill,amswh,https://amswh.avature.net/careers/SearchJobs
+Berenberg,berenberg,https://berenberg.avature.net/careers/SearchJobs
+BMC,bmcrecruit,https://bmcrecruit.avature.net/careers/SearchJobs
+Booz Allen Hamilton,boozallen,https://boozallen.avature.net/careers/SearchJobs
+Broad Institute,broadinstitute,https://broadinstitute.avature.net/careers/SearchJobs
+Deloitte Belgium,deloittebe,https://deloittebe.avature.net/careers/SearchJobs
+Deloitte Central Mediterranean,deloittecm,https://deloittecm.avature.net/careers/SearchJobs
+Deloitte US,deloitteus,https://deloitteus.avature.net/careers/SearchJobs
+DFI Retail Group,dfiretailgroup,https://dfiretailgroup.avature.net/careers/SearchJobs
+Electronic Arts,ea,https://ea.avature.net/careers/SearchJobs
 epic,epic,https://epic.avature.net/careers/SearchJobs
-frequentis,frequentis,https://frequentis.avature.net/careers/SearchJobs
-genpact,genpact,https://genpact.avature.net/careers/SearchJobs
-harmanglobal,harmanglobal,https://harmanglobal.avature.net/careers/SearchJobs
-infor,infor,https://infor.avature.net/careers/SearchJobs
-insperity,insperity,https://insperity.avature.net/careers/SearchJobs
-intercaretherapy,intercaretherapy,https://intercaretherapy.avature.net/careers/SearchJobs
-jackhenry,jackhenry,https://jackhenry.avature.net/careers/SearchJobs
-jardinematheson,jardinematheson,https://jardinematheson.avature.net/careers/SearchJobs
-jrg,jrg,https://jrg.avature.net/careers/SearchJobs
-lenovo,lenovo,https://lenovo.avature.net/careers/SearchJobs
-loa,loa,https://loa.avature.net/careers/SearchJobs
-lululemoninc,lululemoninc,https://lululemoninc.avature.net/careers/SearchJobs
-mantech,mantech,https://mantech.avature.net/careers/SearchJobs
-mclaren,mclaren,https://mclaren.avature.net/careers/SearchJobs
-mercadona,mercadona,https://mercadona.avature.net/careers/SearchJobs
-pomerleau,pomerleau,https://pomerleau.avature.net/careers/SearchJobs
-pontoonsolutions,pontoonsolutions,https://pontoonsolutions.avature.net/careers/SearchJobs
-primero,primero,https://primero.avature.net/careers/SearchJobs
-regis,regis,https://regis.avature.net/careers/SearchJobs
-rgpuat,rgpuat,https://rgpuat.avature.net/careers/SearchJobs
-rhg,rhg,https://rhg.avature.net/careers/SearchJobs
-sandboxashfieldhealthcare,sandboxashfieldhealthcare,https://sandboxashfieldhealthcare.avature.net/careers/SearchJobs
-sandboxbnc,sandboxbnc,https://sandboxbnc.avature.net/careers/SearchJobs
-sandboxsmurfitwestrockta,sandboxsmurfitwestrockta,https://sandboxsmurfitwestrockta.avature.net/careers/SearchJobs
-sandboxtesco,sandboxtesco,https://sandboxtesco.avature.net/careers/SearchJobs
-smurfitwestrockta,smurfitwestrockta,https://smurfitwestrockta.avature.net/careers/SearchJobs
-stagingkoch,stagingkoch,https://stagingkoch.avature.net/careers/SearchJobs
-tesco,tesco,https://tesco.avature.net/careers/SearchJobs
-traderjoes,traderjoes,https://traderjoes.avature.net/careers/SearchJobs
-transcom,transcom,https://transcom.avature.net/careers/SearchJobs
-uop,uop,https://uop.avature.net/careers/SearchJobs
-voutiqueiuat,voutiqueiuat,https://voutiqueiuat.avature.net/careers/SearchJobs
-wickes,wickes,https://wickes.avature.net/careers/SearchJobs
+Frequentis,frequentis,https://frequentis.avature.net/careers/SearchJobs
+Genpact,genpact,https://genpact.avature.net/careers/SearchJobs
+HARMAN,harmanglobal,https://harmanglobal.avature.net/careers/SearchJobs
+Insperity,insperity,https://insperity.avature.net/careers/SearchJobs
+Intercare Therapy,intercaretherapy,https://intercaretherapy.avature.net/careers/SearchJobs
+Jack Henry,jackhenry,https://jackhenry.avature.net/careers/SearchJobs
+Jardine Matheson,jardinematheson,https://jardinematheson.avature.net/careers/SearchJobs
+JRG,jrg,https://jrg.avature.net/careers/SearchJobs
+Lenovo,lenovo,https://lenovo.avature.net/careers/SearchJobs
+L'Oreal,loa,https://loa.avature.net/careers/SearchJobs
+lululemon,lululemoninc,https://lululemoninc.avature.net/careers/SearchJobs
+ManTech,mantech,https://mantech.avature.net/careers/SearchJobs
+McLaren,mclaren,https://mclaren.avature.net/careers/SearchJobs
+Mercadona,mercadona,https://mercadona.avature.net/careers/SearchJobs
+Pomerleau,pomerleau,https://pomerleau.avature.net/careers/SearchJobs
+Pontoon Solutions,pontoonsolutions,https://pontoonsolutions.avature.net/careers/SearchJobs
+Primero,primero,https://primero.avature.net/careers/SearchJobs
+Regis,regis,https://regis.avature.net/careers/SearchJobs
+Rosewood Hotel Group,rhg,https://rhg.avature.net/careers/SearchJobs
+Smurfit Westrock,smurfitwestrockta,https://smurfitwestrockta.avature.net/careers/SearchJobs
+Tesco,tesco,https://tesco.avature.net/careers/SearchJobs
+Trader Joe's,traderjoes,https://traderjoes.avature.net/careers/SearchJobs
+Transcom,transcom,https://transcom.avature.net/careers/SearchJobs
+UOP,uop,https://uop.avature.net/careers/SearchJobs
+Wickes,wickes,https://wickes.avature.net/careers/SearchJobs


### PR DESCRIPTION
## Summary
- replace opaque Avature slug-derived display names with verified company names from live page titles and career-page evidence
- remove broken Avature tenants returning 404, DNS/httpcloak failures, or non-production sandbox/staging/uat/integration pages
- keep real career domains that are WAF-gated rather than treating bot challenges as broken entries

## Validation
- audited 88 original Avature rows with the same `httpcloak` path used by the scraper for Avature tenants
- final CSV sanity: 65 rows, no missing fields, no duplicate slug/url values, no sandbox/staging/uat entries
- final live check: 65 rows checked; 0 bad entries outside known WAF gates; 53 listings with jobs; 556 listing jobs detected

CSV-only change, so no unit tests were added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned the Avature company dataset to use verified company names and ensure only valid, production career pages are listed. This improves data quality and reduces failed scrapes.

- **Bug Fixes**
  - Replaced slug-based display names with names from live page titles.
  - Removed 23 tenants that 404, fail DNS, or point to sandbox/staging/uat.
  - Kept WAF-gated career pages as valid targets.
  - Final CSV: 65 rows (from 88), no duplicates or missing fields; 53 active listings with 556 jobs.

<sup>Written for commit e84241cbfa4ad18ff09529b0154111228f92adb1. Summary will update on new commits. <a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/147?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

