### PR TITLE
Add validated Cornerstone companies

### DIFF
--- a/ats-companies/cornerstone.csv
+++ b/ats-companies/cornerstone.csv
@@ -265,3 +265,31 @@ Registers of Scotland,https://ros.csod.com/ux/ats/careersite/1/home?c=ros,https:
 San Jacinto College,https://sanjac.csod.com/ux/ats/careersite/3/home?c=sanjac,https://sanjac.csod.com/ux/ats/careersite/3/home?c=sanjac
 Stats Perform Academy,https://statsperformacademy.csod.com/ux/ats/careersite/3/home?c=statsperformacademy,https://statsperformacademy.csod.com/ux/ats/careersite/3/home?c=statsperformacademy
 Trinity House,https://trinityhouse.csod.com/ux/ats/careersite/1/home?c=trinityhouse,https://trinityhouse.csod.com/ux/ats/careersite/1/home?c=trinityhouse
+Wayne State University,https://waynetalent.csod.com/ux/ats/careersite/2/home?c=waynetalent,https://waynetalent.csod.com/ux/ats/careersite/2/home?c=waynetalent
+College of DuPage,https://cod.csod.com/ux/ats/careersite/4/home?c=cod,https://cod.csod.com/ux/ats/careersite/4/home?c=cod
+Groupe Mutuel,https://groupemutuel.csod.com/ux/ats/careersite/4/home?c=groupemutuel,https://groupemutuel.csod.com/ux/ats/careersite/4/home?c=groupemutuel
+N-SIDE,https://n-side.csod.com/ux/ats/careersite/1/home?c=n-side,https://n-side.csod.com/ux/ats/careersite/1/home?c=n-side
+Valamar,https://valamar.csod.com/ux/ats/careersite/4/home?c=valamar,https://valamar.csod.com/ux/ats/careersite/4/home?c=valamar
+Massachusetts Bay Community College,https://mbcc-mass.csod.com/ux/ats/careersite/4/home?c=mbcc-mass,https://mbcc-mass.csod.com/ux/ats/careersite/4/home?c=mbcc-mass
+Benedictine University,https://benu.csod.com/ux/ats/careersite/6/home?c=benu,https://benu.csod.com/ux/ats/careersite/6/home?c=benu
+Turner Construction,https://turnerconstruction.csod.com/ux/ats/careersite/3/home?c=turnerconstruction,https://turnerconstruction.csod.com/ux/ats/careersite/3/home?c=turnerconstruction
+University of New Mexico,https://unm.csod.com/ux/ats/careersite/18/home?c=unm,https://unm.csod.com/ux/ats/careersite/18/home?c=unm
+University of Arizona,https://arizona.csod.com/ux/ats/careersite/4/home?c=arizona,https://arizona.csod.com/ux/ats/careersite/4/home?c=arizona
+CMPC,https://cmpc.csod.com/ux/ats/careersite/25/home?c=cmpc,https://cmpc.csod.com/ux/ats/careersite/25/home?c=cmpc
+Wienerberger,https://wienerberger.csod.com/ux/ats/careersite/4/home?c=wienerberger,https://wienerberger.csod.com/ux/ats/careersite/4/home?c=wienerberger
+Cuatrecasas,https://cuatrecasas.csod.com/ux/ats/careersite/4/home?c=cuatrecasas,https://cuatrecasas.csod.com/ux/ats/careersite/4/home?c=cuatrecasas
+Bradesco,https://bradesco.csod.com/ux/ats/careersite/2/home?c=bradesco,https://bradesco.csod.com/ux/ats/careersite/2/home?c=bradesco
+RSM UK,https://mypathway-rsmuk.csod.com/ux/ats/careersite/5/home?c=mypathway-rsmuk,https://mypathway-rsmuk.csod.com/ux/ats/careersite/5/home?c=mypathway-rsmuk
+VASS,https://vasscompany.csod.com/ux/ats/careersite/1/home?c=vasscompany,https://vasscompany.csod.com/ux/ats/careersite/1/home?c=vasscompany
+EMPLOYERS,https://employers.csod.com/ux/ats/careersite/4/home?c=employers,https://employers.csod.com/ux/ats/careersite/4/home?c=employers
+Fozzy Group,https://fozzy.csod.com/ux/ats/careersite/1/home?c=fozzy,https://fozzy.csod.com/ux/ats/careersite/1/home?c=fozzy
+OEBB,https://oebb.csod.com/ux/ats/careersite/4/home?c=oebb,https://oebb.csod.com/ux/ats/careersite/4/home?c=oebb
+Idaho State University,https://isu.csod.com/ux/ats/careersite/5/home?c=isu,https://isu.csod.com/ux/ats/careersite/5/home?c=isu
+eWake Talent,https://ewaketalent.csod.com/ux/ats/careersite/3/home?c=ewaketalent,https://ewaketalent.csod.com/ux/ats/careersite/3/home?c=ewaketalent
+Bradesco,https://bradesco.csod.com/ux/ats/careersite/8/home?c=bradesco,https://bradesco.csod.com/ux/ats/careersite/8/home?c=bradesco
+MSC,https://msc.csod.com/ux/ats/careersite/4/home?c=msc,https://msc.csod.com/ux/ats/careersite/4/home?c=msc
+University of Saskatchewan,https://usask.csod.com/ux/ats/careersite/14/home?c=usask,https://usask.csod.com/ux/ats/careersite/14/home?c=usask
+Grupo Cosan,https://grupocosan.csod.com/ux/ats/careersite/7/home?c=grupocosan,https://grupocosan.csod.com/ux/ats/careersite/7/home?c=grupocosan
+Kohler,https://kohler.csod.com/ux/ats/careersite/16/home?c=kohler,https://kohler.csod.com/ux/ats/careersite/16/home?c=kohler
+Douglas County,https://douglasco.csod.com/ux/ats/careersite/6/home?c=douglasco,https://douglasco.csod.com/ux/ats/careersite/6/home?c=douglasco
+OUC,https://ouc.csod.com/ux/ats/careersite/6/home?c=ouc,https://ouc.csod.com/ux/ats/careersite/6/home?c=ouc

