### PR TITLE
Fix Pinpoint company entries

### DIFF
--- a/ats-companies/pinpoint.csv
+++ b/ats-companies/pinpoint.csv
@@ -220,6 +220,7 @@ Peninsula,peninsula360,https://peninsula360.pinpointhq.com
 Penrose Health,penrosehealth,https://penrosehealth.pinpointhq.com
 PEX,pexcard,https://pexcard.pinpointhq.com
 Pinnacle Bank/Bank of Colorado,pinnbank,https://pinnbank.pinpointhq.com
+Pinpoint,workwithus,https://workwithus.pinpointhq.com
 PipeDreams,pipedreams,https://pipedreams.pinpointhq.com
 Pipeworks Studios,pipeworks,https://pipeworks.pinpointhq.com
 Pod,pod-point,https://pod-point.pinpointhq.com
@@ -275,6 +276,7 @@ Superside: Your creative team’s creative team™,superside,https://superside.p
 Surgo Health,surgohealth,https://surgohealth.pinpointhq.com
 Systematica Investments,systematica,https://systematica.pinpointhq.com
 Tabby,tabby,https://tabby.pinpointhq.com
+Tata Chemicals Europe,tatachemicals,https://tatachemicals.pinpointhq.com
 Teacher Apprenticeship Network,teacherapprenticeship,https://teacherapprenticeship.pinpointhq.com
 "Teaching Strategies, LLC",teaching-strategies,https://teaching-strategies.pinpointhq.com
 TeachMichigan,teachmichigan,https://teachmichigan.pinpointhq.com

--- a/ats-companies/pinpoint.csv
+++ b/ats-companies/pinpoint.csv
@@ -1,354 +1,329 @@
 name,slug,url
