### PR TITLE
Add validated Pinpoint companies

### DIFF
--- a/ats-companies/pinpoint.csv
+++ b/ats-companies/pinpoint.csv
@@ -341,3 +341,6 @@ International WELL Building Institute (IWBI),iwbi,https://iwbi.pinpointhq.com
 Tata Chemicals Europe,tatachemicals,https://tatachemicals.pinpointhq.com
 Icario,icario,https://icario.pinpointhq.com
 Lendable,lendable,https://lendable.pinpointhq.com
+Sport 54,weare54,https://weare54.pinpointhq.com
+Tails.com,tails,https://tails.pinpointhq.com
+BSC Analytics,bluesentry,https://bluesentry.pinpointhq.com

--- a/ats-companies/pinpoint.csv
+++ b/ats-companies/pinpoint.csv
@@ -346,3 +346,6 @@ Tails.com,tails,https://tails.pinpointhq.com
 BSC Analytics,bluesentry,https://bluesentry.pinpointhq.com
 Aston Martin F1,astonmartinf1,https://astonmartinf1.pinpointhq.com
 Imagemaker,imagemaker,https://imagemaker.pinpointhq.com
+Virtual Staffing Solutions,virtualstaffing,https://virtualstaffing.pinpointhq.com
+interop.io,interopio,https://interopio.pinpointhq.com
+Mechanism Ventures,mechanismventures,https://mechanismventures.pinpointhq.com

--- a/ats-companies/pinpoint.csv
+++ b/ats-companies/pinpoint.csv
@@ -344,3 +344,5 @@ Lendable,lendable,https://lendable.pinpointhq.com
 Sport 54,weare54,https://weare54.pinpointhq.com
 Tails.com,tails,https://tails.pinpointhq.com
 BSC Analytics,bluesentry,https://bluesentry.pinpointhq.com
+Aston Martin F1,astonmartinf1,https://astonmartinf1.pinpointhq.com
+Imagemaker,imagemaker,https://imagemaker.pinpointhq.com

--- a/ats-companies/pinpoint.csv
+++ b/ats-companies/pinpoint.csv
@@ -339,3 +339,5 @@ Butlin's,butlins,https://butlins.pinpointhq.com
 DAZN,dazn,https://dazn.pinpointhq.com
 International WELL Building Institute (IWBI),iwbi,https://iwbi.pinpointhq.com
 Tata Chemicals Europe,tatachemicals,https://tatachemicals.pinpointhq.com
+Icario,icario,https://icario.pinpointhq.com
+Lendable,lendable,https://lendable.pinpointhq.com

--- a/ats-companies/pinpoint.csv
+++ b/ats-companies/pinpoint.csv
@@ -334,3 +334,8 @@ Buckinghamshire Mind,bucksmindcareers,https://bucksmindcareers.pinpointhq.com
 Codec,codec,https://codec.pinpointhq.com
 MIGSO-PCUBED,migso-pcubed,https://migso-pcubed.pinpointhq.com
 Pinpoint,workwithus,https://workwithus.pinpointhq.com
+Blue Cross,bluecross,https://bluecross.pinpointhq.com
+Butlin's,butlins,https://butlins.pinpointhq.com
+DAZN,dazn,https://dazn.pinpointhq.com
+International WELL Building Institute (IWBI),iwbi,https://iwbi.pinpointhq.com
+Tata Chemicals Europe,tatachemicals,https://tatachemicals.pinpointhq.com

--- a/ats-companies/pinpoint.csv
+++ b/ats-companies/pinpoint.csv
@@ -329,3 +329,8 @@ YMCA of Greater Boston,ymcaboston,https://ymcaboston.pinpointhq.com
 YNAB,ynab,https://ynab.pinpointhq.com
 Zencargo,zencargo,https://zencargo.pinpointhq.com
 Zinc,zincwork,https://zincwork.pinpointhq.com
+Alternative Heat,alternativeheat,https://alternativeheat.pinpointhq.com
+Buckinghamshire Mind,bucksmindcareers,https://bucksmindcareers.pinpointhq.com
+Codec,codec,https://codec.pinpointhq.com
+MIGSO-PCUBED,migso-pcubed,https://migso-pcubed.pinpointhq.com
+Pinpoint,workwithus,https://workwithus.pinpointhq.com


### PR DESCRIPTION
## Summary
- Add 20 validated Pinpoint tenants to `ats-companies/pinpoint.csv`.
- Keeps the CSV edit append-only to avoid reordering existing provider entries.

## Added tenants
- Alternative Heat
- Buckinghamshire Mind
- Codec
- MIGSO-PCUBED
- Pinpoint
- Blue Cross
- Butlin's
- DAZN
- International WELL Building Institute (IWBI)
- Tata Chemicals Europe
- Icario
- Lendable
- Sport 54
- Tails.com
- BSC Analytics
- Aston Martin F1
- Imagemaker
- Virtual Staffing Solutions
- interop.io
- Mechanism Ventures

## Validation
- Live checked every new tenant against `https://{slug}.pinpointhq.com/postings.json` through the scraper/API path for HTTP 200 JSON and non-empty postings.
- Also checked tenant roots/URLs stay on the expected `{slug}.pinpointhq.com` board and do not redirect to generic/global pages.
- Additional live counts for the latest batch:
  - `virtualstaffing`: 36 jobs
  - `interopio`: 1 job
  - `mechanismventures`: 1 job
- Previous latest batch:
  - `astonmartinf1`: 17 jobs
  - `imagemaker`: 46 jobs
- Previous batch:
  - `weare54`: 1 job
  - `tails`: 5 jobs
  - `bluesentry`: 2 jobs
- Prior batch counts:
  - `icario`: 1 job
  - `lendable`: 5 jobs
  - `bluecross`: 14 jobs
  - `butlins`: 122 jobs
  - `dazn`: 150 jobs
  - `iwbi`: 1 job
  - `tatachemicals`: 2 jobs
- Confirmed `ats-companies/pinpoint.csv` parses with 350 rows, 350 unique slugs, and 350 unique URLs.
- Skipped invalid, zero-posting, redirected, generic, or duplicate candidates from these passes: `impulsespace`, `anthesisgroup`, `nypl`, `greenwoodproject`, `confluence`, `magic`, `bluestreamfiber`, `groupo`, `tabby`, `impactassets`, and `cfc` were already present; `cybernetic-controls`, `cerkl`, `tenovallc`, `london-nelson`, `emerald`, `freshformdraft`, `verdantas`, and `branch` returned zero postings; `fever`, `jagex`, `cera`, `flo`, `octopusenergy`, `breathe`, `citizenm`, and `monzo` were not active Pinpoint tenants through the scraper path.
- `uv run pytest tests/test_pinpoint.py tests/test_run_pipeline_guards.py -q` (30 passed)
- `uv run pytest -q` (929 passed)
- `git diff --check`

## Notes
- Public Pinpoint pages and urlscan results indicate they have far more customers than the current CSV. This update only adds live, non-duplicate tenants with non-empty `postings.json` responses.