### PR TITLE
Fix Recruitee company names

### DIFF
--- a/ats-companies/recruitee.csv
+++ b/ats-companies/recruitee.csv
@@ -557,33 +557,33 @@ Ziflow,ziflow,https://ziflow.recruitee.com
 Zoku,livezoku,https://livezoku.recruitee.com
 abaltatechnologiesinc,abaltatechnologiesinc,https://abaltatechnologiesinc.recruitee.com
 abracadabra,abracadabra,https://abracadabra.recruitee.com
-achmeainnovationhub,achmeainnovationhub,https://achmeainnovationhub.recruitee.com
-acomo,acomo,https://acomo.recruitee.com
-acturis,acturis,https://acturis.recruitee.com
+ACHMEA B.V.,achmeainnovationhub,https://achmeainnovationhub.recruitee.com
+ACOMO N.V.,acomo,https://acomo.recruitee.com
+Acturis,acturis,https://acturis.recruitee.com
 adamsmithinternational,adamsmithinternational,https://adamsmithinternational.recruitee.com
 adesso Belgium,adesso1,https://adesso1.recruitee.com
-afsenergy,afsenergy,https://afsenergy.recruitee.com
+AFS Energy B.V.,afsenergy,https://afsenergy.recruitee.com
 againbio,againbio,https://againbio.recruitee.com
-akur8,akur8,https://akur8.recruitee.com
-allredi,allredi,https://allredi.recruitee.com
-almavivadebelgique,almavivadebelgique,https://almavivadebelgique.recruitee.com
+Akur8,akur8,https://akur8.recruitee.com
+Allredi,allredi,https://allredi.recruitee.com
+AlmavivA de Belgique,almavivadebelgique,https://almavivadebelgique.recruitee.com
 amilia,amilia,https://amilia.recruitee.com
-anandaventuresgmbh,anandaventuresgmbh,https://anandaventuresgmbh.recruitee.com
-anchr,anchr,https://anchr.recruitee.com
-appetiser,appetiser,https://appetiser.recruitee.com
+Ananda Ventures GmbH,anandaventuresgmbh,https://anandaventuresgmbh.recruitee.com
+Anchr,anchr,https://anchr.recruitee.com
+Appetiser,appetiser,https://appetiser.recruitee.com
 arbio,arbio,https://arbio.recruitee.com
-artifactsa,artifactsa,https://artifactsa.recruitee.com
+Artifact,artifactsa,https://artifactsa.recruitee.com
 ascendingai,ascendingai,https://ascendingai.recruitee.com
-ascensionisland,ascensionisland,https://ascensionisland.recruitee.com
-asmpthk,asmpthk,https://asmpthk.recruitee.com
-astontec,astontec,https://astontec.recruitee.com
-balchem,balchem,https://balchem.recruitee.com
-ballysintralotsa,ballysintralotsa,https://ballysintralotsa.recruitee.com
-basgroup,basgroup,https://basgroup.recruitee.com
-bauer,bauer,https://bauer.recruitee.com
+Ascension Island Government,ascensionisland,https://ascensionisland.recruitee.com
+ASMPT,asmpthk,https://asmpthk.recruitee.com
+ASTONTEC,astontec,https://astontec.recruitee.com
+Balchem,balchem,https://balchem.recruitee.com
+BALLY’S INTRALOT SA,ballysintralotsa,https://ballysintralotsa.recruitee.com
+BAS Group,basgroup,https://basgroup.recruitee.com
+Willy Bauer KG,bauer,https://bauer.recruitee.com
 bbb,bbb,https://bbb.recruitee.com
 benuta GmbH,benutagmbh,https://benutagmbh.recruitee.com
-bespokebritannia,bespokebritannia,https://bespokebritannia.recruitee.com
+Bespoke Britannia,bespokebritannia,https://bespokebritannia.recruitee.com
 bibliu,bibliu,https://bibliu.recruitee.com
 bunq,bunq,https://bunq.recruitee.com
 bwhhotelsemea,bwhhotelsemea,https://bwhhotelsemea.recruitee.com
@@ -598,245 +598,245 @@ cbs Corporate Business Solutions GmbH,cbsconsulting,https://cbsconsulting.recrui
 celebrate company GmbH,celebratecompany,https://celebratecompany.recruitee.com
 cellexgmbh,cellexgmbh,https://cellexgmbh.recruitee.com
 centerfortechandciviclife,centerfortechandciviclife,https://centerfortechandciviclife.recruitee.com