-aawdc,aawdc,https://aawdc.pinpointhq.com
-accenture,accenture,https://accenture.pinpointhq.com
-aciedge,aciedge,https://aciedge.pinpointhq.com
-acme,acme,https://acme.pinpointhq.com
-acrobat,acrobat,https://acrobat.pinpointhq.com
-actica,actica,https://actica.pinpointhq.com
-adaptix,adaptix,https://adaptix.pinpointhq.com
-adblock,adblock,https://adblock.pinpointhq.com
-admgroup,admgroup,https://admgroup.pinpointhq.com
-advitaortho,advitaortho,https://advitaortho.pinpointhq.com
-aeriz,aeriz,https://aeriz.pinpointhq.com
-agencyanalytics,agencyanalytics,https://agencyanalytics.pinpointhq.com
-aireon,aireon,https://aireon.pinpointhq.com
-airtanker,airtanker,https://airtanker.pinpointhq.com
-alcumus,alcumus,https://alcumus.pinpointhq.com
-algomarketing,algomarketing,https://algomarketing.pinpointhq.com
-alliedtalentpartners,alliedtalentpartners,https://alliedtalentpartners.pinpointhq.com
-americanveterinarygroup,americanveterinarygroup,https://americanveterinarygroup.pinpointhq.com
-anthesisgroup,anthesisgroup,https://anthesisgroup.pinpointhq.com
-anthonycollins,anthonycollins,https://anthonycollins.pinpointhq.com
-apd,apd,https://apd.pinpointhq.com
-apollo,apollo,https://apollo.pinpointhq.com
-appquantum,appquantum,https://appquantum.pinpointhq.com
-aria,aria,https://aria.pinpointhq.com
-arkatechture,arkatechture,https://arkatechture.pinpointhq.com
-armis,armis,https://armis.pinpointhq.com
-arrowglobal,arrowglobal,https://arrowglobal.pinpointhq.com
-arthurcox,arthurcox,https://arthurcox.pinpointhq.com
-article,article,https://article.pinpointhq.com
-asc-es-reliable,asc-es-reliable,https://asc-es-reliable.pinpointhq.com
-astorg,astorg,https://astorg.pinpointhq.com
-astranahealth,astranahealth,https://astranahealth.pinpointhq.com
-astrolab,astrolab,https://astrolab.pinpointhq.com
-auroraer,auroraer,https://auroraer.pinpointhq.com
-bactobio,bactobio,https://bactobio.pinpointhq.com
-barnetsouthgate,barnetsouthgate,https://barnetsouthgate.pinpointhq.com
-bathcollege,bathcollege,https://bathcollege.pinpointhq.com
-bathspa,bathspa,https://bathspa.pinpointhq.com
-bdoireland,bdoireland,https://bdoireland.pinpointhq.com
-bedegaming,bedegaming,https://bedegaming.pinpointhq.com
-betterlesson,betterlesson,https://betterlesson.pinpointhq.com
-bighatbiosciences,bighatbiosciences,https://bighatbiosciences.pinpointhq.com
-bluemantis,bluemantis,https://bluemantis.pinpointhq.com
-bluestreamfiber,bluestreamfiber,https://bluestreamfiber.pinpointhq.com
-bluon,bluon,https://bluon.pinpointhq.com
-bmt,bmt,https://bmt.pinpointhq.com
-bsr,bsr,https://bsr.pinpointhq.com
-btny,btny,https://btny.pinpointhq.com
-buildarocketboy,buildarocketboy,https://buildarocketboy.pinpointhq.com
-calligo,calligo,https://calligo.pinpointhq.com
-carma,carma,https://carma.pinpointhq.com
-carmel,carmel,https://carmel.pinpointhq.com
-carto,carto,https://carto.pinpointhq.com
-cdlsoftware,cdlsoftware,https://cdlsoftware.pinpointhq.com
-celnor,celnor,https://celnor.pinpointhq.com
-certn,certn,https://certn.pinpointhq.com
-cfc,cfc,https://cfc.pinpointhq.com
-cfcunderwriting,cfcunderwriting,https://cfcunderwriting.pinpointhq.com
-cfra,cfra,https://cfra.pinpointhq.com
-cgt,cgt,https://cgt.pinpointhq.com
-chetwood-bank,chetwood-bank,https://chetwood-bank.pinpointhq.com
-cinven,cinven,https://cinven.pinpointhq.com
-clareps,clareps,https://clareps.pinpointhq.com
-clearlyrated,clearlyrated,https://clearlyrated.pinpointhq.com
-climatebonds,climatebonds,https://climatebonds.pinpointhq.com
-cmap,cmap,https://cmap.pinpointhq.com
-codexis,codexis,https://codexis.pinpointhq.com
-coforma,coforma,https://coforma.pinpointhq.com
-colegsirgar,colegsirgar,https://colegsirgar.pinpointhq.com
-company,company,https://company.pinpointhq.com
-compasshealthnetwork,compasshealthnetwork,https://compasshealthnetwork.pinpointhq.com
-compregroup,compregroup,https://compregroup.pinpointhq.com
-confluence,confluence,https://confluence.pinpointhq.com
-continentalserves,continentalserves,https://continentalserves.pinpointhq.com
-convexin,convexin,https://convexin.pinpointhq.com
-conveylaw,conveylaw,https://conveylaw.pinpointhq.com
-coopereyecare,coopereyecare,https://coopereyecare.pinpointhq.com
-cottonholdings,cottonholdings,https://cottonholdings.pinpointhq.com
-coursedog,coursedog,https://coursedog.pinpointhq.com
-covers,covers,https://covers.pinpointhq.com
-cpcatapult,cpcatapult,https://cpcatapult.pinpointhq.com
-crawfordtech,crawfordtech,https://crawfordtech.pinpointhq.com
-ctidigital,ctidigital,https://ctidigital.pinpointhq.com
-ctrl,ctrl,https://ctrl.pinpointhq.com
-cybernetic-controls,cybernetic-controls,https://cybernetic-controls.pinpointhq.com
-d1a,d1a,https://d1a.pinpointhq.com
-davies,davies,https://davies.pinpointhq.com
-db1group,db1group,https://db1group.pinpointhq.com
-dea,dea,https://dea.pinpointhq.com
-desmos,desmos,https://desmos.pinpointhq.com
-developers-test,developers-test,https://developers-test.pinpointhq.com
-digitalscience,digitalscience,https://digitalscience.pinpointhq.com
-dixonwilson,dixonwilson,https://dixonwilson.pinpointhq.com
-dmchealthcare,dmchealthcare,https://dmchealthcare.pinpointhq.com
-doradosoftwaregroup,doradosoftwaregroup,https://doradosoftwaregroup.pinpointhq.com
-eastlandsvsl,eastlandsvsl,https://eastlandsvsl.pinpointhq.com
-ebcap,ebcap,https://ebcap.pinpointhq.com
-eberjey,eberjey,https://eberjey.pinpointhq.com
-ebiquity,ebiquity,https://ebiquity.pinpointhq.com
-elevategroup,elevategroup,https://elevategroup.pinpointhq.com
-elliptic,elliptic,https://elliptic.pinpointhq.com
-embark,embark,https://embark.pinpointhq.com
-emeraldtransformer,emeraldtransformer,https://emeraldtransformer.pinpointhq.com
-enablemedicine,enablemedicine,https://enablemedicine.pinpointhq.com
-endsight,endsight,https://endsight.pinpointhq.com
-enosisbd,enosisbd,https://enosisbd.pinpointhq.com
-eptura,eptura,https://eptura.pinpointhq.com
-epuki,epuki,https://epuki.pinpointhq.com
-esland,esland,https://esland.pinpointhq.com
-estalent,estalent,https://estalent.pinpointhq.com
-eventbase,eventbase,https://eventbase.pinpointhq.com
-everi,everi,https://everi.pinpointhq.com
+Accenture,accenture,https://accenture.pinpointhq.com
+ACME candidate 1,acme,https://acme.pinpointhq.com
+Acrobat Talent,acrobat,https://acrobat.pinpointhq.com
+Actica Consulting,actica,https://actica.pinpointhq.com
+Adaptix,adaptix,https://adaptix.pinpointhq.com
+adm-Indicia,admgroup,https://admgroup.pinpointhq.com
+Advita Ortho,advitaortho,https://advitaortho.pinpointhq.com
+Aeriz,aeriz,https://aeriz.pinpointhq.com
+AgencyAnalytics,agencyanalytics,https://agencyanalytics.pinpointhq.com
+Aireon,aireon,https://aireon.pinpointhq.com
+AirTanker,airtanker,https://airtanker.pinpointhq.com
+Algomarketing®,algomarketing,https://algomarketing.pinpointhq.com
+Allied Talent Partners,alliedtalentpartners,https://alliedtalentpartners.pinpointhq.com
+American Veterinary Group,americanveterinarygroup,https://americanveterinarygroup.pinpointhq.com
+Anne Arundel Workforce Development Corporation (AAWDC),aawdc,https://aawdc.pinpointhq.com
+Anthesis Group,anthesisgroup,https://anthesisgroup.pinpointhq.com
+Anthony Collins,anthonycollins,https://anthonycollins.pinpointhq.com
+"APD Engineering & Architecture, PLLC",apd,https://apd.pinpointhq.com
+Apollo,apollo,https://apollo.pinpointhq.com
+AppQuantum,appquantum,https://appquantum.pinpointhq.com
+ARIA,aria,https://aria.pinpointhq.com
+Arkatechture,arkatechture,https://arkatechture.pinpointhq.com
+Armis,armis,https://armis.pinpointhq.com
+Arrow Global Group,arrowglobal,https://arrowglobal.pinpointhq.com
+Arthur Cox,arthurcox,https://arthurcox.pinpointhq.com
+Article,article,https://article.pinpointhq.com
+ASC Engineered Solutions,asc-es-reliable,https://asc-es-reliable.pinpointhq.com
+Astorg,astorg,https://astorg.pinpointhq.com
+"Astrana Health, Inc.",astranahealth,https://astranahealth.pinpointhq.com
+Astrolab,astrolab,https://astrolab.pinpointhq.com
+Augustine Consulting Inc.,aciedge,https://aciedge.pinpointhq.com
+Aurora Energy Research,auroraer,https://auroraer.pinpointhq.com
+Bactobio,bactobio,https://bactobio.pinpointhq.com
+Barnet and Southgate College,barnetsouthgate,https://barnetsouthgate.pinpointhq.com
+Bath College,bathcollege,https://bathcollege.pinpointhq.com
+Bath Spa University,bathspa,https://bathspa.pinpointhq.com
+BDO Ireland,bdoireland,https://bdoireland.pinpointhq.com
+Bede Gaming,bedegaming,https://bedegaming.pinpointhq.com
+BigHat Biosciences,bighatbiosciences,https://bighatbiosciences.pinpointhq.com
+Blue Mantis,bluemantis,https://bluemantis.pinpointhq.com
+Blue Stream Fiber,bluestreamfiber,https://bluestreamfiber.pinpointhq.com
+BMT,bmt,https://bmt.pinpointhq.com
+Breakthrough New York,btny,https://btny.pinpointhq.com
+British Society for Rheumatology,bsr,https://bsr.pinpointhq.com
+Build A Rocket Boy,buildarocketboy,https://buildarocketboy.pinpointhq.com
+Calligo,calligo,https://calligo.pinpointhq.com
+Careers at Knack,knack,https://knack.pinpointhq.com
+Carma,carma,https://carma.pinpointhq.com
+Carmel College,carmel,https://carmel.pinpointhq.com
+CARTO,carto,https://carto.pinpointhq.com
+CDL Software,cdlsoftware,https://cdlsoftware.pinpointhq.com
+Celnor,celnor,https://celnor.pinpointhq.com
+Centellic,lbresearch,https://lbresearch.pinpointhq.com
+CFC,cfc,https://cfc.pinpointhq.com
+CFRA Research,cfra,https://cfra.pinpointhq.com
+CGT U.S. Limited,cgt,https://cgt.pinpointhq.com
+Chetwood Bank,chetwood-bank,https://chetwood-bank.pinpointhq.com
+Chuck Latham Associates,clareps,https://clareps.pinpointhq.com
+Cinven,cinven,https://cinven.pinpointhq.com
+ClearlyRated,clearlyrated,https://clearlyrated.pinpointhq.com
+Climate Bonds Initiative,climatebonds,https://climatebonds.pinpointhq.com
+CMap,cmap,https://cmap.pinpointhq.com
+Codexis Inc,codexis,https://codexis.pinpointhq.com
+Coforma,coforma,https://coforma.pinpointhq.com
+Coleg Sir Gâr and Coleg Ceredigion,colegsirgar,https://colegsirgar.pinpointhq.com
+Columbia Safety & Supply Family of Companies,gmesupply,https://gmesupply.pinpointhq.com
+Company,company,https://company.pinpointhq.com
+Compass Health Network,compasshealthnetwork,https://compasshealthnetwork.pinpointhq.com
+Compre Group,compregroup,https://compregroup.pinpointhq.com
+Confluence Technologies,confluence,https://confluence.pinpointhq.com
+Connected Places Catapult,cpcatapult,https://cpcatapult.pinpointhq.com
+Continental Services,continentalserves,https://continentalserves.pinpointhq.com
+Convex Insurance,convexin,https://convexin.pinpointhq.com
+Convey Law,conveylaw,https://conveylaw.pinpointhq.com
+Cotton Holdings,cottonholdings,https://cottonholdings.pinpointhq.com
+Coursedog,coursedog,https://coursedog.pinpointhq.com
+Crawford Technologies,crawfordtech,https://crawfordtech.pinpointhq.com
+CTI Digital,ctidigital,https://ctidigital.pinpointhq.com
+Current job openings - Wagepoint,wagepoint,https://wagepoint.pinpointhq.com
+Cybernetic Controls Limited,cybernetic-controls,https://cybernetic-controls.pinpointhq.com
+Davies,davies,https://davies.pinpointhq.com
+Day One Agency,d1a,https://d1a.pinpointhq.com
+DB1,db1group,https://db1group.pinpointhq.com
+DEA Aviation Ltd,dea,https://dea.pinpointhq.com
+Default,instantimpactrecruitment,https://instantimpactrecruitment.pinpointhq.com
+Desmos Studio PBC,desmos,https://desmos.pinpointhq.com
+Developer Acme,developers-test,https://developers-test.pinpointhq.com
+Digital Science,digitalscience,https://digitalscience.pinpointhq.com
+Discover What Life at Elliptic is Like & View Our Vacancies,elliptic,https://elliptic.pinpointhq.com
+Dixon Wilson,dixonwilson,https://dixonwilson.pinpointhq.com
+DMC Healthcare,dmchealthcare,https://dmchealthcare.pinpointhq.com
+East Bay Community Action Program,ebcap,https://ebcap.pinpointhq.com
+Eastlands Venue Services Limited,eastlandsvsl,https://eastlandsvsl.pinpointhq.com
+Eberjey,eberjey,https://eberjey.pinpointhq.com
+Ebiquity,ebiquity,https://ebiquity.pinpointhq.com
+Elevate Group,elevategroup,https://elevategroup.pinpointhq.com
+Embark Student Corp.,embark,https://embark.pinpointhq.com
+Emerald Transformer,emeraldtransformer,https://emeraldtransformer.pinpointhq.com
+Endsight,endsight,https://endsight.pinpointhq.com
+Enosis Solutions,enosisbd,https://enosisbd.pinpointhq.com
+Eptura,eptura,https://eptura.pinpointhq.com
+ES Talent Management,estalent,https://estalent.pinpointhq.com
+Esland,esland,https://esland.pinpointhq.com
+Eventbase Technology,eventbase,https://eventbase.pinpointhq.com
 exclaimer,exclaimer,https://exclaimer.pinpointhq.com
