### PR TITLE
Add validated Oracle companies

### DIFF
--- a/ats-companies/oracle.csv
+++ b/ats-companies/oracle.csv
@@ -428,3 +428,14 @@ MARTA,fa-evii-saasfaprod1,https://fa-evii-saasfaprod1.fa.ocs.oraclecloud.com/hcm
 Computershare,fa-evdq-saasfaprod1,https://fa-evdq-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/computersharecareers
 Hillsborough County,fa-eqsg-saasfaprod1,https://fa-eqsg-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 AutoZone,egud,https://egud.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Navy Federal Credit Union,fa-etbx-saasfaprod1,https://fa-etbx-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/nfcu
+KPMG Global Services,ejgk,https://ejgk.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3
+CooperCompanies,hcjy,https://hcjy.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/hu/sites/CX_1
+Blue Cross Blue Shield of Michigan,ejko,https://ejko.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3
+Network International,fa-euqk-saasfaprod1,https://fa-euqk-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Airtel Africa,erey,https://erey.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+JPMorgan Chase,jpmc,https://jpmc.fa.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Tremco CPG Inc.,hcwx,https://hcwx.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_6
+Arqiva,ehik,https://ehik.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Fortive,ejta,https://ejta.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+SCV Water,fa-epmn-saasfaprod1,https://fa-epmn-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/SCVWaterCareers

--- a/ats-companies/oracle.csv
+++ b/ats-companies/oracle.csv
@@ -364,3 +364,60 @@ ibnjjb.fa.ocs.oraclecloud.com,ibnjjb,https://ibnjjb.fa.ocs.oraclecloud.com/hcmUI
 icfcjb.fa.ocs.oraclecloud.com,icfcjb,https://icfcjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 ooba,ejuu,https://ejuu.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 the Myriad Genetics Candidate site,ekgn,https://ekgn.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Apollo Hospitals,cgs,https://cgs.fa.ap2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Vanderbilt University,ecsr,https://ecsr.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Fortinet,edel,https://edel.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+SBIC,edox,https://edox.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3001
+SBIC,edox,https://edox.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_33
+NRI,edtq,https://edtq.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Oracle,eeho,https://eeho.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/jobsearch
+UW,eeik,https://eeik.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+CDS Global,eevd,https://eevd.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_8
+ATCO,eezy,https://eezy.fa.ca2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Ford Model-e U.S.,efds,https://efds.fa.em5.oraclecloud.com/hcmUI/CandidateExperience/en/sites/Ford-Model-e
+King's College,effb,https://effb.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/KingsCareerPortal
+UOW,efhc,https://efhc.fa.ca2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+NOV,egay,https://egay.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_4001
+Calderys Career Opportunities,egmk,https://egmk.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+CNRL Professional,ehaa,https://ehaa.fa.ca2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CNRL-Professional
+FAB,ehjd,https://ehjd.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/fabCareers
+Barrick Mining Corporation,ehkn,https://ehkn.fa.ca2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Carnival Corporation,eicl,https://eicl.fa.em5.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CORP
+CSSI,eicl,https://eicl.fa.em5.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CSSI
+Holland America Group,eicl,https://eicl.fa.em5.oraclecloud.com/hcmUI/CandidateExperience/en/sites/HAGroup
+Private Destinations,eicl,https://eicl.fa.em5.oraclecloud.com/hcmUI/CandidateExperience/en/sites/PD
+CECONY,ejcu,https://ejcu.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1033
+Beyonics,ejxf,https://ejxf.fa.ap2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Te Herenga Waka—Victoria University of Wellington,ejye,https://ejye.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Al-Othman Holding Company,eknh,https://eknh.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+COTTON ON,ekxm,https://ekxm.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Brazos County,ekzl,https://ekzl.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+UoE Student jobs,elxw,https://elxw.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1004
+WM,emcm,https://emcm.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/WMCareers
+ArcelorMittal,emfg,https://emfg.fa.em4.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+ArcelorMittal - Recommended Jobs,emfg,https://emfg.fa.em4.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+ArcelorMittal,emfg,https://emfg.fa.em4.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_4001
+AM/NS India,emfg,https://emfg.fa.em4.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_5001
+Southern Company,emje,https://emje.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/SouthernCompanyJobs
+OCBC,empq,https://empq.fa.ap2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Essential Energy,enno,https://enno.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Skidmore,eodq,https://eodq.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Albertsons Companies,eofd,https://eofd.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+KCB Group,eoin,https://eoin.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3001
+PETRONAS,epuc,https://epuc.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+UN Women - UNDP ACCESS,estm,https://estm.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Harper College,fa-eneh-saasfaprod1,https://fa-eneh-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/HarperCollege
+Polk BoCC,fa-eqpz-saasfaprod1,https://fa-eqpz-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+SAFE,fa-esiu-saasfaprod1,https://fa-esiu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+IOM Supplier Portal,fa-evlj-saasfaprod1,https://fa-evlj-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+ENBD Recruitment Team,fa-evlo-saasfaprod1,https://fa-evlo-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Startek®,fa-evuf-saasfaprod1,https://fa-evuf-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Our Emaar Get Together - EMAAR Misr,fa-ewtd-saasfaprod1,https://fa-ewtd-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_7001
+APS,fa-ewxu-saasfaprod1,https://fa-ewxu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/APS-Career-Site
+Downer,fa-exfs-saasfaprod1,https://fa-exfs-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CareersAtDowner
+ADIB,hciq,https://hciq.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+JDI,hcpd,https://hcpd.fa.ca2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/Careers
+HBL People,hdcs,https://hdcs.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_9001
+BNM,iaartj,https://iaartj.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/BNMCareers
+BNMKGP,iaartj,https://iaartj.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/BNMKGP
+BNMSCHOLAR,iaartj,https://iaartj.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/BNMSCHOLAR