-centreon,centreon,https://centreon.recruitee.com
+CENTREON,centreon,https://centreon.recruitee.com
 cityscience,cityscience,https://cityscience.recruitee.com
-clanx,clanx,https://clanx.recruitee.com
-codelessinteractivellc,codelessinteractivellc,https://codelessinteractivellc.recruitee.com
-coffeespace,coffeespace,https://coffeespace.recruitee.com
-compelson,compelson,https://compelson.recruitee.com
-compliancechamps,compliancechamps,https://compliancechamps.recruitee.com
+ClanX,clanx,https://clanx.recruitee.com
+"Codeless, Interactive LLC",codelessinteractivellc,https://codelessinteractivellc.recruitee.com
+CoffeeSpace,coffeespace,https://coffeespace.recruitee.com
+Compelson,compelson,https://compelson.recruitee.com
+Compliance Champs,compliancechamps,https://compliancechamps.recruitee.com
 constellr GmbH,constellr,https://constellr.recruitee.com
 consulting1x1 GmbH,consulting1x1,https://consulting1x1.recruitee.com
-consulting1x1gmbh,consulting1x1gmbh,https://consulting1x1gmbh.recruitee.com
-consultport,consultport,https://consultport.recruitee.com
-coreso,coreso,https://coreso.recruitee.com
-cortexreply,cortexreply,https://cortexreply.recruitee.com
-cottage,cottage,https://cottage.recruitee.com
-cpitechnologiesgmbh,cpitechnologiesgmbh,https://cpitechnologiesgmbh.recruitee.com
+consulting1x1 GmbH,consulting1x1gmbh,https://consulting1x1gmbh.recruitee.com
+Consultport,consultport,https://consultport.recruitee.com
+Coreso,coreso,https://coreso.recruitee.com
+Cortex Reply,cortexreply,https://cortexreply.recruitee.com
+Cottage,cottage,https://cottage.recruitee.com
+CPI Technologies GmbH,cpitechnologiesgmbh,https://cpitechnologiesgmbh.recruitee.com
 creamyfabrics,creamyfabrics,https://creamyfabrics.recruitee.com
 creandum,creandum,https://creandum.recruitee.com
 cross-ING AG,crossing,https://crossing.recruitee.com
-crowdsec,crowdsec,https://crowdsec.recruitee.com
+Crowdsec,crowdsec,https://crowdsec.recruitee.com
 ctrl-s GmbH,ctrls,https://ctrls.recruitee.com
 dataforce,dataforce,https://dataforce.recruitee.com
-dataline,dataline,https://dataline.recruitee.com
+Dataline nv,dataline,https://dataline.recruitee.com
 deCircle,decircletalentpartner,https://decircletalentpartner.recruitee.com
 deepomatic,deepomatic,https://deepomatic.recruitee.com
-demvsystemsgmbh,demvsystemsgmbh,https://demvsystemsgmbh.recruitee.com
+DEMV Systems Gmbh,demvsystemsgmbh,https://demvsystemsgmbh.recruitee.com
 dexterenergyservices,dexterenergyservices,https://dexterenergyservices.recruitee.com
 die Bayerische,diebayerische,https://diebayerische.recruitee.com
 digital dna,digitaldna,https://digitaldna.recruitee.com
-diponteducation,diponteducation,https://diponteducation.recruitee.com
+Dipont Education,diponteducation,https://diponteducation.recruitee.com
 dnata B.V.,dnata,https://dnata.recruitee.com
 dss+,consultdss,https://consultdss.recruitee.com
 e-Luscious,eluscious,https://eluscious.recruitee.com
 eGroup,egroup,https://egroup.recruitee.com
 eXtra Shop,extrashop,https://extrashop.recruitee.com
-ecconsultants,ecconsultants,https://ecconsultants.recruitee.com
+E&C,ecconsultants,https://ecconsultants.recruitee.com
 echourbandesign,echourbandesign,https://echourbandesign.recruitee.com
 ecochain,ecochain,https://ecochain.recruitee.com
 edubily GmbH,edubilygmbh,https://edubilygmbh.recruitee.com
 eleQtron GmbH,eleqtron,https://eleqtron.recruitee.com
 elementinsuranceag,elementinsuranceag,https://elementinsuranceag.recruitee.com
 elockers,elockers,https://elockers.recruitee.com