-fidelitone,fidelitone,https://fidelitone.pinpointhq.com
-field,field,https://field.pinpointhq.com
-forterro,forterro,https://forterro.pinpointhq.com
-foxconnwi,foxconnwi,https://foxconnwi.pinpointhq.com
-franklin-electric,franklin-electric,https://franklin-electric.pinpointhq.com
-frazil,frazil,https://frazil.pinpointhq.com
-freetrade,freetrade,https://freetrade.pinpointhq.com
-fremontgroup,fremontgroup,https://fremontgroup.pinpointhq.com
-frontline,frontline,https://frontline.pinpointhq.com
-fulwellentertainment,fulwellentertainment,https://fulwellentertainment.pinpointhq.com
-fundapps,fundapps,https://fundapps.pinpointhq.com
-futuregroup,futuregroup,https://futuregroup.pinpointhq.com
-gainuk,gainuk,https://gainuk.pinpointhq.com
-gameplaygalaxy,gameplaygalaxy,https://gameplaygalaxy.pinpointhq.com
-gappify,gappify,https://gappify.pinpointhq.com
-gardiner,gardiner,https://gardiner.pinpointhq.com
-geeiq,geeiq,https://geeiq.pinpointhq.com
-gembaadvantage,gembaadvantage,https://gembaadvantage.pinpointhq.com
-gig,gig,https://gig.pinpointhq.com
-girlsontherun,girlsontherun,https://girlsontherun.pinpointhq.com
-gloryglobal,gloryglobal,https://gloryglobal.pinpointhq.com
-gmesupply,gmesupply,https://gmesupply.pinpointhq.com
-gordonmurraygroup,gordonmurraygroup,https://gordonmurraygroup.pinpointhq.com
-gravityglobal,gravityglobal,https://gravityglobal.pinpointhq.com
-greenergy,greenergy,https://greenergy.pinpointhq.com
-greenwoodproject,greenwoodproject,https://greenwoodproject.pinpointhq.com
-groupgti,groupgti,https://groupgti.pinpointhq.com
-groupo,groupo,https://groupo.pinpointhq.com
-gs1ca,gs1ca,https://gs1ca.pinpointhq.com
-harmeny,harmeny,https://harmeny.pinpointhq.com
-harnham,harnham,https://harnham.pinpointhq.com
-hazelcast,hazelcast,https://hazelcast.pinpointhq.com
-healthcomp,healthcomp,https://healthcomp.pinpointhq.com
-herrs,herrs,https://herrs.pinpointhq.com
-hollandamericagroup,hollandamericagroup,https://hollandamericagroup.pinpointhq.com
-hollandamericaprincess,hollandamericaprincess,https://hollandamericaprincess.pinpointhq.com
-hooli,hooli,https://hooli.pinpointhq.com
-hughbaird,hughbaird,https://hughbaird.pinpointhq.com
-hyperhippo,hyperhippo,https://hyperhippo.pinpointhq.com
-ifx,ifx,https://ifx.pinpointhq.com
-impactassets,impactassets,https://impactassets.pinpointhq.com
-impulsespace,impulsespace,https://impulsespace.pinpointhq.com
-indrive,indrive,https://indrive.pinpointhq.com
-inmusicbrands,inmusicbrands,https://inmusicbrands.pinpointhq.com
-innovetivepetcare,innovetivepetcare,https://innovetivepetcare.pinpointhq.com
-instantimpactrecruitment,instantimpactrecruitment,https://instantimpactrecruitment.pinpointhq.com
-intellihr,intellihr,https://intellihr.pinpointhq.com
-intermedia,intermedia,https://intermedia.pinpointhq.com
-investorhub,investorhub,https://investorhub.pinpointhq.com
-invictus-verus,invictus-verus,https://invictus-verus.pinpointhq.com
-isginc,isginc,https://isginc.pinpointhq.com
-itvet,itvet,https://itvet.pinpointhq.com
-iventure,iventure,https://iventure.pinpointhq.com
-jbs-ltd,jbs-ltd,https://jbs-ltd.pinpointhq.com
-jed,jed,https://jed.pinpointhq.com
-jimersonfirm,jimersonfirm,https://jimersonfirm.pinpointhq.com
-joe-testing,joe-testing,https://joe-testing.pinpointhq.com
-joinparachute,joinparachute,https://joinparachute.pinpointhq.com
-joveo-sandbox,joveo-sandbox,https://joveo-sandbox.pinpointhq.com
-judge-priestley,judge-priestley,https://judge-priestley.pinpointhq.com
-karpstrategies,karpstrategies,https://karpstrategies.pinpointhq.com
-kempinski,kempinski,https://kempinski.pinpointhq.com
-kenwayconsulting,kenwayconsulting,https://kenwayconsulting.pinpointhq.com
-knack,knack,https://knack.pinpointhq.com
-krestonreeves,krestonreeves,https://krestonreeves.pinpointhq.com
-lancashire-group,lancashire-group,https://lancashire-group.pinpointhq.com
-lbresearch,lbresearch,https://lbresearch.pinpointhq.com
-leadingedgeaviation,leadingedgeaviation,https://leadingedgeaviation.pinpointhq.com
-leski,leski,https://leski.pinpointhq.com
-lichfields,lichfields,https://lichfields.pinpointhq.com
-lingoda,lingoda,https://lingoda.pinpointhq.com
-livelink,livelink,https://livelink.pinpointhq.com
-loccitane,loccitane,https://loccitane.pinpointhq.com
-londonhireltd,londonhireltd,https://londonhireltd.pinpointhq.com
-londonyouth,londonyouth,https://londonyouth.pinpointhq.com
-lush,lush,https://lush.pinpointhq.com
-made-tech,made-tech,https://made-tech.pinpointhq.com
-madfishdigital,madfishdigital,https://madfishdigital.pinpointhq.com
-magic,magic,https://magic.pinpointhq.com
-mainstreetanesthesia,mainstreetanesthesia,https://mainstreetanesthesia.pinpointhq.com
-malaa,malaa,https://malaa.pinpointhq.com
-marlboroughhighways,marlboroughhighways,https://marlboroughhighways.pinpointhq.com
-matter,matter,https://matter.pinpointhq.com
-maverick-games,maverick-games,https://maverick-games.pinpointhq.com
-meadenmoore,meadenmoore,https://meadenmoore.pinpointhq.com
-medium,medium,https://medium.pinpointhq.com
-menzies,menzies,https://menzies.pinpointhq.com
-midkent,midkent,https://midkent.pinpointhq.com
-moleonline,moleonline,https://moleonline.pinpointhq.com
-mooreks,mooreks,https://mooreks.pinpointhq.com
-mosaicvet,mosaicvet,https://mosaicvet.pinpointhq.com
-mountainwarehouse,mountainwarehouse,https://mountainwarehouse.pinpointhq.com
-mpdn,mpdn,https://mpdn.pinpointhq.com
-mplc,mplc,https://mplc.pinpointhq.com
-multiplier-careers,multiplier-careers,https://multiplier-careers.pinpointhq.com
-myinterview,myinterview,https://myinterview.pinpointhq.com
-mymedtrust,mymedtrust,https://mymedtrust.pinpointhq.com
-naimaudio,naimaudio,https://naimaudio.pinpointhq.com
-napier,napier,https://napier.pinpointhq.com
-nasstar,nasstar,https://nasstar.pinpointhq.com
-natcen,natcen,https://natcen.pinpointhq.com
-navigatepower,navigatepower,https://navigatepower.pinpointhq.com
-ncheurope,ncheurope,https://ncheurope.pinpointhq.com
-networkplus,networkplus,https://networkplus.pinpointhq.com
-newfireglobal,newfireglobal,https://newfireglobal.pinpointhq.com
-nfamilyclub,nfamilyclub,https://nfamilyclub.pinpointhq.com
-nmc,nmc,https://nmc.pinpointhq.com
-nodalexchange,nodalexchange,https://nodalexchange.pinpointhq.com
-northcodersgroup,northcodersgroup,https://northcodersgroup.pinpointhq.com
-northernbedrockcorps,northernbedrockcorps,https://northernbedrockcorps.pinpointhq.com
-notonthehighstreet,notonthehighstreet,https://notonthehighstreet.pinpointhq.com
-nuvitek,nuvitek,https://nuvitek.pinpointhq.com
-nypl,nypl,https://nypl.pinpointhq.com
-ohiovalleyelectriccorporation,ohiovalleyelectriccorporation,https://ohiovalleyelectriccorporation.pinpointhq.com
-oilchange,oilchange,https://oilchange.pinpointhq.com
-oneapp,oneapp,https://oneapp.pinpointhq.com
-oneplan,oneplan,https://oneplan.pinpointhq.com
-onlineriver,onlineriver,https://onlineriver.pinpointhq.com
-orbisoperations,orbisoperations,https://orbisoperations.pinpointhq.com
-ouswre,ouswre,https://ouswre.pinpointhq.com
-overlandpartners,overlandpartners,https://overlandpartners.pinpointhq.com
-oxfordinternational,oxfordinternational,https://oxfordinternational.pinpointhq.com
-partnersforhome,partnersforhome,https://partnersforhome.pinpointhq.com
-pastaevangelists,pastaevangelists,https://pastaevangelists.pinpointhq.com
-pathify,pathify,https://pathify.pinpointhq.com
-peninsula360,peninsula360,https://peninsula360.pinpointhq.com
-penrosehealth,penrosehealth,https://penrosehealth.pinpointhq.com
-pexcard,pexcard,https://pexcard.pinpointhq.com
-pinnbank,pinnbank,https://pinnbank.pinpointhq.com
-pipedreams,pipedreams,https://pipedreams.pinpointhq.com
-pipeworks,pipeworks,https://pipeworks.pinpointhq.com
-pod-point,pod-point,https://pod-point.pinpointhq.com
-polfed,polfed,https://polfed.pinpointhq.com
-poloworks,poloworks,https://poloworks.pinpointhq.com
-portakabin,portakabin,https://portakabin.pinpointhq.com
-portnox,portnox,https://portnox.pinpointhq.com
-ports,ports,https://ports.pinpointhq.com
-precisionneuro,precisionneuro,https://precisionneuro.pinpointhq.com
-premierleague,premierleague,https://premierleague.pinpointhq.com
-pricebrotherskc,pricebrotherskc,https://pricebrotherskc.pinpointhq.com
-princesscruises,princesscruises,https://princesscruises.pinpointhq.com
-projectcanary,projectcanary,https://projectcanary.pinpointhq.com
-propelleraero,propelleraero,https://propelleraero.pinpointhq.com
-pssg,pssg,https://pssg.pinpointhq.com
-pxlimited,pxlimited,https://pxlimited.pinpointhq.com
-qac,qac,https://qac.pinpointhq.com
-qellus,qellus,https://qellus.pinpointhq.com
-qualitylogic,qualitylogic,https://qualitylogic.pinpointhq.com
-rangeline,rangeline,https://rangeline.pinpointhq.com
-ravelin,ravelin,https://ravelin.pinpointhq.com
-recentive,recentive,https://recentive.pinpointhq.com
-reconomy,reconomy,https://reconomy.pinpointhq.com
-recycle,recycle,https://recycle.pinpointhq.com
-reimaginedcareers,reimaginedcareers,https://reimaginedcareers.pinpointhq.com
-rethinkpriorities,rethinkpriorities,https://rethinkpriorities.pinpointhq.com
-rewardgateway,rewardgateway,https://rewardgateway.pinpointhq.com
-riipen,riipen,https://riipen.pinpointhq.com
-rivalry,rivalry,https://rivalry.pinpointhq.com
-rlb,rlb,https://rlb.pinpointhq.com
-rowdentech,rowdentech,https://rowdentech.pinpointhq.com
-rwdi,rwdi,https://rwdi.pinpointhq.com
-sabio,sabio,https://sabio.pinpointhq.com
-safetywing,safetywing,https://safetywing.pinpointhq.com
-saffery,saffery,https://saffery.pinpointhq.com
-sans,sans,https://sans.pinpointhq.com
-sbgl,sbgl,https://sbgl.pinpointhq.com
+FIDELITONE,fidelitone,https://fidelitone.pinpointhq.com
+FIELD,field,https://field.pinpointhq.com
+Forterro,forterro,https://forterro.pinpointhq.com
+Foxconn WI,foxconnwi,https://foxconnwi.pinpointhq.com
+Franklin Electric,franklin-electric,https://franklin-electric.pinpointhq.com
+Frazil,frazil,https://frazil.pinpointhq.com
+Fremont Group,fremontgroup,https://fremontgroup.pinpointhq.com
+Frontline,frontline,https://frontline.pinpointhq.com
+Fulwell Entertainment,fulwellentertainment,https://fulwellentertainment.pinpointhq.com
+FundApps,fundapps,https://fundapps.pinpointhq.com
+Future Group,futuregroup,https://futuregroup.pinpointhq.com
+GAIN,gainuk,https://gainuk.pinpointhq.com
+Gameplay Galaxy,gameplaygalaxy,https://gameplaygalaxy.pinpointhq.com
+Gaming Innovation Group,gig,https://gig.pinpointhq.com
+Gappify,gappify,https://gappify.pinpointhq.com
+Gardiner and Theobald LLP,gardiner,https://gardiner.pinpointhq.com
+GEEIQ,geeiq,https://geeiq.pinpointhq.com
+Gemba Advantage,gembaadvantage,https://gembaadvantage.pinpointhq.com
+Girls on the Run,girlsontherun,https://girlsontherun.pinpointhq.com
+GLORY,gloryglobal,https://gloryglobal.pinpointhq.com
+Gordon Murray Group,gordonmurraygroup,https://gordonmurraygroup.pinpointhq.com
+Gravity Global,gravityglobal,https://gravityglobal.pinpointhq.com
+Greenergy,greenergy,https://greenergy.pinpointhq.com
+Greenwood Project,greenwoodproject,https://greenwoodproject.pinpointhq.com
+Group GTI,groupgti,https://groupgti.pinpointhq.com
+Group O,groupo,https://groupo.pinpointhq.com
+GS1 Canada,gs1ca,https://gs1ca.pinpointhq.com
+Harmeny Education Trust,harmeny,https://harmeny.pinpointhq.com
+Harnham,harnham,https://harnham.pinpointhq.com
+Hazelcast,hazelcast,https://hazelcast.pinpointhq.com
+Herr Foods Inc.,herrs,https://herrs.pinpointhq.com
+Holland America Line & Seabourn,hollandamericagroup,https://hollandamericagroup.pinpointhq.com
+Holland America/Princess Alaska-Yukon Land Operations,hollandamericaprincess,https://hollandamericaprincess.pinpointhq.com
+Hooli,hooli,https://hooli.pinpointhq.com
+Hugh Baird College,hughbaird,https://hughbaird.pinpointhq.com
+IFX Payments,ifx,https://ifx.pinpointhq.com
+IGT,everi,https://everi.pinpointhq.com
+ImpactAssets,impactassets,https://impactassets.pinpointhq.com
+Impulse Space,impulsespace,https://impulsespace.pinpointhq.com
+inDrive,indrive,https://indrive.pinpointhq.com
+inMusic,inmusicbrands,https://inmusicbrands.pinpointhq.com
+Innovetive Petcare,innovetivepetcare,https://innovetivepetcare.pinpointhq.com
+intelliHR,intellihr,https://intellihr.pinpointhq.com
+Intermedia Intelligent Communications,intermedia,https://intermedia.pinpointhq.com
+InvestorHub,investorhub,https://investorhub.pinpointhq.com
+Invictus Capital Partners / Verus Mortgage Capital,invictus-verus,https://invictus-verus.pinpointhq.com
+ISG,isginc,https://isginc.pinpointhq.com
+ITVET,itvet,https://itvet.pinpointhq.com
+iVenture Solutions,iventure,https://iventure.pinpointhq.com
+Jaguar Building Services,jbs-ltd,https://jbs-ltd.pinpointhq.com
+"Jimerson Birr, P.A.",jimersonfirm,https://jimersonfirm.pinpointhq.com
+Joe's Test Platform,joe-testing,https://joe-testing.pinpointhq.com
+Join Parachute,joinparachute,https://joinparachute.pinpointhq.com
+joveo dev sandbox,joveo-sandbox,https://joveo-sandbox.pinpointhq.com
+Judge & Priestley LLP,judge-priestley,https://judge-priestley.pinpointhq.com
+Karp Strategies,karpstrategies,https://karpstrategies.pinpointhq.com
+Kempinski Hotels,kempinski,https://kempinski.pinpointhq.com
+Kenway Consulting,kenwayconsulting,https://kenwayconsulting.pinpointhq.com
+Kreston Reeves,krestonreeves,https://krestonreeves.pinpointhq.com
+L'OCCITANE EN PROVENCE,loccitane,https://loccitane.pinpointhq.com
+Le Ski,leski,https://leski.pinpointhq.com
+Leading Edge Aviation,leadingedgeaviation,https://leadingedgeaviation.pinpointhq.com
+Lichfields,lichfields,https://lichfields.pinpointhq.com
+Lingoda,lingoda,https://lingoda.pinpointhq.com
+LiveLink,livelink,https://livelink.pinpointhq.com
+London Hire Group,londonhireltd,https://londonhireltd.pinpointhq.com
+London Youth,londonyouth,https://londonyouth.pinpointhq.com
+Lush,lush,https://lush.pinpointhq.com
+Mad Fish Digital,madfishdigital,https://madfishdigital.pinpointhq.com
+Made Tech,made-tech,https://made-tech.pinpointhq.com
+"Magic, Inc",magic,https://magic.pinpointhq.com
+Main Street Anesthesia,mainstreetanesthesia,https://mainstreetanesthesia.pinpointhq.com
+Malaa,malaa,https://malaa.pinpointhq.com
+MAPP,wearemapp,https://wearemapp.pinpointhq.com
+Marlborough Highways,marlboroughhighways,https://marlboroughhighways.pinpointhq.com
+Matter,matter,https://matter.pinpointhq.com
+Maverick Games,maverick-games,https://maverick-games.pinpointhq.com
+MedTrust,mymedtrust,https://mymedtrust.pinpointhq.com
+Menzies LLP,menzies,https://menzies.pinpointhq.com
+MidKent College,midkent,https://midkent.pinpointhq.com
+Mole Valley Farmers Limited,moleonline,https://moleonline.pinpointhq.com
+Monkey Puzzle Day Nurseries,mpdn,https://mpdn.pinpointhq.com
+Moore Kingston Smith,mooreks,https://mooreks.pinpointhq.com
+Mosaic Veterinary Partners,mosaicvet,https://mosaicvet.pinpointhq.com
+Mountain Warehouse,mountainwarehouse,https://mountainwarehouse.pinpointhq.com
+MPLC,mplc,https://mplc.pinpointhq.com
+Multiplier,multiplier-careers,https://multiplier-careers.pinpointhq.com
+myInterview - Staging,myinterview,https://myinterview.pinpointhq.com
+N Family Club,nfamilyclub,https://nfamilyclub.pinpointhq.com
+Naim Audio,naimaudio,https://naimaudio.pinpointhq.com
+Napier AI,napier,https://napier.pinpointhq.com
+Nasstar,nasstar,https://nasstar.pinpointhq.com
+Navigate Power & Verde Solutions,navigatepower,https://navigatepower.pinpointhq.com
+NCH Europe,ncheurope,https://ncheurope.pinpointhq.com
+Network Plus,networkplus,https://networkplus.pinpointhq.com
+Newfire Global Partners,newfireglobal,https://newfireglobal.pinpointhq.com
+Nodal Exchange,nodalexchange,https://nodalexchange.pinpointhq.com
+Northcoders Group,northcodersgroup,https://northcodersgroup.pinpointhq.com
+Northern Bedrock Historic Preservation Corps,northernbedrockcorps,https://northernbedrockcorps.pinpointhq.com
+Not On The High Street,notonthehighstreet,https://notonthehighstreet.pinpointhq.com
+Nüvitek,nuvitek,https://nuvitek.pinpointhq.com
+Ohio Valley Electric Corporation / Indiana - Kentucky Electric Corporation,ohiovalleyelectriccorporation,https://ohiovalleyelectriccorporation.pinpointhq.com
+Oil Change International,oilchange,https://oilchange.pinpointhq.com
+"OneApp, Inc.",oneapp,https://oneapp.pinpointhq.com
+OnePlan Solutions,oneplan,https://oneplan.pinpointhq.com
+Online River,onlineriver,https://onlineriver.pinpointhq.com
+Optitex,doradosoftwaregroup,https://doradosoftwaregroup.pinpointhq.com
+Overland Partners,overlandpartners,https://overlandpartners.pinpointhq.com
+Oxford International Education Group,oxfordinternational,https://oxfordinternational.pinpointhq.com
+Partners for HOME,partnersforhome,https://partnersforhome.pinpointhq.com
+Pathify,pathify,https://pathify.pinpointhq.com
+Payroll Software & Services Group,pssg,https://pssg.pinpointhq.com
+Peninsula,peninsula360,https://peninsula360.pinpointhq.com
+Penrose Health,penrosehealth,https://penrosehealth.pinpointhq.com
+PEX,pexcard,https://pexcard.pinpointhq.com
+Pinnacle Bank/Bank of Colorado,pinnbank,https://pinnbank.pinpointhq.com
+PipeDreams,pipedreams,https://pipedreams.pinpointhq.com
+Pipeworks Studios,pipeworks,https://pipeworks.pinpointhq.com
+Pod,pod-point,https://pod-point.pinpointhq.com
+Police Federation of England and Wales,polfed,https://polfed.pinpointhq.com
+PoloWorks,poloworks,https://poloworks.pinpointhq.com
+Portakabin,portakabin,https://portakabin.pinpointhq.com
+Portnox,portnox,https://portnox.pinpointhq.com
+Ports of Jersey,ports,https://ports.pinpointhq.com
+Precision Neuroscience,precisionneuro,https://precisionneuro.pinpointhq.com
+Price Brothers,pricebrotherskc,https://pricebrotherskc.pinpointhq.com
+Princess Cruises,princesscruises,https://princesscruises.pinpointhq.com
+Project Canary,projectcanary,https://projectcanary.pinpointhq.com
+Propeller,propelleraero,https://propelleraero.pinpointhq.com
+px Group,pxlimited,https://pxlimited.pinpointhq.com
+"Qellus, LLC",qellus,https://qellus.pinpointhq.com
+QualityLogic,qualitylogic,https://qualitylogic.pinpointhq.com
+Queen Alexandra Charity,qac,https://qac.pinpointhq.com
+Rangeline Group,rangeline,https://rangeline.pinpointhq.com
+Ravelin Technology,ravelin,https://ravelin.pinpointhq.com
+Recentive Analytics,recentive,https://recentive.pinpointhq.com
+Reconomy,reconomy,https://reconomy.pinpointhq.com
+Reimagined Parking,reimaginedcareers,https://reimaginedcareers.pinpointhq.com
+Rethink Priorities,rethinkpriorities,https://rethinkpriorities.pinpointhq.com
+Reward Gateway,rewardgateway,https://rewardgateway.pinpointhq.com
+Rider Levett Bucknall,rlb,https://rlb.pinpointhq.com
+Riipen,riipen,https://riipen.pinpointhq.com
+Rivalry,rivalry,https://rivalry.pinpointhq.com
+Rowden,rowdentech,https://rowdentech.pinpointhq.com
+RRS,recycle,https://recycle.pinpointhq.com
+RWDI,rwdi,https://rwdi.pinpointhq.com
+Sabio Group,sabio,https://sabio.pinpointhq.com
+SafetyWing,safetywing,https://safetywing.pinpointhq.com
+Saffery Trust,saffery,https://saffery.pinpointhq.com
+SANS Institute,sans,https://sans.pinpointhq.com
 scandiweb,scandiweb,https://scandiweb.pinpointhq.com
