### PR TITLE
Fix Recruiterbox company entries

### DIFF
--- a/ats-companies/recruiterbox.csv
+++ b/ats-companies/recruiterbox.csv
@@ -1,64 +1,67 @@
 name,slug,url
-Lattice Technologies Pvt Ltd,1lattice,https://1lattice.recruiterbox.com
+#twiceasnice Recruiting,twonice,https://twonice.recruiterbox.com
 2 WorkOnline,2workonline1,https://2workonline1.recruiterbox.com
-Alameda County Community Food Bank,accfb,https://accfb.recruiterbox.com
 Adgistics Ltd.,adgistics,https://adgistics.recruiterbox.com
 Adidev Technologies Inc,adidevtechnologies,https://adidevtechnologies.recruiterbox.com
 Advanced Solutions International,advsol,https://advsol.recruiterbox.com
-Aerosonic,aerosonic,https://aerosonic.recruiterbox.com
+Advertising Production Resources,aprco,https://aprco.recruiterbox.com
 AE Works,aeworks,https://aeworks.recruiterbox.com
+Aerosonic,aerosonic,https://aerosonic.recruiterbox.com
 Agila Documents Clearing Services LLC,agila,https://agila.recruiterbox.com
 Aixial Group,aixialgroup,https://aixialgroup.recruiterbox.com
-American Jewish Committee,ajc,https://ajc.recruiterbox.com
 Ajob,ajob,https://ajob.recruiterbox.com
+Alameda County Community Food Bank,accfb,https://accfb.recruiterbox.com
 ALICE + OLIVIA,aliceandolivia,https://aliceandolivia.recruiterbox.com
 alignable,alignable,https://alignable.hire.trakstar.com
 Alleghany Health,alleghanyhealth,https://alleghanyhealth.recruiterbox.com
 Allen Online,allendigital,https://allendigital.recruiterbox.com
 AlphaSights,alphasights,https://alphasights.recruiterbox.com
 Alvine,alvine,https://alvine.recruiterbox.com
+American Jewish Committee,ajc,https://ajc.recruiterbox.com
 American University In the Emirates (AUE),americanuniversity,https://americanuniversity.recruiterbox.com
 Anchorfree,anchorfree,https://anchorfree.recruiterbox.com
+Andel Star,hertzdollarthriftyrd,https://hertzdollarthriftyrd.recruiterbox.com
 Anduin Transactions,anduin,https://anduin.recruiterbox.com
-Advertising Production Resources,aprco,https://aprco.recruiterbox.com
 Aquila Software Group,aquilasw,https://aquilasw.recruiterbox.com
 "Ardent Learning, Inc.",ardentlearninginc,https://ardentlearninginc.recruiterbox.com
 "Ascella Technologies, Inc.",ascellatech,https://ascellatech.recruiterbox.com
 Athlete Lab,athlete,https://athlete.recruiterbox.com
-Avaaz,avaaz,https://avaaz.recruiterbox.com
 Ava Community Energy,avaenergy,https://avaenergy.recruiterbox.com
-Servicolt,avisbudgetpaylessrd,https://avisbudgetpaylessrd.recruiterbox.com
+Avaaz,avaaz,https://avaaz.recruiterbox.com
 Babbel,babbellonian,https://babbellonian.recruiterbox.com
+Barbarian,wearebarbarian,https://wearebarbarian.recruiterbox.com
 Bennington College,bennington,https://bennington.recruiterbox.com
+Berman Sobin Gross LLP,bsglaw,https://bsglaw.recruiterbox.com
 "Bionews, Inc.",bionews,https://bionews.recruiterbox.com
 BookMyShow,bookmyshow,https://bookmyshow.recruiterbox.com
 BRAC INTERNATIONAL,bracinternational,https://bracinternational.recruiterbox.com
 "Brudis & Associates, Inc.",brudis,https://brudis.recruiterbox.com
-Berman Sobin Gross LLP,bsglaw,https://bsglaw.recruiterbox.com
-CARE S.A. (Cactus shoppi),cactusshoppi,https://cactusshoppi.recruiterbox.com
 Caixa Mágica Software,caixamagica,https://caixamagica.recruiterbox.com
 "Cambridge Computer Services, Inc",cambridgecomputer,https://cambridgecomputer.recruiterbox.com
 cambrio,cambrio,https://cambrio.recruiterbox.com