-embrace,embrace,https://embrace.recruitee.com
-emergentsoftware,emergentsoftware,https://emergentsoftware.recruitee.com
+Embrace The Human Cloud,embrace,https://embrace.recruitee.com
+Emergent Software,emergentsoftware,https://emergentsoftware.recruitee.com
 emmiai,emmiai,https://emmiai.recruitee.com
-energy21,energy21,https://energy21.recruitee.com
-enjoygaming,enjoygaming,https://enjoygaming.recruitee.com
+Eneve,energy21,https://energy21.recruitee.com
+Enjoy Gaming LLC,enjoygaming,https://enjoygaming.recruitee.com
 enomyc GmbH,enomyc,https://enomyc.recruitee.com
-envipco,envipco,https://envipco.recruitee.com
-equalsmoney,equalsmoney,https://equalsmoney.recruitee.com
-equito,equito,https://equito.recruitee.com
-erstedigital,erstedigital,https://erstedigital.recruitee.com
+Envipco,envipco,https://envipco.recruitee.com
+Equals Money,equalsmoney,https://equalsmoney.recruitee.com
+Equito,equito,https://equito.recruitee.com
+Erste Digital GmbH,erstedigital,https://erstedigital.recruitee.com
 ethon,ethonai,https://ethonai.recruitee.com
-eurosparcareers,eurosparcareers,https://eurosparcareers.recruitee.com
+EUROSPAR Ireland,eurosparcareers,https://eurosparcareers.recruitee.com
 exbgroup,exbgroup,https://exbgroup.recruitee.com
-exeon,exeon,https://exeon.recruitee.com
-experiencegift,experiencegift,https://experiencegift.recruitee.com
-famly,famly,https://famly.recruitee.com
-fashioncloudgmbh,fashioncloudgmbh,https://fashioncloudgmbh.recruitee.com
-ferillis,ferillis,https://ferillis.recruitee.com
+Exeon Analytics,exeon,https://exeon.recruitee.com
+Experiencegift,experiencegift,https://experiencegift.recruitee.com
+Famly,famly,https://famly.recruitee.com
+Fashion Cloud,fashioncloudgmbh,https://fashioncloudgmbh.recruitee.com
+Ferilli's Hospitality Group,ferillis,https://ferillis.recruitee.com
 filestage,filestage,https://filestage.recruitee.com
-formofoodsgmbh,formofoodsgmbh,https://formofoodsgmbh.recruitee.com
-forwardearth,forwardearth,https://forwardearth.recruitee.com
-freshminds,freshminds,https://freshminds.recruitee.com
-fumo,fumo,https://fumo.recruitee.com
-fundamentalhospitality,fundamentalhospitality,https://fundamentalhospitality.recruitee.com
-funex,funex,https://funex.recruitee.com
+Formo Foods GmbH,formofoodsgmbh,https://formofoodsgmbh.recruitee.com
+forward earth,forwardearth,https://forwardearth.recruitee.com
+FreshMinds,freshminds,https://freshminds.recruitee.com
+FUMO,fumo,https://fumo.recruitee.com
+Fundamental Hospitality,fundamentalhospitality,https://fundamentalhospitality.recruitee.com
+FunEx Head Office,funex,https://funex.recruitee.com
 fxth,fxth,https://fxth.recruitee.com
-gallaghereurope,gallaghereurope,https://gallaghereurope.recruitee.com
-gemcorehealth,gemcorehealth,https://gemcorehealth.recruitee.com
+Gallagher Europe BV,gallaghereurope,https://gallaghereurope.recruitee.com
+"Edwards Health Care Services, Inc.",gemcorehealth,https://gemcorehealth.recruitee.com
 ggz,ggz,https://ggz.recruitee.com
-ginmon,ginmon,https://ginmon.recruitee.com
-glassix,glassix,https://glassix.recruitee.com
+Ginmon GmbH,ginmon,https://ginmon.recruitee.com
+Glassix,glassix,https://glassix.recruitee.com
 goedemiddag,goedemiddag,https://goedemiddag.recruitee.com
 gpvsweden,gpvsweden,https://gpvsweden.recruitee.com
-graphcms,graphcms,https://graphcms.recruitee.com
+Hygraph,graphcms,https://graphcms.recruitee.com
 gravity9,gravity9,https://gravity9.recruitee.com
-grb,grb,https://grb.recruitee.com
+GRB Gemeinnütziges Rheinisches Bildungszentrum GmbH,grb,https://grb.recruitee.com
 gridscale,gridscale,https://gridscale.recruitee.com