--- a/ats-companies/cornerstone.csv
+++ b/ats-companies/cornerstone.csv
@@ -293,3 +293,6 @@ Grupo Cosan,https://grupocosan.csod.com/ux/ats/careersite/7/home?c=grupocosan,ht
 Kohler,https://kohler.csod.com/ux/ats/careersite/16/home?c=kohler,https://kohler.csod.com/ux/ats/careersite/16/home?c=kohler
 Douglas County,https://douglasco.csod.com/ux/ats/careersite/6/home?c=douglasco,https://douglasco.csod.com/ux/ats/careersite/6/home?c=douglasco
 OUC,https://ouc.csod.com/ux/ats/careersite/6/home?c=ouc,https://ouc.csod.com/ux/ats/careersite/6/home?c=ouc
+University of Louisiana at Lafayette,https://louisiana.csod.com/ux/ats/careersite/1/home?c=louisiana,https://louisiana.csod.com/ux/ats/careersite/1/home?c=louisiana
+Canadian National Railway,https://cn360.csod.com/ux/ats/careersite/4/home?c=cn360,https://cn360.csod.com/ux/ats/careersite/4/home?c=cn360
+Restaurant Brands,https://rbd.csod.com/ux/ats/careersite/7/home?c=rbd,https://rbd.csod.com/ux/ats/careersite/7/home?c=rbd

--- a/ats-companies/cornerstone.csv
+++ b/ats-companies/cornerstone.csv
@@ -251,3 +251,16 @@ Wayne State University,waynetalent,https://waynetalent.csod.com/ux/ats/careersit
 Wienerberger,wienerberger,https://wienerberger.csod.com/ux/ats/careersite/1/home?c=wienerberger
 World Bank Group,worldbankgroup,https://worldbankgroup.csod.com/ux/ats/careersite/1/home?c=worldbankgroup
 Xella,xella,https://xella.csod.com/ux/ats/careersite/1/home?c=xella