+CARE S.A. (Cactus shoppi),cactusshoppi,https://cactusshoppi.recruiterbox.com
 CaribbeanCatalyst,caribbeancatalyst,https://caribbeancatalyst.recruiterbox.com
 Cassaday & Company,cassaday,https://cassaday.recruiterbox.com
 "Celtra, Inc.",celtra,https://celtra.recruiterbox.com
+Certas Energy Luxembourg sàrl,petrodiff,https://petrodiff.recruiterbox.com
 chartcube,chartcube,https://chartcube.hire.trakstar.com
 Cheesecake Labs,cheesecakelabs,https://cheesecakelabs.recruiterbox.com
 Chilindo,chilindo,https://chilindo.recruiterbox.com
+"City of Conyers, GA",conyersga,https://conyersga.recruiterbox.com
 Classe365,classe365,https://classe365.recruiterbox.com
+Clean Power Finance,mkearney,https://mkearney.recruiterbox.com
 Cleanreturns,cleanreturns,https://cleanreturns.recruiterbox.com
 Climate Action Campaign,climateactioncampaign,https://climateactioncampaign.recruiterbox.com
 CMR University,cmruni,https://cmruni.recruiterbox.com
 Commsignia,commsignia,https://commsignia.recruiterbox.com
-"City of Conyers, GA",conyersga,https://conyersga.recruiterbox.com
 CrelioHealth,creliohealth,https://creliohealth.recruiterbox.com
 crowdhouse,crowdhouse,https://crowdhouse.hire.trakstar.com
 Crystal Knows,crystalknows,https://crystalknows.recruiterbox.com
+D&L Electric,dlelectric,https://dlelectric.recruiterbox.com
 Datawords,datawords,https://datawords.recruiterbox.com
 Decathlon China,decathlonchina,https://decathlonchina.recruiterbox.com
 Dekoit,dekoit,https://dekoit.recruiterbox.com
 Dito,dito,https://dito.recruiterbox.com
-D&L Electric,dlelectric,https://dlelectric.recruiterbox.com
 DN Capital,dncapital,https://dncapital.recruiterbox.com
 doyouconvert.com,doyouconvert,https://doyouconvert.recruiterbox.com
 Dream11 Inc.,dream11,https://dream11.recruiterbox.com
@@ -66,26 +69,27 @@ Dreamclinic Massage & Acupuncture,dreamclinic84937,https://dreamclinic84937.recr
 Drip Capital,dripcapital,https://dripcapital.recruiterbox.com
 driveai,driveai,https://driveai.hire.trakstar.com
 Dyverse,dyversemarketing,https://dyversemarketing.recruiterbox.com
-eagleandfox,eagleandfox,https://eagleandfox.hire.trakstar.com
 "Eagle Technologies, Inc.",eagletechva,https://eagletechva.recruiterbox.com
+eagleandfox,eagleandfox,https://eagleandfox.hire.trakstar.com
 Easebuzz Pvt Ltd,easebuzz,https://easebuzz.recruiterbox.com
 ECM Energy Services,ecmenergy,https://ecmenergy.recruiterbox.com
 eGovernments Foundation,egovernments,https://egovernments.recruiterbox.com
 Ellenoff Grossman and Schole LLP,egsllp,https://egsllp.recruiterbox.com
 Elliott-Lewis | Sautter Crane | AA Duckett,elliottlewis,https://elliottlewis.recruiterbox.com
+enFocus,enfocus,https://enfocus.hire.trakstar.com
 Enterprise Knowledge LLC,enterpriseknowledge,https://enterpriseknowledge.recruiterbox.com
 Eridanis,eridanis,https://eridanis.recruiterbox.com
 Exotel Techcom Pvt Ltd,exotel,https://exotel.recruiterbox.com
-Oakland Children's Fairyland,fairyland,https://fairyland.recruiterbox.com
-First Baptist Church of Rogers,fbcrogers,https://fbcrogers.recruiterbox.com
-Franklin County Memorial Hospital,fcmh,https://fcmh.recruiterbox.com
 Finario,finario,https://finario.recruiterbox.com
 Firespring,firespring,https://firespring.recruiterbox.com
+First American Insurance Underwriters,faiu,https://faiu.hire.trakstar.com
+First Baptist Church of Rogers,fbcrogers,https://fbcrogers.recruiterbox.com
 Fitfyles LLP,fitfyles,https://fitfyles.recruiterbox.com
 Foodora Italia,foodoraitalia,https://foodoraitalia.recruiterbox.com
 Football Radar,footballradar,https://footballradar.recruiterbox.com
 Forge Performance Group,forgeperform,https://forgeperform.recruiterbox.com
 Forthright Staffing By Dion,forthright,https://forthright.recruiterbox.com
