### PR TITLE
Add validated Avature company

### DIFF
--- a/ats-companies/avature.csv
+++ b/ats-companies/avature.csv
@@ -5,6 +5,7 @@ Ally Financial,ally,https://ally.avature.net/careers/SearchJobs
 AMS PSR,amspsr,https://amspsr.avature.net/careers/SearchJobs
 Astellas Pharma Inc.,astellas,https://astellas.avature.net/careers/SearchJobs
 Australia Post,https://jobs.auspost.com.au/en_GB,https://jobs.auspost.com.au/en_GB/careers/SearchJobs
+Avature,avature,https://careers.avature.net/en_US/main/SearchJobs
 avanade,avanade,https://avanade.avature.net/careers/SearchJobs
 Berenberg,berenberg,https://berenberg.avature.net/careers/SearchJobs
 Bloomberg,bloomberg,https://bloomberg.avature.net/careers/SearchJobs
@@ -57,7 +58,7 @@ Optavise,optavise,https://optavise.avature.net/careers/SearchJobs
 Plantemoran,plantemoran,https://plantemoran.avature.net/careers/SearchJobs
 Pomerleau,pomerleau,https://pomerleau.avature.net/careers/SearchJobs
 Pontoon Solutions,pontoonsolutions,https://pontoonsolutions.avature.net/careers/SearchJobs
-Premium Retail Services,premium,https://premium.avature.net/en_US/jobs
+Premium Retail Services,premium,https://premium.avature.net/en_US/jobs/SearchJobsMaps
 Primero,primero,https://primero.avature.net/careers/SearchJobs
 Radiology Partners,radpartners,https://radpartners.avature.net/careers/SearchJobs
 Regis,regis,https://regis.avature.net/careers/SearchJobs
@@ -75,7 +76,6 @@ UCLA Health,uclahealth,https://uclahealth.avature.net/careers/SearchJobs
 Unifi,unifi,https://unifi.avature.net/careers/SearchJobs
 UOP,uop,https://uop.avature.net/careers/SearchJobs
 Uskpmgats,uskpmgats,https://uskpmgats.avature.net/careers/SearchJobs
-Virgin Media O2,virginmediao2,https://virginmediao2.avature.net/careers
 Voutiqueintegrations,voutiqueintegrations,https://voutiqueintegrations.avature.net/careers/SearchJobs
 Walmartsourcingeu,walmartsourcingeu,https://walmartsourcingeu.avature.net/careers/SearchJobs
 Wickes,wickes,https://wickes.avature.net/careers/SearchJobs

--- a/ats-companies/avature.csv
+++ b/ats-companies/avature.csv
@@ -65,6 +65,7 @@ Regis,regis,https://regis.avature.net/careers/SearchJobs
 ResourceBank,resourcebank,https://resourcebank.avature.net/careers/SearchJobs
 Rosewood Hotel Group,rhg,https://rhg.avature.net/careers/SearchJobs
 Skanska,skanska,https://skanska.avature.net/careers/SearchJobs
+Siemens Healthineers,https://jobs.siemens-healthineers.com/en_US/searchjobs/SearchJobs,https://jobs.siemens-healthineers.com/en_US/searchjobs/SearchJobs
 Smurfit Westrock,smurfitwestrockta,https://smurfitwestrockta.avature.net/careers/SearchJobs
 Synopsys,synopsys,https://synopsys.avature.net/careers/SearchJobs
 Tesco,tesco,https://tesco.avature.net/careers/SearchJobs
@@ -77,6 +78,7 @@ Unifi,unifi,https://unifi.avature.net/careers/SearchJobs
 UOP,uop,https://uop.avature.net/careers/SearchJobs
 Uskpmgats,uskpmgats,https://uskpmgats.avature.net/careers/SearchJobs
 Voutiqueintegrations,voutiqueintegrations,https://voutiqueintegrations.avature.net/careers/SearchJobs
+Virgin Media O2,https://jobs.virginmediao2.co.uk/en_US/careersmarketplace/SearchJobs,https://jobs.virginmediao2.co.uk/en_US/careersmarketplace/SearchJobs
 Walmartsourcingeu,walmartsourcingeu,https://walmartsourcingeu.avature.net/careers/SearchJobs
 Wickes,wickes,https://wickes.avature.net/careers/SearchJobs
 William Hill,amswh,https://amswh.avature.net/careers/SearchJobs

--- a/ats-companies/avature.csv
+++ b/ats-companies/avature.csv
@@ -83,3 +83,4 @@ William Hill,amswh,https://amswh.avature.net/careers/SearchJobs
 Wilsonhcg,wilsonhcg,https://wilsonhcg.avature.net/careers/SearchJobs
 Xerox,xerox,https://xerox.avature.net/careers/SearchJobs
 Zung Fu,zungfu,https://zungfu.avature.net/en_US/careers/SearchJobs