-scottishfa,scottishfa,https://scottishfa.pinpointhq.com
-securiancanada,securiancanada,https://securiancanada.pinpointhq.com
-sevenpointscapital,sevenpointscapital,https://sevenpointscapital.pinpointhq.com
-shieldtp,shieldtp,https://shieldtp.pinpointhq.com
+Scottish Football Association,scottishfa,https://scottishfa.pinpointhq.com
+Securian Canada,securiancanada,https://securiancanada.pinpointhq.com
+Seven Points Capital,sevenpointscapital,https://sevenpointscapital.pinpointhq.com
+Shield,shieldtp,https://shieldtp.pinpointhq.com
 simpleclub,simpleclub,https://simpleclub.pinpointhq.com
-skims,skims,https://skims.pinpointhq.com
-skinspirit,skinspirit,https://skinspirit.pinpointhq.com
-slabemachine,slabemachine,https://slabemachine.pinpointhq.com
-smartthings,smartthings,https://smartthings.pinpointhq.com
-snapanalytics,snapanalytics,https://snapanalytics.pinpointhq.com
-sobencc,sobencc,https://sobencc.pinpointhq.com
-sparelabs,sparelabs,https://sparelabs.pinpointhq.com
-spektrix,spektrix,https://spektrix.pinpointhq.com
-spiralyze,spiralyze,https://spiralyze.pinpointhq.com
-stratom,stratom,https://stratom.pinpointhq.com
-summitk12,summitk12,https://summitk12.pinpointhq.com
-sunking,sunking,https://sunking.pinpointhq.com
-superside,superside,https://superside.pinpointhq.com
-surgohealth,surgohealth,https://surgohealth.pinpointhq.com
-swiftcomply,swiftcomply,https://swiftcomply.pinpointhq.com
-syspro,syspro,https://syspro.pinpointhq.com
-systematica,systematica,https://systematica.pinpointhq.com
-tabby,tabby,https://tabby.pinpointhq.com
-tailscale,tailscale,https://tailscale.pinpointhq.com
-teacherapprenticeship,teacherapprenticeship,https://teacherapprenticeship.pinpointhq.com
-teaching-strategies,teaching-strategies,https://teaching-strategies.pinpointhq.com
-teachmichigan,teachmichigan,https://teachmichigan.pinpointhq.com
-telesolvconsulting,telesolvconsulting,https://telesolvconsulting.pinpointhq.com
-tenovallc,tenovallc,https://tenovallc.pinpointhq.com
-thearchco,thearchco,https://thearchco.pinpointhq.com
-thebulwark,thebulwark,https://thebulwark.pinpointhq.com
-theiagen,theiagen,https://theiagen.pinpointhq.com
-themischgroup,themischgroup,https://themischgroup.pinpointhq.com
-therapymgmt,therapymgmt,https://therapymgmt.pinpointhq.com
-theready,theready,https://theready.pinpointhq.com
-thompsonslaw,thompsonslaw,https://thompsonslaw.pinpointhq.com
-thorne,thorne,https://thorne.pinpointhq.com
-tithely,tithely,https://tithely.pinpointhq.com
-tradingtechnologies,tradingtechnologies,https://tradingtechnologies.pinpointhq.com
-transformuk,transformuk,https://transformuk.pinpointhq.com
-trilongroup,trilongroup,https://trilongroup.pinpointhq.com
-trinidadbenham,trinidadbenham,https://trinidadbenham.pinpointhq.com
+SKIMS,skims,https://skims.pinpointhq.com
+SkinSpirit,skinspirit,https://skinspirit.pinpointhq.com
+SmartThings,smartthings,https://smartthings.pinpointhq.com
+Snap Analytics,snapanalytics,https://snapanalytics.pinpointhq.com
+Soben part of Accenture,sobencc,https://sobencc.pinpointhq.com
+Somerset Bridge Group,sbgl,https://sbgl.pinpointhq.com
+Spektrix,spektrix,https://spektrix.pinpointhq.com
+Spiralyze,spiralyze,https://spiralyze.pinpointhq.com
+Stratom,stratom,https://stratom.pinpointhq.com
+Summit K12,summitk12,https://summitk12.pinpointhq.com
+Sun King,sunking,https://sunking.pinpointhq.com
+Superside: Your creative team’s creative team™,superside,https://superside.pinpointhq.com
+Surgo Health,surgohealth,https://surgohealth.pinpointhq.com
+Systematica Investments,systematica,https://systematica.pinpointhq.com
+Tabby,tabby,https://tabby.pinpointhq.com
+Teacher Apprenticeship Network,teacherapprenticeship,https://teacherapprenticeship.pinpointhq.com
+"Teaching Strategies, LLC",teaching-strategies,https://teaching-strategies.pinpointhq.com
+TeachMichigan,teachmichigan,https://teachmichigan.pinpointhq.com
+TeleSolv Consulting,telesolvconsulting,https://telesolvconsulting.pinpointhq.com
+The Arch Company,thearchco,https://thearchco.pinpointhq.com
+The Bulwark,thebulwark,https://thebulwark.pinpointhq.com
+The Jed Foundation,jed,https://jed.pinpointhq.com
+The Lancashire Group,lancashire-group,https://lancashire-group.pinpointhq.com
+The Misch Group,themischgroup,https://themischgroup.pinpointhq.com
+the National Centre for Social Research,natcen,https://natcen.pinpointhq.com
+The New York Public Library,nypl,https://nypl.pinpointhq.com
+The Nursing and Midwifery Council,nmc,https://nmc.pinpointhq.com
+The Premier League,premierleague,https://premierleague.pinpointhq.com
+The Ready,theready,https://theready.pinpointhq.com
+Theiagen Genomics,theiagen,https://theiagen.pinpointhq.com
+Thompsons Solicitors,thompsonslaw,https://thompsonslaw.pinpointhq.com
+Thorne,thorne,https://thorne.pinpointhq.com
+Tithely,tithely,https://tithely.pinpointhq.com
+TMC,therapymgmt,https://therapymgmt.pinpointhq.com
+Trading Technologies,tradingtechnologies,https://tradingtechnologies.pinpointhq.com
+Transform,transformuk,https://transformuk.pinpointhq.com
+Trilon Group,trilongroup,https://trilongroup.pinpointhq.com
+Trinidad Benham,trinidadbenham,https://trinidadbenham.pinpointhq.com
 tripledotstudios,tripledotstudios,https://tripledotstudios.pinpointhq.com
