### PR TITLE
Add validated Gem companies

### DIFF
--- a/ats-companies/gem.csv
+++ b/ats-companies/gem.csv
@@ -489,3 +489,5 @@ Recharged,recharged,https://jobs.gem.com/recharged
 Rootly,rootly,https://jobs.gem.com/rootly
 Wyze,wyzecam-com,https://jobs.gem.com/wyzecam-com
 Zelos Cloud,zeloscloud,https://jobs.gem.com/zeloscloud
+Fan Pier Labs,fanpierlabs-com,https://jobs.gem.com/fanpierlabs-com
+Patlytics,patlytics,https://jobs.gem.com/patlytics

--- a/ats-companies/gem.csv
+++ b/ats-companies/gem.csv
@@ -474,7 +474,7 @@ Vocode Dev,vocode-dev,https://jobs.gem.com/vocode-dev
 Voker Ai,voker-ai,https://jobs.gem.com/voker-ai
 Voltai Com,voltai-com,https://jobs.gem.com/voltai-com
 Weeatbig Com,weeatbig-com,https://jobs.gem.com/weeatbig-com
-Whatconverts,whatconverts,https://jobs.gem.com/whatconverts
+WhatConverts,whatconverts,https://jobs.gem.com/whatconverts
 Wizecamel,wizecamel,https://jobs.gem.com/wizecamel
 Wonolo,wonolo,https://jobs.gem.com/wonolo
 Woodsideai,woodsideai,https://jobs.gem.com/woodsideai

--- a/ats-companies/gem.csv
+++ b/ats-companies/gem.csv
@@ -491,3 +491,5 @@ Wyze,wyzecam-com,https://jobs.gem.com/wyzecam-com
 Zelos Cloud,zeloscloud,https://jobs.gem.com/zeloscloud
 Fan Pier Labs,fanpierlabs-com,https://jobs.gem.com/fanpierlabs-com
 Patlytics,patlytics,https://jobs.gem.com/patlytics
+Sequencing,sequencing,https://jobs.gem.com/sequencing
+InstaSwitch,instaswitch,https://jobs.gem.com/instaswitch

--- a/ats-companies/gem.csv
+++ b/ats-companies/gem.csv
@@ -482,3 +482,10 @@ Yext Ats,yext-ats,https://jobs.gem.com/yext-ats
 Zealous Consultancy,zealous-consultancy,https://jobs.gem.com/zealous-consultancy
 Zefi Ai,zefi-ai,https://jobs.gem.com/zefi-ai
 Zep,zep,https://jobs.gem.com/zep
+Dexicon Recruiting,dexicon-recruiting,https://jobs.gem.com/dexicon-recruiting
+Forage,-joinforage,https://jobs.gem.com/-joinforage
+heyiris.ai,heyiris-ai,https://jobs.gem.com/heyiris-ai
+Recharged,recharged,https://jobs.gem.com/recharged
+Rootly,rootly,https://jobs.gem.com/rootly
+Wyze,wyzecam-com,https://jobs.gem.com/wyzecam-com
+Zelos Cloud,zeloscloud,https://jobs.gem.com/zeloscloud

--- a/ats-companies/gem.csv
+++ b/ats-companies/gem.csv
@@ -493,3 +493,5 @@ Fan Pier Labs,fanpierlabs-com,https://jobs.gem.com/fanpierlabs-com
 Patlytics,patlytics,https://jobs.gem.com/patlytics
 Sequencing,sequencing,https://jobs.gem.com/sequencing
 InstaSwitch,instaswitch,https://jobs.gem.com/instaswitch
+Cardda,cardda,https://jobs.gem.com/cardda
+Condor,condor,https://jobs.gem.com/condor


### PR DESCRIPTION
## Summary

Adds 13 validated Gem-hosted company boards to `ats-companies/gem.csv` and fixes the display casing for the existing WhatConverts row.

I kept this conservative because some discovered Gem GraphQL board IDs still have jobs while the hosted board URL itself returns a 404 or generic page, and some public links now resolve to zero-job boards. This PR only includes boards where the hosted URL is a specific public company job board and the scraper's exact `JobBoardList` GraphQL query returns at least one live posting.

## Validation

- Live-validated every appended `https://jobs.gem.com/{board}` URL with the Gem scraper / exact `JobBoardList` GraphQL query.
- Newly added in the latest add pass:
  - Cardda / `cardda`: 1 job
  - Condor / `condor`: 3 jobs
- Latest correction pass:
  - `whatconverts` was re-probed and still has 2 live jobs, but it was already present, so I only corrected the display name from `Whatconverts` to `WhatConverts` and did not add a duplicate row.
- Previously added in this PR: Dexicon Recruiting, Forage, heyiris.ai, Recharged, Rootly, Wyze, Zelos Cloud, Fan Pier Labs, Patlytics, Sequencing, and InstaSwitch.
- Confirmed `ats-companies/gem.csv` parses with 496 rows, 496 unique slugs, and 496 unique URLs.
- Discovery notes: Avidity Events, Inception AI, HOAi, Cadre AI, East Energy Renewables, Obsidian Systems, Trojan, and many GitHub-code-search candidates were probed but not added because they returned zero jobs, 404 board pages, generic/test-looking boards, or were already present. Roforco was skipped because its only live posting title was `test`.
- `uv run pytest tests/test_scrapers_extra.py tests/test_run_pipeline_guards.py -q` -> 44 passed
- `uv run pytest -q` -> 929 passed
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add thirteen validated Gem-hosted company boards to ats-companies/gem.csv. Each has a public jobs.gem.com URL and at least one live posting via the JobBoardList GraphQL query.

Added: Dexicon Recruiting, Forage, heyiris.ai, Recharged, Rootly, Wyze, Zelos Cloud, Fan Pier Labs, Patlytics, Sequencing, InstaSwitch, Cardda, Condor.

<sup>Written for commit 3982cd255330fecb5b033fd18942d91d196cee07. Summary will update on new commits. <a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/174?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->