-gtn,gtn,https://gtn.recruitee.com
-hardrockdigital,hardrockdigital,https://hardrockdigital.recruitee.com
+ELAN Languages,gtn,https://gtn.recruitee.com
+Hard Rock Digital,hardrockdigital,https://hardrockdigital.recruitee.com
 healthiergeneration,healthiergeneration,https://healthiergeneration.recruitee.com
-heyharper,heyharper,https://heyharper.recruitee.com
-highspiritshospitality,highspiritshospitality,https://highspiritshospitality.recruitee.com
-holzlandbecker,holzlandbecker,https://holzlandbecker.recruitee.com
-hometouch,hometouch,https://hometouch.recruitee.com
+Hey Harper,heyharper,https://heyharper.recruitee.com
+High Spirits Hospitality,highspiritshospitality,https://highspiritshospitality.recruitee.com
+Holzland Becker,holzlandbecker,https://holzlandbecker.recruitee.com
+Hometouch,hometouch,https://hometouch.recruitee.com
 hued,hued,https://hued.recruitee.com
 hyble,hyble,https://hyble.recruitee.com
 hypepartners,hypepartners,https://hypepartners.recruitee.com
 i-profile GmbH,iprofilegmbh,https://iprofilegmbh.recruitee.com
 iChoosr,ichoosr,https://ichoosr.recruitee.com
 iddi,iddi,https://iddi.recruitee.com
-illinoisenergywindowsandsidinginc,illinoisenergywindowsandsidinginc,https://illinoisenergywindowsandsidinginc.recruitee.com
+"Illinois Energy Windows and Siding, Inc.",illinoisenergywindowsandsidinginc,https://illinoisenergywindowsandsidinginc.recruitee.com
 incentivio,incentivio,https://incentivio.recruitee.com
 independentstaffingservices,independentstaffingservices,https://independentstaffingservices.recruitee.com
-individuals,individuals,https://individuals.recruitee.com
+INDIVIDUALS,individuals,https://individuals.recruitee.com
 intent,intent,https://intent.recruitee.com
-internationaledeutscheschulebrussel,internationaledeutscheschulebrussel,https://internationaledeutscheschulebrussel.recruitee.com
-internationalfoodconnectors,internationalfoodconnectors,https://internationalfoodconnectors.recruitee.com
-interoeumea,interoeumea,https://interoeumea.recruitee.com
-interothesniffers,interothesniffers,https://interothesniffers.recruitee.com
-intralot,intralot,https://intralot.recruitee.com
-intuitionstaffing,intuitionstaffing,https://intuitionstaffing.recruitee.com
-irisvanherpen,irisvanherpen,https://irisvanherpen.recruitee.com
+Internationale Deutsche Schule Brüssel,internationaledeutscheschulebrussel,https://internationaledeutscheschulebrussel.recruitee.com
+International Food Connectors,internationalfoodconnectors,https://internationalfoodconnectors.recruitee.com
+Intero Integrity Services,interoeumea,https://interoeumea.recruitee.com
+Intero - The Sniffers,interothesniffers,https://interothesniffers.recruitee.com
+BALLY’S INTRALOT SA,intralot,https://intralot.recruitee.com
+Intuition Staffing,intuitionstaffing,https://intuitionstaffing.recruitee.com
+Iris van Herpen BV,irisvanherpen,https://irisvanherpen.recruitee.com
 isc,isc,https://isc.recruitee.com
-itxuklimited,itxuklimited,https://itxuklimited.recruitee.com
-iwe,iwe,https://iwe.recruitee.com
-jeranexbp,jeranexbp,https://jeranexbp.recruitee.com
-jetrails,jetrails,https://jetrails.recruitee.com
-jobsatlanticvcfoodlabs,jobsatlanticvcfoodlabs,https://jobsatlanticvcfoodlabs.recruitee.com
+INDITEX,itxuklimited,https://itxuklimited.recruitee.com
+iWE,iwe,https://iwe.recruitee.com
+JERA Nex bp,jeranexbp,https://jeranexbp.recruitee.com
+JetRails,jetrails,https://jetrails.recruitee.com
+FoodLabs & Atlantic,jobsatlanticvcfoodlabs,https://jobsatlanticvcfoodlabs.recruitee.com
 johann dettendorfer spedition ferntrans gmbh & co. kg,dettendorfer,https://dettendorfer.recruitee.com
