### PR TITLE
Add validated Taleo companies

### DIFF
--- a/ats-companies/taleo.csv
+++ b/ats-companies/taleo.csv
@@ -109,3 +109,36 @@ City of Artesia,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org
 Conservation International,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=CONSERVATION&cws=39,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=CONSERVATION&cws=39
 DCS Corporation,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=DCSCORP2&cws=37,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=DCSCORP2&cws=37
 Pinellas County Government,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=PCG&cws=47,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=PCG&cws=47
+AlMansoori Petroleum Services,https://lde.tbe.taleo.net/lde01/ats/careers/v2/searchResults?org=ALMANSSP&cws=39,https://lde.tbe.taleo.net/lde01/ats/careers/v2/searchResults?org=ALMANSSP&cws=39
+DT Global,https://lde.tbe.taleo.net/lde01/ats/careers/v2/searchResults?org=URSAUS&cws=39,https://lde.tbe.taleo.net/lde01/ats/careers/v2/searchResults?org=URSAUS&cws=39
+Brown Thomas Arnotts,https://lde.tbe.taleo.net/lde02/ats/careers/v2/searchResults?org=ARNOTTS&cws=73,https://lde.tbe.taleo.net/lde02/ats/careers/v2/searchResults?org=ARNOTTS&cws=73
+Tillys,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=TILLCLOT&cws=118,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=TILLCLOT&cws=118
+Banff Centre,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=BANFFCENTRE&cws=39,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=BANFFCENTRE&cws=39
+Olin Corporation,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=OLIN&cws=47,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=OLIN&cws=47
+Covestic,https://phf.tbe.taleo.net/phf01/ats/careers/v2/searchResults?org=COVESTIC2&cws=37,https://phf.tbe.taleo.net/phf01/ats/careers/v2/searchResults?org=COVESTIC2&cws=37
+Hong Kong Trade Development Council,https://phf.tbe.taleo.net/phf01/ats/careers/v2/searchResults?org=HKTDC&cws=45,https://phf.tbe.taleo.net/phf01/ats/careers/v2/searchResults?org=HKTDC&cws=45
+Organization of American States,https://phf.tbe.taleo.net/phf01/ats/careers/v2/searchResults?org=OAS2&cws=39,https://phf.tbe.taleo.net/phf01/ats/careers/v2/searchResults?org=OAS2&cws=39
+J.F. Shea Family of Companies,https://phf.tbe.taleo.net/phf02/ats/careers/v2/searchResults?org=SHEA&cws=53,https://phf.tbe.taleo.net/phf02/ats/careers/v2/searchResults?org=SHEA&cws=53
+Caltech,https://phf.tbe.taleo.net/phf03/ats/careers/v2/searchResults?org=CALTECH&cws=37,https://phf.tbe.taleo.net/phf03/ats/careers/v2/searchResults?org=CALTECH&cws=37
+Graybar Canada,https://phf.tbe.taleo.net/phf03/ats/careers/v2/searchResults?org=GRAYBARCANADA&cws=42,https://phf.tbe.taleo.net/phf03/ats/careers/v2/searchResults?org=GRAYBARCANADA&cws=42
+Kamaxi,https://phf.tbe.taleo.net/phf03/ats/careers/v2/searchResults?org=KAMAXI&cws=40,https://phf.tbe.taleo.net/phf03/ats/careers/v2/searchResults?org=KAMAXI&cws=40
+IFPRI,https://phf.tbe.taleo.net/phf04/ats/careers/v2/searchResults?org=IFPRI&cws=43,https://phf.tbe.taleo.net/phf04/ats/careers/v2/searchResults?org=IFPRI&cws=43
+NVR Inc,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=NVRINC&cws=65,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=NVRINC&cws=65
+Palouse Brand,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=PALOBRAN&cws=40,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=PALOBRAN&cws=40
+DHL eCommerce,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=DHLECOMMERCE&cws=43,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=DHLECOMMERCE&cws=43
+Great Hearts Academies,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=GREATHEARTS&cws=40,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=GREATHEARTS&cws=40
+Federal Home Loan Bank of Boston,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=FHLBBOSTON&cws=38,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=FHLBBOSTON&cws=38
+Dyno Nobel,https://phh.tbe.taleo.net/phh02/ats/careers/v2/searchResults?org=DYNONOBEL&cws=43,https://phh.tbe.taleo.net/phh02/ats/careers/v2/searchResults?org=DYNONOBEL&cws=43
+Sierra Nevada Brewing Co,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=SIERRANEVADABREWINGCO&cws=39,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=SIERRANEVADABREWINGCO&cws=39
+Wagman,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=WAGMAN&cws=37,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=WAGMAN&cws=37
+Defence Construction Canada,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=DEFENCECONSTRUCTIONCANADA&cws=47,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=DEFENCECONSTRUCTIONCANADA&cws=47
+Hamilton Island Enterprises Limited,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=HAMILTONISLAND&cws=42,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=HAMILTONISLAND&cws=42
+Wilco,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=WILCO&cws=37,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=WILCO&cws=37
+Yakima Valley Farm Workers Clinic,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=YVFWC&cws=47,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=YVFWC&cws=47
+Ecole de technologie superieure,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=ETS&cws=42,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=ETS&cws=42
+Niagara College,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=NIAGARACOLLEGE&cws=38,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=NIAGARACOLLEGE&cws=38
+HEC Montreal,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=NYQEDG&cws=42,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=NYQEDG&cws=42
+Seneca College,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=SENECOLL4&cws=41,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=SENECOLL4&cws=41
+SEPAQ,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=SEPAQ&cws=37,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=SEPAQ&cws=37
+Telecon Inc,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=TELECONINC&cws=39,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=TELECONINC&cws=39
+Town of Oakville,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=TOWNOFOA&cws=43,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=TOWNOFOA&cws=43

