### PR TITLE
Preserve Avature full URL slug casing

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -133,6 +133,8 @@ def _avature_slug(row: dict[str, Any]) -> str | None:
     """Avature tenants live at ``{slug}.avature.net`` (or sometimes the
     full careers URL). Extract the subdomain when a URL is present."""
     if (slug := _slug_col(row)):
+        if slug.startswith(("http://", "https://")):
+            return slug
         return slug.lower()
     url = (row.get("url") or "").strip()
     if url.startswith("http"):

--- a/tests/test_run_pipeline_guards.py
+++ b/tests/test_run_pipeline_guards.py
@@ -50,6 +50,23 @@ def test_provider_slug_normalizers_match_current_company_csv_shape() -> None:
     assert kwargs["domain"] == "johndeere.com"
     assert kwargs["company_name"] == "John Deere"
 
+    avature_full_url_row = {
+        "name": "Australia Post",
+        "slug": "https://jobs.auspost.com.au/en_GB",
+        "url": "https://jobs.auspost.com.au/en_GB/careers/SearchJobs",
+    }
+    assert (
+        runner._avature_slug(avature_full_url_row)
+        == "https://jobs.auspost.com.au/en_GB"
+    )
+
+    avature_subdomain_row = {
+        "name": "Bloomberg",
+        "slug": "Bloomberg",
+        "url": "https://bloomberg.avature.net/careers/SearchJobs",
+    }
+    assert runner._avature_slug(avature_subdomain_row) == "bloomberg"
+
 
 def test_catastrophic_failure_preserves_previous_jobs_csv(
     tmp_path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary
- Preserve full URL `slug` values in `_avature_slug` instead of lowercasing them.
- Keep lowercasing for plain Avature tenant slugs.
- Add a pipeline guard for the Australia Post `en_GB` custom-domain shape from PR #165 review feedback.

## Validation
- `uv run pytest tests/test_run_pipeline_guards.py tests/test_avature.py -q` -> 32 passed
- `uv run pytest -q` -> 928 passed

Addresses https://github.com/kalil0321/ats-scrapers/pull/165#discussion_r3293127611

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes `_avature_slug` preserve the original casing of full-URL slugs (those beginning with `http://` or `https://`), while still lowercasing plain tenant subdomain slugs. It also adds a pipeline-guard test covering both the Australia Post custom-domain shape and the standard Bloomberg subdomain shape.

- `scripts/run_pipeline.py`: two-line guard added to `_avature_slug`; full-URL slugs short-circuit before the `.lower()` call.
- `tests/test_run_pipeline_guards.py`: two new assertions appended to the existing normalizer test, one per slug shape.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is a small, focused guard with matching tests and no impact on existing slug paths.

The guard only fires when the slug column already contains a full URL, leaving the lowercasing path for every other value unchanged. Both new code paths are directly exercised by the appended assertions, and the description notes all 928 existing tests continue to pass.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/run_pipeline.py | Adds an early-return guard in `_avature_slug` so full-URL slugs (http/https) are returned verbatim while plain tenant slugs continue to be lowercased. |
| tests/test_run_pipeline_guards.py | Adds two new assertions covering the Australia Post full-URL slug (casing preserved) and Bloomberg plain-slug (lowercased) cases. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Preserve Avature full URL slug casing"](https://github.com/kalil0321/ats-scrapers/commit/cc28f3165ade8891e01567f9794c6f46d67b1e00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33597016)</sub>

<!-- /greptile_comment -->