### PR TITLE
Fix Gem company entries

### DIFF
--- a/ats-companies/gem.csv
+++ b/ats-companies/gem.csv
@@ -1,16 +1,10 @@
 name,slug,url
-10Xconstruction Ai,10xconstruction-ai,https://jobs.gem.com/10xconstruction-ai
 11X Ai,11x-ai,https://jobs.gem.com/11x-ai
 43North,43north,https://jobs.gem.com/43north
 8020 Consulting,8020-consulting,https://jobs.gem.com/8020-consulting
 A16Z Speedrun,a16z-speedrun,https://jobs.gem.com/a16z-speedrun
-Aarden Ai,aarden-ai,https://jobs.gem.com/aarden-ai
 Accel,accel,https://jobs.gem.com/accel
-Accelos,accelos,https://jobs.gem.com/accelos
-Acely,acely,https://jobs.gem.com/acely
 Acre,acre,https://jobs.gem.com/acre
-Advancelevelllc Com,advancelevelllc-com,https://jobs.gem.com/advancelevelllc-com
-Advisorey Com,advisorey-com,https://jobs.gem.com/advisorey-com
 Afori,afori,https://jobs.gem.com/afori
 Afterquery,afterquery,https://jobs.gem.com/afterquery
 Agenta Ai,agenta-ai,https://jobs.gem.com/agenta-ai
@@ -22,35 +16,26 @@ Airframe,airframe,https://jobs.gem.com/airframe
 Airvet Com,airvet-com,https://jobs.gem.com/airvet-com
 Alex And Ani,alex-and-ani,https://jobs.gem.com/alex-and-ani
 Alinia Ai,alinia-ai,https://jobs.gem.com/alinia-ai
-Alitheon,alitheon,https://jobs.gem.com/alitheon
-Alleviatehealth Care,alleviatehealth-care,https://jobs.gem.com/alleviatehealth-care
 Alpharun,alpharun,https://jobs.gem.com/alpharun
-Altzero Xyz,altzero-xyz,https://jobs.gem.com/altzero-xyz
 Amya Agency,amya-agency,https://jobs.gem.com/amya-agency
 Andrenam,andrenam,https://jobs.gem.com/andrenam
-Anysphere,anysphere,https://jobs.gem.com/anysphere
 Aoniclife,aoniclife,https://jobs.gem.com/aoniclife
 Apartment List,apartment-list,https://jobs.gem.com/apartment-list
 Apella,apella,https://jobs.gem.com/apella
 Aptdeco,aptdeco,https://jobs.gem.com/aptdeco
 Apticore Io,apticore-io,https://jobs.gem.com/apticore-io
 Archal Ai,archal-ai,https://jobs.gem.com/archal-ai
-Arlo,arlo,https://jobs.gem.com/arlo
 Artico Search,artico-search,https://jobs.gem.com/artico-search
 Ascenda Loyalty,ascenda-loyalty,https://jobs.gem.com/ascenda-loyalty
 Ascendarc,ascendarc,https://jobs.gem.com/ascendarc
 Asl,asl,https://jobs.gem.com/asl
 Astroforge Io,astroforge-io,https://jobs.gem.com/astroforge-io
-Asymptotic,asymptotic,https://jobs.gem.com/asymptotic
-Athletes Global,athletes-global,https://jobs.gem.com/athletes-global
 Atla Ai Com,atla-ai-com,https://jobs.gem.com/atla-ai-com
 Atomica,atomica,https://jobs.gem.com/atomica
 Audicus,audicus,https://jobs.gem.com/audicus
 Auditoria Ai,auditoria-ai,https://jobs.gem.com/auditoria-ai
 Auger,auger,https://jobs.gem.com/auger
 Aurelian Io,aurelian-io,https://jobs.gem.com/aurelian-io
-Aureliussystems Us,aureliussystems-us,https://jobs.gem.com/aureliussystems-us
-Autopilotbrand Com,autopilotbrand-com,https://jobs.gem.com/autopilotbrand-com
 Avoca,avoca,https://jobs.gem.com/avoca
 Avol,avol,https://jobs.gem.com/avol
 Axelyc Com,axelyc-com,https://jobs.gem.com/axelyc-com
@@ -59,7 +44,6 @@ Backops Ai,backops-ai,https://jobs.gem.com/backops-ai
 Basalt Health,basalt-health,https://jobs.gem.com/basalt-health
 Baxter Aerospace,baxter-aerospace,https://jobs.gem.com/baxter-aerospace
 Bead Ai,bead-ai,https://jobs.gem.com/bead-ai
-Beaminghealth Com,beaminghealth-com,https://jobs.gem.com/beaminghealth-com
 Benbase,benbase,https://jobs.gem.com/benbase
 Better Auth,better-auth,https://jobs.gem.com/better-auth
 Betterbasket Ai,betterbasket-ai,https://jobs.gem.com/betterbasket-ai
@@ -67,32 +51,24 @@ Bigeye,bigeye,https://jobs.gem.com/bigeye
 Bigpanda,bigpanda,https://jobs.gem.com/bigpanda
 Bikky,bikky,https://jobs.gem.com/bikky
 Bilt,bilt,https://jobs.gem.com/bilt
-Binarly,binarly,https://jobs.gem.com/binarly
-Biofire,biofire,https://jobs.gem.com/biofire
 Biorender,biorender,https://jobs.gem.com/biorender
 Biorender Inc  Ats,biorender-inc--ats,https://jobs.gem.com/biorender-inc--ats
-Birdwood Therapeutics,birdwood-therapeutics,https://jobs.gem.com/birdwood-therapeutics
 Bizhaven,bizhaven,https://jobs.gem.com/bizhaven
 Black Ore,black-ore,https://jobs.gem.com/black-ore