+Franklin County Memorial Hospital,fcmh,https://fcmh.recruiterbox.com
 Freestone Property Group,freestonepg,https://freestonepg.recruiterbox.com
 Frontline Managed Services,frontlinems,https://frontlinems.recruiterbox.com
 Gestionline,gestionline,https://gestionline.recruiterbox.com
@@ -98,7 +102,6 @@ HappyFox,happyfox,https://happyfox.recruiterbox.com
 Headline Media,headlinemedia,https://headlinemedia.recruiterbox.com
 Healthix,healthix,https://healthix.recruiterbox.com
 helpshift,helpshift,https://helpshift.hire.trakstar.com
-Andel Star,hertzdollarthriftyrd,https://hertzdollarthriftyrd.recruiterbox.com
 "Holloway Sportswear, Inc.",holloway,https://holloway.recruiterbox.com
 home,home,https://home.recruiterbox.com
 Hudson's Furniture,hudsonsfurniturecareers,https://hudsonsfurniturecareers.recruiterbox.com
@@ -122,18 +125,20 @@ Kingsmill Resort,kingsmill,https://kingsmill.recruiterbox.com
 KLB Group,klbgroup1,https://klbgroup1.recruiterbox.com
 Kyosk Digital Services,kyosk,https://kyosk.recruiterbox.com
 Ladybird Web Solution Pvt Ltd,ladybird,https://ladybird.recruiterbox.com
+Laird Norton Wetherby,lnwadvisors,https://lnwadvisors.recruiterbox.com
 Lakepointe Church,lakepointe,https://lakepointe.recruiterbox.com
 lambda3,lambda3,https://lambda3.recruiterbox.com
+Lattice Technologies Pvt Ltd,1lattice,https://1lattice.recruiterbox.com
 LEAMS Education Services (Gamma Holdings LLC.),leamseducation,https://leamseducation.recruiterbox.com
 Les Petits Riens | Spullenhulp,lespetitsriens,https://lespetitsriens.recruiterbox.com
 LMN,lmnarchitects,https://lmnarchitects.recruiterbox.com
-Laird Norton Wetherby,lnwadvisors,https://lnwadvisors.recruiterbox.com
 "Lodestar Consulting, Inc.",lodestar,https://lodestar.recruiterbox.com
 LogiNext,loginext,https://loginext.recruiterbox.com
+Lucid Private Offices,worksuites,https://worksuites.recruiterbox.com
 Lummo (Formerly Bukukas),lummo,https://lummo.recruiterbox.com
-The Lutheran World Federation,lutheranworld,https://lutheranworld.recruiterbox.com
-MAİSON DE MAA KOZMETİK SANAYİ VE DIŞ TİCARET LİMİT,maalthahb,https://maalthahb.recruiterbox.com
+M.M. LaFleur,mmlafleur,https://mmlafleur.recruiterbox.com
 madebymany,madebymany,https://madebymany.hire.trakstar.com
+MAİSON DE MAA KOZMETİK SANAYİ VE DIŞ TİCARET LİMİT,maalthahb,https://maalthahb.recruiterbox.com
 MediBuddy,medibuddy,https://medibuddy.recruiterbox.com
 Mekari (PT. Mid Solusi Nusantara),mekari,https://mekari.recruiterbox.com
 Mercana,mercana,https://mercana.recruiterbox.com
@@ -141,13 +146,12 @@ Mercycorps69469,mercycorps69469,https://mercycorps69469.recruiterbox.com
 mgm technology partners,mgmtp,https://mgmtp.recruiterbox.com
 Midea,midea,https://midea.recruiterbox.com
 Mind Games,mindgames,https://mindgames.recruiterbox.com
-Clean Power Finance,mkearney,https://mkearney.recruiterbox.com
-M.M. LaFleur,mmlafleur,https://mmlafleur.recruiterbox.com
 MoEngage Inc,moengage,https://moengage.recruiterbox.com
 mordorintelligence,mordorintelligence,https://mordorintelligence.recruiterbox.com
 MPower Direct,mpowerdirect,https://mpowerdirect.recruiterbox.com
 myAgro Farms,myagro,https://myagro.recruiterbox.com
 naseba,naseba,https://naseba.recruiterbox.com