+A2Dominion,https://a2dominion.csod.com/ux/ats/careersite/3/home?c=a2dominion,https://a2dominion.csod.com/ux/ats/careersite/3/home?c=a2dominion
+Town of Concord,https://concordconnection.csod.com/ux/ats/careersite/2/home?c=concordconnection,https://concordconnection.csod.com/ux/ats/careersite/2/home?c=concordconnection
+Duquesne University,https://duq.csod.com/ux/ats/careersite/1/home?c=duq,https://duq.csod.com/ux/ats/careersite/1/home?c=duq
+ECMS,https://ecms.csod.com/ux/ats/careersite/1/home?c=ecms,https://ecms.csod.com/ux/ats/careersite/1/home?c=ecms
+Fluidra,https://fluidra.csod.com/ux/ats/careersite/1/home?c=fluidra,https://fluidra.csod.com/ux/ats/careersite/1/home?c=fluidra
+Haley & Aldrich,https://haleyaldrich.csod.com/ux/ats/careersite/1/home?c=haleyaldrich,https://haleyaldrich.csod.com/ux/ats/careersite/1/home?c=haleyaldrich
+Jacto,https://jacto.csod.com/ux/ats/careersite/1/home?c=jacto,https://jacto.csod.com/ux/ats/careersite/1/home?c=jacto
+Manuloc,https://manuloc.csod.com/ux/ats/careersite/1/home?c=manuloc,https://manuloc.csod.com/ux/ats/careersite/1/home?c=manuloc
+Project HOPE,https://projecthope.csod.com/ux/ats/careersite/2/home?c=projecthope,https://projecthope.csod.com/ux/ats/careersite/2/home?c=projecthope
+Registers of Scotland,https://ros.csod.com/ux/ats/careersite/1/home?c=ros,https://ros.csod.com/ux/ats/careersite/1/home?c=ros
+San Jacinto College,https://sanjac.csod.com/ux/ats/careersite/3/home?c=sanjac,https://sanjac.csod.com/ux/ats/careersite/3/home?c=sanjac
+Stats Perform Academy,https://statsperformacademy.csod.com/ux/ats/careersite/3/home?c=statsperformacademy,https://statsperformacademy.csod.com/ux/ats/careersite/3/home?c=statsperformacademy
+Trinity House,https://trinityhouse.csod.com/ux/ats/careersite/1/home?c=trinityhouse,https://trinityhouse.csod.com/ux/ats/careersite/1/home?c=trinityhouse

--- a/ats-companies/cornerstone.csv
+++ b/ats-companies/cornerstone.csv
@@ -43,7 +43,7 @@ Chartway,chartway,https://chartway.csod.com/ux/ats/careersite/1/home?c=chartway
 Chedraui USA,chedrauiusa,https://chedrauiusa.csod.com/ux/ats/careersite/1/home?c=chedrauiusa
 CMPC,cmpc,https://cmpc.csod.com/ux/ats/careersite/1/home?c=cmpc
 CMSU,cmsu,https://cmsu.csod.com/ux/ats/careersite/1/home?c=cmsu
-CN360,cn360,https://cn360.csod.com/ux/ats/careersite/1/home?c=cn360
+Canadian National Railway,cn360,https://cn360.csod.com/ux/ats/careersite/1/home?c=cn360
 Codere,codere,https://codere.csod.com/ux/ats/careersite/1/home?c=codere
 Cofinimmo,cofinimmo,https://cofinimmo.csod.com/ux/ats/careersite/1/home?c=cofinimmo
 Cognita People,cognitapeople,https://cognitapeople.csod.com/ux/ats/careersite/1/home?c=cognitapeople
@@ -237,6 +237,7 @@ Unither,unither,https://unither.csod.com/ux/ats/careersite/1/home?c=unither
 University of Arizona,arizona,https://arizona.csod.com/ux/ats/careersite/1/home?c=arizona
 University of Illinois,illinois,https://illinois.csod.com/ux/ats/careersite/1/home?c=illinois
 University of Illinois Chicago,uic,https://uic.csod.com/ux/ats/careersite/1/home?c=uic