-Blaze Ai,blaze-ai,https://jobs.gem.com/blaze-ai
 Blazetalent,blazetalent,https://jobs.gem.com/blazetalent
 Blend Inc,blend-inc,https://jobs.gem.com/blend-inc
 Blue J,blue-j,https://jobs.gem.com/blue-j
 Bluejeanfinancial Com,bluejeanfinancial-com,https://jobs.gem.com/bluejeanfinancial-com
 Blueonion Ai,blueonion-ai,https://jobs.gem.com/blueonion-ai
-Blueprint,blueprint,https://jobs.gem.com/blueprint
 Bluesky,bluesky,https://jobs.gem.com/bluesky
 Blume Technologies,blume-technologies,https://jobs.gem.com/blume-technologies
 Bohler,bohler-,https://jobs.gem.com/bohler-
-Bohler Engineering Gemats,bohler-engineering-gemats,https://jobs.gem.com/bohler-engineering-gemats
 Bolna,bolna,https://jobs.gem.com/bolna
 Boltz,boltz,https://jobs.gem.com/boltz
 Bond Partners,bond-partners,https://jobs.gem.com/bond-partners
 Boost Robotics,boost-robotics,https://jobs.gem.com/boost-robotics
 Boostbusiness Global,boostbusiness-global,https://jobs.gem.com/boostbusiness-global
-Boredm,boredm,https://jobs.gem.com/boredm
 Breadcrumb Ai,breadcrumb-ai,https://jobs.gem.com/breadcrumb-ai
-Breakline Ats,breakline-ats,https://jobs.gem.com/breakline-ats
 Breakline Education,breakline-education,https://jobs.gem.com/breakline-education
 Brewbird,brewbird,https://jobs.gem.com/brewbird
 Buildtrayd Com,buildtrayd-com,https://jobs.gem.com/buildtrayd-com
@@ -101,14 +77,10 @@ Cadstrom Io,cadstrom-io,https://jobs.gem.com/cadstrom-io
 Caffeine Ai,caffeine-ai,https://jobs.gem.com/caffeine-ai
 Caffelabs Com,caffelabs-com,https://jobs.gem.com/caffelabs-com
 Calaveras,calaveras,https://jobs.gem.com/calaveras
-Canals,canals,https://jobs.gem.com/canals
-Caplight Com,caplight-com,https://jobs.gem.com/caplight-com
 Carbon,carbon,https://jobs.gem.com/carbon
-Cardnexus,cardnexus,https://jobs.gem.com/cardnexus
 Careers,careers,https://jobs.gem.com/careers
 Careers Readyon,careers-readyon,https://jobs.gem.com/careers-readyon
 Carry,carry,https://jobs.gem.com/carry
-Caseflood Ai,caseflood-ai,https://jobs.gem.com/caseflood-ai
 Ccr Search,ccr-search,https://jobs.gem.com/ccr-search
 Cellbyte,cellbyte,https://jobs.gem.com/cellbyte
 Chartahealth,chartahealth,https://jobs.gem.com/chartahealth
@@ -123,8 +95,6 @@ Codegen,codegen,https://jobs.gem.com/codegen
 Codesignal,codesignal,https://jobs.gem.com/codesignal
 Cognna,cognna,https://jobs.gem.com/cognna
 Cogram,cogram,https://jobs.gem.com/cogram
-Comfy,comfy,https://jobs.gem.com/comfy
-Conductorai,conductorai,https://jobs.gem.com/conductorai
 Confida Ai,confida-ai,https://jobs.gem.com/confida-ai
 Context Wtf,context-wtf,https://jobs.gem.com/context-wtf
 Contour App,contour-app,https://jobs.gem.com/contour-app
@@ -135,63 +105,46 @@ Crabi Robotics Com,crabi-robotics-com,https://jobs.gem.com/crabi-robotics-com
 Crackenagi,crackenagi,https://jobs.gem.com/crackenagi
 Create Talent Group,create-talent-group,https://jobs.gem.com/create-talent-group
 Createdbyhumans Ai,createdbyhumans-ai,https://jobs.gem.com/createdbyhumans-ai
-Creatoreconomyjobs,creatoreconomyjobs,https://jobs.gem.com/creatoreconomyjobs
 Credit Key,credit-key,https://jobs.gem.com/credit-key
 Crosby,crosby,https://jobs.gem.com/crosby
 Crucibl Ai,crucibl-ai,https://jobs.gem.com/crucibl-ai
-Curex Org,curex-org,https://jobs.gem.com/curex-org
 Curiouscardinals Com,curiouscardinals-com,https://jobs.gem.com/curiouscardinals-com
-Cyvl,cyvl,https://jobs.gem.com/cyvl
 D4M International,d4m-international,https://jobs.gem.com/d4m-international
-Dalus,dalus,https://jobs.gem.com/dalus
 Darwin Cx,darwin-cx,https://jobs.gem.com/darwin-cx
-Dash Fi,dash-fi,https://jobs.gem.com/dash-fi
 Data Masters,data-masters,https://jobs.gem.com/data-masters
-Datacurve Ai,datacurve-ai,https://jobs.gem.com/datacurve-ai
 Dataday Technology Solutions,dataday-technology-solutions,https://jobs.gem.com/dataday-technology-solutions
 Datagrid,datagrid,https://jobs.gem.com/datagrid
-Dawn Media,dawn-media,https://jobs.gem.com/dawn-media
 Daxko,daxko,https://jobs.gem.com/daxko
 Deep Infra,deep-infra,https://jobs.gem.com/deep-infra
 Deliver,deliver,https://jobs.gem.com/deliver
 Detections Ai,detections-ai,https://jobs.gem.com/detections-ai
 Dianahr Ai,dianahr-ai,https://jobs.gem.com/dianahr-ai
-Distributed Spectrum,distributed-spectrum,https://jobs.gem.com/distributed-spectrum
 Dlvrlog,dlvrlog,https://jobs.gem.com/dlvrlog
 Doowii,doowii,https://jobs.gem.com/doowii
 Dragme,dragme,https://jobs.gem.com/dragme
 Dragonfly Careers,dragonfly-careers,https://jobs.gem.com/dragonfly-careers
 Dropback,dropback,https://jobs.gem.com/dropback