-jpweltersgorgensgmbhcobekleidungskg,jpweltersgorgensgmbhcobekleidungskg,https://jpweltersgorgensgmbhcobekleidungskg.recruitee.com
-jump,jump,https://jump.recruitee.com
-kayrros1,kayrros1,https://kayrros1.recruitee.com
-kcoverseaseducation,kcoverseaseducation,https://kcoverseaseducation.recruitee.com
-keunecareers,keunecareers,https://keunecareers.recruitee.com
-keyencecanadainc,keyencecanadainc,https://keyencecanadainc.recruitee.com
-kravet,kravet,https://kravet.recruitee.com
-kring,kring,https://kring.recruitee.com
+Görgens Gruppe,jpweltersgorgensgmbhcobekleidungskg,https://jpweltersgorgensgmbhcobekleidungskg.recruitee.com
+Jump,jump,https://jump.recruitee.com
+Kayrros,kayrros1,https://kayrros1.recruitee.com
+KC Overseas Education,kcoverseaseducation,https://kcoverseaseducation.recruitee.com
+Keune Haircosmetics Manufacturing B.V.,keunecareers,https://keunecareers.recruitee.com
+KEYENCE CANADA INC.,keyencecanadainc,https://keyencecanadainc.recruitee.com
+Kravet LLC,kravet,https://kravet.recruitee.com
+KRING A/S,kring,https://kring.recruitee.com
 kriptomat,kriptomat,https://kriptomat.recruitee.com
-kti,kti,https://kti.recruitee.com
-laveste,laveste,https://laveste.recruitee.com
-leadershippathway,leadershippathway,https://leadershippathway.recruitee.com
-learnbydoinginc,learnbydoinginc,https://learnbydoinginc.recruitee.com
-legalfly,legalfly,https://legalfly.recruitee.com
-lleverage,lleverage,https://lleverage.recruitee.com
-loavies,loavies,https://loavies.recruitee.com
-logex,logex,https://logex.recruitee.com
-lss,lss,https://lss.recruitee.com
+KTI Installatietechniek,kti,https://kti.recruitee.com
+La Veste,laveste,https://laveste.recruitee.com
+Leadership Pathway,leadershippathway,https://leadershippathway.recruitee.com
+"Learn By Doing, Inc.",learnbydoinginc,https://learnbydoinginc.recruitee.com
+LegalFly,legalfly,https://legalfly.recruitee.com
+LLEVERAGE,lleverage,https://lleverage.recruitee.com
+LOAVIES,loavies,https://loavies.recruitee.com
+LOGEX,logex,https://logex.recruitee.com
+SSC,lss,https://lss.recruitee.com
 ltn,ltn,https://ltn.recruitee.com
-macecareers,macecareers,https://macecareers.recruitee.com
-mainstream,mainstream,https://mainstream.recruitee.com
-make,make,https://make.recruitee.com
+MACE Ireland,macecareers,https://macecareers.recruitee.com
+Mainstream,mainstream,https://mainstream.recruitee.com
+Make,make,https://make.recruitee.com
 manroland Goss web systems GmbH,manrolandgoss,https://manrolandgoss.recruitee.com
-maschinenraum,maschinenraum,https://maschinenraum.recruitee.com
-masttrucking,masttrucking,https://masttrucking.recruitee.com
-mdlbeast,mdlbeast,https://mdlbeast.recruitee.com
-mhiecpd,mhiecpd,https://mhiecpd.recruitee.com
-mirka,mirka,https://mirka.recruitee.com
-moneyhash,moneyhash,https://moneyhash.recruitee.com
-moweryschoenfeldllc,moweryschoenfeldllc,https://moweryschoenfeldllc.recruitee.com
+Maschinenraum GmbH,maschinenraum,https://maschinenraum.recruitee.com
+"Mast Trucking, Inc.",masttrucking,https://masttrucking.recruitee.com
+MDLBEAST,mdlbeast,https://mdlbeast.recruitee.com
+MHIE-CPD,mhiecpd,https://mhiecpd.recruitee.com
+Oy Mirka Ab,mirka,https://mirka.recruitee.com
+MoneyHash,moneyhash,https://moneyhash.recruitee.com
+Mowery & Schoenfeld LLC,moweryschoenfeldllc,https://moweryschoenfeldllc.recruitee.com
 nanameue,nanameue,https://nanameue.recruitee.com
 neXenio Engineering GmbH,nexenio,https://nexenio.recruitee.com
 nextaillabs,nextaillabs,https://nextaillabs.recruitee.com
