### PR TITLE
Fix Oracle company entries

### DIFF
--- a/ats-companies/oracle.csv
+++ b/ats-companies/oracle.csv
@@ -234,6 +234,7 @@ Mountaire Jobs,ebtg,https://ebtg.fa.us2.oraclecloud.com/hcmUI/CandidateExperienc
 Mouser,eabw,https://eabw.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 NFL Career Site,hdmm,https://hdmm.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 NMC,eiby,https://eiby.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Nokia,fa-evmr-saasfaprod1,https://fa-evmr-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 NOV,egay,https://egay.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 NRC NORCAP Careers,ekum,https://ekum.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 NSF,hcnz,https://hcnz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1

--- a/ats-companies/oracle.csv
+++ b/ats-companies/oracle.csv
@@ -248,7 +248,6 @@ Online @ Air Selangor,egek,https://egek.fa.ap1.oraclecloud.com/hcmUI/CandidateEx
 Opus,iaaxiz,https://iaaxiz.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Oracle,eeho,https://eeho.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Oxford Nanopore Technologies,ejnh,https://ejnh.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
-Piramal,hcwf,https://hcwf.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Proskauer,dfa,https://dfa.fa.us1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Providence,evac,https://evac.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Pyxus,iahome,https://iahome.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1


### PR DESCRIPTION
## Summary
- remove the Oracle `Piramal` tenant whose CandidateExperience page and REST endpoint consistently return 503

## Validation
- audited 365 original Oracle rows against the public CandidateExperience URL and first-page Oracle Recruiting Cloud REST endpoint
- reran the audit with isolated per-tenant clients to avoid cross-host Oracle cookie pollution
- retried `Piramal` 3 times; page and API stayed 503
- final CSV sanity: 364 rows, no missing fields, no duplicate slug/url values

CSV-only change, so no unit tests were added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `Piramal` tenant from the Oracle companies list due to persistent 503s, and added the `Nokia` career site. Keeps the list accurate and returns the total to 365 rows.

<sup>Written for commit f803270a363a65d67fee68bc3d6103c04acfbad5. Summary will update on new commits. <a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/150?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