-Durin,durin,https://jobs.gem.com/durin
 Dydx,dydx,https://jobs.gem.com/dydx
 Eastenergyllc Com,eastenergyllc-com,https://jobs.gem.com/eastenergyllc-com
 Eats2Seats,eats2seats,https://jobs.gem.com/eats2seats
-Echelon,echelon,https://jobs.gem.com/echelon
-Ecocart Io,ecocart-io,https://jobs.gem.com/ecocart-io
 Edgetrace Ai,edgetrace-ai,https://jobs.gem.com/edgetrace-ai
 Efference Ai,efference-ai,https://jobs.gem.com/efference-ai
-Elite Talent Consulting,elite-talent-consulting,https://jobs.gem.com/elite-talent-consulting
 Eliza,eliza,https://jobs.gem.com/eliza
 Elloe Ai,elloe-ai,https://jobs.gem.com/elloe-ai
 Elo Ai,elo-ai,https://jobs.gem.com/elo-ai
 Elsewhere Partners,elsewhere-partners,https://jobs.gem.com/elsewhere-partners
 Emerge Career,emerge-career,https://jobs.gem.com/emerge-career
 Empathic,empathic,https://jobs.gem.com/empathic
-Employment Practices Group,employment-practices-group,https://jobs.gem.com/employment-practices-group
 Engineering  Codified,engineering--codified,https://jobs.gem.com/engineering--codified
 Entrusted Contracting,entrusted-contracting,https://jobs.gem.com/entrusted-contracting
 Epsilon,epsilon,https://jobs.gem.com/epsilon
-Escargot Com,escargot-com,https://jobs.gem.com/escargot-com
 Ethisphere Com,ethisphere-com,https://jobs.gem.com/ethisphere-com
 Everfit Io,everfit-io,https://jobs.gem.com/everfit-io
-Everhires Com,everhires-com,https://jobs.gem.com/everhires-com
 Excelity Careers,excelity-careers,https://jobs.gem.com/excelity-careers
 Exponent,exponent,https://jobs.gem.com/exponent
 Ezraailabs Tech,ezraailabs-tech,https://jobs.gem.com/ezraailabs-tech
 Fabric,fabric,https://jobs.gem.com/fabric
 Fabrichealth,fabrichealth,https://jobs.gem.com/fabrichealth
-Fancypeople,fancypeople,https://jobs.gem.com/fancypeople
-Fanpierlabs Com,fanpierlabs-com,https://jobs.gem.com/fanpierlabs-com
 Faraday,faraday,https://jobs.gem.com/faraday
 Farmers Business Network,farmers-business-network,https://jobs.gem.com/farmers-business-network
 Fathom Org,fathom-org,https://jobs.gem.com/fathom-org
@@ -208,13 +161,11 @@ Flatfee Corp,flatfee-corp,https://jobs.gem.com/flatfee-corp
 Fledge,fledge,https://jobs.gem.com/fledge
 Fleet,fleet,https://jobs.gem.com/fleet
 Flightcrew,flightcrew,https://jobs.gem.com/flightcrew
-Flint,flint,https://jobs.gem.com/flint
 Floot,floot,https://jobs.gem.com/floot
 Forgent Ai,forgent-ai,https://jobs.gem.com/forgent-ai
 Formal,formal,https://jobs.gem.com/formal
 Foss Warren,foss-warren,https://jobs.gem.com/foss-warren
 Fountainplatform Com,fountainplatform-com,https://jobs.gem.com/fountainplatform-com
-Foxbox Digital,foxbox-digital,https://jobs.gem.com/foxbox-digital
 Fragmentdata,fragmentdata,https://jobs.gem.com/fragmentdata
 Freestone Grove Partners,freestone-grove-partners,https://jobs.gem.com/freestone-grove-partners
 Freight Wizards,freight-wizards,https://jobs.gem.com/freight-wizards
@@ -229,30 +180,22 @@ Galaxyventures,galaxyventures,https://jobs.gem.com/galaxyventures
 Gatewayx,gatewayx,https://jobs.gem.com/gatewayx
 Gc Ai,gc-ai,https://jobs.gem.com/gc-ai
 Gem,gem,https://jobs.gem.com/gem
-Gem Gabs Sandbox,gem-gabs-sandbox,https://jobs.gem.com/gem-gabs-sandbox
 Gem Mckesson,gem-mckesson,https://jobs.gem.com/gem-mckesson
-Gem Michelle,gem-michelle,https://jobs.gem.com/gem-michelle
 Gem Migration,gem-migration,https://jobs.gem.com/gem-migration
-Gem Test Board,gem-test-board,https://jobs.gem.com/gem-test-board
 Generation Alpha Transistor,generation-alpha-transistor,https://jobs.gem.com/generation-alpha-transistor
 Genesia Ventures,genesia-ventures,https://jobs.gem.com/genesia-ventures
 Genspark,genspark,https://jobs.gem.com/genspark
 Gerra,gerra,https://jobs.gem.com/gerra
-Getaero Io,getaero-io,https://jobs.gem.com/getaero-io
-Getbirdeye Com Au,getbirdeye-com-au,https://jobs.gem.com/getbirdeye-com-au
-Getro,getro,https://jobs.gem.com/getro
 Gigaml,gigaml,https://jobs.gem.com/gigaml
 Glyphic Biotechnologies,glyphic-biotechnologies,https://jobs.gem.com/glyphic-biotechnologies
 Go Cadre,go-cadre,https://jobs.gem.com/go-cadre
 Goatrecruit Com,goatrecruit-com,https://jobs.gem.com/goatrecruit-com
 Good Life Companies,good-life-companies,https://jobs.gem.com/good-life-companies
 Goodbill,goodbill,https://jobs.gem.com/goodbill
-Goose Lane Limited,goose-lane-limited,https://jobs.gem.com/goose-lane-limited
 Grailpay Com,grailpay-com,https://jobs.gem.com/grailpay-com
 Granger Construction,granger-construction,https://jobs.gem.com/granger-construction
 Gratia Health,gratia-health,https://jobs.gem.com/gratia-health
 Greenlite Ai,greenlite-ai,https://jobs.gem.com/greenlite-ai
