### PR TITLE
Fix Personio company entries

### DIFF
--- a/ats-companies/personio.csv
+++ b/ats-companies/personio.csv
@@ -110,7 +110,6 @@ Balltec,balltec,https://balltec.jobs.personio.com
 Banxware,banxware,https://banxware.jobs.personio.com
 Baqend,baqend,https://baqend.jobs.personio.com
 Barra Technologies,barra-technologies,https://barra-technologies.jobs.personio.com
-Barrabes,barrabes,https://barrabes.jobs.personio.com
 Bbl Brockdorff Rgmbh,bbl-brockdorff-rgmbh-1,https://bbl-brockdorff-rgmbh-1.jobs.personio.com
 Beaglesystems,beaglesystems,https://beaglesystems.jobs.personio.com
 Becanex,becanex,https://becanex.jobs.personio.com
@@ -246,7 +245,6 @@ Courtyard Hamburg City,courtyard-hamburg-city,https://courtyard-hamburg-city.job
 Covermanager,covermanager,https://covermanager.jobs.personio.com
 Crate IO,crate-io,https://crate-io.jobs.personio.com
 Creatision,creatision,https://creatision.jobs.personio.com
-Creative,creative-group,https://creative-group.jobs.personio.com
 Crisalix Labs Slu,crisalix-labs-slu,https://crisalix-labs-slu.jobs.personio.com
 Crk,crk,https://crk.jobs.personio.com
 Croftstone,croftstone,https://croftstone.jobs.personio.com
@@ -284,10 +282,8 @@ Ddbm,ddbm,https://ddbm.jobs.personio.com
 Dealstack,dealstack,https://dealstack.jobs.personio.com
 Deepspin,deepspin-gmbh,https://deepspin-gmbh.jobs.personio.com
 Degussa Holding,degussa-holding,https://degussa-holding.jobs.personio.com
-Deliciously Ella,deliciously-ella,https://deliciously-ella.jobs.personio.com
 Deltia AI,deltia-ai,https://deltia-ai.jobs.personio.com
 Demont,demont,https://demont.jobs.personio.com
-Demorecruiting,demorecruiting,https://demorecruiting.jobs.personio.com
 Depoly,depoly,https://depoly.jobs.personio.com
 Dermatopathologie Essen,dermatopathologie-essen,https://dermatopathologie-essen.jobs.personio.com
 Deromein,deromein-gmbh,https://deromein-gmbh.jobs.personio.com
@@ -523,7 +519,6 @@ Haut AI,haut-ai,https://haut-ai.jobs.personio.com
 Hbsn,hbsn,https://hbsn.jobs.personio.com
 Healthcare Convention,healthcare-convention,https://healthcare-convention.jobs.personio.com
 Hector Kitchen,hector-kitchen,https://hector-kitchen.jobs.personio.com
-Heidelberg Instruments Nano,heidelberg-instruments-nano,https://heidelberg-instruments-nano.jobs.personio.com
 Helbako,helbako,https://helbako.jobs.personio.com
 Helin Data,helin-data,https://helin-data.jobs.personio.com
 Hellermanntyton,hellermanntyton-gmbh,https://hellermanntyton-gmbh.jobs.personio.com
@@ -819,7 +814,6 @@ Obsidian,obsidian,https://obsidian.jobs.personio.com
 Obsidian,obsidian-group,https://obsidian-group.jobs.personio.com
 Obsidianbanjaluka,obsidianbanjaluka,https://obsidianbanjaluka.jobs.personio.com
 Oc Hairsystems,oc-hairsystems,https://oc-hairsystems.jobs.personio.com
-Ocean Science Consulting Limited,ocean-science-consulting-limited,https://ocean-science-consulting-limited.jobs.personio.com
 Oceonix SErvices Limited,oceonix-services-limited,https://oceonix-services-limited.jobs.personio.com
 Octomind,octomind,https://octomind.jobs.personio.com
 Odds Scanner,odds-scanner,https://odds-scanner.jobs.personio.com
@@ -973,7 +967,6 @@ Samedi,samedi-de,https://samedi-de.jobs.personio.com
 Sammedia,sammedia,https://sammedia.jobs.personio.com
 Sammediabv,sammediabv,https://sammediabv.jobs.personio.com
 Sana Life Science Holdings,sana-life-science-holdings,https://sana-life-science-holdings.jobs.personio.com
-Sandbox,sandbox,https://sandbox.jobs.personio.com
 Sandhp,sandhp,https://sandhp.jobs.personio.com
 Sanoptis,sanoptis,https://sanoptis.jobs.personio.com
 Sava Technologies,sava-technologies,https://sava-technologies.jobs.personio.com
@@ -1129,7 +1122,6 @@ Topikpartner,topikpartner,https://topikpartner.jobs.personio.com
 Tozero,tozero,https://tozero.jobs.personio.com
 Tpg,tpg-gmbh,https://tpg-gmbh.jobs.personio.com
 Tradetracker,tradetracker,https://tradetracker.jobs.personio.com
-Trailtest3,trailtest3,https://trailtest3.jobs.personio.com
 Transconnect,transconnect,https://transconnect.jobs.personio.com
 Transitionzero,transitionzero,https://transitionzero.jobs.personio.com
 Transmare Chemie,transmare-chemie,https://transmare-chemie.jobs.personio.com