+University of Illinois Chicago Faculty,https://uic.csod.com/ux/ats/careersite/2/home?c=uic,https://uic.csod.com/ux/ats/careersite/2/home?c=uic
 University of Illinois Springfield,uis,https://uis.csod.com/ux/ats/careersite/1/home?c=uis
 University of New Mexico,unm,https://unm.csod.com/ux/ats/careersite/1/home?c=unm
 University of Northern Colorado,unco,https://unco.csod.com/ux/ats/careersite/1/home?c=unco

--- a/src/jobhive/scrapers/cornerstone.py
+++ b/src/jobhive/scrapers/cornerstone.py
@@ -72,6 +72,7 @@ class CornerstoneScraper(BaseScraper):
         company_name: str | None = None,
     ) -> None:
         super().__init__(company_slug, timeout=timeout)
+        # Full URLs containing a career-site ID take precedence over site_id.
         self.career_url, self.slug, resolved_site_id = _resolve_career_url(
             company_slug, site_id
         )

--- a/src/jobhive/scrapers/cornerstone.py
+++ b/src/jobhive/scrapers/cornerstone.py
@@ -72,8 +72,10 @@ class CornerstoneScraper(BaseScraper):
         company_name: str | None = None,
     ) -> None:
         super().__init__(company_slug, timeout=timeout)
-        self.site_id = site_id
-        self.career_url, self.slug = _resolve_career_url(company_slug, site_id)
+        self.career_url, self.slug, resolved_site_id = _resolve_career_url(
+            company_slug, site_id
+        )
+        self.site_id = resolved_site_id
         self.company_name = (
             company_name.strip()
             if company_name and company_name.strip()
@@ -253,8 +255,13 @@ class CornerstoneScraper(BaseScraper):
         )
 
 
-def _resolve_career_url(slug_or_url: str, site_id: int) -> tuple[str, str]:
-    """Return ``(career_url, slug)``. Accepts a bare slug or the full URL."""
+def _resolve_career_url(slug_or_url: str, site_id: int) -> tuple[str, str, int]:
+    """Return ``(career_url, slug, site_id)``.
+
+    Accepts a bare slug or the full URL. Full URLs may point at non-default
+    career sites such as ``/careersite/3/home``; keep that site id for API
+    requests instead of silently using the constructor default.
+    """
     if slug_or_url.startswith(("http://", "https://")):
         # Try to extract slug from the URL's `?c=` query param or hostname.
         m = re.search(r"[?&]c=([^&#]+)", slug_or_url)
@@ -263,11 +270,14 @@ def _resolve_career_url(slug_or_url: str, site_id: int) -> tuple[str, str]:
         else:
             host = urlparse(slug_or_url).hostname or ""
             slug = host.split(".")[0] if host else slug_or_url
-        return slug_or_url, slug
+        site_match = re.search(r"/careersite/(\d+)/", slug_or_url)
+        resolved_site_id = int(site_match.group(1)) if site_match else site_id
+        return slug_or_url, slug, resolved_site_id
     slug = slug_or_url
     return (
         f"https://{slug}.csod.com/ux/ats/careersite/{site_id}/home?c={slug}",
         slug,
+        site_id,
     )
 
 

--- a/tests/test_cornerstone.py
+++ b/tests/test_cornerstone.py
@@ -8,6 +8,7 @@ pin token extraction, region detection, pagination, and field parsing.
 from __future__ import annotations
 
 import asyncio
+import json
 
 import pytest
 
@@ -71,6 +72,22 @@ def test_full_url_accepted() -> None:
     assert s.career_url.startswith("https://thekids.csod.com")
     assert s.slug == "thekids"
     assert s.site_id == 4