-Greenvalleyjobs,greenvalleyjobs,https://jobs.gem.com/greenvalleyjobs
 Grit,grit,https://jobs.gem.com/grit
 Groq,groq,https://jobs.gem.com/groq
 Growthbook,growthbook,https://jobs.gem.com/growthbook
@@ -260,7 +203,6 @@ Guardrail Ai,guardrail-ai,https://jobs.gem.com/guardrail-ai
 Guidesage Ai,guidesage-ai,https://jobs.gem.com/guidesage-ai
 Hacktron,hacktron,https://jobs.gem.com/hacktron
 Hallow,hallow,https://jobs.gem.com/hallow
-Happydance Partnership Integration,happydance-partnership-integration,https://jobs.gem.com/happydance-partnership-integration
 Harmonic,harmonic,https://jobs.gem.com/harmonic
 Hash,hash,https://jobs.gem.com/hash
 Hayla,hayla,https://jobs.gem.com/hayla
@@ -268,15 +210,8 @@ Heavy Construction Systems Specialists Llc,heavy-construction-systems-specialist
 Helix,helix,https://jobs.gem.com/helix
 Hellotrade,hellotrade,https://jobs.gem.com/hellotrade
 Helm Health,helm-health,https://jobs.gem.com/helm-health
-Heygen,heygen,https://jobs.gem.com/heygen
 Hilabs Ie,hilabs-ie,https://jobs.gem.com/hilabs-ie
-Hipeople,hipeople,https://jobs.gem.com/hipeople
-Hire5,hire5,https://jobs.gem.com/hire5
 Holacasa Yc W23,holacasa-yc-w23,https://jobs.gem.com/holacasa-yc-w23
-Homeboost,homeboost,https://jobs.gem.com/homeboost
-Hospitable,hospitable,https://jobs.gem.com/hospitable
-Howrecruit Io,howrecruit-io,https://jobs.gem.com/howrecruit-io
-Hubspot,hubspot,https://jobs.gem.com/hubspot
 Hypernatural Ai,hypernatural-ai,https://jobs.gem.com/hypernatural-ai
 Inception,inception,https://jobs.gem.com/inception
 Index Exchange,index-exchange,https://jobs.gem.com/index-exchange
@@ -284,16 +219,10 @@ Infrastructure Modernization Solutions,infrastructure-modernization-solutions,ht
 Inspiration Commerce Group,inspiration-commerce-group,https://jobs.gem.com/inspiration-commerce-group
 Inspiresemi Com,inspiresemi-com,https://jobs.gem.com/inspiresemi-com
 Instrumental Inc,instrumental-inc-,https://jobs.gem.com/instrumental-inc-
-Integral Xyz,integral-xyz,https://jobs.gem.com/integral-xyz
 Integrationscaptain,integrationscaptain,https://jobs.gem.com/integrationscaptain
-Intelligentresourcing Co,intelligentresourcing-co,https://jobs.gem.com/intelligentresourcing-co
 Interfere Old,interfere-old,https://jobs.gem.com/interfere-old
-Inversioncap Com,inversioncap-com,https://jobs.gem.com/inversioncap-com
-Invoicebutler Ai,invoicebutler-ai,https://jobs.gem.com/invoicebutler-ai
 Iris,iris,https://jobs.gem.com/iris
 Ironsite Ai,ironsite-ai,https://jobs.gem.com/ironsite-ai
-Itsvaleria Co,itsvaleria-co,https://jobs.gem.com/itsvaleria-co
-Jaguaracareers,jaguaracareers,https://jobs.gem.com/jaguaracareers
 Janie,janie,https://jobs.gem.com/janie
 Jayla Careers,jayla-careers,https://jobs.gem.com/jayla-careers
 Jobma,jobma,https://jobs.gem.com/jobma
@@ -301,51 +230,35 @@ Jobtarget,jobtarget,https://jobs.gem.com/jobtarget
 Joinanvil Com,joinanvil-com,https://jobs.gem.com/joinanvil-com
 Joinformal,joinformal,https://jobs.gem.com/joinformal
 Joyful Health,joyful-health,https://jobs.gem.com/joyful-health
-Juicebox,juicebox,https://jobs.gem.com/juicebox
 Kaikaku,kaikaku,https://jobs.gem.com/kaikaku
-Kaironhealth,kaironhealth,https://jobs.gem.com/kaironhealth
-Kaironhealth Com,kaironhealth-com,https://jobs.gem.com/kaironhealth-com
 Kanu Ai,kanu-ai,https://jobs.gem.com/kanu-ai
 Kcs Hiring,kcs-hiring,https://jobs.gem.com/kcs-hiring
-Keru Ai,keru-ai,https://jobs.gem.com/keru-ai
 Key To Web3,key-to-web3,https://jobs.gem.com/key-to-web3
 Knight Electric Inc,knight-electric-inc-,https://jobs.gem.com/knight-electric-inc-
-Koala,koala,https://jobs.gem.com/koala
 Kollectiv Ai,kollectiv-ai,https://jobs.gem.com/kollectiv-ai
 Kumo Ai,kumo-ai,https://jobs.gem.com/kumo-ai
 Lancey,lancey,https://jobs.gem.com/lancey
 Lantern,lantern,https://jobs.gem.com/lantern
-Lattitude Recruiting,lattitude-recruiting,https://jobs.gem.com/lattitude-recruiting
-Lavapayments Com,lavapayments-com,https://jobs.gem.com/lavapayments-com
 Leap Tools,leap-tools,https://jobs.gem.com/leap-tools
 Letsdata,letsdata,https://jobs.gem.com/letsdata
 Letter Ai,letter-ai,https://jobs.gem.com/letter-ai
 Level,level,https://jobs.gem.com/level
 Linktree,linktree,https://jobs.gem.com/linktree