-ninjasinpyjamas,ninjasinpyjamas,https://ninjasinpyjamas.recruitee.com
-novasphere,novasphere,https://novasphere.recruitee.com
-nrb,nrb,https://nrb.recruitee.com
-nthermllc,nthermllc,https://nthermllc.recruitee.com
+Ninjas in Pyjamas,ninjasinpyjamas,https://ninjasinpyjamas.recruitee.com
+Novasphere,novasphere,https://novasphere.recruitee.com
+NRB,nrb,https://nrb.recruitee.com
+nTherm LLC,nthermllc,https://nthermllc.recruitee.com
 o2h Group,o2h,https://o2h.recruitee.com
-oil,oil,https://oil.recruitee.com
-olsamgroup,olsamgroup,https://olsamgroup.recruitee.com
-omybag,omybag,https://omybag.recruitee.com
-opplebv,opplebv,https://opplebv.recruitee.com
+Normec Sustainability UK,oil,https://oil.recruitee.com
+Olsam Group,olsamgroup,https://olsamgroup.recruitee.com
+O My Bag,omybag,https://omybag.recruitee.com
+Opple Lighting BV,opplebv,https://opplebv.recruitee.com
 paiqo GmbH,paiqo,https://paiqo.recruitee.com
-palazzohospitality,palazzohospitality,https://palazzohospitality.recruitee.com
-performancemanagement,performancemanagement,https://performancemanagement.recruitee.com
-peterson,peterson,https://peterson.recruitee.com
-plukonfoodgroupspain,plukonfoodgroupspain,https://plukonfoodgroupspain.recruitee.com
+PALAZZO HOSPITALITY,palazzohospitality,https://palazzohospitality.recruitee.com
+Finext B.V.,performancemanagement,https://performancemanagement.recruitee.com
+Peterson,peterson,https://peterson.recruitee.com
+Plukon Food Group Spain,plukonfoodgroupspain,https://plukonfoodgroupspain.recruitee.com
 policyengineer,policyengineer,https://policyengineer.recruitee.com
-popcorngrowth,popcorngrowth,https://popcorngrowth.recruitee.com
-properfood,properfood,https://properfood.recruitee.com
+Popcorn Growth,popcorngrowth,https://popcorngrowth.recruitee.com
+Proper Food,properfood,https://properfood.recruitee.com
 qa,qa,https://qa.recruitee.com
-raketech,raketech,https://raketech.recruitee.com
-ravo,ravo,https://ravo.recruitee.com
-recaregmbh,recaregmbh,https://recaregmbh.recruitee.com
-redsky,redsky,https://redsky.recruitee.com
-resatohydrogentechnology,resatohydrogentechnology,https://resatohydrogentechnology.recruitee.com
-resourcefultalentgroup,resourcefultalentgroup,https://resourcefultalentgroup.recruitee.com
+Raketech Group Limited,raketech,https://raketech.recruitee.com
+RAVO Holding BV,ravo,https://ravo.recruitee.com
+Recare Deutschland GmbH,recaregmbh,https://recaregmbh.recruitee.com
+Red Sky,redsky,https://redsky.recruitee.com
+Resato Hydrogen Technology B.V.,resatohydrogentechnology,https://resatohydrogentechnology.recruitee.com
+Resourceful Talent Group,resourcefultalentgroup,https://resourcefultalentgroup.recruitee.com
 riscure,riscure,https://riscure.recruitee.com
 rkpt,rkpt,https://rkpt.recruitee.com
 rpa,rpa,https://rpa.recruitee.com
-rtl,rtl,https://rtl.recruitee.com
+RTL,rtl,https://rtl.recruitee.com
 safesize,safesize,https://safesize.recruitee.com
-scioteq,scioteq,https://scioteq.recruitee.com
-scrumventures,scrumventures,https://scrumventures.recruitee.com
-sequra,sequra,https://sequra.recruitee.com
-sevensons,sevensons,https://sevensons.recruitee.com
-sgbsmitgroup,sgbsmitgroup,https://sgbsmitgroup.recruitee.com
+ScioTeq BV,scioteq,https://scioteq.recruitee.com
+Scrum Ventures,scrumventures,https://scrumventures.recruitee.com
+SeQura,sequra,https://sequra.recruitee.com
+Seven Sons,sevensons,https://sevensons.recruitee.com
+SGB-SMIT Group,sgbsmitgroup,https://sgbsmitgroup.recruitee.com
 shopware AG,shopwareag,https://shopwareag.recruitee.com