--- a/ats-companies/taleo.csv
+++ b/ats-companies/taleo.csv
@@ -142,3 +142,10 @@ Seneca College,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=
 SEPAQ,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=SEPAQ&cws=37,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=SEPAQ&cws=37
 Telecon Inc,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=TELECONINC&cws=39,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=TELECONINC&cws=39
 Town of Oakville,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=TOWNOFOA&cws=43,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=TOWNOFOA&cws=43
+Aurora Flight Sciences,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=AURORA&cws=37,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=AURORA&cws=37
+Systems Technologies (Systek),https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=SYSTEK&cws=42,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=SYSTEK&cws=42
+Alakaina Family of Companies,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=AKIMEKATECH&cws=43,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=AKIMEKATECH&cws=43
+ActionLink,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=ACTIONLINK&cws=41,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=ACTIONLINK&cws=41
+Canadian Air Transport Security Authority,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=CATSA&cws=46,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=CATSA&cws=46
+David Evans and Associates,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=DEAINC&cws=51,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=DEAINC&cws=51
+Punahou School,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=PUNAHOU&cws=39,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=PUNAHOU&cws=39

--- a/ats-companies/taleo.csv
+++ b/ats-companies/taleo.csv
@@ -21,7 +21,7 @@ Carley Corporation,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?
 Celestar,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=CELESTAR&cws=1,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=CELESTAR&cws=1
 City of Burnaby,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CITYBURNABY&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CITYBURNABY&cws=1
 City of Kawartha Lakes,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CITYOFKA&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CITYOFKA&cws=1
-Canadian Nuclear Laboratories,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CNLLTD&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CNLLTD&cws=1
+Canadian Nuclear Laboratories,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CNLLTD&cws=37,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CNLLTD&cws=37
 Memorial Health System of Southwest Oklahoma,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=COMACOUN&cws=1,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=COMACOUN&cws=1
 "CPS Solutions, LLC",https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=COMPREHENSIVEPS&cws=1,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=COMPREHENSIVEPS&cws=1
 City of St. Catharines,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=COSC&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=COSC&cws=1
