### PR TITLE
Add validated Eightfold companies

### DIFF
--- a/ats-companies/eightfold.csv
+++ b/ats-companies/eightfold.csv
@@ -67,3 +67,5 @@ Vialto Partners,vialto,https://vialto.eightfold.ai/careers,
 Vodafone,vodafone,https://vodafone.eightfold.ai/careers,
 Whirlpool,whirlpool,https://whirlpool.eightfold.ai/careers,
 Worley,worley,https://worley.eightfold.ai/careers,
+MM Group,mm-group,https://mm-group.eightfold.ai/careers,
+Millennium,mlp,https://career.mlp.com/careers,mlp.com

--- a/ats-companies/eightfold.csv
+++ b/ats-companies/eightfold.csv
@@ -22,6 +22,9 @@ Estée Lauder Companies,elcompanies,https://elcompanies.eightfold.ai/careers,
 Ford,ford,https://ford.eightfold.ai/careers,
 Fortive,fortive,https://fortive.eightfold.ai/careers,
 Forvia,faurecia,https://faurecia.eightfold.ai/careers,
+Freeport-McMoRan,fcx,https://fcx.eightfold.ai/careers,fcx.com
+Frontier Communications,ftr,https://ftr.eightfold.ai/careers,ftr.com
+GlobalFoundries,globalfoundries,https://globalfoundries.eightfold.ai/careers,globalfoundries.com
 Haleon,haleon,https://haleon.eightfold.ai/careers,
 Hasbro,hasbro,https://hasbro.eightfold.ai/careers,
 Houston ISD,houstonisd,https://apply.houstonisd.org/careers,houstonisd.org
@@ -51,12 +54,14 @@ Ralliant,ralliant,https://ralliant.eightfold.ai/careers,
 SLB,slb,https://slb.eightfold.ai/careers,
 Softtek,softtek,https://softtek.eightfold.ai/careers,
 Starbucks,starbucks,https://starbucks.eightfold.ai/careers,
+STMicroelectronics,stmicroelectronics,https://stmicroelectronics.eightfold.ai/careers,stmicroelectronics.com
 Symetra,symetra,https://symetra.eightfold.ai/careers,
 Tailored Brands,tailoredbrands,https://tailoredbrands.eightfold.ai/careers,
 Trimble,trimble,https://trimble.eightfold.ai/careers,
 TriNet,trinet,https://trinet.eightfold.ai/careers,
 Twilio,twilio,https://twilio.eightfold.ai/careers,
 UKG,ukg,https://ukg.eightfold.ai/careers,
+Vale,vale,https://vale.eightfold.ai/careers,vale.com
 Vialto Partners,vialto,https://vialto.eightfold.ai/careers,
 Vodafone,vodafone,https://vodafone.eightfold.ai/careers,
 Whirlpool,whirlpool,https://whirlpool.eightfold.ai/careers,

--- a/ats-companies/eightfold.csv
+++ b/ats-companies/eightfold.csv
@@ -17,6 +17,7 @@ Dexcom,dexcom,https://dexcom.eightfold.ai/careers,
 Dolby,dolby,https://dolby.eightfold.ai/careers,
 dsm-firmenich,dsm,https://dsm.eightfold.ai/careers,
 Eaton,eaton,https://eaton.eightfold.ai/careers,
+Eightfold,app,https://app.eightfold.ai/careers,eightfold.ai
 Ericsson,ericsson,https://ericsson.eightfold.ai/careers,
 Estée Lauder Companies,elcompanies,https://elcompanies.eightfold.ai/careers,
 Ford,ford,https://ford.eightfold.ai/careers,

--- a/ats-companies/eightfold.csv
+++ b/ats-companies/eightfold.csv
@@ -69,3 +69,4 @@ Whirlpool,whirlpool,https://whirlpool.eightfold.ai/careers,
 Worley,worley,https://worley.eightfold.ai/careers,
 MM Group,mm-group,https://mm-group.eightfold.ai/careers,
 Millennium,mlp,https://career.mlp.com/careers,mlp.com