-sioux,sioux,https://sioux.recruitee.com
-skinvision1,skinvision1,https://skinvision1.recruitee.com
-skipr,skipr,https://skipr.recruitee.com
-skygeo,skygeo,https://skygeo.recruitee.com
-smarthr,smarthr,https://smarthr.recruitee.com
+Sioux High Tech Software Ltd.,sioux,https://sioux.recruitee.com
+SkinVision,skinvision1,https://skinvision1.recruitee.com
+Skipr,skipr,https://skipr.recruitee.com
+SkyGeo,skygeo,https://skygeo.recruitee.com
+SmartHR,smarthr,https://smarthr.recruitee.com
 smartsupp,smartsupp,https://smartsupp.recruitee.com
-softgames,softgames,https://softgames.recruitee.com
-solidstake,solidstake,https://solidstake.recruitee.com
-speedlinehub,speedlinehub,https://speedlinehub.recruitee.com
+SOFTGAMES,softgames,https://softgames.recruitee.com
+SolidStake,solidstake,https://solidstake.recruitee.com
+SpeedlineHub,speedlinehub,https://speedlinehub.recruitee.com
 spoke,spoke,https://spoke.recruitee.com
-spotlab,spotlab,https://spotlab.recruitee.com
-sqe,sqe,https://sqe.recruitee.com
-sspcs,sspcs,https://sspcs.recruitee.com
-sterlingfabricationtechnology,sterlingfabricationtechnology,https://sterlingfabricationtechnology.recruitee.com
-strategyeng,strategyeng,https://strategyeng.recruitee.com
-studentmedicover,studentmedicover,https://studentmedicover.recruitee.com
+SpotLab,spotlab,https://spotlab.recruitee.com
+S-Quantum Engine,sqe,https://sqe.recruitee.com
+Suspicious Antwerp,sspcs,https://sspcs.recruitee.com
+Sterling Fab Tech,sterlingfabricationtechnology,https://sterlingfabricationtechnology.recruitee.com
+"Strategy Engineering & Consulting, LLC.",strategyeng,https://strategyeng.recruitee.com
+Student Medicover,studentmedicover,https://studentmedicover.recruitee.com
 superlist,superlist,https://superlist.recruitee.com
 surfly,surfly,https://surfly.recruitee.com
-sustainablecomfort,sustainablecomfort,https://sustainablecomfort.recruitee.com
-suttons,suttons,https://suttons.recruitee.com
+Sustainable Comfort Inc,sustainablecomfort,https://sustainablecomfort.recruitee.com
+Sutton's,suttons,https://suttons.recruitee.com
 swisselect ag,swisselect,https://swisselect.recruitee.com
-switchojob,switchojob,https://switchojob.recruitee.com
+Switcho Srl,switchojob,https://switchojob.recruitee.com
 syngenta,syngenta,https://syngenta.recruitee.com
-talentheroesclientats,talentheroesclientats,https://talentheroesclientats.recruitee.com
-taroko,taroko,https://taroko.recruitee.com
+Talent Heroes (client ATS),talentheroesclientats,https://talentheroesclientats.recruitee.com
+Taroko Software,taroko,https://taroko.recruitee.com
 taskus,taskus,https://taskus.recruitee.com
 teccle group GmbH,tecclegroup,https://tecclegroup.recruitee.com
-techbizglobal,techbizglobal,https://techbizglobal.recruitee.com
-technicaelectronics,technicaelectronics,https://technicaelectronics.recruitee.com
+TechBiz Global GmbH,techbizglobal,https://techbizglobal.recruitee.com
+Technica Electronics,technicaelectronics,https://technicaelectronics.recruitee.com
 tensortechnologies,tensortechnologies,https://tensortechnologies.recruitee.com
-tgs,tgs,https://tgs.recruitee.com
-thecodest,thecodest,https://thecodest.recruitee.com
-thejulyhotels,thejulyhotels,https://thejulyhotels.recruitee.com
+TransPerfect,tgs,https://tgs.recruitee.com
+"Codest Ltd. Company No. 12590542, VAT number: GB363431020",thecodest,https://thecodest.recruitee.com
+The July B.V.,thejulyhotels,https://thejulyhotels.recruitee.com
 thepottershouseone1,thepottershouseone1,https://thepottershouseone1.recruitee.com