@@ -37,7 +37,7 @@ Dah Sing Bank,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=D
 ERT,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=ERT&cws=1,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=ERT&cws=1
 Experitec,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=EXPERITEC&cws=1,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=EXPERITEC&cws=1
 First Hawaiian Bank,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=FHB&cws=38,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=FHB&cws=38
-"Three Saints Bay, LLC",https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=GATEWAYVENT&cws=1,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=GATEWAYVENT&cws=1
+"Three Saints Bay, LLC",https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=GATEWAYVENT&cws=55,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=GATEWAYVENT&cws=55
 Gemini Industries Inc.,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=GEMINIIND&cws=1,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=GEMINIIND&cws=1
 Graniterock,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=GRANITEROCK&cws=41,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=GRANITEROCK&cws=41
 Doane Grant Thornton,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=GRANTTHORNTON&cws=1,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=GRANTTHORNTON&cws=1
@@ -48,7 +48,7 @@ ICANN,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=ICANN&cws
 International Development Research Centre (IDRC),https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=IDRC&cws=1,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=IDRC&cws=1
 IESC,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=IESCORG&cws=1,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=IESCORG&cws=1
 Information Gateways Inc,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=INFOGATEWAYS&cws=1,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=INFOGATEWAYS&cws=1
-Institute for Defense Analyses,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=INSTITUTEDA&cws=1,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=INSTITUTEDA&cws=1
+Institute for Defense Analyses,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=INSTITUTEDA&cws=39,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=INSTITUTEDA&cws=39
 "INVENSENSE, INC.",https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=INVENSENSE&cws=1,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=INVENSENSE&cws=1
 RealmOne,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=INVXIS&cws=1,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=INVXIS&cws=1
 Sierra-Cedar,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=ITS&cws=1,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=ITS&cws=1


### PR DESCRIPTION
## Summary

Adds 40 validated Taleo company entries to `ats-companies/taleo.csv`.

Discovery came from indexed `tbe.taleo.net` Taleo v2 search-results pages, public job posts, and public PDFs/pages linking to Taleo TBE boards. I kept one row per new URL/org, skipped stale and zero-job references, and used readable organization names from JSON-LD, page metadata, or clearly identifying listing context.

## Latest Additions

- Aurora Flight Sciences
- Systems Technologies (Systek)
- Alakaina Family of Companies
- ActionLink
- Canadian Air Transport Security Authority
- David Evans and Associates
- Punahou School

## Validation

- Live-validated every appended Taleo URL from the CSV: HTTP 200 and at least one `viewJobLink` job anchor.
- Latest batch live counts:
  - `AURORA`: 10 jobs
  - `SYSTEK`: 10 jobs
  - `AKIMEKATECH`: 10 jobs
  - `ACTIONLINK`: 10 jobs
  - `CATSA`: 5 jobs
  - `DEAINC`: 10 jobs
  - `PUNAHOU`: 10 jobs
- Confirmed `ats-companies/taleo.csv` parses with 150 rows, 150 unique slugs, and 150 unique URLs on this branch.
- Skipped already-present or invalid candidates from this pass, including `CUSTOMONLINE` and `MEDIACOMCC` as duplicates, plus `SYDNEYAIRPORT`, `AYS`, `JEWETELE`, `WEBCOR`, `SEPC`, and `UNISOURCE` because their referenced Taleo sections currently have zero jobs.
- `uv run pytest tests/test_taleo.py tests/test_run_pipeline_guards.py -q` -> 28 passed
- `uv run pytest -q` -> 929 passed
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 40 validated Taleo v2 company search-result URLs to `ats-companies/taleo.csv` and canonicalizes `cws` IDs for three existing entries to the correct career sites.

Each URL was live-verified (HTTP 200 and `viewJobLink` present); no new org/URL duplicates; all tests pass.

<sup>Written for commit 1638966cc784a37c119703664e0079ecfdb91509. Summary will update on new commits. <a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/173?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

