### PR TITLE
Add validated SuccessFactors companies

### DIFF
--- a/ats-companies/successfactors.csv
+++ b/ats-companies/successfactors.csv
@@ -1266,3 +1266,7 @@ Trabaja en Gentera,vacantesbancocompartamos,https://vacantesbancocompartamos.gen
 vacaturesuvahva,huva,https://vacaturesuvahva.nl
 Kronesusa,kronesinc,https://workfor.kronesusa.com
 Agresearch,agresearch,https://yourcareer.agresearch.co.nz
+EssilorLuxottica,essilorluxottica,https://careers.essilorluxottica.com
+Jerónimo Martins,jeronimomartins,https://careers.jeronimomartins.com
+AmRest,amrest,https://careers.amrest.eu
+Vodafone,vodafone,https://opportunities.vodafone.com

--- a/ats-companies/successfactors.csv
+++ b/ats-companies/successfactors.csv
@@ -710,3 +710,559 @@ Uneteaestafeta,uneteaestafeta,https://uneteaestafeta.com
 Ura,ura,https://ura.kela.fi
 Us Careers,us-careers,https://us-careers.crown.com
 Werkenbijvitens,werkenbijvitens,https://werkenbijvitens.nl
+Southco,SOUTHCO,https://160100.jobs2web.com
+Interpol,interpol,https://209400.jobs2web.com
+Careers at African Development Bank,africandev,https://afdb.jobs2web.com
+Ørsted,dongenergyP2,https://applyforjob.orsted.com
+Jobs at Aramark,ARAMARKPROD,https://aramarkcareers.com
+Bertrandt Jobs,bertrandta,https://bertrandt.jobs.hr.cloud.sap
+Alle offenen Jobs bei BAUHAUS,bahagag,https://bewerben.bauhaus.info
+Nttdata,nttdatade,https://bewerben.de.nttdata.com
+Canal Empleo,clecesa,https://canaldeempleo.es
+Constantia Flexibles Jobs,CFlex,https://career.cflex.com
+DAT Karriere,deutscheau,https://career.dat.de
+Deutz,deutzag,https://career.deutz.com
+Hamburg Commercial Bank AG,hamburgcom,https://career.hcob-bank.com
+Karlstorz,karlstor01,https://career.karlstorz.com
+Jobs at Krones,kronesag,https://career.krones.com
+Marlabs Innovations Private Limited Careers,marlabsinn,https://career.marlabs.com
+Medice,medicearzn,https://career.medice-health-family.com
+Nexans,NEXANS,https://career.nexans.com
+ONE Line,oceannetwo,https://career.one-line.com
+Rosenberger,rosenberge,https://career.rosenberger.com
+Witglobal,wrthitinteP2,https://career.witglobal.net
+SMBC,SMBC,https://careerasia.smbc.co.jp
+Careers | SMBC Hong Kong Branch,smbcP6,https://careerhk.smbc.co.jp
+Hyundai,hmc1,https://careers-americas.hyundai.com
+Jobs at Stulz,stulzairteP,https://careers-us.stulz.com
+Careers - AAW,aliabdulwa,https://careers.aaw.com
+ACA Group Jobs,foresidefi,https://careers.acaglobal.com
+Acps Automotive,acpsautomo,https://careers.acps-automotive.com
+Actylis,acetousllc,https://careers.actylis.com
+Acwapower,acwapowerc,https://careers.acwapower.com
+ADB SAFEGATE Careers,ADBDP,https://careers.adbsafegate.com
+AFL,careers,https://careers.afl
+Careers at AFP,digitaltra,https://careers.afp.gov.au
+Careers at Royal Agrifirm Group,careers,https://careers.agrifirm.com
+Agthia,agthiagrouP,https://careers.agthia.com
+Albaughllc,albaughllc,https://careers.albaughllc.com
+Jobs at AG Group,AGPeopleFirst,https://careers.anadolukariyerim.com
+Open jobs at ANDRITZ,andritzag,https://careers.andritz.com
+AngloGold Ashanti | Jobs and Careers | Home,AGAprod,https://careers.anglogoldashanti.com
+ANSA McAL Careers,ansamcalli,https://careers.ansamcal.com
+Ansto,careers,https://careers.ansto.gov.au
+ANZ Banking Careers,anzbanking,https://careers.anz.com
+AO Foundation - Working at AO,AOF,https://careers.aofoundation.org
+AMOREPACIFIC CAREERS,amorepacif,https://careers.apgroup.com
+Arcacontal,ARCACONTAL,https://careers.arcacontal.com
+VAGO Careers,victoriana,https://careers.audit.vic.gov.au
+Avolta Careers,avoltaP,https://careers.avoltaworld.com
+Bajajauto,BAL,https://careers.bajajauto.com
+Career at Bank Islam,bankislammP2,https://careers.bankislam.com.my
+Bartonmalow,BartonMalowP,https://careers.bartonmalow.com
+BCX,BCXP,https://careers.bcx.co.za
+Careers at Belden,beldeninc,https://careers.belden.com
+Betagro,betagropub,https://careers.betagro.com
+BMT - Careers,bmtinterna,https://careers.bmt.be
+Bonfiglioli Job Opportunities,careers,https://careers.bonfiglioli.com
+Bouygues Construction,bouyguescoP,https://careers.bouygues-construction.com
+Brakebush,brakebushb,https://careers.brakebush.com
+Careers homepage,breitlinga,https://careers.breitling.com
+Briibio,briibiosci,https://careers.briibio.com
+Browardschools,browardcou,https://careers.browardschools.com
+ÇALIK'TA KARİYER,calikholdi,https://careers.calik.com
+Careers | Grupo Casais,casaisenge,https://careers.casais.pt
+Centerpointenergy,centerpoin,https://careers.centerpointenergy.com
+Charlotte Pipe & Foundry Company,charlottep,https://careers.charlottepipe.com
+Chiesi,chiesifarm,https://careers.chiesi.com
+Clap Partners,clappartne,https://careers.clap-partners.com
+Clariant Careers,Clariant,https://careers.clariant.com
+Cmco,columbusmc,https://careers.cmco.com
+Coats,jpcoatsltd,https://careers.coats.com
+Crocs,crocs,https://careers.crocs.com
+Daikin,daikineuro,https://careers.daikin.eu
+Dentons,dentonsgro,https://careers.dentons.com
+Dentsply Sirona Careers,DENTSPLY,https://careers.dentsplysirona.com
+DFS,dfsventure,https://careers.dfs.com
+Dufry,careers,https://careers.dufry.com
+Duke Careers,dukeuniverP1,https://careers.duke.edu
+EBZ Group,ebzse,https://careers.ebz-group.com
+EG,eurogarage,https://careers.eg.group
+Eisai Jobs Home,EisaiP,https://careers.eisai.net
+Electranet,electranet,https://careers.electranet.com.au
+Engbim,engbimcomp,https://careers.engbim.com
+Careers EPA NZ,environmen,https://careers.epa.govt.nz
+Careers at ESB,electric02,https://careers.esb.ie
+Jobs at Essar Oil (UK),essaroiluk,https://careers.essaroil.co.uk
+Careers at ESTEVE,careers,https://careers.esteve.com
+Eurobank,eurobanker,https://careers.eurobank.gr
+Eutelsat,2236044P,https://careers.eutelsat.com
+Careers | Evident,olympussci,https://careers.evidentscientific.com
+Careers at EY: search jobs,EYHRISPRD1,https://careers.ey.com
+Careers at FBD Holdings PLC  | Job Openings & Vacancies,fbdholding,https://careers.fbdgroup.com
+FCC Asrgroup,634633P,https://careers.fcc-asrgroup.com
+Careers | Farm Credit Services of America,farmcred01,https://careers.fcsamerica.com
+Careers At First Mills,millingc01,https://careers.firstmills.com
+Fitch,careers,https://careers.fitch.group
+Jobs at Flowers Foods,FlocorpPRD,https://careers.flowersfoods.com
+Careers at SSP,sspfinanci,https://careers.foodtravelexperts.com
+Fortisalberta,careers,https://careers.fortisalberta.com
+Fphcare,fphcPRD,https://careers.fphcare.com
+Frasersproperty,tcctechnolP1,https://careers.frasersproperty.com
+Fressnapf Maxizoo,fressnapftP,https://careers.fressnapf-maxizoo.com
+Fuelcellenergy,fuelcellen,https://careers.fuelcellenergy.com
+G3enterprises,G3,https://careers.g3enterprises.com
+Garney Construction,garneyhold,https://careers.garney.com
+Richter Gedeon karrier,richterged,https://careers.gedeonrichter.com
+Geistlich,Geistlich,https://careers.geistlich.com
+Careers at Getinge,GetingeProd,https://careers.getinge.com
+GEZE GmbH,gezegmbh,https://careers.geze.com
+GKN Aerospace Careers,gknaerospa,https://careers.gknaerospace.com
+Glanbia,glanbiaplc,https://careers.glanbia.com
+Gold Fields Careers,careers,https://careers.goldfields.com
+Gruma,asesoradee,https://careers.gruma.com
+Grünenthal Careers,Grunenthal,https://careers.grunenthal.com
+H Eparts,HEPPROD,https://careers.h-eparts.com
+Careers at Hallmark UK&I,hallmarkca,https://careers.hallmark.co.uk
+Jobs at Hanes,hanesbrand,https://careers.hanes.com
+Hanglung,HangLung,https://careers.hanglung.com
+Heliostowers,heliostoweP,https://careers.heliostowers.com
+Henderson Group,hendersonw,https://careers.henderson-group.com
+Hero Group Careers,gaiushragP8,https://careers.hero-group.ch
+Hexion,Momentive,https://careers.hexion.com
+HHC,thehealtha,https://careers.hhcorp.org
+Careers at Houghton Mifflin Harcourt: K-12 Learning Technology Company,houghtonmiP,https://careers.hmhco.com
+Careers at HOERBIGER,HOEProd,https://careers.hoerbiger.com
+Deine Zukunft bei HR Campus,HRC,https://careers.hr-campus.ch
+HSH - Careers,hshmanagem,https://careers.hshgroup.com
+HSITP,hongkongsh,https://careers.hsitp.org
+Hubbell,Hubbell,https://careers.hubbell.com
+JM Huber,JMHGPS,https://careers.huber.com
+Hudbay Minerals Careers,hudbay,https://careers.hudbayminerals.com
+HII - Build Your Career,huntingt01P2,https://careers.huntingtoningalls.com
+Hysan Development Company Limited,hysancorpo,https://careers.hysan.com.hk
+Hyundai Translead Careers,hyundaiautP2,https://careers.hyundaitranslead.com
+I-CAR Job Opportunities for a Rewarding Career,interindus,https://careers.i-car.com
+ICL Careers,ICLPROD,https://careers.icl-group.com
+Icrc,ICRCPROD,https://careers.icrc.org
+Idorsia,gaiushragP4,https://careers.idorsia.com
+Careers at IJM Group,ijmcorpora,https://careers.ijm.com
+INOVYN Careers Portal,inovynchlo,https://careers.inovyn.com
+Inpex,careers,https://careers.inpex.com.au
+Inspirecommunities,inspirecom,https://careers.inspirecommunities.com
+International SOS Careers,INTLSOS,https://careers.internationalsos.com
+Careers at IRPC,irpcpublic,https://careers.irpc.co.th
+Careers at IRT,illawarrarP,https://careers.irt.org.au
+Jobs at Irvine Company,irvinecompany,https://careers.irvinecompany.com
+Itpaero,ITP,https://careers.itpaero.com
+Ixom Careers,careers,https://careers.ixom.com
+Careers at JBS Australia,jbsaustral,https://careers.jbssa.com.au
+Jetblue,jetblueair,https://careers.jetblue.com
+Johnsonville,1972592P,https://careers.johnsonville.com
+Joysonsafety,joysonsafety,https://careers.joysonsafety.com
+KAESER Careers,KAESERP,https://careers.kaeser.com
+Careers At King Abdullah University of Science & Technology,kingabdull,https://careers.kaust.edu.sa
+KBC Group,careers,https://careers.kbc-group.com
+Career Opportunities,johnkeells,https://careers.keells.com
+Kemira,kemira,https://careers.kemira.com
+Jobs at Keolis,SIRHP,https://careers.keolis.com
+Careers at Keyence Corporation,keyencec01,https://careers.keyence.com
+Kidana,kidanadeve,https://careers.kidana.com.sa
+KiwiRail Careers,kiwiraillt,https://careers.kiwirail.co.nz
+KNAPP AG | Jobs,knappag,https://careers.knapp.com
+Careers at Knorr-Bremse,knorrbremsP2,https://careers.knorr-bremse.com
+Kodak,eastmankod,https://careers.kodak.com
+Jobs at Knights of Columbus,knightsofc,https://careers.kofc.org
+Careers • klöckner pentaplast,klcknerpenP,https://careers.kpfilms.com
+Kpmg,KPMGHITPRD,https://careers.kpmg.it
+Kurita Water,kuritaeuro,https://careers.kurita-water.com
+Lakesidefoods,lakesidefo,https://careers.lakesidefoods.com
+Landis+Gyr Careers,LandisGyrPROD,https://careers.landisgyr.com
+Lane Crawford Careers,LaneCrawford,https://careers.lanecrawford.com.hk
+Langan Careers,langan,https://careers.langan.com
+LATECOERE Careers,LATECOERE,https://careers.latecoere.aero
+LAUSD's Career Center,losangel01,https://careers.lausd.org
+Careers at Leggett  & Platt | L&P Jobs,leggettplatt,https://careers.leggett.com
+Careers at Leonardo DRS,drs,https://careers.leonardodrs.com
+Liebherr,LiMySLive,https://careers.liebherr.com
+Lifeblood,australi02,https://careers.lifeblood.com.au
+Lightsourcebp,lightsourc,https://careers.lightsourcebp.com
+Careers at Lindsay,careers,https://careers.lindsay.com
+Careers | Link,linkassetm,https://careers.linkreit.com
+Login,login,https://careers.login.org
+Lsgskychefs,lsglufthanP1,https://careers.lsgskychefs.com
+Lukb,LUKB,https://careers.lukb.ch
+Careers at Luminous,luminouspo,https://careers.luminousindia.com
+Lupin Ltd,careers,https://careers.lupin.com
+Lyondellbasell,LBI,https://careers.lyondellbasell.com
+Macmahon Careers,macmahonho,https://careers.macmahon.com.au
+MAG Careers,careers,https://careers.magairports.com
+Mahle,mahleinter,https://careers.mahle.com
+Malaysiaairports,malaysia01,https://careers.malaysiaairports.com.my
+Mapletree,careers,https://careers.mapletree.com.sg
+Careers at Martur Fompak,stnberkhol,https://careers.marturfompak.com
+Matthews International Careers,Matthews,https://careers.matw.com
+McCormick Careers,McCormick,https://careers.mccormick.com
+Meaa MEA,mitsubis07,https://careers.meaa-mea.com
+Medartis,Medartis,https://careers.medartis.com
+Mediamarktsaturn,mediasatur,https://careers.mediamarktsaturn.com
+Mediclinic Careers,mediclinicP,https://careers.mediclinic.com
+Trabajos en Melia Hotels International,prodigiosiP,https://careers.melia.com
+MERIVALE CAREERS,hemmestrad,https://careers.merivale.com
+Mersgoodwill,mersmissou,https://careers.mersgoodwill.org
+Metcash Careers,metcashtra,https://careers.metcash.com
+Metrobank,MBTCHCM,https://careers.metrobank.com.ph
+Careers at Milliken & Company,millikenco,https://careers.milliken.com
+Mizuhoemea,mizuhoba01,https://careers.mizuhoemea.com
+Jobs at Mizhuo OSI,mizuhoorthP,https://careers.mizuhosi.com
+Mnyl,segurosmty,https://careers.mnyl.com.mx
+Modine,modinemanu,https://careers.modine.com
+Mohawk Industries | Careers,careers,https://careers.mohawkind.com
+Proving it every day | Careers At Molnlycke,mlnlyckehe,https://careers.molnlycke.com
+Job Opportunities,mondiag,https://careers.mondigroup.com
+Mota-Engil Careers,careers,https://careers.mota-engil.com
+careers msg global solutions,msgglobals,https://careers.msg-global.com
+Msimarinesolutions,marinesolu,https://careers.msimarinesolutions.com
+Unternehmensgruppe Theo Müller,mllerservi,https://careers.muellergroup.com
+Nakilat,Nakilat,https://careers.nakilat.com
+Jobs at NCH,nch,https://careers.nch.com
+Nemak,Nemak,https://careers.nemak.com
+Nesmapartners,nesmapartn,https://careers.nesmapartners.com
+Careers at Neuland,neulandlab,https://careers.neulandlabs.com
+Public Sector jobs in Local Government and Emergency Services,hampshirecP,https://careers.newjob.org.uk
+Nexeoplastics,nexeoplast,https://careers.nexeoplastics.com
+NFA,nationalfu,https://careers.nfa.org
+Ngkntk,ngksparkpl,https://careers.ngkntk.com
+Nibco,nibcoinc,https://careers.nibco.com
+Careers I NOMURA,nomurahold,https://careers.nomura.com
+Nord Anglia Education,careers,https://careers.nordangliaeducation.com
+Novaresteam,novaresfra,https://careers.novaresteam.com
+Careers - Novocure,novocurein,https://careers.novocure.com
+Novo Nordisk,novonordisk,https://careers.novonordisk.com
+Careers | NRG Energy,careers,https://careers.nrgenergy.com
+Nwnatural,northwestn,https://careers.nwnatural.com
+New York Power Authority,NYPAPROD,https://careers.nypa.gov
+Octapharma Career,Octapharma,https://careers.octapharma.com
+Odysseygroup,Odyssey,https://careers.odysseygroup.com
+ofi Careers,OLAMP1,https://careers.ofi.com
+Olam Careers,OLAM,https://careers.olamgroup.com
+Careers at Olympus,olympuscorP,https://careers.olympusamerica.com
+OMV,omvagPRD,https://careers.omv.com
+Careers at Ontex,careers,https://careers.ontex.com
+Jobs at OPEC Fund,opecfundfo,https://careers.opecfund.org
+Optos,optosplc,https://careers.optos.com
+ORAFOL Europe GmbH,orafol,https://careers.orafol.com
+Careers at Orbia,mexichemP,https://careers.orbia.com
+Orica,oricaaus01,https://careers.orica.com
+Origin Energy Services Ltd | Jobs,Origin,https://careers.originenergy.com.au
+Orioncarbons,orioncarbonP,https://careers.orioncarbons.com
+Orior,Orior,https://careers.orior.ch
+Available Jobs at Orkla,careers,https://careers.orkla.com
+Ormat Careers,ormatsyste,https://careers.ormat.com
+Ornua Co-operative Limited,Ornua,https://careers.ornua.com
+Oryxgtl,sasoloryxg,https://careers.oryxgtl.com.qa
+OTB Careers,otbspa,https://careers.otb.net
+OUP Careers | Home,OUP,https://careers.oup.com
+Outokumpu,outokumpuoP,https://careers.outokumpu.com
+OXB Careers,oxfordbiom,https://careers.oxb.com
+Careers at PacifiCorp,pacificorp,https://careers.pacificorp.com
+Par Pacific Careers,parpacific,https://careers.parpacific.com
+PartnerRe Careers,careers,https://careers.partnerre.com
+Patrickind,patrickind,https://careers.patrickind.com
+PCL,PCLcompanies,https://careers.pcl.com
+Pedders,synchronysP8,https://careers.pedders.com.au
+Jobs at Pembina,careers,https://careers.pembina.com
+Perrigo Careers,Perrigo,https://careers.perrigo.com
+Careers @ Pestana Hotel Group,pestanaman,https://careers.pestanagroup.com
+Jobs at Pacific Gas And Electric Company,careers,https://careers.pge.com
+Phillips 66 Careers,Phillips66,https://careers.phillips66.com
+Playaresorts,playaPRD,https://careers.playaresorts.com
+Postgroup,postluxemb,https://careers.postgroup.lu
+Careers - PowerCo,PowerCoSEp,https://careers.powerco.de
+Powercor Careers,careers,https://careers.powercor.com.au
+Careers - Protan,protanas,https://careers.protan.com
+Prym,williampry,https://careers.prym.com
+Psychogenics,psychogeni,https://careers.psychogenics.com
+PWC,04T2,https://careers.pwc.com
+Qatarenergylng,QELNGP,https://careers.qatarenergylng.qa
+Quantumscape,QUANTUMP,https://careers.quantumscape.com
+Quiktrip,qtrcorpora,https://careers.quiktrip.com
+Jobs RHI Magnesita,rhimagnesi,https://careers.rhimagnesita.com
+Ricoh Americalatina,RCHLATpr,https://careers.ricoh-americalatina.com
+Jobs at Republic National Distribution Company,republicna,https://careers.rndc-usa.com
+Rocagroup,Roca,https://careers.rocagroup.com
+Rovensa,rovensa,https://careers.rovensa.com
+Sappi,sappipapie,https://careers.sappi.com
+Sariba,saribaasT2,https://careers.sariba.com
+Jobs at Saudia Group,careers,https://careers.saudia.com
+Jobs at schülke,schlkemayr,https://careers.schuelke.com
+Careers @ SES SD,sesengin,https://careers.sessd.com
+Jobs at Saudi Entertainment Ventures,saudienter,https://careers.seven.sa
+Scandinavian Health Limited,PSshlmedical,https://careers.shl-medical.com
+Careers at SMBC,smbcP2,https://careers.smbcgroup.com
+Smud,SMUDHCM20,https://careers.smud.org
+Jobs and Careers at Smyths Toys Superstores,smythstoys,https://careers.smythstoys.com
+Sofidel Jobs,sofidelspa,https://careers.sofidel.com
+Solvay Jobs,solvaysa,https://careers.solvay.com
+SPX,SPX,https://careers.spx.com
+SSG Service,careers,https://careers.ssg-service.com
+Jobs at stc,stc,https://careers.stc.com.sa
+Careers - ST Engineering North America,STENAHCM20,https://careers.stengg.us
+Careers at Sumitomo Corporation,SCOA,https://careers.sumitomocorp.com
+Careers and Job Opportunities with Superior Industries,superiorin,https://careers.supind.com
+Nexus Water Group (SouthWest Water Company) | Water and Wastewater Professionals,southwes01,https://careers.swwc.com
+Syngeneintl,syngeneP1,https://careers.syngeneintl.com
+Taulia,tauliainc,https://careers.taulia.com
+Technipfmc,fmctechno,https://careers.technipfmc.com
+Tenova Careers,Techint,https://careers.tenova.com
+Terumoamericas,Terumomedical,https://careers.terumoamericas.com
+Career Opportunities at Hersheys,Hersheys,https://careers.thehersheycompany.com
+Jobs at Trivium Packaging,triviumpac,https://careers.triviumpackaging.com
+Trulieve | Careers,trulieve,https://careers.trulieve.com
+TSG Hoffenheim,HheimProd,https://careers.tsg-hoffenheim.de
+Uniqagroup,Uniqa,https://careers.uniqagroup.com
+Universiteitleiden,LeidenProd,https://careers.universiteitleiden.nl
+Vacco Careers,VACHCM20,https://careers.vacco.com
+Vaisala,vaisalaoyj,https://careers.vaisala.com
+Valiant Jobs,ValiantP,https://careers.valiant.ch
+Jobs at Vandemoortele,vandemoort,https://careers.vandemoortele.com
+Verano Careers,veranohold,https://careers.verano.com
+Viega,viegaholdi,https://careers.viega.com
+Westernmidstream,westernmid,https://careers.westernmidstream.com
+Wilson Group,wilsongroup,https://careers.wilsongroupau.com
+Careers at Wizz Air,wizzairhun,https://careers.wizzair.com
+Xchemrx,xcheminc,https://careers.xchemrx.com
+Yamaha Motor,careers,https://careers.yamaha-motor.eu
+Careers at YKK Corporation,ykkcorpora,https://careers.ykkamericas.com
+YORGLASS,yorglass,https://careers.yorglass.com
+Zahid Group Careers,zahidtract,https://careers.zahid.com
+Careers at Zespri,zesprigrou,https://careers.zespri.com
+Zimvie,741838241,https://careers.zimvie.com
+careersatmediq,Mediq,https://careersatmediq.com
+careersemea,smbcP,https://careersemea.smbcgroup.com
+Belagrícola,carreiras,https://carreiras.belagricola.com.br
+carreiras,sumolcompa,https://carreiras.sumolcompal.pt
+Home Page Career Site,italgasret,https://carriere.italgas.it
+Tea S.p.A. Carriere,teaspa,https://carriere.teaspa.it
+Carrières et offres d'emploi Generali France,generalivi,https://carrieres.generali.fr
+Claro Puerto Rico,puertorico,https://claroquetequeremos.claropr.com
+creamosdesarrollo-oportunidadeslaborales,ferreyrossP,https://creamosdesarrollo-oportunidadeslaborales.com
+cybercareers,BAE,https://cybercareers.baesystems.com
+Personas - Ofertas de empleo,finycarsl,https://empleo.sorigue.com
+VITHAS SANIDAD SL,vithassani,https://empleo.vithas.es
+Jobs at Eversheds Sutherland,evershedss,https://esi-vacancies.eversheds-sutherland.com
+experienced,KPMGHUKPROD,https://experienced.kpmgcareers.co.uk
+globalcareers,tekasystemP,https://globalcareers.jobs.hr.cloud.sap
+himalayawellness,himalayawellness,https://himalayawellness.jobs.hr.cloud.sap
+Jobs at Houston Independent School District,hisd,https://hisd.jobs2web.com
+ioc,comitinter,https://ioc.jobs.hr.cloud.sap
+IOC RD changed june28 2021,Siemens36dup,https://iocrdv3dc12.jobs2web.com
+iter,ITER,https://iter.jobs.hr.cloud.sap
+job,brosefahrz,https://job.brose.com
+Jobsite Stad Gent,4079913P,https://job.gent.be
+job,hktservice,https://job.pccw.com
+USZ Jobs & Karriere,USZ,https://job.usz.ch
+Karriere BRUNATA-METRONA,brunatawrm,https://jobs-hamburg.brunata-metrona.de
+jobs-sf,Amcor,https://jobs-sf.amcor.com
+Careers at Advanced Acoustic Concepts,advancedac,https://jobs.aaccorp.com
+Abyat,abyatmegas,https://jobs.abyat.com
+Ajinomoto,ajinomotoc,https://jobs.ajinomoto-be.com
+Alfasigma jobs,alfasigmas,https://jobs.alfasigma.com
+Jobs - All for One Group,all41Group,https://jobs.all-for-one.com
+Careers at Almosafer,altayyartr,https://jobs.almosafer.com
+ALTANA Job Portal,altanamana,https://jobs.altana.com
+Careers - AMT Consulting,amt,https://jobs.amt-consulting.com
+Arjo,arjohuntle,https://jobs.arjo.com
+Working at Athlon - getting you there,athloncarl,https://jobs.athlon.com
+Karriereside - Avarn Security,nokasas,https://jobs.avarnsecurity.com
+Bakkavor (now part of Greencore): More opportunities for brilliant people to shape the future,bakkavor01,https://jobs.bakkavor.com
+Job Opportunities | Barilla Group,barilla,https://jobs.barillagroup.com
+Bayernlb,SFHR,https://jobs.bayernlb.de
+B. Braun Group Global Job Market,bbraunprd,https://jobs.bbraun.com
+Careers at Bell,Bell,https://jobs.bce.ca
+BCV,BCV,https://jobs.bcv.ch
+Belfius,belfiusban,https://jobs.belfius.be
+NMBS Jobs,nmbsnation,https://jobs.belgiantrain.be
+Beneteau Group,beneteau,https://jobs.beneteau-group.com
+Karriere - BG-Phoenics,bgphoenicsP2,https://jobs.bg-phoenics.de
+Bigdutchman,bigdutchma,https://jobs.bigdutchman.com
+Biontech,biontechse,https://jobs.biontech.com
+Bombardier,Bombardier,https://jobs.bombardier.com
+Jobs at Bourns,bournsinc,https://jobs.bourns.com
+Careers | BT Group Plc,britisht01P1,https://jobs.bt.com
+BWB,berlinerwa,https://jobs.bwb.de
+Canadalife,thegreatweP2,https://jobs.canadalife.com
+Capgemini Careers,jobs,https://jobs.capgemini.com
+Jobs at Cargill,cargill,https://jobs.cargill.com
+Central Bedfordshire Council Jobs,centralbed,https://jobs.centralbedfordshire.gov.uk
+Careers at City Edge Developments,cityedgede,https://jobs.cityedgedevelopments.com
+Clean Energy Jobs Program,PNCEHCM20,https://jobs.cleanenergyjobspartnership.com
+Conitas GmbH,itaddition,https://jobs.conitas.de
+Constellium Careers,jobs,https://jobs.constellium.com
+CPP,octechnoloP,https://jobs.cpp.canon
+Daba Jobs,jobs,https://jobs.daba.es
+Dana,DanaLimitedP,https://jobs.dana.com
+Danfoss,danfossas,https://jobs.danfoss.com
+Jobs at DAWN,dfprod,https://jobs.dawnfoods.com
+Day and Zimmermann Careers Site,dayzimme01,https://jobs.dayzim.com
+Decathlon Careers,gavdiasP9,https://jobs.decathlon.co.uk
+Denora,industried,https://jobs.denora.com
+Desigual Jobs,Desigual,https://jobs.desigual.com
+DKMS Job- und Karriereportal,dkmsprod,https://jobs.dkms.de
+DLG,DLG,https://jobs.dlg.dk
+DLR,dlrdeutsch,https://jobs.dlr.de
+Dolcegabbana,dolcegabba,https://jobs.dolcegabbana.com
+Jobs DRV Mitteldeutschland,SFP09,https://jobs.drv-md.de
+Dtswiss,DTSwiss,https://jobs.dtswiss.com
+Welsh Water Careers,dwrcymrucy,https://jobs.dwrcymru.com
+Jobs - Energie Steiermark,energieste,https://jobs.e-steiermark.com
+Elia jobs,eliasystem,https://jobs.eliagroup.eu
+Emch,emchaufzge,https://jobs.emch.com
+Endress EHS,ehsP,https://jobs.endress-ehs.com
+Evertec,evertecgro,https://jobs.evertecinc.com
+EVS Career Site,EVS,https://jobs.evs.com
+Excelitas,excelitast,https://jobs.excelitas.com
+Exolum Corporation S.A.,compaialog,https://jobs.exolum.com
+Farmersinsurance,Farmers,https://jobs.farmersinsurance.com
+Jobs an der FernUniversität in Hagen,fernuniver,https://jobs.fernuni-hagen.de
+Your career at FFT,fftprodukt,https://jobs.fft.de
+Flugger,flggeras,https://jobs.flugger.com
+Offres d'emploi de l'Etat de Fribourg | Stellenangebote Staat Freiburg,administ04,https://jobs.fr.ch
+Karriere Fraunhofer-Gesellschaft,fraunhofer,https://jobs.fraunhofer.de
+Karriere bei Frenzelit,frenzelitg,https://jobs.frenzelit.com
+Gebhardt Group,gebhardtP,https://jobs.gebhardt-group.com
+Gestamp - Jobs,gestampser,https://jobs.gestamp.com
+Gjensidige Jobs,gjensidige,https://jobs.gjensidige.com
+Groz-Beckert Jobs,grozbecker,https://jobs.groz-beckert.com
+Grupo Fuertes Career,grupocor01,https://jobs.grupofuertes.com
+GXO,xpologisti,https://jobs.gxo.com
+Hausbetreuung Wien,wienerwohn,https://jobs.hausbetreuung-wien.at
+Heinz Glas,heinzglasg,https://jobs.heinz-glas.com
+Helsingin yliopisto,helsinginy,https://jobs.helsinki.fi
+Hoermann,hrmannkgve,https://jobs.hoermann.com
+Jobs at Home Affairs,DIAC,https://jobs.homeaffairs.gov.au
+career.huf,hufhlsbeck,https://jobs.huf-group.com
+Offres d'emploi,idelux,https://jobs.idelux.be
+IMD,imdinterna,https://jobs.imd.org
+Jobs - Implenia,impleniasc,https://jobs.implenia.com
+Jobs at Indorama Ventures,indoramaveP2,https://jobs.indoramaventures.com
+Ineos Styrolution,ineoseurop,https://jobs.ineos-styrolution.com
+Infrabel - HR Rail,infrabelnvP2,https://jobs.infrabel.be
+Jobs at ISS,issworldseP,https://jobs.issworld.com
+Itdz Berlin,itdienstle,https://jobs.itdz-berlin.de
+Ivy Technology,iqorglobal,https://jobs.ivytech.com
+Jebsen,jebsen,https://jobs.jebsen.com
+Jowat - Jobs,jowatse,https://jobs.jowat.com
+Karriere bei Champignon-Hofmeister Familienunternehmen,ksereicham,https://jobs.karriere-bei-champignon.de
+KB Kookmin Bank,kbkookminb,https://jobs.kbstar.com
+Kmart Group,kmartaustr,https://jobs.kmart.com.au
+KMD,kmd,https://jobs.kmd.net
+Working at L3Harris Technologies,L3HHCM20,https://jobs.l3harris.com
+Jobs | LEMKEN The Agrovision Company,lemkengmbh,https://jobs.lemken.com
+Letec,srwttec,https://jobs.letec.be
+LIDL,lidlstiftuP2,https://jobs.lidl
+Lopesan,lopesan,https://jobs.lopesan.com
+Jobs at Lake Superior Consulting,lakesuperi,https://jobs.lsconsulting.com
+Jobs at Marvin Group,MECHCM20,https://jobs.marvingroup.com
+"Jobs at Ministry of Business, Innovation & Employment",MBIEPROD,https://jobs.mbie.govt.nz
+Ofertas - Bolsa de trabajo | Mediapro,imaginamed,https://jobs.mediapro.tv
+Mfat,ministry07,https://jobs.mfat.govt.nz
+Minebea Intec,SartoriusTP2,https://jobs.minebea-intec.com
+Murata Americas,murataamer,https://jobs.murata.com
+Open jobs at Neste,jobs,https://jobs.neste.com
+Oberalp Careers,oberalpspa,https://jobs.oberalp.com
+OG&E Jobs,ogeprod,https://jobs.oge.com
+The OU Career Site,OUP1,https://jobs.open.ac.uk
+Werken bij Oxfam Novib,OxfamNovibP,https://jobs.oxfamnovib.nl
+Careers at Peel Ports,peelportsi,https://jobs.peelports.com
+Precision Drilling Career Site,precisiondril,https://jobs.precisiondrilling.com
+Prezero,PreZero,https://jobs.prezero.com
+Progreso,jobs,https://jobs.progreso.com
+Talento Reganosa,regasifica,https://jobs.reganosa.com
+Richard Wolf,richardwol,https://jobs.richard-wolf.com
+Rpggroup,jobs,https://jobs.rpggroup.com
+Careers at SABIC,SABIC,https://jobs.sabic.com
+Safholland,SAFHOLLAND,https://jobs.safholland.com
+Careers with City of San Diego,jobs,https://jobs.sandiego.gov
+Sasol,sasolchemP3,https://jobs.sasol.com
+Saudi Paper Group Career Site,saudipaper,https://jobs.saudipaper.com
+Jobs at Scania | We drive real change,volkswagenP20,https://jobs.scania.com
+Schönmackers Umweltdienste GmbH &Co.KG Careers,schnmacker,https://jobs.schoenmackers.de
+Dr. Schumacher Karriere,drschumach,https://jobs.schumacher-online.com
+SERTO AG,sertoag,https://jobs.serto.com
+skyguide | Jobs,SkyguidePROD,https://jobs.skyguide.ch
+Stadt Zürich,STZH,https://jobs.stadt-zuerich.ch
+Stobag,stobag,https://jobs.stobag.com
+Tenneco,TennecoP1,https://jobs.tenneco.com
+Terna,ternaspa,https://jobs.terna.it
+Value Retail,S001955610P,https://jobs.thebicestercollection.com
+Tuyển dụng THG,thmilkfoodP2,https://jobs.thgroupglobal.com
+Tillotts,Tillotts,https://jobs.tillotts.com
+Turbo,ngernturbo,https://jobs.turbo.co.th
+University of Cape Town Jobs,universi07,https://jobs.uct.ac.za
+USB,USB,https://jobs.unispital-basel.ch
+Jobs@Universität Wien,univie,https://jobs.univie.ac.at
+Valentino Careers,valentinos,https://jobs.valentino.com
+Jobs at Valvoline Global,vgpholding,https://jobs.valvolineglobal.com
+Vitesco Technologies - Careers,VitescoProd,https://jobs.vitesco-technologies.com
+Your job at the Volkswagen Group,VWAGLPPROD10,https://jobs.volkswagen-group.com
+Warsteiner Gruppe Karriere,warsteiner,https://jobs.warsteiner-gruppe.de
+Weill Cornell Medicine,jobs,https://jobs.weill.cornell.edu
+Jobs at WFS,worldwidef,https://jobs.wfs.aero
+Wintersteiger,winterstei,https://jobs.wintersteiger.com
+Wirthwein,Wirthwein,https://jobs.wirthwein.de
+Witzenmann,witzenmann,https://jobs.witzenmann.com
+Woodgrain,woodgrainmP2,https://jobs.woodgrain.com
+Yunextraffic,YunexPROD,https://jobs.yunextraffic.com
+Zorgbedrijf,Zorgbedrijf,https://jobs.zorgbedrijf.be
+jobs1,orona,https://jobs1.orona-group.com
+jobslotusbakeries,Lotus,https://jobslotusbakeries.com
+Viridor Waste Limited,3136788P,https://join.viridor.co.uk
+Our jobs - CANAL+ Group,groupecana,https://joinus.canalplus.com
+Telekom karijera,telekomsrb,https://karijera.mts.rs
+Netas,netastelek,https://kariyer.netas.com.tr
+Karjera,jsclithuan,https://karjera.litrail.lt
+BUD,budapestaiP2,https://karrier.bud.hu
+ERP,erpconsult,https://karrier.erp.hu
+Kozut,magyarkztz,https://karrier.kozut.hu
+ABS Group,adecco,https://karriere.abs-group.de
+Karriere - Bane NOR,banenorP1,https://karriere.banenor.no
+BwFuhrparkService GmbH,bwfuhrpark,https://karriere.bwfuhrpark.de
+DAAD - Karriere,daaddeutsc,https://karriere.daad.de
+Karriere bei DekaBank,dekabankdeP,https://karriere.deka.de
+Erzbistum Muenchen,erzdizesem,https://karriere.erzbistum-muenchen.de
+Gisa,gisagmbh,https://karriere.gisa.de
+HIL Karriere,hilheeresiP,https://karriere.hilgmbh.de
+Karriere - Lyse Konsern,lyseas,https://karriere.lysekonsern.no
+Nordlb,nordlbnord,https://karriere.nordlb.de
+Jobs - Rehaklinik Bellikon,rehaklinik,https://karriere.rehabellikon.ch
+Stadt Koeln,kdndachverP2,https://karriere.stadt-koeln.de
+Stiebel Eltron,stiebelelt,https://karriere.stiebel-eltron.de
+Stellen der ZURZACH Care,ZURZACHCare,https://karriere.zurzachcare.ch
+Finiper,northgateiP18,https://lavoraconnoi.finiper.it
+mainova-karriere,mainovaag,https://mainova-karriere.de
+Mindray Jobs,Mindray,https://mindray.jobs.hr.cloud.sap
+Alnylam Pharmaceuticals Jobs,alnylampha,https://opportunities.alnylam.com
+Opportunities,bestseller,https://opportunities.bestseller.com
+Draeger,draegerP,https://recruitment.draeger.jobs
+SCK CEN HR & Academy,centredtud,https://recruitment.sckcen.be
+Tenaris,Tenaris,https://recruitment.tenaris.com
+Bluepharmagroup,bluepharmaP,https://recrutamento.bluepharmagroup.com
+Brisa,brisaautoe,https://recrutamento.brisa.pt
+Recrutamento NOS,noscomunic,https://recrutamento.nos.pt
+Novo Banco,novobancos,https://recrutamento.novobanco.pt
+Bouygues Immobilier Corporate,bouyguesim,https://recrutement.bouygues-immobilier-corporate.com
+Ksgr,kantonsspi,https://sfjobs.ksgr.ch
+Stellenangebote | BGV Badische Versicherungen,bgvversich,https://stellenangebote.bgv.de
+Stellenangebote | Mobil Krankenkasse,bkkmobiloi,https://stellenangebote.mobil-krankenkasse.de
+WGV,wgvhr,https://stellenangebote.wgv.de
+Citeo,citeo,https://talents.citeo.com
+Feda,FEDA,https://treball.feda.ad
+Keralty Jobs,keraltysas,https://uneteakeralty.keralty.com
+Welcome to Union Pacific Careers,UPProd,https://up.jobs
+Ecco,eccoskoas,https://vacancies.ecco.com
+Grupo CCN,CCN,https://vacantes.grupoccn.com.ni
+Trabaja en Gentera,vacantesbancocompartamos,https://vacantesbancocompartamos.gentera.com.mx
+vacaturesuvahva,huva,https://vacaturesuvahva.nl
+Kronesusa,kronesinc,https://workfor.kronesusa.com
+Agresearch,agresearch,https://yourcareer.agresearch.co.nz