+National Parks Conservation Association,npca,https://npca.recruiterbox.com
 Native,native,https://native.recruiterbox.com
 nebb,nebb,https://nebb.recruiterbox.com
 Nemetschek OOD Bulgaria,nemetschek,https://nemetschek.recruiterbox.com
@@ -155,22 +159,23 @@ NeoPollard Interactive,neopollard,https://neopollard.recruiterbox.com
 "Neptune.io, Inc.",neptuneio,https://neptuneio.recruiterbox.com
 New Age Technologies,newat,https://newat.recruiterbox.com
 New Mexico Admin Office of the District Attorneys,nmdas,https://nmdas.recruiterbox.com
-National Parks Conservation Association,npca,https://npca.recruiterbox.com
+North American Bancard,merchantservices,https://merchantservices.hire.trakstar.com
+Oakland Children's Fairyland,fairyland,https://fairyland.recruiterbox.com
 Ocient Inc.,ocient,https://ocient.recruiterbox.com
 ONeil Interactive,oneilinteractive,https://oneilinteractive.recruiterbox.com
+P. F. Chang´s,pfchangsrd,https://pfchangsrd.recruiterbox.com
 PerBlue,perblue,https://perblue.recruiterbox.com
 Perfect Audience,perfectaudience,https://perfectaudience.recruiterbox.com
-Certas Energy Luxembourg sàrl,petrodiff,https://petrodiff.recruiterbox.com
-P. F. Chang´s,pfchangsrd,https://pfchangsrd.recruiterbox.com
+PharmEng Technology,pharmeng,https://pharmeng.hire.trakstar.com
 Planate Management Group,planate,https://planate.recruiterbox.com
 Planet Beauty,planetbeauty,https://planetbeauty.recruiterbox.com
-Sentinel Dock & Door Solutions,prodoor,https://prodoor.recruiterbox.com
 Property Masters,propertymasters,https://propertymasters.recruiterbox.com
 Providence Engineering,proveng,https://proveng.recruiterbox.com
 psyoptions,psyoptions,https://psyoptions.recruiterbox.com
 Purecars,purecars,https://purecars.recruiterbox.com
 Quartus Engineering,quartus,https://quartus.recruiterbox.com
 redbranch,redbranch,https://redbranch.hire.trakstar.com
+Regenified,regenified,https://regenified.hire.trakstar.com
 Registrar Corp,registrarcorp,https://registrarcorp.recruiterbox.com
 Relevate Health,relevatehealth,https://relevatehealth.recruiterbox.com
 Renewal by Andersen,renewalcarolinas,https://renewalcarolinas.recruiterbox.com
@@ -186,16 +191,20 @@ Saje Natural Wellness | Retail,sajenaturalwellnessretail,https://sajenaturalwell
 SCIS-HIS,scishis,https://scishis.recruiterbox.com
 Selerix,selerix,https://selerix.recruiterbox.com
 Sensedia,sensedia,https://sensedia.recruiterbox.com
+Sentinel Dock & Door Solutions,prodoor,https://prodoor.recruiterbox.com
+Servicolt,avisbudgetpaylessrd,https://avisbudgetpaylessrd.recruiterbox.com
 Shanti Recruitment Agency Co. Ltd Mauritius,shantirecruitment,https://shantirecruitment.recruiterbox.com
 sharechat,sharechat,https://sharechat.recruiterbox.com
 Sigmabit,sigmabit,https://sigmabit.recruiterbox.com
 Simple Energy,simpleenergy,https://simpleenergy.recruiterbox.com
+"SITECAST SOLUTIONS & TECHNOLOGY, LLC",sitecastsolutions,https://sitecastsolutions.hire.trakstar.com
 SMART Technologies,smarttechnologies,https://smarttechnologies.recruiterbox.com
 Smoke,smoketest,https://smoketest.recruiterbox.com
 "Solari Enterprises, Inc.",solarient,https://solarient.recruiterbox.com
+SSG,strategicsolutions,https://strategicsolutions.recruiterbox.com
 Stealth Startup,stealthstartup,https://stealthstartup.recruiterbox.com
 Stop Net Services,stopnetservices,https://stopnetservices.recruiterbox.com