-Little Otter,little-otter,https://jobs.gem.com/little-otter
 Littlebird,littlebird,https://jobs.gem.com/littlebird
 Lostlakegames Com,lostlakegames-com,https://jobs.gem.com/lostlakegames-com
 Lower Llc,lower-llc,https://jobs.gem.com/lower-llc
 Lumalabs Ai,lumalabs-ai,https://jobs.gem.com/lumalabs-ai
 Lunajoy,lunajoy,https://jobs.gem.com/lunajoy
-Lunch,lunch,https://jobs.gem.com/lunch
 Lunos Ai,lunos-ai,https://jobs.gem.com/lunos-ai
 Lutra,lutra,https://jobs.gem.com/lutra
 Luzernrisk,luzernrisk,https://jobs.gem.com/luzernrisk
 Magnetic,magnetic,https://jobs.gem.com/magnetic
-Manifest,manifest,https://jobs.gem.com/manifest
 Manifested Com,manifested-com,https://jobs.gem.com/manifested-com
 Marble Health,marble-health,https://jobs.gem.com/marble-health
 Match Relevant,match-relevant,https://jobs.gem.com/match-relevant
 Matchdb Talent,matchdb-talent,https://jobs.gem.com/matchdb-talent
-Mavi,mavi,https://jobs.gem.com/mavi
-Meetdex Ai,meetdex-ai,https://jobs.gem.com/meetdex-ai
-Megapot,megapot,https://jobs.gem.com/megapot
-Meineautosdirekt,meineautosdirekt,https://jobs.gem.com/meineautosdirekt
 Menten Ai,menten-ai,https://jobs.gem.com/menten-ai
-Merge Sandbox,merge-sandbox,https://jobs.gem.com/merge-sandbox
 Metal Ai,metal-ai,https://jobs.gem.com/metal-ai
-Microsoft Demo Gem Com,microsoft-demo-gem-com,https://jobs.gem.com/microsoft-demo-gem-com
 Mimicrobotics Com,mimicrobotics-com,https://jobs.gem.com/mimicrobotics-com
 Mindbloom,mindbloom,https://jobs.gem.com/mindbloom
 Mindright Io,mindright-io,https://jobs.gem.com/mindright-io
@@ -353,18 +266,14 @@ Mission,mission,https://jobs.gem.com/mission
 Modular,modular,https://jobs.gem.com/modular
 Monark Markets,monark-markets,https://jobs.gem.com/monark-markets
 Monterra Ai,monterra-ai,https://jobs.gem.com/monterra-ai
-Moosehead Talent,moosehead-talent,https://jobs.gem.com/moosehead-talent
 Motion,motion,https://jobs.gem.com/motion
-Moxa,moxa,https://jobs.gem.com/moxa
 Multiplierhq,multiplierhq,https://jobs.gem.com/multiplierhq
-Multiscale Ai,multiscale-ai,https://jobs.gem.com/multiscale-ai
 Myprize,myprize,https://jobs.gem.com/myprize
 Myriad Technology,myriad-technology,https://jobs.gem.com/myriad-technology
 Myrrsgroup,myrrsgroup,https://jobs.gem.com/myrrsgroup
 Nabla Bio,nabla-bio,https://jobs.gem.com/nabla-bio
 Nacelle,nacelle,https://jobs.gem.com/nacelle
 Nativemsg,nativemsg,https://jobs.gem.com/nativemsg
-Ncc 2024   Test 1,ncc-2024---test-1,https://jobs.gem.com/ncc-2024---test-1
 Nclusion,nclusion,https://jobs.gem.com/nclusion
 Nerdery,nerdery,https://jobs.gem.com/nerdery
 Nerve,nerve,https://jobs.gem.com/nerve
@@ -376,30 +285,23 @@ Niva,niva,https://jobs.gem.com/niva
 Nofraud,nofraud,https://jobs.gem.com/nofraud
 Nominal,nominal,https://jobs.gem.com/nominal
 Norderia Com,norderia-com,https://jobs.gem.com/norderia-com
-Northone,northone,https://jobs.gem.com/northone
 Ntop,ntop,https://jobs.gem.com/ntop
 Nue,nue,https://jobs.gem.com/nue
-Nue Ai,nue-ai,https://jobs.gem.com/nue-ai
-Numeric,numeric,https://jobs.gem.com/numeric
 Nutrislice,nutrislice,https://jobs.gem.com/nutrislice
 Nuvo,nuvo,https://jobs.gem.com/nuvo
 Obin Ai,obin-ai,https://jobs.gem.com/obin-ai
-Obsidian Systems,obsidian-systems,https://jobs.gem.com/obsidian-systems
 Odo Do,odo-do,https://jobs.gem.com/odo-do
 Omegahhagency Com,omegahhagency-com,https://jobs.gem.com/omegahhagency-com
 Oncko Com,oncko-com,https://jobs.gem.com/oncko-com
 Ondo Finance,ondo-finance,https://jobs.gem.com/ondo-finance
 Onesignal,onesignal,https://jobs.gem.com/onesignal
 Onesignal Ats,onesignal-ats,https://jobs.gem.com/onesignal-ats
-Onezyme,onezyme,https://jobs.gem.com/onezyme
 Onfrontiers,onfrontiers,https://jobs.gem.com/onfrontiers
 Open Earth Foundation,open-earth-foundation,https://jobs.gem.com/open-earth-foundation
-Openphone,openphone,https://jobs.gem.com/openphone
 Openreqstaffing,openreqstaffing,https://jobs.gem.com/openreqstaffing
 Operator Search,operator-search,https://jobs.gem.com/operator-search
 Opine,opine,https://jobs.gem.com/opine
 Ora So,ora-so,https://jobs.gem.com/ora-so
-Orphicdigital Com,orphicdigital-com,https://jobs.gem.com/orphicdigital-com
 Overlay,overlay,https://jobs.gem.com/overlay
 Overmind,overmind,https://jobs.gem.com/overmind
 Overwatch,overwatch,https://jobs.gem.com/overwatch