+
+
+def test_full_url_site_id_used_in_api_request(httpx_mock) -> None:
+    career_url = "https://thekids.csod.com/ux/ats/careersite/4/home?c=thekids"
+    httpx_mock.add_response(url=career_url, text=_site_html())
+    httpx_mock.add_response(url=API_URL, json=_search_response([_req()], total=1))
+
+    jobs = CornerstoneScraper(career_url).fetch()
+
+    request = httpx_mock.get_requests(url=API_URL)[0]
+    body = json.loads(request.content)
+    assert body["careerSiteId"] == 4
+    assert body["careerSitePageId"] == 4
+    assert str(jobs[0].url) == (
+        "https://thekids.csod.com/ux/ats/careersite/4/job/100?c=thekids"
+    )
 
 
 def test_custom_site_id() -> None:

--- a/tests/test_cornerstone.py
+++ b/tests/test_cornerstone.py
@@ -70,6 +70,7 @@ def test_full_url_accepted() -> None:
     s = CornerstoneScraper("https://thekids.csod.com/ux/ats/careersite/4/home?c=thekids")
     assert s.career_url.startswith("https://thekids.csod.com")
     assert s.slug == "thekids"
+    assert s.site_id == 4
 
 
 def test_custom_site_id() -> None:


### PR DESCRIPTION
## Summary

Adds 45 validated Cornerstone company/site entries to `ats-companies/cornerstone.csv` and fixes full-URL site ID handling.

Discovery came from indexed `csod.com/ux/ats/careersite/...` URLs and urlscan career-site hits. I normalized requisition URLs to career-site home URLs, then validated each candidate by extracting the Cornerstone token/API host and calling the same public `rec-job-search/external/jobs` endpoint used by the scraper.

The scraper now derives `site_id` from full career-site URLs, so rows like `/careersite/2/home?c=uic` call the correct API career site instead of silently using default site 1.

## Latest Additions

The latest batch adds 3 validated career-site URLs:
- University of Louisiana at Lafayette (`louisiana` site 1): 15 jobs
- Canadian National Railway (`cn360` site 4): 2 jobs
- Restaurant Brands (`rbd` site 7): 2 jobs

Previous latest batch added 28 validated career-site URLs, including Wayne State University site 2, College of DuPage site 4, Turner Construction site 3, University of New Mexico site 18, University of Arizona site 4, Bradesco sites 2 and 8, OEBB site 4, Kohler site 16, and several other non-default Cornerstone career sites.

## Validation

- Live-validated every appended row from the CSV:
  - career-site URL returns HTTP 200 and final URL matches the submitted URL
  - JWT token can be extracted from the page
  - Cornerstone job-search API returns HTTP 200 and non-empty `requisitions`
- Latest batch adds 19 live requisitions by Cornerstone scraper counts across 3 URLs.
- Previous 28-row batch adds 4,265 live requisitions by Cornerstone API/scraper counts.
- Earlier pass:
  - Renamed existing `CN360` display name to `Canadian National Railway`; live scraper validation returns 62 jobs for site 1.
  - Added `University of Illinois Chicago Faculty` at `https://uic.csod.com/ux/ats/careersite/2/home?c=uic`; live scraper validation returns 73 jobs and generated job URLs preserve `careersite/2`.
- Confirmed `ats-companies/cornerstone.csv` parses with 297 rows and 297 unique URLs.
- Excluded invalid/unsafe candidates with DNS failures, empty job lists, redirects to a different tenant, generic/ambiguous titles, placeholder/test-heavy postings, or zero-job career sites. Latest skips included `alsa`, `house`, `honeywell`, and `uscp` DNS failures; `bbva`, `pima`, `ssspr`, `fhda`, `apexnc`, `coloradomesa`, and `nrucfc` zero-job sites; plus `myhr`, `sncfl`, and `olympic` because the employer/board quality could not be verified confidently.
- `uv run pytest tests/test_cornerstone.py tests/test_run_pipeline_guards.py -q` -> 34 passed
- `uv run pytest -q` -> 929 passed
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 40+ validated Cornerstone career-site entries and updates the scraper to read and forward site IDs from full career-site URLs. Expands coverage across non-default sites and prevents wrong-site API calls and wrong job URLs.