+Netflix,netflix,https://explore.jobs.netflix.net/careers,netflix.com

--- a/src/jobhive/scrapers/eightfold.py
+++ b/src/jobhive/scrapers/eightfold.py
@@ -122,6 +122,10 @@ class EightfoldScraper(BaseScraper):
         # httpx or auto: try httpx first
         try:
             await self._fetch_via_httpx(seen, all_jobs)
+        except _SmartApplyRequired:
+            seen.clear()
+            all_jobs.clear()
+            await self._fetch_via_smartapply_httpx(seen, all_jobs)
         except _WAFBlocked as exc:
             if self.client_kind == "httpx":
                 raise ScraperError(
@@ -173,6 +177,35 @@ class EightfoldScraper(BaseScraper):
                     self._enrich_position_details(client, detail_sem, j)
                     for j in all_jobs
                 ))
+
+    async def _fetch_via_smartapply_httpx(
+        self, seen: set[str], all_jobs: list[Job]
+    ) -> None:
+        """Fetch tenants backed by Eightfold's public SmartApply endpoint."""
+        async with httpx.AsyncClient(
+            timeout=self.timeout,
+            follow_redirects=True,
+            limits=httpx.Limits(
+                max_connections=MAX_CONCURRENCY_HTTPX * 2,
+                max_keepalive_connections=MAX_CONCURRENCY_HTTPX,
+            ),
+        ) as client:
+            first = await self._fetch_page_smartapply_httpx(client, start=0)
+            self._collect(first.get("positions") or [], seen, all_jobs)
+            count = int(first.get("count") or 0)
+            if count <= PAGE_SIZE:
+                return
+            offsets = list(range(PAGE_SIZE, count, PAGE_SIZE))
+            sem = asyncio.Semaphore(MAX_CONCURRENCY_HTTPX)
+
+            async def task(offset: int) -> None:
+                async with sem:
+                    page = await self._fetch_page_smartapply_httpx(
+                        client, start=offset
+                    )
+                    self._collect(page.get("positions") or [], seen, all_jobs)
+
+            await asyncio.gather(*(task(o) for o in offsets))
 
     async def _enrich_position_details(
         self,
@@ -262,6 +295,8 @@ class EightfoldScraper(BaseScraper):
             if response.status_code == 200:
                 return response.json().get("data") or {}
             if response.status_code == 403:
+                if _is_pcsx_unavailable(response):
+                    raise _SmartApplyRequired(self.company_name)
                 raise _WAFBlocked(self.company_name, start)
             if response.status_code == 429:  # rate-limited
                 if attempt == MAX_RETRIES:
@@ -290,6 +325,73 @@ class EightfoldScraper(BaseScraper):
         # Defensive — loop should always raise or return.
         raise ScraperError(
             f"Eightfold ({self.company_name}) exhausted retries at start={start}: {last_exc}"
+        )
+
+    async def _fetch_page_smartapply_httpx(
+        self, client: httpx.AsyncClient, *, start: int
+    ) -> dict[str, Any]:
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                response = await client.get(
+                    f"{self.base_url}/api/apply/v2/jobs",
+                    params={
+                        "domain": self.domain,
+                        "query": "",
+                        "location": "",
+                        "start": start,
+                        "sort_by": "timestamp",
+                    },
+                    headers={
+                        "User-Agent": "Mozilla/5.0",
+                        "Accept": "application/json, text/plain, */*",
+                    },
+                )
+            except httpx.HTTPError as exc:
+                last_exc = exc
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Eightfold ({self.company_name}) SmartApply fetch "
+                        f"failed at start={start}: {exc}"
+                    ) from exc
+                await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                continue
+
+            if response.status_code == 200:
+                try:
+                    payload = response.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"Eightfold ({self.company_name}) SmartApply returned "
+                        f"malformed JSON at start={start}: {exc}"
+                    ) from exc
+                return {
+                    "positions": payload.get("positions") or [],
+                    "count": payload.get("count") or 0,
+                }
+            if response.status_code in (429, 500, 502, 503, 504):
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Eightfold ({self.company_name}) SmartApply returned "
+                        f"{response.status_code} at start={start} after "
+                        f"{MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after)
+                    if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"Eightfold ({self.company_name}) SmartApply returned "
+                f"{response.status_code} at start={start}"
+            )
+
+        raise ScraperError(
+            f"Eightfold ({self.company_name}) SmartApply exhausted retries at "
+            f"start={start}: {last_exc}"
         )
 
     # --- httpcloak path (sync, but parallelized via to_thread) ----------