@@ -407,27 +309,19 @@ Paces,paces,https://jobs.gem.com/paces
 Pae,pae,https://jobs.gem.com/pae
 Pagebound,pagebound,https://jobs.gem.com/pagebound
 Pally,pally,https://jobs.gem.com/pally
-Paramark,paramark,https://jobs.gem.com/paramark
 Partao,partao,https://jobs.gem.com/partao
 Partnerhq,partnerhq,https://jobs.gem.com/partnerhq
-Patlytics,patlytics,https://jobs.gem.com/patlytics
-Pave,pave,https://jobs.gem.com/pave
 Perceptyx,perceptyx,https://jobs.gem.com/perceptyx
 Photalabs Com,photalabs-com,https://jobs.gem.com/photalabs-com
 Photon,photon,https://jobs.gem.com/photon
 Pinnacleconnect Llc,pinnacleconnect-llc,https://jobs.gem.com/pinnacleconnect-llc
-Piqenergy Com,piqenergy-com,https://jobs.gem.com/piqenergy-com
-Planet Fans,planet-fans,https://jobs.gem.com/planet-fans
 Planned,planned,https://jobs.gem.com/planned
 Plixai,plixai,https://jobs.gem.com/plixai
 Pogo Recruiting,pogo-recruiting,https://jobs.gem.com/pogo-recruiting
 Polar,polar,https://jobs.gem.com/polar
-Polywork,polywork,https://jobs.gem.com/polywork
-Pomerium,pomerium,https://jobs.gem.com/pomerium
 Portal Ai,portal-ai,https://jobs.gem.com/portal-ai
 Poseidonaero,poseidonaero,https://jobs.gem.com/poseidonaero
 Prahsys Com,prahsys-com,https://jobs.gem.com/prahsys-com
-Praxisiq Ai,praxisiq-ai,https://jobs.gem.com/praxisiq-ai
 Precision Ai,precision-ai,https://jobs.gem.com/precision-ai
 Prodia,prodia,https://jobs.gem.com/prodia
 Productboard,productboard,https://jobs.gem.com/productboard
@@ -437,15 +331,11 @@ Project Method,project-method,https://jobs.gem.com/project-method
 Promptql,promptql,https://jobs.gem.com/promptql
 Propel,propel,https://jobs.gem.com/propel
 Prospermedical Com,prospermedical-com,https://jobs.gem.com/prospermedical-com
-Protegeai,protegeai,https://jobs.gem.com/protegeai
 Purespectrum,purespectrum,https://jobs.gem.com/purespectrum
 Questdb Com,questdb-com,https://jobs.gem.com/questdb-com
-Quitwithjones,quitwithjones,https://jobs.gem.com/quitwithjones
 Quo,quo,https://jobs.gem.com/quo
 Rain Aero,rain-aero,https://jobs.gem.com/rain-aero
-Raincode Bahrain W L L,raincode-bahrain-w-l-l,https://jobs.gem.com/raincode-bahrain-w-l-l
 Rainier Recruiting,rainier-recruiting,https://jobs.gem.com/rainier-recruiting
-Rankinhr Com,rankinhr-com,https://jobs.gem.com/rankinhr-com
 Raylu Ai,raylu-ai,https://jobs.gem.com/raylu-ai
 Rctsglobal Com,rctsglobal-com,https://jobs.gem.com/rctsglobal-com
 Rditrials,rditrials,https://jobs.gem.com/rditrials
@@ -453,10 +343,8 @@ Rebuild Work,rebuild-work,https://jobs.gem.com/rebuild-work
 Redcar,redcar,https://jobs.gem.com/redcar
 Redenvelope Co,redenvelope-co,https://jobs.gem.com/redenvelope-co
 Redo,redo,https://jobs.gem.com/redo
-Referred Fyi,referred-fyi,https://jobs.gem.com/referred-fyi
 Refinedvida,refinedvida,https://jobs.gem.com/refinedvida
 Rehearsals,rehearsals,https://jobs.gem.com/rehearsals
-Rektech,rektech,https://jobs.gem.com/rektech
 Renew,renew,https://jobs.gem.com/renew
 Replo,replo,https://jobs.gem.com/replo
 Responsiv,responsiv,https://jobs.gem.com/responsiv
@@ -471,42 +359,27 @@ Rinsed,rinsed,https://jobs.gem.com/rinsed
 Rise Search,rise-search,https://jobs.gem.com/rise-search
 Risely Ai,risely-ai,https://jobs.gem.com/risely-ai
 Rivia,rivia,https://jobs.gem.com/rivia
-Roadio Ai,roadio-ai,https://jobs.gem.com/roadio-ai
 Roamless,roamless,https://jobs.gem.com/roamless
 Roe Ai,roe-ai,https://jobs.gem.com/roe-ai
 Rossibuilders Com,rossibuilders-com,https://jobs.gem.com/rossibuilders-com
 Roundhouse Media,roundhouse-media,https://jobs.gem.com/roundhouse-media
 Rove,rove,https://jobs.gem.com/rove
 Runsybil,runsybil,https://jobs.gem.com/runsybil
-Sadnaconsulting Com,sadnaconsulting-com,https://jobs.gem.com/sadnaconsulting-com
 Safebeatrx Com,safebeatrx-com,https://jobs.gem.com/safebeatrx-com
-Sailorhealth Com,sailorhealth-com,https://jobs.gem.com/sailorhealth-com
 Sales Marker,sales-marker,https://jobs.gem.com/sales-marker
 Salesqueze Com,salesqueze-com,https://jobs.gem.com/salesqueze-com
-Sandbar Inc,sandbar-inc,https://jobs.gem.com/sandbar-inc
-Sandboxschonfeld Com,sandboxschonfeld-com,https://jobs.gem.com/sandboxschonfeld-com
 Sauron Systems,sauron-systems,https://jobs.gem.com/sauron-systems
 Sava,sava,https://jobs.gem.com/sava