- **New Features**
  - Added 40+ companies and non-default sites (e.g., UIC Faculty `careersite/2`, A2Dominion `3`, San Jacinto College `3`, College of DuPage `4`, Kohler `16`, Project HOPE `2`, Wayne State University `2`, Bradesco `2` and `8`, Registers of Scotland `1`, University of Saskatchewan `14`); corrected CN360’s display name to Canadian National Railway.
  - For non-default sites, stored the full career-site URL in both `slug` and `url` to preserve site IDs.

- **Bug Fixes**
  - Scraper now extracts the site ID from full career-site URLs and uses it in API requests (`careerSiteId`, `careerSitePageId`) and generated job URLs.
  - Added a mock test to assert the API payload includes the URL’s site ID and that job URLs keep the correct `/careersite/N/` segment.

<sup>Written for commit d0b5b9ef319dd2e128825eba5655907ec819b921. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds 45 live-validated Cornerstone career-site entries and fixes the scraper to extract `site_id` from full career-site URLs, preventing wrong-API-site calls and malformed job URLs for non-default sites.

- `_resolve_career_url` now returns a 3-tuple and parses `/careersite/(\d+)/` from full URLs, propagating the correct ID into `careerSiteId`, `careerSitePageId`, and the constructed job URL path. The bare-slug path is unchanged.
- New CSV rows for non-default sites store the full career-site URL in both the slug and URL columns; the updated scraper correctly reads the site ID from that URL at construction time.
- `test_full_url_site_id_used_in_api_request` provides end-to-end mock coverage, asserting both the API request payload and the generated job URL, directly addressing the gap flagged in the previous review cycle.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the scraper fix is narrowly scoped, the new behavior is fully exercised by mock tests, and all 45 CSV entries were live-validated before submission.

The site_id extraction logic in _resolve_career_url is straightforward and correct: full URLs with a /careersite/N/ segment yield N, everything else falls back to the constructor default. Both the API body fields and the generated job URLs consume self.site_id consistently. The new test closes the previously identified coverage gap by asserting careerSiteId, careerSitePageId, and the job URL in a single mock-fetch round-trip. No data-loss, wrong-result, or auth-boundary issues were found.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/cornerstone.py | Extends _resolve_career_url to return site_id extracted from the URL path and propagates it into both the API request body and job URL construction — correct logic, well-scoped change. |
| tests/test_cornerstone.py | Adds site_id assertion to existing construction test and a new mock-fetch test verifying careerSiteId/careerSitePageId in the API body and /careersite/N/ in job URLs — closes the gap flagged in the previous review. |
| ats-companies/cornerstone.csv | Adds 45 validated entries and renames CN360 display name; non-default-site rows store the full career-site URL in the slug column so the scraper reads the correct site ID. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/test_cornerstone.py`, line 69-73 ([link](https://github.com/kalil0321/ats-scrapers/blob/ed9476578182fa5d9e4dd9d3bf51229c7f1a0440/tests/test_cornerstone.py#L69-L73)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The new assertion confirms `site_id` is resolved correctly at construction time, but there is no mock-fetch test verifying that the resolved `site_id` is actually forwarded in the `careerSiteId` / `careerSitePageId` fields of the API request body. A regression in `_search` that resets or ignores `self.site_id` would not be caught. Adding a small mock-based check would close this gap.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: tests/test_cornerstone.py
   Line: 69-73

   Comment:
   The new assertion confirms `site_id` is resolved correctly at construction time, but there is no mock-fetch test verifying that the resolved `site_id` is actually forwarded in the `careerSiteId` / `careerSitePageId` fields of the API request body. A regression in `_search` that resets or ignores `self.site_id` would not be caught. Adding a small mock-based check would close this gap.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Cover Cornerstone URL site IDs in API re..."](https://github.com/kalil0321/ats-scrapers/commit/d0b5b9ef319dd2e128825eba5655907ec819b921) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34030027)</sub>

<!-- /greptile_comment -->