-SSG,strategicsolutions,https://strategicsolutions.recruiterbox.com
+Stratpoint Technologies,stratpoint,https://stratpoint.hire.trakstar.com
 Synergenhealth,synergenhealth,https://synergenhealth.recruiterbox.com
 "SystemOne, LLC",systemone,https://systemone.recruiterbox.com
 "TakeCare Insurance Company, Inc.",takecareinsurance,https://takecareinsurance.recruiterbox.com
@@ -208,6 +217,8 @@ Test Double,testdouble,https://testdouble.recruiterbox.com
 testhuset,testhuset,https://testhuset.recruiterbox.com
 Thalle Construction Company,thalle,https://thalle.recruiterbox.com
 The Bush School,thebushschool,https://thebushschool.recruiterbox.com
+The California Wellness Foundation,calwellness79804,https://calwellness79804.hire.trakstar.com
+The Lutheran World Federation,lutheranworld,https://lutheranworld.recruiterbox.com
 Therap (BD) Ltd.,therap,https://therap.recruiterbox.com
 Times Square Alliance,timessquarenyc,https://timessquarenyc.recruiterbox.com
 Togetherall,togetherall,https://togetherall.recruiterbox.com
@@ -216,17 +227,14 @@ Tookitaki Holding PTE LTD,tookitaki78808,https://tookitaki78808.recruiterbox.com
 Trakstar,trakstar,https://trakstar.recruiterbox.com
 Trickle Up,trickleup,https://trickleup.recruiterbox.com
 Trusting Social & Kompato AI,trustingsocial,https://trustingsocial.recruiterbox.com
-#twiceasnice Recruiting,twonice,https://twonice.recruiterbox.com
-University Growth Fund,ugrowthfund,https://ugrowthfund.recruiterbox.com
 UK Courtesans,ukcourtesans,https://ukcourtesans.recruiterbox.com
-Tokka Labs,vegasolutions,https://vegasolutions.recruiterbox.com
+University Growth Fund,ugrowthfund,https://ugrowthfund.recruiterbox.com
 Veritas Press,veritaspress,https://veritaspress.recruiterbox.com
 Viaconseil,viaconseil,https://viaconseil.recruiterbox.com
 Viking Cruises US,vikingcruises,https://vikingcruises.recruiterbox.com
 Wandoo Finance Group,wandoo,https://wandoo.recruiterbox.com
 WattTime,watttime,https://watttime.recruiterbox.com
-World Council of Churches,wcccoe,https://wcccoe.recruiterbox.com
-Barbarian,wearebarbarian,https://wearebarbarian.recruiterbox.com
+Western Turnpike Rescue Squad,wtrs,https://wtrs.recruiterbox.com
 WeWork India,weworkindia,https://weworkindia.recruiterbox.com
 Whatfix,whatfix101,https://whatfix101.recruiterbox.com
 Windrose Staffing,windrosestaffing,https://windrosestaffing.recruiterbox.com
@@ -234,8 +242,7 @@ Wired YBP Radio,wiredybpradio,https://wiredybpradio.recruiterbox.com
 Witekio,witekio,https://witekio.recruiterbox.com
 Wolfram,wolframresearch,https://wolframresearch.recruiterbox.com
 Workforce Source,workforcesource,https://workforcesource.recruiterbox.com
-Lucid Private Offices,worksuites,https://worksuites.recruiterbox.com
-Western Turnpike Rescue Squad,wtrs,https://wtrs.recruiterbox.com
+World Council of Churches,wcccoe,https://wcccoe.recruiterbox.com
 Xideral,xideral,https://xideral.recruiterbox.com
 XS Telecom,xstelecom,https://xstelecom.recruiterbox.com
 Yeled v'Yalda,yeledvyalda,https://yeledvyalda.recruiterbox.com


### PR DESCRIPTION
## Summary
- Normalize Recruiterbox/Trakstar entries to actual company names from validated board page titles.
- Canonicalize board URLs to the active `hire.trakstar.com` company boards where the old Recruiterbox host redirects.
- Add validated boards for The California Wellness Foundation and SiteCast Solutions & Technology.
- Remove invalid tenants that fail the public Recruiterbox API/page validation.

## Validation
- Recruiterbox API validation: kept 246 valid tenants; removed invalid slugs `cashfree`, `codehs`, `olark`, `scopicsoftware`, and `testbook`.
- URL validation: checked every final CSV URL; 246 checked, 0 bad.
- CSV check: no duplicate slugs, no duplicate URLs, required fields present.
- `uv run pytest tests/test_recruiterbox.py tests/test_run_pipeline_guards.py -q` -> 26 passed.