-Scope Labs,scope-labs,https://jobs.gem.com/scope-labs
-Scowtt Com,scowtt-com,https://jobs.gem.com/scowtt-com
-Seated,seated,https://jobs.gem.com/seated
 Seed2Series Com,seed2series-com,https://jobs.gem.com/seed2series-com
 Seen,seen,https://jobs.gem.com/seen
 Sembleai Com,sembleai-com,https://jobs.gem.com/sembleai-com
 Seniorverse,seniorverse,https://jobs.gem.com/seniorverse
-Sennder Gmbh,sennder-gmbh,https://jobs.gem.com/sennder-gmbh
 Senndertechnologies Gmbh,senndertechnologies-gmbh,https://jobs.gem.com/senndertechnologies-gmbh
 Sensorum Health,sensorum-health,https://jobs.gem.com/sensorum-health
-Serv Ai,serv-ai,https://jobs.gem.com/serv-ai
-Servi,servi,https://jobs.gem.com/servi
-Seven Starling,seven-starling,https://jobs.gem.com/seven-starling
 Shef Com,shef-com,https://jobs.gem.com/shef-com
 Shorebird Dev,shorebird-dev,https://jobs.gem.com/shorebird-dev
 Showtime,showtime,https://jobs.gem.com/showtime
-Signoz,signoz,https://jobs.gem.com/signoz
 Silkline,silkline,https://jobs.gem.com/silkline
-Skypilot Co,skypilot-co,https://jobs.gem.com/skypilot-co
-Slash,slash,https://jobs.gem.com/slash
 Sleep Center,sleep-center,https://jobs.gem.com/sleep-center
 Smacktechnologies Com,smacktechnologies-com,https://jobs.gem.com/smacktechnologies-com
 Snout,snout,https://jobs.gem.com/snout
@@ -521,7 +394,6 @@ Sphere Semi,sphere-semi,https://jobs.gem.com/sphere-semi
 Splashventures Com,splashventures-com,https://jobs.gem.com/splashventures-com
 Ssg,ssg,https://jobs.gem.com/ssg
 Stack Auth Com,stack-auth-com,https://jobs.gem.com/stack-auth-com
-Startup People Solutions,startup-people-solutions,https://jobs.gem.com/startup-people-solutions
 Stealth Startup,stealth-startup,https://jobs.gem.com/stealth-startup
 Stockapp Com,stockapp-com,https://jobs.gem.com/stockapp-com
 Strantsolutions,strantsolutions,https://jobs.gem.com/strantsolutions
@@ -536,24 +408,20 @@ Supio,supio,https://jobs.gem.com/supio
 Suppliercanada Com,suppliercanada-com,https://jobs.gem.com/suppliercanada-com
 Switchgrowth Com,switchgrowth-com,https://jobs.gem.com/switchgrowth-com
 Symbiotic Security,symbiotic-security,https://jobs.gem.com/symbiotic-security
-Symbolica,symbolica,https://jobs.gem.com/symbolica
 Syndesus,syndesus,https://jobs.gem.com/syndesus
 System Two Security,system-two-security,https://jobs.gem.com/system-two-security
 Talent Al,talent-al,https://jobs.gem.com/talent-al
 Taro,taro,https://jobs.gem.com/taro
-Tash And Co,tash-and-co-,https://jobs.gem.com/tash-and-co-
 Taxgpt Inc,taxgpt-inc-,https://jobs.gem.com/taxgpt-inc-
 Taxo Ai,taxo-ai,https://jobs.gem.com/taxo-ai
 Tektome Com,tektome-com,https://jobs.gem.com/tektome-com
 Telemetrytv Com,telemetrytv-com,https://jobs.gem.com/telemetrytv-com
 Telora,telora,https://jobs.gem.com/telora
-Temporal Io,temporal-io,https://jobs.gem.com/temporal-io
 Tensorstax Com,tensorstax-com,https://jobs.gem.com/tensorstax-com
 Tenx Recruiting,tenx-recruiting,https://jobs.gem.com/tenx-recruiting
 Terminal,terminal,https://jobs.gem.com/terminal
 Terra,terra,https://jobs.gem.com/terra
 Terraai Earth,terraai-earth,https://jobs.gem.com/terraai-earth
-Test Board,test-board,https://jobs.gem.com/test-board
 Testedojo Com,testedojo-com,https://jobs.gem.com/testedojo-com
 The Boring Company,the-boring-company,https://jobs.gem.com/the-boring-company
 The Brewer Garrett Company,the-brewer-garrett-company,https://jobs.gem.com/the-brewer-garrett-company
@@ -563,12 +431,9 @@ The Talent Project Com,the-talent-project-com,https://jobs.gem.com/the-talent-pr
 Theburntapp Com,theburntapp-com,https://jobs.gem.com/theburntapp-com
 Theflex Global,theflex-global,https://jobs.gem.com/theflex-global
 Theinterface,theinterface,https://jobs.gem.com/theinterface
-Thejobbridge,thejobbridge,https://jobs.gem.com/thejobbridge
-Thelma,thelma,https://jobs.gem.com/thelma
 Theluckyfoundation,theluckyfoundation,https://jobs.gem.com/theluckyfoundation
 Thenewclub Fyi,thenewclub-fyi,https://jobs.gem.com/thenewclub-fyi
 Theseus Us,theseus-us,https://jobs.gem.com/theseus-us
-Thinkific,thinkific,https://jobs.gem.com/thinkific
 Third Dimension,third-dimension,https://jobs.gem.com/third-dimension
 Thrivory,thrivory,https://jobs.gem.com/thrivory
 Thunder,thunder,https://jobs.gem.com/thunder
@@ -581,18 +446,13 @@ Traceroot Ai,traceroot-ai,https://jobs.gem.com/traceroot-ai
 Transluce,transluce,https://jobs.gem.com/transluce
 Trashlab,trashlab,https://jobs.gem.com/trashlab
 Trially Ai,trially-ai,https://jobs.gem.com/trially-ai