--- a/ats-companies/oracle.csv
+++ b/ats-companies/oracle.csv
@@ -421,3 +421,10 @@ HBL People,hdcs,https://hdcs.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en
 BNM,iaartj,https://iaartj.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/BNMCareers
 BNMKGP,iaartj,https://iaartj.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/BNMKGP
 BNMSCHOLAR,iaartj,https://iaartj.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/BNMSCHOLAR
+Weatherford,fa-exmi-saasfaprod1,https://fa-exmi-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+University of Tennessee,fa-ewlq-saasfaprod1,https://fa-ewlq-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Cotiviti,fa-euxw-saasfaprod1,https://fa-euxw-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+MARTA,fa-evii-saasfaprod1,https://fa-evii-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Computershare,fa-evdq-saasfaprod1,https://fa-evdq-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/computersharecareers
+Hillsborough County,fa-eqsg-saasfaprod1,https://fa-eqsg-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+AutoZone,egud,https://egud.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1

--- a/ats-companies/oracle.csv
+++ b/ats-companies/oracle.csv
@@ -439,3 +439,5 @@ Tremco CPG Inc.,hcwx,https://hcwx.fa.us2.oraclecloud.com/hcmUI/CandidateExperien
 Arqiva,ehik,https://ehik.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
 Fortive,ejta,https://ejta.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
 SCV Water,fa-epmn-saasfaprod1,https://fa-epmn-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/SCVWaterCareers
+Hermès,fa-eoic-saasfaprod1,https://fa-eoic-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Mapei,fa-elhu-saasfaprod1,https://fa-elhu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX


### PR DESCRIPTION
## Summary
- Add 77 validated Oracle HCM CandidateExperience sites to `ats-companies/oracle.csv`.
- Keep the provider CSV append-only; the latest update adds Hermès and Mapei.
- Source candidates from indexed CandidateExperience URLs, public job posts/PDFs, search result snippets, and urlscan CandidateExperience hits, then keep only host/site pairs that the Oracle REST API can consume.

## Added in the latest batches
- Navy Federal Credit Union
- KPMG Global Services
- CooperCompanies
- Blue Cross Blue Shield of Michigan
- Network International
- Airtel Africa
- JPMorgan Chase
- Tremco CPG Inc.
- Arqiva
- Fortive
- SCV Water
- Hermès
- Mapei

## Validation
- Validated appended rows against Oracle's public REST endpoint through the `OracleScraper` path or equivalent first-page REST probe:
  `recruitingCEJobRequisitions?finder=findReqs;siteNumber=...,limit=...,offset=0&expand=requisitionList`
- Required HTTP 200, parseable JSON, and non-empty requisitions. Latest live counts:
  - Hermès: 1,053 jobs
  - Mapei: 142 jobs
- Previous latest batch:
  - Navy Federal Credit Union: 87 jobs
  - KPMG Global Services: 983 jobs
  - CooperCompanies: 232 jobs
  - Blue Cross Blue Shield of Michigan: 26 jobs
  - Network International: 30 jobs
  - Airtel Africa: 14 jobs
  - JPMorgan Chase: 7,444 jobs
  - Tremco CPG Inc.: 399 jobs
  - Arqiva: 14 jobs
  - Fortive: 327 jobs
  - SCV Water: 1 job
- Earlier batch:
  - Weatherford: 190 jobs
  - University of Tennessee: 569 jobs
  - Cotiviti: 239 jobs
  - MARTA: 27 jobs
  - Computershare: 109 jobs
  - Hillsborough County: 58 jobs
  - AutoZone: 10000 jobs returned by the scraper/API path
- Confirmed the CSV parses with 442 rows and 442 unique URLs. Oracle host slugs can repeat for distinct `sites/...` career sites, so duplicate filtering used the full URL.
- Skipped duplicate, ambiguous, zero-job, redirected/generic, and failing API cases. Latest skips included `ia-erp-iaedkf` / `CX_1001` with zero requisitions.
- `uv run pytest tests/test_scrapers_extra.py tests/test_run_pipeline_guards.py -q` -> 44 passed
- `uv run pytest -q` -> 929 passed
- `git diff --check`

## Notes
- This expands Oracle from 365 to 442 provider entries on this PR branch.