+Bravura Solutions Limited,bravura,https://bravura.avature.net/careers/SearchJobs

--- a/ats-companies/avature.csv
+++ b/ats-companies/avature.csv
@@ -12,6 +12,7 @@ Bloomberg,bloomberg,https://bloomberg.avature.net/careers/SearchJobs
 BMC,bmcrecruit,https://bmcrecruit.avature.net/careers/SearchJobs
 Booz Allen Hamilton,boozallen,https://boozallen.avature.net/careers/SearchJobs
 BradyPLUS,bradyplus,https://bradyplus.avature.net/careers/SearchJobs
+Bravura Solutions Limited,bravura,https://bravura.avature.net/careers/SearchJobs
 Broad Institute,broadinstitute,https://broadinstitute.avature.net/careers/SearchJobs
 Bupa ANZ,bupaanz,https://bupaanz.avature.net/careers/SearchJobs
 CBRE,cbreglobal,https://cbreglobal.avature.net/careers/SearchJobs
@@ -64,8 +65,8 @@ Radiology Partners,radpartners,https://radpartners.avature.net/careers/SearchJob
 Regis,regis,https://regis.avature.net/careers/SearchJobs
 ResourceBank,resourcebank,https://resourcebank.avature.net/careers/SearchJobs
 Rosewood Hotel Group,rhg,https://rhg.avature.net/careers/SearchJobs
-Skanska,skanska,https://skanska.avature.net/careers/SearchJobs
 Siemens Healthineers,https://jobs.siemens-healthineers.com/en_US/searchjobs/SearchJobs,https://jobs.siemens-healthineers.com/en_US/searchjobs/SearchJobs
+Skanska,skanska,https://skanska.avature.net/careers/SearchJobs
 Smurfit Westrock,smurfitwestrockta,https://smurfitwestrockta.avature.net/careers/SearchJobs
 Synopsys,synopsys,https://synopsys.avature.net/careers/SearchJobs
 Tesco,tesco,https://tesco.avature.net/careers/SearchJobs
@@ -77,12 +78,11 @@ UCLA Health,uclahealth,https://uclahealth.avature.net/careers/SearchJobs
 Unifi,unifi,https://unifi.avature.net/careers/SearchJobs
 UOP,uop,https://uop.avature.net/careers/SearchJobs
 Uskpmgats,uskpmgats,https://uskpmgats.avature.net/careers/SearchJobs
-Voutiqueintegrations,voutiqueintegrations,https://voutiqueintegrations.avature.net/careers/SearchJobs
 Virgin Media O2,https://jobs.virginmediao2.co.uk/en_US/careersmarketplace/SearchJobs,https://jobs.virginmediao2.co.uk/en_US/careersmarketplace/SearchJobs
+Voutiqueintegrations,voutiqueintegrations,https://voutiqueintegrations.avature.net/careers/SearchJobs
 Walmartsourcingeu,walmartsourcingeu,https://walmartsourcingeu.avature.net/careers/SearchJobs
 Wickes,wickes,https://wickes.avature.net/careers/SearchJobs
 William Hill,amswh,https://amswh.avature.net/careers/SearchJobs
 Wilsonhcg,wilsonhcg,https://wilsonhcg.avature.net/careers/SearchJobs
 Xerox,xerox,https://xerox.avature.net/careers/SearchJobs
 Zung Fu,zungfu,https://zungfu.avature.net/en_US/careers/SearchJobs
-Bravura Solutions Limited,bravura,https://bravura.avature.net/careers/SearchJobs

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -132,11 +132,15 @@ def _personio_slug(row: dict[str, Any]) -> str | None:
 def _avature_slug(row: dict[str, Any]) -> str | None:
     """Avature tenants live at ``{slug}.avature.net`` (or sometimes the
     full careers URL). Extract the subdomain when a URL is present."""
+    url = (row.get("url") or "").strip()
     if (slug := _slug_col(row)):
         if slug.startswith(("http://", "https://")):
             return slug
+        if url.startswith("http"):
+            base = _avature_base_from_url(url)
+            if base is not None:
+                return base
         return slug.lower()
-    url = (row.get("url") or "").strip()
     if url.startswith("http"):
         m = re.match(r"https?://([a-z0-9][a-z0-9-]+)\.avature\.net",
                      url, re.IGNORECASE)
@@ -144,6 +148,16 @@ def _avature_slug(row: dict[str, Any]) -> str | None:
             return m.group(1).lower()
     name = (row.get("name") or "").strip()
     return name or None
+
+
+def _avature_base_from_url(url: str) -> str | None:
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    path = parsed.path.rstrip("/")
+    if path == "/careers/SearchJobs":
+        return None
+    return f"{parsed.scheme}://{parsed.netloc}{path}".rstrip("/")
 
 
 def _successfactors_slug(row: dict[str, Any]) -> str | None:

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -19,10 +19,10 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import fcntl
 import csv