-Tricentis,tricentis,https://jobs.gem.com/tricentis
-Trilliumhiring Com,trilliumhiring-com,https://jobs.gem.com/trilliumhiring-com
-Tripworks Com,tripworks-com,https://jobs.gem.com/tripworks-com
 Tristero,tristero,https://jobs.gem.com/tristero
 Trojan Trading,trojan-trading,https://jobs.gem.com/trojan-trading
 Tropic,tropic,https://jobs.gem.com/tropic
 Trove,trove,https://jobs.gem.com/trove
-Trybree Com,trybree-com,https://jobs.gem.com/trybree-com
 Tryhelium Com,tryhelium-com,https://jobs.gem.com/tryhelium-com
 Trytrueclaim Com,trytrueclaim-com,https://jobs.gem.com/trytrueclaim-com
 Tungsten Dev,tungsten-dev,https://jobs.gem.com/tungsten-dev
-Turbohome,turbohome,https://jobs.gem.com/turbohome
 Twentyfour7 Dev,twentyfour7-dev,https://jobs.gem.com/twentyfour7-dev
 Ultra,ultra,https://jobs.gem.com/ultra
 Ultralightlabs Com,ultralightlabs-com,https://jobs.gem.com/ultralightlabs-com
@@ -602,40 +462,23 @@ Unsiloed Ai,unsiloed-ai,https://jobs.gem.com/unsiloed-ai
 Untolabs Com,untolabs-com,https://jobs.gem.com/untolabs-com
 Up Labs,up-labs,https://jobs.gem.com/up-labs
 Upstream Do,upstream-do,https://jobs.gem.com/upstream-do
-Uscale Ai,uscale-ai,https://jobs.gem.com/uscale-ai
 Useful,useful,https://jobs.gem.com/useful
-Usemalleable Com,usemalleable-com,https://jobs.gem.com/usemalleable-com
-Vamo Xyz,vamo-xyz,https://jobs.gem.com/vamo-xyz
-Vanguard Cleaning Systems,vanguard-cleaning-systems,https://jobs.gem.com/vanguard-cleaning-systems
 Vantaca,vantaca,https://jobs.gem.com/vantaca
 Vantager,vantager,https://jobs.gem.com/vantager
-Vantara Ai,vantara-ai,https://jobs.gem.com/vantara-ai
 Vectorworks,vectorworks,https://jobs.gem.com/vectorworks
-Vectrasim,vectrasim,https://jobs.gem.com/vectrasim
 Veho Technologies,veho-technologies,https://jobs.gem.com/veho-technologies
-Ventionteams Com,ventionteams-com,https://jobs.gem.com/ventionteams-com
-Venture Guides,venture-guides,https://jobs.gem.com/venture-guides
-Vercel Ats Sandbox,vercel-ats-sandbox,https://jobs.gem.com/vercel-ats-sandbox
 Verlynk,verlynk,https://jobs.gem.com/verlynk
 Vesseltalent Com,vesseltalent-com,https://jobs.gem.com/vesseltalent-com
 Village,village,https://jobs.gem.com/village
 Vocode Dev,vocode-dev,https://jobs.gem.com/vocode-dev
 Voker Ai,voker-ai,https://jobs.gem.com/voker-ai
 Voltai Com,voltai-com,https://jobs.gem.com/voltai-com
-Wayback Labs,wayback-labs,https://jobs.gem.com/wayback-labs
-Webflow Ats Sandbox,webflow-ats-sandbox,https://jobs.gem.com/webflow-ats-sandbox
 Weeatbig Com,weeatbig-com,https://jobs.gem.com/weeatbig-com
-Western Governors University,western-governors-university,https://jobs.gem.com/western-governors-university
 Whatconverts,whatconverts,https://jobs.gem.com/whatconverts
-Wiseroad Recruiting Inc,wiseroad-recruiting-inc,https://jobs.gem.com/wiseroad-recruiting-inc
 Wizecamel,wizecamel,https://jobs.gem.com/wizecamel
-Wolfjaw Careers,wolfjaw-careers,https://jobs.gem.com/wolfjaw-careers
 Wonolo,wonolo,https://jobs.gem.com/wonolo
 Woodsideai,woodsideai,https://jobs.gem.com/woodsideai
-Y Combinator Sandbox,y-combinator-sandbox,https://jobs.gem.com/y-combinator-sandbox
 Yext Ats,yext-ats,https://jobs.gem.com/yext-ats
-Youtrip,youtrip,https://jobs.gem.com/youtrip
 Zealous Consultancy,zealous-consultancy,https://jobs.gem.com/zealous-consultancy
 Zefi Ai,zefi-ai,https://jobs.gem.com/zefi-ai
 Zep,zep,https://jobs.gem.com/zep
-Zorrorx,zorrorx,https://jobs.gem.com/zorrorx


### PR DESCRIPTION
## Summary
- remove Gem boards whose public `jobs.gem.com/<slug>` page returns a real 404
- remove clear sandbox/test/demo Gem boards from the tenant list

## Validation
- audited 640 original Gem rows against both the public board URL and Gem's public GraphQL `JobBoardList` endpoint
- final live check: 483/483 retained rows returned 200 public pages and valid GraphQL responses
- final retained set includes 386 boards with jobs and 3,685 first-page jobs detected
- final CSV sanity: no missing fields, no duplicate slug/url values, no obvious sandbox/test/demo rows

CSV-only change, so no unit tests were added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed invalid and sandbox Gem job boards from `ats-companies/gem.csv` to keep the list accurate and prevent broken links. This ensures only live, public Gem boards are included.

- **Bug Fixes**
  - Deleted 157 entries: boards whose public `jobs.gem.com/<slug>` pages 404 and clear sandbox/test/demo boards.
  - Verified 483 remaining boards return 200 pages and valid GraphQL responses; 386 have jobs (3,685 first-page jobs).

<sup>Written for commit 63fb0cc3c46f1aecff7bee4429e42d6681edbf89. Summary will update on new commits. <a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/151?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