-thirdway,thirdway,https://thirdway.recruitee.com
+Third Way,thirdway,https://thirdway.recruitee.com
 thorizon,thorizon,https://thorizon.recruitee.com
 tinybeans,tinybeans,https://tinybeans.recruitee.com
 translations,translations,https://translations.recruitee.com
-treasuryspring,treasuryspring,https://treasuryspring.recruitee.com
+TreasurySpring,treasuryspring,https://treasuryspring.recruitee.com
 tuh,tuh,https://tuh.recruitee.com
-unwatch,unwatch,https://unwatch.recruitee.com
+United Nations Watch,unwatch,https://unwatch.recruitee.com
 utrustinsuranceagencyllc,utrustinsuranceagencyllc,https://utrustinsuranceagencyllc.recruitee.com
 valantic NL,ism,https://ism.recruitee.com
-valveandmeter,valveandmeter,https://valveandmeter.recruitee.com
+Valve and Meter,valveandmeter,https://valveandmeter.recruitee.com
 vamatbv,vamatbv,https://vamatbv.recruitee.com
 vandervalk+degroot,vacaturesvandervalk,https://vacaturesvandervalk.recruitee.com
-veratronag,veratronag,https://veratronag.recruitee.com
+Veratron AG,veratronag,https://veratronag.recruitee.com
 vicotx,vicotx,https://vicotx.recruitee.com
-vilgain,vilgain,https://vilgain.recruitee.com
+Vilgain s.r.o.,vilgain,https://vilgain.recruitee.com
 vineyardusa,vineyardusa,https://vineyardusa.recruitee.com
 virtual7 GmbH,virtual7jobs,https://virtual7jobs.recruitee.com
 viryah2,viryah2,https://viryah2.recruitee.com
-vlt,vlt,https://vlt.recruitee.com
-vsparticle,vsparticle,https://vsparticle.recruitee.com
-wassonece,wassonece,https://wassonece.recruitee.com
-waterslakecapital,waterslakecapital,https://waterslakecapital.recruitee.com
-wellsterhealthtechgroup,wellsterhealthtechgroup,https://wellsterhealthtechgroup.recruitee.com
-werkenbijnlr,werkenbijnlr,https://werkenbijnlr.recruitee.com
+VLT,vlt,https://vlt.recruitee.com
+VSPARTICLE B.V.,vsparticle,https://vsparticle.recruitee.com
+Wasson-ECE Instrumentation,wassonece,https://wassonece.recruitee.com
+Waterslake Capital,waterslakecapital,https://waterslakecapital.recruitee.com
+Wellster Healthtech Group,wellsterhealthtechgroup,https://wellsterhealthtechgroup.recruitee.com
+Koninklijk Nederlands Lucht- en Ruimtevaartcentrum,werkenbijnlr,https://werkenbijnlr.recruitee.com
 whiffle,whiffle,https://whiffle.recruitee.com
-whitecoatglobal1,whitecoatglobal1,https://whitecoatglobal1.recruitee.com
-xmco,xmco,https://xmco.recruitee.com
-youngandlaramore,youngandlaramore,https://youngandlaramore.recruitee.com
+WhiteCoat,whitecoatglobal1,https://whitecoatglobal1.recruitee.com
+XMCO,xmco,https://xmco.recruitee.com
+Young & Laramore,youngandlaramore,https://youngandlaramore.recruitee.com
 zackdfilms,zackdfilms,https://zackdfilms.recruitee.com
 Óscala,oscalabv,https://oscalabv.recruitee.com


### PR DESCRIPTION
## Summary
- Replace slug-derived Recruitee display names with `company_name` values from validated offer payloads.
- No rows were removed; all endpoints validated after retrying rate-limited responses.

## Validation
- Audited 841 rows against `{url}/api/offers`.
- Retried all 49 initial `429` responses slowly; all recovered with 200 JSON offer payloads.
- Validation result: 841 retained rows, 0 unresolved bad API responses, 724 boards with jobs, 13,773 jobs counted.
- Final CSV sanity check: 841 rows, no missing fields, no duplicate slugs, no duplicate URLs.
- CSV-only change, so no tests were added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced slug-based Recruitee display names with canonical `company_name` values from validated offer payloads to fix inaccurate or inconsistent company names. Only `ats-companies/recruitee.csv` changed; all 841 entries were validated, rate-limited endpoints were retried, and no rows were removed.

<sup>Written for commit 8b77bbc750c3be172d2b5a36229084a2f214c22f. Summary will update on new commits. <a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/159?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