### PR DESCRIPTION
## Summary
- Add 560 validated SuccessFactors Recruiting Marketing hosts to `ats-companies/successfactors.csv`.
- Keep the CSV edit append-only to avoid reordering existing provider entries.
- Source candidates from the public Cetteup SuccessFactors instance API, high-volume public SuccessFactors indexes, and targeted host probes, then keep only hosts that the scraper can consume via `/sitemal.xml`.

## Added in the latest batch
- EssilorLuxottica: `https://careers.essilorluxottica.com`
- Jerónimo Martins: `https://careers.jeronimomartins.com`
- AmRest: `https://careers.amrest.eu`
- Vodafone: `https://opportunities.vodafone.com`

## Validation
- Validated every appended row from the actual CSV against `https://{host}/sitemal.xml` through the `SuccessFactorsScraper` path.
- Required HTTP 200, parseable RSS/XML, and at least one `<item>` per new host. Latest live counts:
  - EssilorLuxottica: 4694 jobs
  - Jerónimo Martins: 1884 jobs
  - AmRest: 1648 jobs
  - Vodafone: 1391 jobs
- Confirmed `ats-companies/successfactors.csv` parses with 1271 rows and 1271 unique URLs. Slug duplicates pre-exist for generic host labels and are not used when URL is present.
- Excluded stage/test/QA-looking hosts, duplicate URLs, 404s, malformed XML, non-resolving hosts, and generic/non-RSS pages. Recent skips included duplicate Bureau Veritas and Checkers rows, invalid Pandora/HSBC guesses, and non-SuccessFactors Vodafone career hosts.
- `uv run pytest tests/test_run_pipeline_guards.py tests/test_scrapers_extra.py -q` -> 44 passed
- `uv run pytest -q` -> 929 passed
- `git diff --check`

## Notes
- This expands SuccessFactors from 711 to 1271 provider entries on this PR branch.
- A few very large feeds need longer per-host validation timeouts, but the retained hosts return non-empty RSS feeds.