@@ -1153,7 +1145,6 @@ Turn2X,turn2x,https://turn2x.jobs.personio.com
 Tutoringforall,tutoringforall,https://tutoringforall.jobs.personio.com
 Twaice,twaice,https://twaice.jobs.personio.com
 TwentyFour Industries,twentyfour-industries,https://twentyfour-industries.jobs.personio.com
-Twinsity,twinsity,https://twinsity.jobs.personio.com
 Tws Partners,tws-partners,https://tws-partners.jobs.personio.com
 URANO,urano,https://urano.jobs.personio.com
 Ubiops,ubiops,https://ubiops.jobs.personio.com
@@ -1369,7 +1360,6 @@ barth,barth,https://barth.jobs.personio.com
 basis,basis,https://basis.jobs.personio.com
 bbb,bbb,https://bbb.jobs.personio.com
 bbe,bbe,https://bbe.jobs.personio.com
-bbq,bbq,https://bbq.jobs.personio.com
 bbz,bbz,https://bbz.jobs.personio.com
 bcc,bcc,https://bcc.jobs.personio.com
 bci,bci,https://bci.jobs.personio.com
@@ -1521,8 +1511,6 @@ deepup,deepup,https://deepup.jobs.personio.com
 deleteme,deleteme,https://deleteme.jobs.personio.com
 delphos-1,delphos-1,https://delphos-1.jobs.personio.com
 deltavision,deltavision,https://deltavision.jobs.personio.com
-demo,demo,https://demo.jobs.personio.com
-demos,demos,https://demos.jobs.personio.com
 des,des,https://des.jobs.personio.com
 desh,desh,https://desh.jobs.personio.com
 desotec,desotec,https://desotec.jobs.personio.com
@@ -1585,7 +1573,6 @@ eeg,eeg,https://eeg.jobs.personio.com
 efa,efa,https://efa.jobs.personio.com
 egm,egm,https://egm.jobs.personio.com
 egroup,egroup,https://egroup.jobs.personio.com
-ehex,ehex,https://ehex.jobs.personio.com
 eict,eict,https://eict.jobs.personio.com
 eidf,eidf,https://eidf.jobs.personio.com
 eigenblue,eigenblue,https://eigenblue.jobs.personio.com
@@ -1729,7 +1716,6 @@ grantlift,grantlift,https://grantlift.jobs.personio.com
 gras,gras,https://gras.jobs.personio.com
 graswald-gmbh,graswald-gmbh,https://graswald-gmbh.jobs.personio.com
 grau,grau,https://grau.jobs.personio.com
-grbv,grbv,https://grbv.jobs.personio.com
 greenfield,greenfield,https://greenfield.jobs.personio.com
 greenforce,greenforce,https://greenforce.jobs.personio.com
 greenpeak,greenpeak,https://greenpeak.jobs.personio.com
@@ -1900,7 +1886,6 @@ ktda,ktda,https://ktda.jobs.personio.com
 kwco,kwco,https://kwco.jobs.personio.com
 kwhc,kwhc,https://kwhc.jobs.personio.com
 kyanhealth,kyanhealth,https://kyanhealth.jobs.personio.com
-kyp,kyp,https://kyp.jobs.personio.com
 kzw,kzw,https://kzw.jobs.personio.com
 lab1720,lab1720,https://lab1720.jobs.personio.com
 laclick,laclick,https://laclick.jobs.personio.com
@@ -1967,7 +1952,6 @@ mda,mda,https://mda.jobs.personio.com
 medercommtech,medercommtech,https://medercommtech.jobs.personio.com
 meko,meko,https://meko.jobs.personio.com
 mellowmessage,mellowmessage,https://mellowmessage.jobs.personio.com
-melotech,melotech,https://melotech.jobs.personio.com
 meo,meo,https://meo.jobs.personio.com
 merida,merida,https://merida.jobs.personio.com
 meshcapade,meshcapade,https://meshcapade.jobs.personio.com
@@ -2324,7 +2308,6 @@ teg,teg,https://teg.jobs.personio.com
 teleport,teleport,https://teleport.jobs.personio.com
 ten,ten,https://ten.jobs.personio.com
 tenz,tenz,https://tenz.jobs.personio.com
-test,test,https://test.jobs.personio.com
 texa,texa,https://texa.jobs.personio.com
 tfs,tfs,https://tfs.jobs.personio.com
 tgc,tgc,https://tgc.jobs.personio.com


### PR DESCRIPTION
## Summary
- Remove 11 Personio tenants that redirect to Personio's main site instead of serving tenant `search.json` content.
- Remove 6 obvious demo/test/sandbox tenant rows.

## Validation
- Audited 2,480 original rows against `{url}/search.json`.
- Retried the 11 failing rows with redirects disabled before removal; all redirect to `https://personio.com`.
- Final live check: 2,463 retained rows, 0 bad JSON responses, 2,016 feeds with jobs, 13,459 first-page jobs counted.
- Final CSV sanity check: 2,463 rows, no missing fields, no duplicate slugs, no duplicate URLs.
- CSV-only change, so no tests were added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed 17 invalid Personio tenants from `ats-companies/personio.csv` to stop redirects and remove test/demo entries. This improves data quality and prevents bad `search.json` requests.

- **Bug Fixes**
  - Removed 11 tenants that redirect to `https://personio.com`.
  - Removed 6 demo/test/sandbox tenants.
  - Validated 2,463 remaining rows: valid JSON, no duplicate slugs or URLs.

<sup>Written for commit 78d4c5b4b8871a668faeb5b2c78f680a0c13dd5c. Summary will update on new commits. <a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/157?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