-trivandi,trivandi,https://trivandi.pinpointhq.com
-trulygoodfoods,trulygoodfoods,https://trulygoodfoods.pinpointhq.com
-turionspace,turionspace,https://turionspace.pinpointhq.com
-twiningsovocareers,twiningsovocareers,https://twiningsovocareers.pinpointhq.com
-uktv,uktv,https://uktv.pinpointhq.com
-universal,universal,https://universal.pinpointhq.com
-upway,upway,https://upway.pinpointhq.com
-utilitiesone,utilitiesone,https://utilitiesone.pinpointhq.com
-vena,vena,https://vena.pinpointhq.com
-vgroup,vgroup,https://vgroup.pinpointhq.com
-vitalbio,vitalbio,https://vitalbio.pinpointhq.com
-wagepoint,wagepoint,https://wagepoint.pinpointhq.com
-wanstor,wanstor,https://wanstor.pinpointhq.com
-waymark,waymark,https://waymark.pinpointhq.com
-wealthwizards,wealthwizards,https://wealthwizards.pinpointhq.com
-wearemapp,wearemapp,https://wearemapp.pinpointhq.com
-weoneil,weoneil,https://weoneil.pinpointhq.com
-whiteswandata,whiteswandata,https://whiteswandata.pinpointhq.com
-windward-energy,windward-energy,https://windward-energy.pinpointhq.com
-wmhsolutions,wmhsolutions,https://wmhsolutions.pinpointhq.com
-woodrodgers,woodrodgers,https://woodrodgers.pinpointhq.com
-workstaff360,workstaff360,https://workstaff360.pinpointhq.com
-worldanimalprotection,worldanimalprotection,https://worldanimalprotection.pinpointhq.com
-wyld,wyld,https://wyld.pinpointhq.com
-xantura,xantura,https://xantura.pinpointhq.com
-xeneta,xeneta,https://xeneta.pinpointhq.com
-ymcaboston,ymcaboston,https://ymcaboston.pinpointhq.com
-ynab,ynab,https://ynab.pinpointhq.com
-zencargo,zencargo,https://zencargo.pinpointhq.com
-zincwork,zincwork,https://zincwork.pinpointhq.com
+Trivandi,trivandi,https://trivandi.pinpointhq.com
+Truly Good Foods,trulygoodfoods,https://trulygoodfoods.pinpointhq.com
+Twinings Ovaltine,twiningsovocareers,https://twiningsovocareers.pinpointhq.com
+UKTV,uktv,https://uktv.pinpointhq.com
+Under Secretary of War for Research & Engineering,ouswre,https://ouswre.pinpointhq.com
+Upway,upway,https://upway.pinpointhq.com
+Utilities One,utilitiesone,https://utilitiesone.pinpointhq.com
+V.Group,vgroup,https://vgroup.pinpointhq.com
+Vena Solutions,vena,https://vena.pinpointhq.com
+Veriforce,alcumus,https://alcumus.pinpointhq.com
+Vital Bio,vitalbio,https://vitalbio.pinpointhq.com
+W.E. O'Neil Construction,weoneil,https://weoneil.pinpointhq.com
+Wanstor,wanstor,https://wanstor.pinpointhq.com
+Waymark,waymark,https://waymark.pinpointhq.com
+Wealth Wizards,wealthwizards,https://wealthwizards.pinpointhq.com
+White Swan Data,whiteswandata,https://whiteswandata.pinpointhq.com
+Windward Energy Group,windward-energy,https://windward-energy.pinpointhq.com
+WMH,wmhsolutions,https://wmhsolutions.pinpointhq.com
+Wood Rodgers,woodrodgers,https://woodrodgers.pinpointhq.com
+WorkStaff360,workstaff360,https://workstaff360.pinpointhq.com
+World Animal Protection,worldanimalprotection,https://worldanimalprotection.pinpointhq.com
+WYLD,wyld,https://wyld.pinpointhq.com
+Xantura,xantura,https://xantura.pinpointhq.com
+Xeneta,xeneta,https://xeneta.pinpointhq.com
+YMCA of Greater Boston,ymcaboston,https://ymcaboston.pinpointhq.com
+YNAB,ynab,https://ynab.pinpointhq.com
+Zencargo,zencargo,https://zencargo.pinpointhq.com
+Zinc,zincwork,https://zincwork.pinpointhq.com


### PR DESCRIPTION
## Summary
- Normalize Pinpoint entries to actual company names from live company board titles.
- Validate every retained tenant through both the public `postings.json` endpoint and the company board URL.
- Remove tenants whose API may still respond but whose company board root is 404, so the CSV no longer points at broken company pages.

## Validation
- Pinpoint validation: 328 final rows checked; 0 bad API/page responses.
- CSV check: no duplicate slugs, no duplicate URLs, required fields present.
- `uv run pytest tests/test_pinpoint.py tests/test_run_pipeline_guards.py -q` -> 30 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalized Pinpoint company names to match live board titles, added valid tenants, and removed tenants with dead boards to stop linking to 404s. This cleans up and updates `ats-companies/pinpoint.csv`.

- **Bug Fixes**
  - Verified all active tenants via `postings.json` and board root; 330 rows kept, 0 bad responses.
  - Ensured CSV integrity: no duplicate slugs/URLs; required fields present; tests pass (30).

<sup>Written for commit 3a84b06c324d422ce5e9a6f2bc26ee25309af2e0. Summary will update on new commits. <a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/167?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