@@ -363,9 +465,14 @@ class EightfoldScraper(BaseScraper):
 
     def _parse_job(self, item: dict[str, Any]) -> Job:
         ats_id = str(
-            item.get("displayJobId") or item.get("id") or item.get("atsJobId") or ""
+            item.get("displayJobId")
+            or item.get("display_job_id")
+            or item.get("id")
+            or item.get("atsJobId")
+            or item.get("ats_job_id")
+            or ""
         )
-        position = item.get("positionUrl") or ""
+        position = item.get("positionUrl") or item.get("canonicalPositionUrl") or ""
         if position.startswith("/"):
             url = f"{self.job_url_host}{position}"
         elif position:
@@ -377,19 +484,30 @@ class EightfoldScraper(BaseScraper):
         # ``atsJobId`` / ``displayJobId`` is the upstream requisition id and
         # collides with the underlying ATS's bulletFields[0]. That's the
         # signal the cross-ATS dedup pass uses (Pass 3).
-        requisition_id = item.get("atsJobId") or item.get("displayJobId")
+        requisition_id = (
+            item.get("atsJobId")
+            or item.get("ats_job_id")
+            or item.get("displayJobId")
+            or item.get("display_job_id")
+        )
 
         raw: dict[str, Any] = {}
-        for k in ("workLocationOption", "locationFlexibility",
-                  "category", "team", "businessUnit", "skills",
-                  "yearsOfExperience", "employmentType"):
+        for k in ("workLocationOption", "work_location_option",
+                  "locationFlexibility", "location_flexibility",
+                  "category", "team", "businessUnit", "business_unit",
+                  "skills", "yearsOfExperience", "employmentType"):
             v = item.get(k)
             if v:
                 raw[k] = v
 
         return Job(
             url=url,
-            title=item.get("name") or item.get("title") or "Untitled",
+            title=(
+                item.get("name")
+                or item.get("posting_name")
+                or item.get("title")
+                or "Untitled"
+            ),
             company=self.company_name,
             ats_type=self.ats,
             ats_id=ats_id,
@@ -397,7 +515,13 @@ class EightfoldScraper(BaseScraper):
             is_remote=_extract_remote(item),
             department=item.get("department"),
             requisition_id=str(requisition_id) if requisition_id and str(requisition_id) != ats_id else None,
-            posted_at=_parse_ts(item.get("postedTs") or item.get("creationTs")),
+            description=_strip_html(item.get("job_description") or "") or None,
+            posted_at=_parse_ts(
+                item.get("postedTs")
+                or item.get("creationTs")
+                or item.get("t_update")
+                or item.get("t_create")
+            ),
             fetched_at=datetime.now(),
             raw=raw or None,
         )
@@ -413,6 +537,23 @@ class _WAFBlocked(Exception):  # noqa: N818
         )
         self.company_name = company_name
         self.start = start
+
+
+class _SmartApplyRequired(Exception):  # noqa: N818
+    """Internal signal that PCSX is disabled for a SmartApply tenant."""
+
+    def __init__(self, company_name: str) -> None:
+        super().__init__(f"Eightfold ({company_name}) requires SmartApply API")
+        self.company_name = company_name
+
+
+def _is_pcsx_unavailable(response: httpx.Response) -> bool:
+    try:
+        payload = response.json()
+    except ValueError:
+        return False
+    message = str(payload.get("message") or "").lower()
+    return "pcsx is not enabled" in message or "not authorized for pcsx" in message
 
 
 def _position_id_from_url(url: object) -> str | None:
@@ -460,7 +601,10 @@ def _extract_remote(item: dict[str, Any]) -> bool | None:
     'Onsite', 'Up to 100% work from home'. We map the obvious ones; unknowns
     fall through to None so consumers can still tell "we don't know" from
     "we know it's not remote"."""
-    for key in ("workLocationOption", "locationFlexibility"):
+    for key in (
+        "workLocationOption", "work_location_option",
+        "locationFlexibility", "location_flexibility",
+    ):
         value = item.get(key)
         if not isinstance(value, str):
             continue

--- a/src/jobhive/scrapers/eightfold.py
+++ b/src/jobhive/scrapers/eightfold.py
@@ -164,7 +164,11 @@ class EightfoldScraper(BaseScraper):
                     page = await self._fetch_page_httpx(client, start=offset)
                     self._collect(page.get("positions") or [], seen, all_jobs)
 
-            await asyncio.gather(*(task(o) for o in offsets))
+            # ``asyncio.gather`` leaves sibling tasks running when one raises
+            # (e.g. a late ``_SmartApplyRequired`` 403 on a fanned-out page).
+            # Cancel and drain them before propagating so nothing writes to
+            # ``all_jobs`` after the caller clears it for the SmartApply retry.
+            await _gather_cancel_on_error(*(task(o) for o in offsets))
 
             # Detail enrichment — pull jobDescription from the public
             # `position_details` XHR endpoint per job. PCSX handles the
@@ -205,7 +209,7 @@ class EightfoldScraper(BaseScraper):
                     )
                     self._collect(page.get("positions") or [], seen, all_jobs)
 
-            await asyncio.gather(*(task(o) for o in offsets))
+            await _gather_cancel_on_error(*(task(o) for o in offsets))
 
     async def _enrich_position_details(
         self,
@@ -472,7 +476,13 @@ class EightfoldScraper(BaseScraper):
             or item.get("ats_job_id")
             or ""
         )
-        position = item.get("positionUrl") or item.get("canonicalPositionUrl") or ""
+        position = (
+            item.get("canonicalPositionUrl")
+            or item.get("canonical_position_url")
+            or item.get("positionUrl")
+            or item.get("position_url")
+            or ""
+        )
         if position.startswith("/"):
             url = f"{self.job_url_host}{position}"
         elif position:
@@ -519,12 +529,26 @@ class EightfoldScraper(BaseScraper):
             posted_at=_parse_ts(
                 item.get("postedTs")
                 or item.get("creationTs")
-                or item.get("t_update")
                 or item.get("t_create")
+                or item.get("t_update")
             ),
             fetched_at=datetime.now(),
             raw=raw or None,
         )
+
+
+async def _gather_cancel_on_error(*coros: Any) -> None:
+    """Like ``asyncio.gather`` but cancels and drains siblings when one task
+    raises, so no in-flight task keeps mutating shared state after the first
+    error propagates."""
+    tasks = [asyncio.ensure_future(c) for c in coros]
+    try:
+        await asyncio.gather(*tasks)
+    except BaseException:
+        for t in tasks:
+            t.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
 
 
 class _WAFBlocked(Exception):  # noqa: N818

--- a/tests/test_eightfold.py
+++ b/tests/test_eightfold.py
@@ -92,6 +92,17 @@ def _mock_url(start: int, *, base: str = URL, domain: str = "dolby.com") -> str:
     )
 
 
+def _smartapply_url(
+    start: int,
+    *,
+    base: str = "https://frontier.eightfold.ai/api/apply/v2/jobs",
+    domain: str = "frontier.com",
+) -> str:
+    return (
+        f"{base}?domain={domain}&query=&location=&start={start}&sort_by=timestamp"
+    )
+
+
 # --- Construction & defaults -------------------------------------------------
 
 
@@ -238,6 +249,79 @@ def test_fetch_fans_out_using_count(httpx_mock) -> None:
     assert len(jobs) == 25
     # Order isn't guaranteed (concurrent fan-out), but the set must match.
     assert {j.ats_id for j in jobs} == {f"P{i}" for i in range(25)}
+
+
+def test_fetch_falls_back_to_smartapply_when_pcsx_is_disabled(httpx_mock) -> None:
+    """Some Eightfold tenants expose jobs through SmartApply instead of PCSX."""
+    api = "https://frontier.eightfold.ai/api/pcsx/search"
+    httpx_mock.add_response(
+        url=_mock_url(0, base=api, domain="frontier.com"),
+        status_code=403,
+        json={"message": "PCSX is not enabled for this user."},
+    )
+    httpx_mock.add_response(
+        url=_smartapply_url(0),
+        json={
+            "positions": [
+                {
+                    "id": 42030927,
+                    "name": "Sales Advisor",
+                    "location": "Dallas,TX,United States",
+                    "locations": ["Dallas,TX,United States"],
+                    "department": "Sales",
+                    "business_unit": "Sales",
+                    "t_update": 1779491393,
+                    "ats_job_id": "ats-1",
+                    "display_job_id": "REQ-1",
+                    "job_description": "<p>Sell things</p>",
+                    "work_location_option": "hybrid",
+                    "canonicalPositionUrl": (
+                        "https://careers.frontier.com/careers/job/42030927"
+                    ),
+                }
+            ],
+            "count": 11,
+        },
+    )
+    httpx_mock.add_response(
+        url=_smartapply_url(10),
+        json={
+            "positions": [
+                {
+                    "id": 42030928,
+                    "posting_name": "Network Engineer",
+                    "locations": ["Remote,United States"],
+                    "t_create": 1779491394,
+                    "display_job_id": "REQ-2",
+                    "canonicalPositionUrl": (
+                        "https://careers.frontier.com/careers/job/42030928"
+                    ),
+                }
+            ],
+            "count": 11,
+        },
+    )
+
+    jobs = EightfoldScraper(
+        "frontier",
+        base_url="https://frontier.eightfold.ai",
+        domain="frontier.com",
+        company_name="Frontier",
+    ).fetch()
+
+    assert [j.title for j in jobs] == ["Sales Advisor", "Network Engineer"]
+    assert str(jobs[0].url) == "https://careers.frontier.com/careers/job/42030927"
+    assert jobs[0].ats_id == "REQ-1"
+    assert jobs[0].requisition_id == "ats-1"
+    assert jobs[0].company == "Frontier"
+    assert jobs[0].department == "Sales"
+    assert jobs[0].description == "Sell things"
+    assert jobs[0].is_remote is None
+    assert jobs[0].raw == {
+        "work_location_option": "hybrid",
+        "business_unit": "Sales",
+    }
+    assert jobs[1].location == "Remote,United States"
 
 
 def test_fetch_returns_empty_when_first_page_empty(httpx_mock) -> None:
@@ -708,6 +792,8 @@ def test_parses_department_field(httpx_mock) -> None:
         ("workLocationOption", "On-site", False),
         ("locationFlexibility", "Fully remote", True),
         ("locationFlexibility", "In office", False),
+        ("work_location_option", "Remote", True),
+        ("location_flexibility", "In office", False),
         ("workLocationOption", "", None),
         ("workLocationOption", "Flexible", None),  # unknown value
     ],

--- a/tests/test_eightfold.py
+++ b/tests/test_eightfold.py
@@ -429,6 +429,49 @@ def test_parse_job_absolute_position_url_used_as_is(httpx_mock) -> None:
     assert str(jobs[0].url) == "https://elsewhere.example.com/job/X"
 
 
+def test_parse_job_prefers_canonical_position_url(httpx_mock) -> None:
+    """When both are present, the canonical URL wins over the raw
+    ``positionUrl`` to avoid non-canonical job links."""
+    httpx_mock.add_response(
+        url=_mock_url(0),
+        json=_page(
+            [
+                {
+                    "displayJobId": "X",
+                    "name": "X",
+                    "positionUrl": "/careers/job/X?utm=noise",
+                    "canonicalPositionUrl": "/careers/job/X",
+                }
+            ],
+            count=1,
+        ),
+    )
+    jobs = EightfoldScraper("dolby").fetch()
+    assert str(jobs[0].url) == "https://dolby.eightfold.ai/careers/job/X"
+
+
+def test_parse_job_posted_at_prefers_creation_over_update(httpx_mock) -> None:
+    """For SmartApply jobs carrying both, ``posted_at`` must reflect the
+    creation time (``t_create``), not the last-edit time (``t_update``)."""
+    httpx_mock.add_response(
+        url=_mock_url(0),
+        json=_page(
+            [
+                {
+                    "displayJobId": "X",
+                    "name": "X",
+                    "positionUrl": "/job/x",
+                    "t_create": "2024-01-01T00:00:00Z",
+                    "t_update": "2025-12-31T00:00:00Z",
+                }
+            ],
+            count=1,
+        ),
+    )
+    jobs = EightfoldScraper("dolby").fetch()
+    assert jobs[0].posted_at == _parse_ts("2024-01-01T00:00:00Z")
+
+
 def test_parse_job_missing_position_url_falls_back_to_synthetic(httpx_mock) -> None:
     httpx_mock.add_response(
         url=_mock_url(0),


### PR DESCRIPTION
## Summary
- Add eight validated Eightfold tenants: Eightfold, Freeport-McMoRan, Frontier Communications, GlobalFoundries, STMicroelectronics, Vale, MM Group, and Millennium.
- Add SmartApply fallback support for Eightfold tenants whose PCSX endpoint returns API-level authorization/disabled responses.
- Extend Eightfold parsing for SmartApply snake_case fields, canonical job URLs, descriptions, and timestamps.

## Validation
- Live-validated all added rows with the actual scraper/API path:
  - app / Eightfold: 58 jobs
  - fcx: 248 jobs
  - ftr: 56 jobs
  - globalfoundries: 601 jobs
  - stmicroelectronics: 461 jobs
  - vale: 231 jobs
  - mm-group: 53 jobs
  - mlp via `https://career.mlp.com/careers`: 236 jobs
- Confirmed `ats-companies/eightfold.csv` parses with 70 rows, 70 unique slugs, and 70 unique URLs.
- Confirmed Sephora was already present on main and did not duplicate it.
- Additional discovery notes: John Deere, Houston ISD, and Insight were already present on this branch; Zebra and American Express returned zero jobs; BNY Mellon returned 404; AstraZeneca UAT sandbox was skipped despite returning jobs; sandbox/demo/direct-sourcing hosts from certificate transparency were skipped.
- `python3 -m py_compile src/jobhive/scrapers/eightfold.py`
- `uv run pytest tests/test_eightfold.py tests/test_run_pipeline_guards.py -q` (96 passed)
- `uv run pytest -q` (932 passed)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds nine validated Eightfold tenants (including Netflix) and a SmartApply fallback when PCSX is disabled. Improves parsing to prefer canonical URLs and corrects timestamp handling; makes fan-out safe when falling back.

- **New Features**
  - Added `Eightfold (app)`, `Freeport-McMoRan (fcx)`, `Frontier (ftr)`, `GlobalFoundries`, `STMicroelectronics`, `Vale`, `MM Group`, `Millennium (mlp)`, and `Netflix` (validated: 563 jobs).
  - SmartApply fallback on PCSX 403 with pagination/retries; parser accepts snake_case fields, prefers `canonicalPositionUrl`, parses `job_description`, falls back title to `posting_name`, supports `t_create`/`t_update`, and handles snake_case remote fields.

- **Bug Fixes**
  - `posted_at` now prefers `t_create` over `t_update` so edits don’t appear as new posts.
  - When a page task errors during fan-out (e.g., SmartApply required), sibling tasks are canceled and drained before retry to prevent stale writes.

<sup>Written for commit b182d24b6a7a16e6163fbe1458fdd0bd7a6951bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds nine Eightfold tenants to the company CSV and introduces a SmartApply fallback path for tenants whose PCSX endpoint returns an authorization-disabled 403. The parser is extended to accept SmartApply's snake_case field variants, canonical job URLs, inline descriptions, and `t_create`/`t_update` timestamps.

- **SmartApply fallback**: `_fetch_page_httpx` now detects \"PCSX is not enabled\" / \"not authorized\" 403 responses via `_is_pcsx_unavailable`, raises `_SmartApplyRequired`, and the async pipeline catches it to retry against `/api/apply/v2/jobs` with the same concurrency model.
- **Parser extensions**: `_parse_job` now tries `display_job_id`, `ats_job_id`, `posting_name`, `canonicalPositionUrl`, and `job_description`; `_extract_remote` checks `work_location_option` / `location_flexibility`; timestamps now fall back to `t_update` / `t_create`.
- **Nine new CSV rows**: Eightfold (`app`), Freeport-McMoRan, Frontier Communications, GlobalFoundries, STMicroelectronics, Vale, MM Group, Millennium (`mlp`), and Netflix — though live validation in the PR description covers only eight of the nine.

<h3>Confidence Score: 3/5</h3>

The SmartApply path and parser additions are well-structured and tested; a timestamp ordering bug in `posted_at` will cause update times to be recorded as posting dates for SmartApply jobs, and Netflix was added without live-validation evidence.

The `t_update`-before-`t_create` ordering in `posted_at` means any SmartApply job that carries both fields will have its last-modification time stored as its posting date. Downstream sort and dedup passes keyed on `posted_at` will treat recently-edited old listings as newly posted, which is a present data-quality defect on the SmartApply path.

`src/jobhive/scrapers/eightfold.py` (timestamp ordering in `_parse_job`) and `ats-companies/eightfold.csv` (Netflix entry lacks a validated job count).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/eightfold.py | Adds SmartApply fallback path and snake_case field support; `t_update` is ordered before `t_create` in `posted_at`, causing update timestamps to override creation timestamps for SmartApply jobs. |
| ats-companies/eightfold.csv | Nine new tenants added (eight with explicit validation in the PR description); Netflix entry present but not listed in the live-validation results. |
| tests/test_eightfold.py | Well-structured integration test covering the PCSX → SmartApply fallback, snake_case fields, canonical URLs, and `posting_name` title fallback. No issues found. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/jobhive/scrapers/eightfold.py:519-524
`t_update` (last-modified) is tried before `t_create` (creation) when populating `posted_at`. For any SmartApply job that carries both fields, `posted_at` will be set to the most-recent edit timestamp rather than the original posting date. This causes recently-edited old listings to appear younger than they are in sort/dedup passes that key on `posted_at`.

```suggestion
            posted_at=_parse_ts(
                item.get("postedTs")
                or item.get("creationTs")
                or item.get("t_create")
                or item.get("t_update")
            ),
```

### Issue 2 of 2
ats-companies/eightfold.csv:72
Netflix was added to the CSV but isn't mentioned in the live-validation section of the PR description (which lists eight tenants and their job counts). If the `explore.jobs.netflix.net` endpoint rejects the PCSX/SmartApply probe at pipeline time, this row will silently produce zero jobs or a `ScraperError` that interrupts the Eightfold run. Can you confirm this was validated and add the job count to the description?

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add validated Netflix Eightfold board"](https://github.com/kalil0321/ats-scrapers/commit/f452bc27da37f26f87bf585ebd1e24fb8149ac97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34029959)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->