-import os
+import fcntl
 import json
+import os
 import re
 import sqlite3
 import sys

--- a/src/jobhive/scrapers/avature.py
+++ b/src/jobhive/scrapers/avature.py
@@ -36,7 +36,7 @@ import os
 import re
 from datetime import datetime
 from typing import TYPE_CHECKING
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
 
@@ -345,8 +345,9 @@ class AvatureScraper(BaseScraper):
         async with httpx.AsyncClient(
             timeout=self.timeout, follow_redirects=True
         ) as client:
+            page_size = _page_size(base)
             for page_num in range(MAX_PAGES):
-                offset = page_num * PAGE_SIZE
+                offset = page_num * page_size
                 html_text = await self._fetch_page(client, base, offset)
                 page_jobs = self._parse_page(html_text, base, company)
                 new = [j for j in page_jobs if j.ats_id not in seen]
@@ -356,7 +357,7 @@ class AvatureScraper(BaseScraper):
                     seen.add(j.ats_id)
                 all_jobs.extend(new)
                 # Termination: short page = last page.
-                if len(page_jobs) < PAGE_SIZE:
+                if len(page_jobs) < page_size:
                     break
 
             # Per-job detail fetch — Avature's search-results page has
@@ -440,8 +441,8 @@ class AvatureScraper(BaseScraper):
                 for page_num in range(MAX_PAGES):
                     offset = page_num * page_size
                     list_url = (
-                        f"{_search_url(base)}"
-                        f"?jobOffset={offset}&jobRecordsPerPage={PAGE_SIZE}"
+                        f"{_search_url(base)}?"
+                        f"{urlencode(_pagination_params(base, offset))}"
                     )
                     try:
                         await page.goto(
@@ -721,7 +722,8 @@ def _join_avature_url(base: str, href: str) -> str:
 
 def _link_base(base: str) -> str:
     base = base.rstrip("/")
-    if base.lower().endswith("/searchjobs"):
+    lowered = base.lower()
+    if lowered.endswith("/searchjobs") or lowered.endswith("/searchjobsmaps"):
         return base.rsplit("/", 1)[0]
     return base
 

--- a/src/jobhive/scrapers/avature.py
+++ b/src/jobhive/scrapers/avature.py
@@ -36,7 +36,7 @@ import os
 import re
 from datetime import datetime
 from typing import TYPE_CHECKING
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 import httpx
 
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
     pass
 
 PAGE_SIZE = 12  # Avature's default page size.
+MAP_PAGE_SIZE = 30  # SearchJobsMaps pages use a different offset scheme.
 MAX_PAGES = 200  # Defensive upper bound — caps a runaway loop at ~2400 jobs.
 MAX_RETRIES = 3
 RETRY_BASE_DELAY = 1.5
@@ -254,8 +255,9 @@ class AvatureScraper(BaseScraper):
 
         seen: set[str] = set()
         all_jobs: list[Job] = []
+        page_size = _page_size(base)
         for page_num in range(MAX_PAGES):
-            offset = page_num * PAGE_SIZE
+            offset = page_num * page_size
             try:
                 html_text = await asyncio.to_thread(
                     self._fetch_page_via_httpcloak_sync, base, offset
@@ -271,7 +273,7 @@ class AvatureScraper(BaseScraper):
             for j in new:
                 seen.add(j.ats_id)
             all_jobs.extend(new)
-            if len(page_jobs) < PAGE_SIZE:
+            if len(page_jobs) < page_size:
                 break
 
         # Same TLS fingerprint for detail enrichment so we don't lose
@@ -288,11 +290,10 @@ class AvatureScraper(BaseScraper):
     def _fetch_page_via_httpcloak_sync(self, base: str, offset: int) -> str:
         import httpcloak
 
-        url = f"{base}/careers/SearchJobs/"
         try:
             response = httpcloak.get(
-                url,
-                params={"jobOffset": offset, "jobRecordsPerPage": PAGE_SIZE},
+                _search_url(base),
+                params=_pagination_params(base, offset),
                 headers=_BROWSER_HEADERS,
                 timeout=self.timeout,
             )
@@ -435,10 +436,11 @@ class AvatureScraper(BaseScraper):
                 page = ctx.pages[0] if ctx.pages else await ctx.new_page()
 
                 # Listing pages — sequential on one tab.
+                page_size = _page_size(base)
                 for page_num in range(MAX_PAGES):
-                    offset = page_num * PAGE_SIZE
+                    offset = page_num * page_size
                     list_url = (
-                        f"{base}/careers/SearchJobs/"
+                        f"{_search_url(base)}"
                         f"?jobOffset={offset}&jobRecordsPerPage={PAGE_SIZE}"
                     )
                     try:
@@ -455,7 +457,7 @@ class AvatureScraper(BaseScraper):
                     for j in new:
                         seen.add(j.ats_id)
                     all_jobs.extend(new)
-                    if len(page_jobs) < PAGE_SIZE:
+                    if len(page_jobs) < page_size:
                         break
 
                 if self.include_descriptions:
@@ -493,12 +495,11 @@ class AvatureScraper(BaseScraper):
     async def _fetch_page(
         self, client: httpx.AsyncClient, base: str, offset: int
     ) -> str:
-        url = f"{base}/careers/SearchJobs/"
-        params = {"jobOffset": offset, "jobRecordsPerPage": PAGE_SIZE}
+        params = _pagination_params(base, offset)
         for attempt in range(1, MAX_RETRIES + 1):
             try:
                 response = await client.get(
-                    url, params=params, headers=_BROWSER_HEADERS
+                    _search_url(base), params=params, headers=_BROWSER_HEADERS
                 )
             except httpx.HTTPError as exc:
                 if attempt == MAX_RETRIES:
@@ -559,14 +560,14 @@ class AvatureScraper(BaseScraper):
             ) from exc
 
         soup = BeautifulSoup(html_text, "html.parser")
-        # Strategy: find all `/JobDetail/` anchors (the canonical job URL
-        # form), then for each walk up to the nearest wrapping container
+        # Strategy: find all job-detail anchors, then for each walk up to
+        # the nearest wrapping container
         # (article / div / li / tr). The wrapper is where title/location/
         # department live as sibling elements. This handles all tenant
         # markups (Bloomberg `article--result`, IBM `div.job-item`, etc.)
         # without maintaining a per-tenant selector list.
         anchors = soup.find_all(
-            "a", href=lambda h: bool(h) and "/JobDetail/" in h
+            "a", href=lambda h: bool(h) and _is_detail_href(str(h))
         )
         seen_ids: set[str] = set()
         jobs: list[Job] = []
@@ -591,17 +592,23 @@ def _parse_job_element(
     element: object, anchor: object, base: str, company: str
 ) -> Job | None:
     href = (anchor.get("href") or "").strip()  # type: ignore[union-attr]
-    if not href or "/JobDetail/" not in href:
+    if not href or not _is_detail_href(href):
         return None
 
     # Build absolute URL.
-    if href.startswith(("http://", "https://")):
-        url = href
-    else:
-        url = f"{base}{href if href.startswith('/') else '/' + href}"
+    url = (
+        href
+        if href.startswith(("http://", "https://"))
+        else _join_avature_url(base, href)
+    )
 
-    # Job ID = last non-empty path segment (strip query string).
-    ats_id = href.rsplit("?", 1)[0].rstrip("/").rsplit("/", 1)[-1]
+    # Job ID = path tail for JobDetail/ProjectDetail pages, or pipelineId
+    # for the SearchJobsMaps/PipelineDetail variant.
+    parsed_href = urlparse(href)
+    query = parse_qs(parsed_href.query)
+    ats_id = (query.get("pipelineId") or [""])[0]
+    if not ats_id:
+        ats_id = href.rsplit("?", 1)[0].rstrip("/").rsplit("/", 1)[-1]
     if not ats_id:
         return None
 
@@ -659,6 +666,64 @@ def _parse_job_element(
         posted_at=None,
         fetched_at=datetime.now(),
     )
+
+
+def _search_url(base: str) -> str:
+    """Return the SearchJobs URL for default and custom-path portals."""
+    parsed = urlparse(base)
+    path = parsed.path.rstrip("/")
+    if path.lower().endswith("/searchjobs"):
+        return f"{base.rstrip('/')}/"
+    if path.lower().endswith("/searchjobsmaps"):
+        return f"{base.rstrip('/')}/"
+    if not path or path.lstrip("/") in _LOCALE_PREFIXES:
+        return f"{base.rstrip('/')}/careers/SearchJobs/"
+    return f"{base.rstrip('/')}/SearchJobs/"
+
+
+def _page_size(base: str) -> int:
+    return MAP_PAGE_SIZE if _is_map_search(base) else PAGE_SIZE
+
+
+def _pagination_params(base: str, offset: int) -> dict[str, int]:
+    if _is_map_search(base):
+        return {"pipelineOffset": offset}
+    return {"jobOffset": offset, "jobRecordsPerPage": PAGE_SIZE}
+
+
+def _is_map_search(base: str) -> bool:
+    return _search_url(base).rstrip("/").lower().endswith("/searchjobsmaps")
+
+
+def _is_detail_href(href: str) -> bool:
+    return (
+        "/JobDetail/" in href
+        or "/ProjectDetail/" in href
+        or "/PipelineDetail" in href
+    )
+
+
+def _join_avature_url(base: str, href: str) -> str:
+    """Resolve Avature detail links without duplicating custom base paths."""
+    if href.startswith(("http://", "https://")):
+        return href
+    base = _link_base(base)
+    if not href.startswith("/"):
+        return f"{base.rstrip('/')}/{href}"
+
+    parsed = urlparse(base)
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+    base_path = parsed.path.rstrip("/")
+    if base_path and (href == base_path or href.startswith(f"{base_path}/")):
+        return f"{origin}{href}"
+    return f"{base.rstrip('/')}{href}"
+
+
+def _link_base(base: str) -> str:
+    base = base.rstrip("/")
+    if base.lower().endswith("/searchjobs"):
+        return base.rsplit("/", 1)[0]
+    return base
 
 
 def _parse_detail(html: str) -> tuple[dict[str, str], str | None]:

--- a/src/jobhive/scrapers/avature.py
+++ b/src/jobhive/scrapers/avature.py
@@ -36,7 +36,7 @@ import os
 import re
 from datetime import datetime
 from typing import TYPE_CHECKING
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import parse_qs, parse_qsl, urlencode, urlparse, urlunparse
 
 import httpx
 
@@ -440,10 +440,7 @@ class AvatureScraper(BaseScraper):
                 page_size = _page_size(base)
                 for page_num in range(MAX_PAGES):
                     offset = page_num * page_size
-                    list_url = (
-                        f"{_search_url(base)}?"
-                        f"{urlencode(_pagination_params(base, offset))}"
-                    )
+                    list_url = _paginated_search_url(base, offset)
                     try:
                         await page.goto(
                             list_url, wait_until="domcontentloaded", timeout=30_000
@@ -496,12 +493,10 @@ class AvatureScraper(BaseScraper):
     async def _fetch_page(
         self, client: httpx.AsyncClient, base: str, offset: int
     ) -> str:
-        params = _pagination_params(base, offset)
+        list_url = _paginated_search_url(base, offset)
         for attempt in range(1, MAX_RETRIES + 1):
             try:
-                response = await client.get(
-                    _search_url(base), params=params, headers=_BROWSER_HEADERS
-                )
+                response = await client.get(list_url, headers=_BROWSER_HEADERS)
             except httpx.HTTPError as exc:
                 if attempt == MAX_RETRIES:
                     raise ScraperError(
@@ -673,13 +668,39 @@ def _search_url(base: str) -> str:
     """Return the SearchJobs URL for default and custom-path portals."""
     parsed = urlparse(base)
     path = parsed.path.rstrip("/")
-    if path.lower().endswith("/searchjobs"):
-        return f"{base.rstrip('/')}/"
-    if path.lower().endswith("/searchjobsmaps"):
-        return f"{base.rstrip('/')}/"
-    if not path or path.lstrip("/") in _LOCALE_PREFIXES:
-        return f"{base.rstrip('/')}/careers/SearchJobs/"
-    return f"{base.rstrip('/')}/SearchJobs/"
+    lowered = path.lower()
+    if lowered.endswith("/searchjobs") or lowered.endswith("/searchjobsmaps"):
+        search_path = f"{path}/"
+    elif not path or path.lstrip("/") in _LOCALE_PREFIXES:
+        search_path = f"{path}/careers/SearchJobs/"
+    else:
+        search_path = f"{path}/SearchJobs/"
+    return urlunparse(
+        (parsed.scheme, parsed.netloc, search_path, "", parsed.query, parsed.fragment)
+    )
+
+
+def _paginated_search_url(base: str, offset: int) -> str:
+    """Build a listing URL while preserving tenant-specific query params."""
+    parsed = urlparse(_search_url(base))
+    page_params = _pagination_params(base, offset)
+    page_keys = set(page_params)
+    query_items = [
+        (key, value)
+        for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+        if key not in page_keys
+    ]
+    query_items.extend((key, str(value)) for key, value in page_params.items())
+    return urlunparse(
+        (
+            parsed.scheme,
+            parsed.netloc,
+            parsed.path,
+            parsed.params,
+            urlencode(query_items),
+            parsed.fragment,
+        )
+    )
 
 
 def _page_size(base: str) -> int:
@@ -693,7 +714,8 @@ def _pagination_params(base: str, offset: int) -> dict[str, int]:
 
 
 def _is_map_search(base: str) -> bool:
-    return _search_url(base).rstrip("/").lower().endswith("/searchjobsmaps")
+    path = urlparse(_search_url(base)).path.rstrip("/").lower()
+    return path.endswith("/searchjobsmaps")
 
 
 def _is_detail_href(href: str) -> bool:
@@ -721,11 +743,12 @@ def _join_avature_url(base: str, href: str) -> str:
 
 
 def _link_base(base: str) -> str:
-    base = base.rstrip("/")
-    lowered = base.lower()
+    parsed = urlparse(base.rstrip("/"))
+    path = parsed.path.rstrip("/")
+    lowered = path.lower()
     if lowered.endswith("/searchjobs") or lowered.endswith("/searchjobsmaps"):
-        return base.rsplit("/", 1)[0]
-    return base
+        path = path.rsplit("/", 1)[0]
+    return urlunparse((parsed.scheme, parsed.netloc, path, "", "", parsed.fragment))
 
 
 def _parse_detail(html: str) -> tuple[dict[str, str], str | None]:

--- a/tests/test_avature.py
+++ b/tests/test_avature.py
@@ -23,6 +23,7 @@ import pytest
 from jobhive.exceptions import CompanyNotFoundError, ScraperError
 from jobhive.models import ATSType
 from jobhive.scrapers import AvatureScraper, ScraperRegistry, get_scraper
+from jobhive.scrapers.avature import _paginated_search_url
 
 
 @pytest.fixture(autouse=True)
@@ -326,6 +327,42 @@ def test_searchjobs_maps_direct_pagination_uses_pipeline_offsets(httpx_mock) -> 
     assert jobs[-1].ats_id == "30"
     assert str(jobs[0].url) == (
         "https://company.example.com/en_US/jobs/PipelineDetail?pipelineId=0"
+    )
+
+
+def test_searchjobs_maps_query_params_are_preserved(httpx_mock) -> None:
+    base = "https://company.example.com/en_US/jobs/SearchJobsMaps?folderId=abc&lang=en"
+    expected_url = (
+        "https://company.example.com/en_US/jobs/SearchJobsMaps/"
+        "?folderId=abc&lang=en&pipelineOffset=0"
+    )
+    httpx_mock.add_response(
+        url=expected_url,
+        text=(
+            "<li class='list__item'>"
+            "<div class='list__item__text__title'>"
+            "<a href='/en_US/jobs/PipelineDetail?pipelineId=123'>Retail Specialist</a>"
+            "</div>"
+            "</li>"
+        ),
+    )
+
+    jobs = AvatureScraper(base).fetch()
+
+    assert len(jobs) == 1
+    assert str(jobs[0].url) == (
+        "https://company.example.com/en_US/jobs/PipelineDetail?pipelineId=123"
+    )
+
+
+def test_browserbase_pagination_url_preserves_searchjobs_maps_query_params() -> None:
+    base = "https://company.example.com/en_US/jobs/SearchJobsMaps?folderId=abc&lang=en"
+
+    url = _paginated_search_url(base, 30)
+
+    assert url == (
+        "https://company.example.com/en_US/jobs/SearchJobsMaps/"
+        "?folderId=abc&lang=en&pipelineOffset=30"
     )
 
 

--- a/tests/test_avature.py
+++ b/tests/test_avature.py
@@ -248,6 +248,61 @@ def test_full_base_url_is_supported_for_custom_domain_tenants(httpx_mock) -> Non
     assert str(jobs[0].url) == "https://careers.example.com/en_US/careers/JobDetail/Eng/1"
 
 
+def test_full_base_url_with_custom_search_path_is_supported(httpx_mock) -> None:
+    """Some custom-domain tenants use `/jobs/SearchJobs` or other portal
+    prefixes instead of the default `/careers/SearchJobs`."""
+    base = "https://jobs.example.com/jobs"
+    httpx_mock.add_response(
+        url=f"{base}/SearchJobs/?jobOffset=0&jobRecordsPerPage=12",
+        text='<a href="/jobs/ProjectDetail/Eng/1">Eng</a>',
+    )
+
+    jobs = AvatureScraper(base).fetch()
+
+    assert len(jobs) == 1
+    assert str(jobs[0].url) == "https://jobs.example.com/jobs/ProjectDetail/Eng/1"
+
+
+def test_full_searchjobs_url_is_supported(httpx_mock) -> None:
+    base = "https://company.example.com/custom/SearchJobs"
+    httpx_mock.add_response(
+        url=f"{base}/?jobOffset=0&jobRecordsPerPage=12",
+        text='<a href="/custom/JobDetail/Eng/1">Eng</a>',
+    )
+
+    jobs = AvatureScraper(base).fetch()
+
+    assert len(jobs) == 1
+    assert str(jobs[0].url) == "https://company.example.com/custom/JobDetail/Eng/1"
+
+
+def test_searchjobs_maps_pipeline_variant_is_supported(httpx_mock) -> None:
+    base = "https://company.example.com/en_US/jobs/SearchJobsMaps"
+    httpx_mock.add_response(
+        url=f"{base}/?pipelineOffset=0",
+        text=(
+            '<li class="list__item">'
+            '<div class="list__item__text__title">'
+            '<a href="https://company.example.com/en_US/jobs/'
+            'PipelineDetail?pipelineId=123">Retail Specialist</a>'
+            "</div>"
+            '<div class="list__item__text__subtitle">'
+            "<span>Chicago, Illinois, United States</span>"
+            "</div>"
+            "</li>"
+        ),
+    )
+
+    jobs = AvatureScraper(base).fetch()
+
+    assert len(jobs) == 1
+    assert jobs[0].ats_id == "123"
+    assert jobs[0].title == "Retail Specialist"
+    assert str(jobs[0].url) == (
+        "https://company.example.com/en_US/jobs/PipelineDetail?pipelineId=123"
+    )
+
+
 # --- Error handling --------------------------------------------------------
 
 

--- a/tests/test_avature.py
+++ b/tests/test_avature.py
@@ -303,6 +303,32 @@ def test_searchjobs_maps_pipeline_variant_is_supported(httpx_mock) -> None:
     )
 
 
+def test_searchjobs_maps_direct_pagination_uses_pipeline_offsets(httpx_mock) -> None:
+    base = "https://company.example.com/en_US/jobs/SearchJobsMaps"
+
+    def mkpage(start: int, count: int) -> str:
+        return "".join(
+            "<li class='list__item'>"
+            "<div class='list__item__text__title'>"
+            f"<a href='/en_US/jobs/PipelineDetail?pipelineId={i}'>Job {i}</a>"
+            "</div>"
+            "<div class='list__item__text__subtitle'><span>Remote</span></div>"
+            "</li>"
+            for i in range(start, start + count)
+        )
+
+    httpx_mock.add_response(url=f"{base}/?pipelineOffset=0", text=mkpage(0, 30))
+    httpx_mock.add_response(url=f"{base}/?pipelineOffset=30", text=mkpage(30, 1))
+
+    jobs = AvatureScraper(base).fetch()
+
+    assert len(jobs) == 31
+    assert jobs[-1].ats_id == "30"
+    assert str(jobs[0].url) == (
+        "https://company.example.com/en_US/jobs/PipelineDetail?pipelineId=0"
+    )
+
+
 # --- Error handling --------------------------------------------------------
 
 

--- a/tests/test_run_pipeline_guards.py
+++ b/tests/test_run_pipeline_guards.py
@@ -76,6 +76,36 @@ def test_provider_slug_normalizers_match_current_company_csv_shape() -> None:
     }
     assert runner._avature_slug(avature_subdomain_row) == "bloomberg"
 
+    avature_custom_path_row = {
+        "name": "Premium Retail Services",
+        "slug": "premium",
+        "url": "https://premium.avature.net/en_US/jobs",
+    }
+    assert (
+        runner._avature_slug(avature_custom_path_row)
+        == "https://premium.avature.net/en_US/jobs"
+    )
+
+    avature_locale_path_row = {
+        "name": "Zung Fu",
+        "slug": "zungfu",
+        "url": "https://zungfu.avature.net/en_US/careers/SearchJobs",
+    }
+    assert (
+        runner._avature_slug(avature_locale_path_row)
+        == "https://zungfu.avature.net/en_US/careers/SearchJobs"
+    )
+
+    avature_maps_path_row = {
+        "name": "Premium Retail Services",
+        "slug": "premium",
+        "url": "https://premium.avature.net/en_US/jobs/SearchJobsMaps",
+    }
+    assert (
+        runner._avature_slug(avature_maps_path_row)
+        == "https://premium.avature.net/en_US/jobs/SearchJobsMaps"
+    )
+
 
 def test_catastrophic_failure_preserves_previous_jobs_csv(
     tmp_path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

- Adds Bravura Solutions Limited, Avature itself, Siemens Healthineers, and Virgin Media O2 to `ats-companies/avature.csv`.
- Fixes Avature custom-path handling so non-default portals use their CSV URL instead of being forced through `/careers/SearchJobs`.
- Adds support for Avature `SearchJobsMaps` / `PipelineDetail` boards, including `pipelineOffset` pagination and `pipelineId` IDs.
- Updates Premium Retail Services to its actual `SearchJobsMaps` results URL.

## Validation

- Live-validated `bravura`: 11 parsed jobs from `https://bravura.avature.net/careers/SearchJobs`.
- Live-validated new custom-domain rows with the actual scraper:
  - Siemens Healthineers: 6 jobs from `https://jobs.siemens-healthineers.com/en_US/searchjobs/SearchJobs`
  - Virgin Media O2: 8 jobs from `https://jobs.virginmediao2.co.uk/en_US/careersmarketplace/SearchJobs`
- Live-validated path-sensitive rows with the actual scraper:
  - Metrobank: 6 jobs from `https://metrobank.avature.net/amazingcareers/SearchJobs`
  - Zung Fu: 6 jobs from `https://zungfu.avature.net/en_US/careers/SearchJobs`
  - Avature: 6 jobs from `https://careers.avature.net/en_US/main/SearchJobs`
  - Premium Retail Services: 42 parsed jobs from the first two bounded `SearchJobsMaps` pages; the live page advertises `999+` results.
- Discovery notes: the old `https://virginmediao2.avature.net/careers` path returns 404, so this PR uses the live custom-domain `careersmarketplace/SearchJobs` path instead. Cisco and IBM were probed but not added because they did not return parseable jobs through the current scraper path.
- `uv run ruff check .`
- `python3 -m py_compile src/jobhive/scrapers/avature.py scripts/run_pipeline.py`
- `uv run pytest tests/test_avature.py tests/test_run_pipeline_guards.py -q` (35 passed)
- `uv run pytest -q` (932 passed)
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the Avature scraper with four new companies (Bravura Solutions Limited, Avature itself, Siemens Healthineers, Virgin Media O2), fixes custom-path handling so tenants with non-default portal paths use their CSV URL rather than the forced `/careers/SearchJobs` default, and adds full `SearchJobsMaps` / `PipelineDetail` board support including `pipelineOffset` pagination.

- `_avature_base_from_url` in `run_pipeline.py` and reworked `_search_url` / `_paginated_search_url` / `_is_map_search` helpers in `avature.py` ensure every scraping path — `_fetch_direct`, `_fetch_via_httpcloak`, and `_fetch_via_browserbase` — uses the correct URL shape and page-size constant for both `SearchJobs` (page size 12) and `SearchJobsMaps` (page size 30) portals.
- `_link_base` now strips both `/SearchJobs` and `/SearchJobsMaps` suffixes before resolving relative detail hrefs, and `_is_detail_href` was broadened to accept `PipelineDetail` anchors; all three previously-flagged pagination and path-construction issues are addressed in this revision.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three scraping paths are consistent, previously flagged pagination and URL-construction problems are addressed, and the new SearchJobsMaps logic is live-validated and unit-tested.

Every changed code path — _fetch_direct, _fetch_via_httpcloak, and _fetch_via_browserbase — now uses _page_size() and _paginated_search_url consistently. The _link_base helper strips both /SearchJobs and /SearchJobsMaps, preventing the duplicate-segment URL bug flagged in earlier review rounds. _avature_base_from_url correctly falls back to the slug for the standard /careers/SearchJobs path while routing custom-path and custom-domain tenants through the URL column. Live validation confirms correct pagination for Premium Retail Services (SearchJobsMaps) and the four new tenants.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/avature.py | Adds SearchJobsMaps support with correct MAP_PAGE_SIZE=30, _paginated_search_url, _pagination_params, _is_map_search, and _link_base; all three scraping paths updated consistently. Previously flagged pagination and URL-construction issues are resolved. |
| scripts/run_pipeline.py | New _avature_base_from_url helper and revised _avature_slug correctly route tenants with custom-path URLs (e.g. Avature on careers.avature.net, Metrobank on /amazingcareers) to the right base instead of always using the subdomain slug. |
| tests/test_avature.py | New tests cover custom search paths, SearchJobsMaps pagination offsets, query-param preservation, and PipelineDetail ID extraction. Good coverage of the new code paths. |
| tests/test_run_pipeline_guards.py | Adds slug-normalizer assertions for custom-path, locale-prefixed, and SearchJobsMaps rows; validates the new _avature_base_from_url behaviour without regression on standard subdomain rows. |
| ats-companies/avature.csv | Four new live-validated companies added; Premium Retail Services updated to SearchJobsMaps URL; Virgin Media O2 corrected to live custom domain. All formats consistent with existing rows. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/jobhive/scrapers/avature.py`, line 345-360 ([link](https://github.com/kalil0321/ats-scrapers/blob/d4c43c3e6565ca9dc010b8d2032ff802393259b5/src/jobhive/scrapers/avature.py#L345-L360)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> `_fetch_direct` was not updated to use `_page_size(base)`. For a `SearchJobsMaps` portal (e.g. Premium Retail Services), `offset` increments by 12 instead of 30, so pages 2+ request the wrong `pipelineOffset` values, returning duplicate or skipped jobs. The termination guard also fires too early (< 12 instead of < 30). Both `_fetch_via_httpcloak` and `_fetch_via_browserbase` received the equivalent fix in this PR; this path was missed.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/jobhive/scrapers/avature.py
   Line: 345-360

   Comment:
   `_fetch_direct` was not updated to use `_page_size(base)`. For a `SearchJobsMaps` portal (e.g. Premium Retail Services), `offset` increments by 12 instead of 30, so pages 2+ request the wrong `pipelineOffset` values, returning duplicate or skipped jobs. The termination guard also fires too early (< 12 instead of < 30). Both `_fetch_via_httpcloak` and `_fetch_via_browserbase` received the equivalent fix in this PR; this path was missed.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Preserve Avature map search query params"](https://github.com/kalil0321/ats-scrapers/commit/c49f86310bc8bb4352903c21f3f0adad84500249) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34029989)</sub>

<!-- /greptile_comment -->