### PR TITLE
Fix description extraction across 12 scrapers + persistent Workday cache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,16 @@ publish = [
     # between aggregators (eures NUTS-code locations vs Bundesagentur
     # full text, trailing parenthesized occupation codes, etc.).
     "rapidfuzz>=3.0",
+    # markdownify is the canonical HTML→markdown converter; used by
+    # scripts/normalize_descriptions.py which runs post-scrape to clean
+    # the raw HTML several scrapers (lever, ashby, greenhouse, the
+    # batch of 6 strip-html scrapers, apple's assembled body) now emit.
+    "markdownify>=0.13",
+    # zstandard backs the optional compress=True path on the persistent
+    # DescriptionCache. Workday's cache uses it to keep ~700k entries
+    # under 3 GB on disk; without this package the persistent cache
+    # raises ModuleNotFoundError on open.
+    "zstandard>=0.22",
 ]
 discovery = [
     "firecrawl-py>=1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,11 @@ publish = [
     # the raw HTML several scrapers (lever, ashby, greenhouse, the
     # batch of 6 strip-html scrapers, apple's assembled body) now emit.
     "markdownify>=0.13",
+    # linkify-it-py runs as the final pass over each normalized
+    # description: bare URLs and emails left in plain-text postings
+    # get wrapped in CommonMark autolinks (``<https://…>``) so the
+    # viewer renders them as clickable links.
+    "linkify-it-py>=2.0",
     # zstandard backs the optional compress=True path on the persistent
     # DescriptionCache. Workday's cache uses it to keep ~700k entries
     # under 3 GB on disk; without this package the persistent cache

--- a/scripts/normalize_descriptions.py
+++ b/scripts/normalize_descriptions.py
@@ -29,6 +29,62 @@ def _md_lazy():
         _MD = md
     return _MD
 
+
+_LINKIFY = None
+def _linkify_lazy():
+    """linkify-it-py is the canonical URL/email/IP detector and the same
+    library markdown-it-py uses for its linkify plugin. Lazy-import so the
+    worker subprocess only pays the import cost once per process."""
+    global _LINKIFY
+    if _LINKIFY is None:
+        from linkify_it import LinkifyIt
+        from linkify_it.tlds import TLDS
+        l = LinkifyIt()
+        l.tlds(TLDS)  # full ICANN/IANA TLD set
+        _LINKIFY = l
+    return _LINKIFY
+
+
+def autolink(text: str) -> str:
+    """Wrap bare URLs and emails in CommonMark autolink syntax (``<url>``).
+
+    Markdownify converts real ``<a href=…>`` anchors to ``[text](url)``
+    already; this pass picks up the URLs that were rendered as plain
+    text in the source (typical in plain-text job postings: "apply at
+    https://acme.com/jobs"). We skip URLs that are already part of a
+    markdown link, an existing autolink, or an image — splicing inside
+    those would double-wrap.
+
+    Email addresses get ``<addr@host>`` which most markdown renderers
+    auto-link as ``mailto:`` links.
+    """
+    if not text:
+        return text
+    linkify = _linkify_lazy()
+    matches = linkify.match(text)
+    if not matches:
+        return text
+    # Walk matches in reverse so earlier indices stay valid as we splice.
+    out = text
+    for m in reversed(matches):
+        start, end = m.index, m.last_index
+        # Skip if already inside an existing markdown link or autolink
+        # by checking the chars immediately around the match.
+        before = out[max(0, start - 2):start]
+        after = out[end:end + 2]
+        if before.endswith("](") or before.endswith("<") or after.startswith(">"):
+            continue
+        # Skip the markdown image syntax ``![alt](url)`` too.
+        if before.endswith("!"):
+            continue
+        if "@" in m.url and not m.url.startswith(("http://", "https://", "ftp://")):
+            replacement = f"<{m.url}>"
+        else:
+            replacement = f"<{m.url}>"
+        out = out[:start] + replacement + out[end:]
+    return out
+
+
 HTML_BLOCK_RE = re.compile(
     r"<(?:p|div|ul|ol|li|h[1-6]|br|table|tr|td|a|strong|em|b|i|span|section|article|hr|blockquote)\b",
     re.IGNORECASE,
@@ -40,6 +96,10 @@ WS_RUN_RE = re.compile(r"\s+")
 
 
 def normalize_one(s):
+    """Pipeline: route to markdownify / strip-unescape / fast-path, then
+    apply autolink to whatever ended up in the output. Bare URLs and
+    emails that survived earlier branches become CommonMark autolinks.
+    """
     if s is None:
         return None
     s = s.strip()
@@ -54,14 +114,17 @@ def normalize_one(s):
         except Exception:
             out = re.sub(r"<[^>]+>", "", s)
             out = html.unescape(out)
-        return (BLANK_RUN_RE.sub("\n\n", out).strip() or None)
+        out = BLANK_RUN_RE.sub("\n\n", out).strip()
+        return autolink(out) or None
     if HTML_ANY_TAG_RE.search(s):
         out = re.sub(r"<[^>]+>", "", s)
         out = html.unescape(out)
-        return (WS_RUN_RE.sub(" ", out).strip() or None)
+        out = WS_RUN_RE.sub(" ", out).strip()
+        return autolink(out) or None
     if HTML_ENTITY_RE.search(s):
-        return (html.unescape(s).strip() or None)
-    return s
+        out = html.unescape(s).strip()
+        return autolink(out) or None
+    return autolink(s)
 
 
 def _normalize_descs(descs):

--- a/scripts/normalize_descriptions.py
+++ b/scripts/normalize_descriptions.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Normalize the `description` column of a jobhive jobs.csv in place,
+streaming chunk-by-chunk so memory stays bounded.
+
+Workflow:
+  - Stream-read input CSV row by row
+  - Buffer rows into chunks (default 2000)
+  - Dispatch each chunk to a worker pool for parallel normalization
+  - Stream-write to a temp file
+  - On EOF: atomic rename temp → input
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import html
+import multiprocessing
+import re
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+_MD = None
+def _md_lazy():
+    global _MD
+    if _MD is None:
+        from markdownify import markdownify as md
+        _MD = md
+    return _MD
+
+HTML_BLOCK_RE = re.compile(
+    r"<(?:p|div|ul|ol|li|h[1-6]|br|table|tr|td|a|strong|em|b|i|span|section|article|hr|blockquote)\b",
+    re.IGNORECASE,
+)
+HTML_ANY_TAG_RE = re.compile(r"<[a-z][a-z0-9]*\b[^>]*>", re.IGNORECASE)
+HTML_ENTITY_RE = re.compile(r"&(?:nbsp|amp|lt|gt|quot|#\d+|[a-z]{2,8});", re.IGNORECASE)
+BLANK_RUN_RE = re.compile(r"\n{3,}")
+WS_RUN_RE = re.compile(r"\s+")
+
+
+def normalize_one(s):
+    if s is None:
+        return None
+    s = s.strip()
+    if not s:
+        return None
+    if HTML_BLOCK_RE.search(s):
+        try:
+            out = _md_lazy()(
+                s, heading_style="ATX", strip=["script", "style"],
+                bullets="-", escape_underscores=False, wrap=False,
+            )
+        except Exception:
+            out = re.sub(r"<[^>]+>", "", s)
+            out = html.unescape(out)
+        return (BLANK_RUN_RE.sub("\n\n", out).strip() or None)
+    if HTML_ANY_TAG_RE.search(s):
+        out = re.sub(r"<[^>]+>", "", s)
+        out = html.unescape(out)
+        return (WS_RUN_RE.sub(" ", out).strip() or None)
+    if HTML_ENTITY_RE.search(s):
+        return (html.unescape(s).strip() or None)
+    return s
+
+
+def _normalize_descs(descs):
+    """Worker: list[str|None] → list[str|None]."""
+    return [normalize_one(d) for d in descs]
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("csv_path", type=Path)
+    p.add_argument("-j", "--workers", type=int, default=max(1, multiprocessing.cpu_count() - 1))
+    p.add_argument("--chunk", type=int, default=2000)
+    p.add_argument("--column", default="description")
+    args = p.parse_args()
+
+    if not args.csv_path.exists():
+        print(f"missing {args.csv_path}", file=sys.stderr)
+        return 1
+
+    csv.field_size_limit(sys.maxsize)
+    print(f"normalize {args.csv_path} (-j {args.workers}, chunk={args.chunk}, column={args.column})", flush=True)
+    t0 = time.time()
+    counts = {"unchanged": 0, "shrunk": 0, "nulled": 0, "grew": 0, "newly_set": 0}
+    total = 0
+
+    tmp = tempfile.NamedTemporaryFile(
+        "w", newline="", delete=False,
+        dir=args.csv_path.parent,
+        prefix=f".{args.csv_path.name}.normalizing.",
+    )
+
+    pool = multiprocessing.Pool(args.workers)
+
+    try:
+        with args.csv_path.open(newline="") as f:
+            reader = csv.DictReader(f)
+            fieldnames = reader.fieldnames or []
+            if args.column not in fieldnames:
+                print(f"column '{args.column}' missing", file=sys.stderr)
+                return 2
+            writer = csv.DictWriter(tmp, fieldnames=fieldnames)
+            writer.writeheader()
+
+            buffer_rows = []
+            for row in reader:
+                buffer_rows.append(row)
+                if len(buffer_rows) >= args.chunk:
+                    _process_chunk(buffer_rows, args.column, pool, writer, counts)
+                    total += len(buffer_rows)
+                    buffer_rows = []
+                    if total % (args.chunk * 10) == 0:
+                        elapsed = time.time() - t0
+                        rate = total / max(elapsed, 0.001)
+                        print(f"  {total:,} rows · {rate:,.0f}/s · "
+                              f"unchanged={counts['unchanged']:,} shrunk={counts['shrunk']:,} "
+                              f"grew={counts['grew']:,} nulled={counts['nulled']:,}",
+                              flush=True)
+
+            if buffer_rows:
+                _process_chunk(buffer_rows, args.column, pool, writer, counts)
+                total += len(buffer_rows)
+    finally:
+        pool.close()
+        pool.join()
+        tmp.close()
+
+    Path(tmp.name).replace(args.csv_path)
+    elapsed = time.time() - t0
+    print(f"DONE total={total:,} in {elapsed:.1f}s · {counts}", flush=True)
+    return 0
+
+
+def _process_chunk(rows, column, pool, writer, counts):
+    """Normalize the column for `rows` (in-place) and write them out."""
+    descs = [r.get(column) for r in rows]
+    # Process the descs through the pool. We split into N sub-batches for
+    # parallelism within this chunk.
+    n_workers = pool._processes
+    sub_size = max(1, len(descs) // n_workers + 1)
+    sub_batches = [descs[i:i+sub_size] for i in range(0, len(descs), sub_size)]
+    results = pool.map(_normalize_descs, sub_batches)
+    # Flatten
+    normalized = [d for sub in results for d in sub]
+    for row, new_desc in zip(rows, normalized):
+        old = row.get(column)
+        if new_desc == old:
+            counts["unchanged"] += 1
+        elif new_desc is None:
+            counts["nulled"] += 1
+        elif old is None or old == "":
+            counts["newly_set"] += 1
+        elif len(new_desc) < len(old):
+            counts["shrunk"] += 1
+        else:
+            counts["grew"] += 1
+        row[column] = new_desc or ""
+        writer.writerow(row)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/normalize_descriptions.py
+++ b/scripts/normalize_descriptions.py
@@ -39,9 +39,9 @@ def _linkify_lazy():
     if _LINKIFY is None:
         from linkify_it import LinkifyIt
         from linkify_it.tlds import TLDS
-        l = LinkifyIt()
-        l.tlds(TLDS)  # full ICANN/IANA TLD set
-        _LINKIFY = l
+        instance = LinkifyIt()
+        instance.tlds(TLDS)  # full ICANN/IANA TLD set
+        _LINKIFY = instance
     return _LINKIFY
 
 
@@ -77,10 +77,15 @@ def autolink(text: str) -> str:
         # Skip the markdown image syntax ``![alt](url)`` too.
         if before.endswith("!"):
             continue
-        if "@" in m.url and not m.url.startswith(("http://", "https://", "ftp://")):
-            replacement = f"<{m.url}>"
-        else:
-            replacement = f"<{m.url}>"
+        # ``m.url`` is linkify-it's normalized form: emails get a
+        # ``mailto:`` prefix automatically. Using it as the autolink
+        # body would corrupt the visible text (``foo@bar.com`` would
+        # render as ``mailto:foo@bar.com`` in viewers that don't
+        # collapse the scheme). The raw substring in ``out`` is what
+        # the source wrote, so use that and rely on CommonMark/GFM to
+        # apply ``mailto:`` at render time.
+        original = out[start:end]
+        replacement = f"<{original}>"
         out = out[:start] + replacement + out[end:]
     return out
 
@@ -167,14 +172,18 @@ def main():
     counts = {"unchanged": 0, "shrunk": 0, "nulled": 0, "grew": 0, "newly_set": 0}
     total = 0
 
-    tmp = tempfile.NamedTemporaryFile(
+    # The streaming-write design needs the handle to live past the
+    # open() call; we close + atomically rename in the finally below.
+    tmp = tempfile.NamedTemporaryFile(  # noqa: SIM115
         "w", newline="", delete=False,
         dir=args.csv_path.parent,
         prefix=f".{args.csv_path.name}.normalizing.",
     )
+    tmp_path = Path(tmp.name)
 
     pool = multiprocessing.Pool(args.workers)
 
+    success = False
     try:
         with args.csv_path.open(newline="") as f:
             reader = csv.DictReader(f)
@@ -203,12 +212,20 @@ def main():
             if buffer_rows:
                 _process_chunk(buffer_rows, args.column, pool, writer, counts)
                 total += len(buffer_rows)
+            success = True
     finally:
         pool.close()
         pool.join()
         tmp.close()
+        # Always clean up the half-written temp on any non-happy path
+        # (missing column, exception in a worker, ctrl-c). The atomic
+        # rename below only fires on the success path, so leaving the
+        # file behind here would litter the workday/ directory with
+        # ``.jobs.csv.normalizing.*`` orphans across reruns.
+        if not success:
+            tmp_path.unlink(missing_ok=True)
 
-    Path(tmp.name).replace(args.csv_path)
+    tmp_path.replace(args.csv_path)
     elapsed = time.time() - t0
     print(f"DONE total={total:,} in {elapsed:.1f}s · {counts}", flush=True)
     return 0
@@ -225,7 +242,7 @@ def _process_chunk(rows, column, pool, writer, counts):
     results = pool.map(_normalize_descs, sub_batches)
     # Flatten
     normalized = [d for sub in results for d in sub]
-    for row, new_desc in zip(rows, normalized):
+    for row, new_desc in zip(rows, normalized, strict=True):
         old = row.get(column)
         if new_desc == old:
             counts["unchanged"] += 1

--- a/scripts/normalize_descriptions.py
+++ b/scripts/normalize_descriptions.py
@@ -69,11 +69,28 @@ def _normalize_descs(descs):
     return [normalize_one(d) for d in descs]
 
 
+def _positive_int(value: str) -> int:
+    """argparse type that rejects 0 and negative values. Used for
+    ``--chunk`` and ``-j`` because both feed into denominators in the
+    progress logger and worker fan-out — a non-positive value would
+    raise ZeroDivisionError or spawn 0 workers."""
+    try:
+        ivalue = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"expected integer, got {value!r}") from exc
+    if ivalue < 1:
+        raise argparse.ArgumentTypeError(
+            f"must be >= 1 (got {ivalue})"
+        )
+    return ivalue
+
+
 def main():
     p = argparse.ArgumentParser()
     p.add_argument("csv_path", type=Path)
-    p.add_argument("-j", "--workers", type=int, default=max(1, multiprocessing.cpu_count() - 1))
-    p.add_argument("--chunk", type=int, default=2000)
+    p.add_argument("-j", "--workers", type=_positive_int,
+                   default=max(1, multiprocessing.cpu_count() - 1))
+    p.add_argument("--chunk", type=_positive_int, default=2000)
     p.add_argument("--column", default="description")
     args = p.parse_args()
 

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -19,10 +19,10 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import fcntl
 import csv
-import os
+import fcntl
 import json
+import os
 import re
 import sqlite3
 import subprocess
@@ -1403,7 +1403,27 @@ def _normalize_output(ats: str, jobs_csv: Path) -> None:
     ]
     t0 = time.time()
     print(f"[{ats}] normalizing descriptions ({workers} workers)...")
-    result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    # Upper-bound the normalize step so a hung worker can't wedge the
+    # whole daily pipeline. EURES (~2.7M rows) is the largest single
+    # CSV we feed in; even at ~500 rows/sec/worker that's ~30 min, so
+    # 2 h leaves a generous margin. ``JOBHIVE_NORMALIZE_TIMEOUT_S``
+    # tunes it for ATSes that grow past that envelope.
+    timeout_s = int(os.environ.get("JOBHIVE_NORMALIZE_TIMEOUT_S", "7200"))
+    try:
+        result = subprocess.run(
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired:
+        elapsed = time.time() - t0
+        print(
+            f"[{ats}] WARN: normalize exceeded {timeout_s}s budget "
+            f"(elapsed={elapsed:.0f}s); jobs.csv left in its pre-normalize state."
+        )
+        return
     if result.returncode != 0:
         print(
             f"[{ats}] WARN: normalize exited {result.returncode}; "

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -871,10 +871,18 @@ class DescriptionCache:
             "SELECT COUNT(*) FROM descriptions"
         ).fetchone()[0]
 
-    def _insert_many(self, rows: list[tuple[str, str, bytes]]) -> int:
+    def _insert_many(self, rows: list[tuple[str, str, bytes]], *, replace: bool = False) -> int:
+        """Bulk insert. ``replace=True`` overwrites existing rows
+        (used by :meth:`set` so an updated description from a fresh
+        scrape supersedes the previous-day cached one); the default
+        ``replace=False`` keeps the existing row, which is what
+        :meth:`load_csv` wants when seeding from a CSV that may have
+        the same URL listed multiple times.
+        """
+        verb = "INSERT OR REPLACE" if replace else "INSERT OR IGNORE"
         cur = self.conn.executemany(
-            """
-            INSERT OR IGNORE INTO descriptions (kind, cache_key, description)
+            f"""
+            {verb} INTO descriptions (kind, cache_key, description)
             VALUES (?, ?, ?)
             """,
             rows,
@@ -898,8 +906,24 @@ class DescriptionCache:
     def set(self, job: Job, description: str) -> None:
         blob = self._encode(description)
         rows = [(*key, blob) for key in _description_keys(job)]
-        if rows:
-            self.count += self._insert_many(rows)
+        if not rows:
+            return
+        # Single-row updates from _ensure_description must replace any
+        # existing entry — that's the whole point of writing back when
+        # the freshly-scraped body is longer than the cached one. The
+        # rowcount returned by executemany with INSERT OR REPLACE counts
+        # both new inserts and updates, so we only bump ``count`` by
+        # the genuine new keys (those not already present).
+        new_keys = 0
+        existing = self.conn.execute(
+            "SELECT COUNT(*) FROM descriptions WHERE (kind, cache_key) IN ("
+            + ",".join("(?,?)" for _ in rows)
+            + ")",
+            [v for kind, key, _ in rows for v in (kind, key)],
+        ).fetchone()[0]
+        new_keys = len(rows) - existing
+        self._insert_many(rows, replace=True)
+        self.count += max(0, new_keys)
 
 
 def _description_keys(job: Job) -> list[tuple[str, str]]:

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -990,10 +990,24 @@ async def _ensure_description(
     cache: DescriptionCache,
 ) -> str:
     cached = _cached_description(job, cache)
+    fresh = job.description
     if cached:
-        job.description = cached
-        return "cache"
-    if job.description:
+        # Prefer the longer description. The cache is the previous run's
+        # jobs.csv (or a persistent SQLite). When the scraper has already
+        # populated ``job.description`` from the current API (e.g. lever,
+        # which assembles ``description`` + ``lists[]`` in _parse_job,
+        # or apple which hydrates per-job detail pages), a recent code
+        # update may produce a fuller body than the previously-cached
+        # one. Trust whichever has more content; ties go to fresh.
+        if not fresh or len(cached) > len(fresh):
+            job.description = cached
+            return "cache"
+        # Fresh is at least as long — keep it AND write it back to the
+        # cache so the next run picks up the improvement immediately
+        # instead of recomputing it.
+        cache.set(job, fresh)
+        return "present"
+    if fresh:
         return "present"
     try:
         description = await asyncio.to_thread(scraper.get_description, job)

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -25,6 +25,7 @@ import os
 import json
 import re
 import sqlite3
+import subprocess
 import sys
 import tempfile
 import time
@@ -707,6 +708,14 @@ def _pipeline_lock(ats: str):
             fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
 
 
+# Schema layout version stored in SQLite's PRAGMA user_version. Bumping
+# this number tells the cache to refuse opening an older file whose row
+# format we no longer know how to decode (e.g. legacy ``description
+# TEXT`` rows that would silently come back as ``str`` through the BLOB
+# read path and crash zstd decompression).
+_CACHE_SCHEMA_VERSION = 2
+
+
 class DescriptionCache:
     """Disk-backed description cache, optionally persistent and zstd-compressed.
 
@@ -764,6 +773,40 @@ class DescriptionCache:
                 self.conn.execute("PRAGMA journal_mode=WAL")
                 self.conn.execute("PRAGMA synchronous=NORMAL")
             self.conn.execute("PRAGMA temp_store=MEMORY")
+            # Schema-version pragma. Bump when the table layout or encoding
+            # changes incompatibly so an older persistent file fails loudly
+            # at open instead of silently mixing schemas. Version 1 is the
+            # original ``description TEXT`` layout; version 2 introduced
+            # ``description BLOB`` to carry optionally-zstd-compressed bytes.
+            current_user_version = self.conn.execute(
+                "PRAGMA user_version"
+            ).fetchone()[0]
+            existing_rows = 0
+            existing_table = self.conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='descriptions'"
+            ).fetchone()
+            if existing_table is not None:
+                existing_rows = self.conn.execute(
+                    "SELECT COUNT(*) FROM descriptions"
+                ).fetchone()[0]
+            if existing_rows > 0 and current_user_version != _CACHE_SCHEMA_VERSION:
+                # Bail loudly rather than try to interpret an unknown layout
+                # — silently returning TEXT bytes through the BLOB path
+                # leaks ``str`` rows that then crash _decode().
+                if self.conn is not None:
+                    self.conn.close()
+                    self.conn = None
+                if self._owns_tempfile:
+                    self.path.unlink(missing_ok=True)
+                raise RuntimeError(
+                    f"DescriptionCache schema mismatch at {self.path}: "
+                    f"file user_version={current_user_version}, "
+                    f"code expects {_CACHE_SCHEMA_VERSION}. Delete the "
+                    f"file and let the pipeline reseed it from the "
+                    f"current jobs.csv (or run scripts/build_workday_cache "
+                    f"if a backfill seed is available)."
+                )
             self.conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS descriptions (
@@ -773,6 +816,9 @@ class DescriptionCache:
                     PRIMARY KEY (kind, cache_key)
                 )
                 """
+            )
+            self.conn.execute(
+                f"PRAGMA user_version = {_CACHE_SCHEMA_VERSION}"
             )
             self.count = self.conn.execute(
                 "SELECT COUNT(*) FROM descriptions"
@@ -1270,6 +1316,25 @@ async def run(ats: str, concurrency: int, max_tenants: int | None, timeout: floa
             return 1
 
         tmp_output_path.replace(output_path)
+
+        # Post-scrape description normalization. Most scrapers now emit
+        # HTML in the description column (lever, ashby, greenhouse, the
+        # batch of 6 that used to strip-and-flatten, apple's assembled
+        # body, etc.) and rely on this step to produce clean markdown
+        # before publish. Skippable per-ATS via ``skip_normalize`` for
+        # paths that handle their own markdown upstream (e.g. workable
+        # which fetches .md natively). Failure is non-fatal — a broken
+        # normalize pass shouldn't lose the day's scrape.
+        if not cfg.get("skip_normalize"):
+            try:
+                _normalize_output(ats, output_path)
+            except Exception as exc:  # pragma: no cover - defensive
+                print(
+                    f"[{ats}] WARN: description normalization failed "
+                    f"({type(exc).__name__}: {str(exc)[:200]}); "
+                    f"leaving raw scraper output in {output_path}"
+                )
+
         if counts["error"] >= failure_threshold:
             print(
                 f"[{ats}] ACTION investigate: scrape kept partial data but "
@@ -1279,6 +1344,37 @@ async def run(ats: str, concurrency: int, max_tenants: int | None, timeout: floa
         return 0
     finally:
         description_cache.close()
+
+
+def _normalize_output(ats: str, jobs_csv: Path) -> None:
+    """Invoke scripts/normalize_descriptions.py on the freshly-written
+    jobs.csv. The normalize script is a separate file rather than an
+    in-process import so a crash in the normalizer can't take down the
+    scraper pipeline.
+    """
+    script_path = Path(__file__).resolve().parent / "normalize_descriptions.py"
+    if not script_path.exists():
+        print(f"[{ats}] WARN: {script_path} missing, skipping normalize")
+        return
+    workers = max(1, (os.cpu_count() or 4) - 1)
+    cmd = [
+        sys.executable,
+        str(script_path),
+        str(jobs_csv),
+        "-j", str(workers),
+    ]
+    t0 = time.time()
+    print(f"[{ats}] normalizing descriptions ({workers} workers)...")
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(
+            f"[{ats}] WARN: normalize exited {result.returncode}; "
+            f"stderr tail: {result.stderr[-400:]}"
+        )
+        return
+    elapsed = time.time() - t0
+    last_line = (result.stdout or "").strip().splitlines()[-1:] or [""]
+    print(f"[{ats}] normalize done in {elapsed:.1f}s — {last_line[0]}")
 
 
 def main() -> int:

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -387,14 +387,15 @@ CONFIGS: dict[str, dict[str, Any]] = {
         },
         "csv": "ats-companies/workday.csv",
         "output": "workday/jobs.csv",
-        # Workday descriptions require per-job detail calls. Let the pipeline
-        # consult the disk-backed description cache before issuing those calls;
-        # otherwise Workday hydrates every row inside fetch() and bypasses cache.
+        # Workday descriptions require per-job detail calls. Defer to the
+        # disk-backed description cache so the scraper's internal enrichment
+        # stays off (it would re-fetch every row, bypassing the cache).
         "defer_descriptions_to_cache": True,
-        # Rehydrating hundreds of thousands of cached descriptions turns the
-        # daily Workday listing refresh into a multi-hour CSV rewrite. Keep the
-        # main run listing-only; description enrichment needs a separate job.
-        "skip_description_enrichment": True,
+        # Persistent zstd-compressed SQLite cache. ~700k entries from the
+        # 2026-05 backfill seed the file; daily runs hit the cache for already
+        # known URLs and only fetch the detail endpoint for new listings.
+        "description_cache_path": "workday/descriptions.sqlite3",
+        "description_cache_compress": True,
         # Workday can take longer than the publish window on bad API days. Keep
         # publishing the previous stable jobs.csv while a replacement is built.
         "publish_previous_while_running": True,
@@ -707,57 +708,111 @@ def _pipeline_lock(ats: str):
 
 
 class DescriptionCache:
-    """Disk-backed description cache built from the previous jobs CSV."""
+    """Disk-backed description cache, optionally persistent and zstd-compressed.
 
-    def __init__(self) -> None:
+    Two modes:
+
+    - **Ephemeral** (default): ``DescriptionCache()`` creates a tempfile that
+      gets removed on :meth:`close`. Behavior matches the legacy single-run
+      cache rebuilt each pipeline invocation via :meth:`load_csv`.
+
+    - **Persistent**: ``DescriptionCache(path=Path("...sqlite3"))`` opens (or
+      creates) the named file and keeps it across runs. Use for ATSes where
+      rebuilding from CSV every day is wasteful — e.g. Workday at ~700k
+      entries. New fetches accumulate in-place via :meth:`set`.
+
+    ``compress=True`` stores the description column as zstd-compressed BLOB.
+    Cuts disk footprint by ~70% on typical HTML/markdown text. Read overhead
+    is single-digit milliseconds per lookup, which is dwarfed by the network
+    fetch cost it replaces.
+    """
+
+    def __init__(self, path: Path | None = None, compress: bool = False) -> None:
         self.conn: sqlite3.Connection | None = None
-        with tempfile.NamedTemporaryFile(
-            prefix="jobhive-description-cache-",
-            suffix=".sqlite3",
-            delete=False,
-        ) as tmp:
-            self.path = Path(tmp.name)
+        self.compress = compress
+        self._compressor = None
+        self._decompressor = None
+        if compress:
+            import zstandard
+            self._compressor = zstandard.ZstdCompressor(level=3)
+            self._decompressor = zstandard.ZstdDecompressor()
+
+        if path is None:
+            with tempfile.NamedTemporaryFile(
+                prefix="jobhive-description-cache-",
+                suffix=".sqlite3",
+                delete=False,
+            ) as tmp:
+                self.path = Path(tmp.name)
+            self._owns_tempfile = True
+        else:
+            self.path = Path(path)
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            self._owns_tempfile = False
+
         try:
             self.conn = sqlite3.connect(self.path)
-            self.conn.execute("PRAGMA journal_mode=OFF")
-            self.conn.execute("PRAGMA synchronous=OFF")
+            if self._owns_tempfile:
+                # Ephemeral tempfile cache — favor raw insert speed over crash
+                # safety (file is discarded on close anyway).
+                self.conn.execute("PRAGMA journal_mode=OFF")
+                self.conn.execute("PRAGMA synchronous=OFF")
+            else:
+                # Persistent cache — WAL gives concurrent reader safety while
+                # writes stay durable. NORMAL sync is sufficient for our
+                # daily-replay-on-loss model.
+                self.conn.execute("PRAGMA journal_mode=WAL")
+                self.conn.execute("PRAGMA synchronous=NORMAL")
             self.conn.execute("PRAGMA temp_store=MEMORY")
             self.conn.execute(
                 """
-                CREATE TABLE descriptions (
+                CREATE TABLE IF NOT EXISTS descriptions (
                     kind TEXT NOT NULL,
                     cache_key TEXT NOT NULL,
-                    description TEXT NOT NULL,
+                    description BLOB NOT NULL,
                     PRIMARY KEY (kind, cache_key)
                 )
                 """
             )
+            self.count = self.conn.execute(
+                "SELECT COUNT(*) FROM descriptions"
+            ).fetchone()[0]
         except Exception:
             if self.conn is not None:
                 self.conn.close()
-            self.path.unlink(missing_ok=True)
+            if self._owns_tempfile:
+                self.path.unlink(missing_ok=True)
             raise
-        self.count = 0
 
     def close(self) -> None:
         if self.conn is not None:
             self.conn.close()
             self.conn = None
-        self.path.unlink(missing_ok=True)
+        if self._owns_tempfile:
+            self.path.unlink(missing_ok=True)
+
+    def _encode(self, description: str) -> bytes:
+        raw = description.encode("utf-8")
+        return self._compressor.compress(raw) if self.compress else raw
+
+    def _decode(self, blob: bytes) -> str:
+        raw = self._decompressor.decompress(blob) if self.compress else blob
+        return raw.decode("utf-8")
 
     def load_csv(self, path: Path) -> None:
         if not path.exists():
             return
 
-        batch: list[tuple[str, str, str]] = []
+        batch: list[tuple[str, str, bytes]] = []
         try:
             with path.open(newline="") as fh:
                 for row in csv.DictReader(fh):
                     description = (row.get("description") or "").strip()
                     if not description:
                         continue
+                    blob = self._encode(description)
                     for key in _row_description_keys(row):
-                        batch.append((*key, description))
+                        batch.append((*key, blob))
                     if len(batch) >= 2_000:
                         self._insert_many(batch)
                         batch.clear()
@@ -770,7 +825,7 @@ class DescriptionCache:
             "SELECT COUNT(*) FROM descriptions"
         ).fetchone()[0]
 
-    def _insert_many(self, rows: list[tuple[str, str, str]]) -> int:
+    def _insert_many(self, rows: list[tuple[str, str, bytes]]) -> int:
         cur = self.conn.executemany(
             """
             INSERT OR IGNORE INTO descriptions (kind, cache_key, description)
@@ -791,11 +846,12 @@ class DescriptionCache:
                 (kind, key),
             ).fetchone()
             if row:
-                return row[0]
+                return self._decode(row[0])
         return None
 
     def set(self, job: Job, description: str) -> None:
-        rows = [(*key, description) for key in _description_keys(job)]
+        blob = self._encode(description)
+        rows = [(*key, blob) for key in _description_keys(job)]
         if rows:
             self.count += self._insert_many(rows)
 
@@ -824,8 +880,33 @@ def _row_description_keys(row: dict[str, str]) -> list[tuple[str, str]]:
     return keys
 
 
-def _load_description_cache(path: Path) -> DescriptionCache:
-    cache = DescriptionCache()
+def _load_description_cache(
+    path: Path,
+    *,
+    persistent_path: Path | None = None,
+    compress: bool = False,
+    bootstrap_csv: Path | None = None,
+) -> DescriptionCache:
+    """Open a description cache, ephemeral or persistent.
+
+    - ``persistent_path``: when set, opens the SQLite file at that path and
+      reuses it across runs. Otherwise builds a fresh tempfile cache from
+      ``path``.
+    - ``compress``: forwarded to :class:`DescriptionCache`. Recommended for
+      persistent caches with large descriptions (e.g. Workday).
+    - ``bootstrap_csv``: if the persistent cache is empty on open, seed it
+      from this CSV. Useful for the first run after enabling persistence.
+    """
+    if persistent_path is not None:
+        cache = DescriptionCache(path=persistent_path, compress=compress)
+        if cache.count == 0 and bootstrap_csv is not None:
+            try:
+                cache.load_csv(bootstrap_csv)
+            except Exception:
+                cache.close()
+                raise
+        return cache
+    cache = DescriptionCache(compress=compress)
     try:
         cache.load_csv(path)
     except Exception:
@@ -907,7 +988,7 @@ def _job_to_row(job: Job) -> dict[str, Any]:
         "employment_type": job.employment_type or "",
         "department": job.department or "",
         "team": job.team or "",
-        "description": (job.description or "")[:25_000].replace("\n", " "),
+        "description": (job.description or "")[:25_000],
         "posted_at": job.posted_at.isoformat() if job.posted_at else "",
         "requisition_id": job.requisition_id or "",
         "apply_url": str(job.apply_url) if job.apply_url else "",
@@ -981,16 +1062,32 @@ async def run(ats: str, concurrency: int, max_tenants: int | None, timeout: floa
         tmp_output_path = output_path.with_name(f".{output_path.name}.tmp")
     uses_streaming = bool(cfg.get("singleton") and hasattr(cfg["scraper"], "fetch_stream"))
     cache_cap = cfg.get("skip_description_cache_if_max_len_lte")
+    persistent_path_rel = cfg.get("description_cache_path")
+    persistent_path = (DATA_ROOT / persistent_path_rel) if persistent_path_rel else None
+    cache_compress = bool(cfg.get("description_cache_compress"))
     if isinstance(cache_cap, int) and _descriptions_look_capped(output_path, cache_cap):
         print(
             f"[{ats}] Skipping previous description cache because "
             f"descriptions look capped at <= {cache_cap} chars"
         )
-        description_cache = DescriptionCache()
+        description_cache = DescriptionCache(compress=cache_compress)
+    elif persistent_path is not None:
+        # Persistent cache: open the file and reuse it across runs. Seed from
+        # the previous jobs.csv only if the cache is empty (first-run bootstrap).
+        description_cache = _load_description_cache(
+            output_path,
+            persistent_path=persistent_path,
+            compress=cache_compress,
+            bootstrap_csv=output_path,
+        )
     else:
-        description_cache = _load_description_cache(output_path)
+        description_cache = _load_description_cache(output_path, compress=cache_compress)
     if description_cache.count:
-        print(f"[{ats}] Loaded {description_cache.count:,} cached description keys")
+        location = "persistent" if persistent_path else "ephemeral"
+        print(
+            f"[{ats}] Loaded {description_cache.count:,} cached description keys "
+            f"({location} cache at {description_cache.path})"
+        )
     seen_keys: set[tuple[str, str]] = set()  # (company, ats_id) for cross-tenant dedup
 
     t0 = time.time()

--- a/src/jobhive/scrapers/apple.py
+++ b/src/jobhive/scrapers/apple.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import re
 import time
 from datetime import datetime
 from typing import TYPE_CHECKING

--- a/src/jobhive/scrapers/apple.py
+++ b/src/jobhive/scrapers/apple.py
@@ -6,11 +6,21 @@ Apple's job board requires a CSRF token before search calls succeed:
     2. POST https://jobs.apple.com/api/v1/jobsTeam     # search payload
 
 The CSRF flow is held in a single httpx.Client session.
+
+Description completeness: the search API only exposes ``jobSummary``
+(the intro paragraph, ~500–1000 chars). The full posting body —
+``description``, ``minimumQualifications``, ``preferredQualifications``
+— lives in the React loader state embedded on each job's detail page
+(``window.__loaderData__`` JSON). After collecting search results, we
+fetch each detail page concurrently and assemble the full description.
 """
 
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
+import re
 import time
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -30,6 +40,12 @@ SEARCH_URL = f"{BASE_URL}/api/v1/search"
 PAGE_SIZE = 20
 MAX_RETRIES = 3
 RETRY_BASE_DELAY = 1.0
+DETAIL_CONCURRENCY = 25
+DETAIL_TIMEOUT_S = 10.0
+# Regex over the raw HTML — the loader payload is a single huge
+# JSON.parse("…escaped JSON…") expression. We pull the inner string
+# and unescape it before json.loads.
+_LOADER_RE = re.compile(r'JSON\.parse\("(.+?)"\)', re.DOTALL)
 
 _LOG = logging.getLogger(__name__)
 
@@ -138,6 +154,17 @@ class AppleScraper(BaseScraper):
                 if page * PAGE_SIZE >= total or len(postings) < PAGE_SIZE:
                     break
                 page += 1
+
+        # Detail-page enrichment: pull the full body (description +
+        # min/preferred qualifications) from each job's React loader
+        # state. Best-effort — a failed detail fetch keeps the job's
+        # listing-level ``jobSummary`` instead.
+        if self.include_descriptions and all_jobs:
+            try:
+                asyncio.run(_enrich_apple_details(all_jobs, self.timeout))
+            except Exception as exc:  # pragma: no cover - defensive
+                _LOG.warning("Apple detail enrichment failed: %s", exc)
+
         return all_jobs
 
     def _parse_job(self, item: dict[str, Any]) -> list[Job]:
@@ -287,3 +314,133 @@ def _parse_iso(value: str | None) -> datetime | None:
         return datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
         return None
+
+
+# ---------------------------------------------------------------------------
+# Detail-page enrichment
+# ---------------------------------------------------------------------------
+
+
+async def _enrich_apple_details(jobs: list[Job], timeout_s: float) -> None:
+    """Concurrent fetch of each job's detail page, replacing ``description``
+    with the full body assembled from the React loader state.
+
+    The detail HTML embeds:
+
+        window.__loaderData__ = JSON.parse("…escaped JSON…");
+
+    which contains ``loaderData.jobDetails.jobsData.localizations.en_US.posting``
+    with fields ``jobSummary`` / ``description`` / ``minimumQualifications``
+    / ``preferredQualifications``. We concatenate them under markdown
+    headings so the post-scrape markdownify pass produces a clean,
+    section-headered description (~3-5× longer than the search summary).
+    """
+    sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
+    seen_positions: set[str] = set()
+
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(DETAIL_TIMEOUT_S, connect=4.0),
+        follow_redirects=True,
+        headers={"User-Agent": "Mozilla/5.0", "Accept": "text/html"},
+    ) as client:
+
+        async def hydrate(job: Job) -> None:
+            # Multi-location jobs share one detail page — fetch each
+            # position once and broadcast the result to all of its
+            # location-specific Job rows further below.
+            position_id = (job.requisition_id or "").split("@")[0]
+            if not position_id:
+                return
+            if position_id in seen_positions:
+                return
+            seen_positions.add(position_id)
+            async with sem:
+                try:
+                    r = await client.get(str(job.url))
+                except (httpx.HTTPError, OSError):
+                    return
+            if r.status_code != 200:
+                return
+            posting = _extract_apple_posting(r.text)
+            if not posting:
+                return
+            description = _assemble_apple_description(posting)
+            if description:
+                job.description = description[:25_000]
+
+        await asyncio.gather(
+            *(hydrate(j) for j in jobs),
+            return_exceptions=True,
+        )
+
+        # Second pass: broadcast hydrated descriptions to sibling jobs
+        # (same position id, different location).
+        by_position: dict[str, str] = {}
+        for j in jobs:
+            pid = (j.requisition_id or "").split("@")[0]
+            if pid and j.description and pid not in by_position:
+                by_position[pid] = j.description
+        for j in jobs:
+            pid = (j.requisition_id or "").split("@")[0]
+            if pid and not j.description and pid in by_position:
+                j.description = by_position[pid]
+
+
+def _extract_apple_posting(html: str) -> dict[str, Any] | None:
+    """Pull the ``posting`` object out of the React loader-data JSON."""
+    m = _LOADER_RE.search(html)
+    if not m:
+        return None
+    encoded = m.group(1)
+    try:
+        # The loader payload is JSON encoded as a JS string. Decode the
+        # JS string escapes (\n, \", \uXXXX) into the real JSON text.
+        raw_json = encoded.encode("utf-8").decode("unicode_escape")
+        data = json.loads(raw_json)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+
+    loader = data.get("loaderData") or {}
+    job_details = loader.get("jobDetails") or {}
+    jobs_data = job_details.get("jobsData") or {}
+    localizations = jobs_data.get("localizations") or {}
+    # Prefer en_US, then en_UK, then anything; fall back to top-level
+    # jobsData fields if the localizations bundle is missing.
+    for key in ("en_US", "en_UK"):
+        loc = localizations.get(key)
+        if isinstance(loc, dict):
+            posting = loc.get("posting") or {}
+            if posting:
+                return posting
+    for loc in localizations.values():
+        if isinstance(loc, dict):
+            posting = loc.get("posting") or {}
+            if posting:
+                return posting
+    # Last resort — top-level fields
+    top = {
+        k: jobs_data[k]
+        for k in ("jobSummary", "description", "minimumQualifications", "preferredQualifications")
+        if k in jobs_data
+    }
+    return top or None
+
+
+def _assemble_apple_description(posting: dict[str, Any]) -> str | None:
+    """Assemble the markdown-ready description from Apple posting fields."""
+    parts: list[str] = []
+    summary = (posting.get("jobSummary") or "").strip()
+    if summary:
+        parts.append(summary)
+    body = (posting.get("description") or "").strip()
+    if body:
+        parts.append("## Description\n\n" + body)
+    min_q = (posting.get("minimumQualifications") or "").strip()
+    if min_q:
+        parts.append("## Minimum qualifications\n\n" + min_q)
+    pref_q = (posting.get("preferredQualifications") or "").strip()
+    if pref_q:
+        parts.append("## Preferred qualifications\n\n" + pref_q)
+    if not parts:
+        return None
+    return "\n\n".join(parts)

--- a/src/jobhive/scrapers/apple.py
+++ b/src/jobhive/scrapers/apple.py
@@ -339,6 +339,13 @@ async def _enrich_apple_details(jobs: list[Job], timeout_s: float) -> None:
     """
     sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
     seen_positions: set[str] = set()
+    # Position ids whose detail page was successfully parsed and whose
+    # corresponding job row got its description replaced with the
+    # assembled long body. Used in the broadcast pass below to tell the
+    # hydrated long description apart from the short ``jobSummary`` that
+    # sibling rows (same posting, different location) inherited from
+    # the search payload.
+    hydrated_positions: set[str] = set()
 
     async with httpx.AsyncClient(
         timeout=httpx.Timeout(DETAIL_TIMEOUT_S, connect=4.0),
@@ -369,23 +376,33 @@ async def _enrich_apple_details(jobs: list[Job], timeout_s: float) -> None:
             description = _assemble_apple_description(posting)
             if description:
                 job.description = description[:25_000]
+                hydrated_positions.add(position_id)
 
         await asyncio.gather(
             *(hydrate(j) for j in jobs),
             return_exceptions=True,
         )
 
-        # Second pass: broadcast hydrated descriptions to sibling jobs
-        # (same position id, different location).
-        by_position: dict[str, str] = {}
+        # Second pass: broadcast each hydrated long description to every
+        # sibling row of the same position. The initial ``jobSummary``
+        # those siblings inherited from search is shorter (often ~500
+        # chars) than the assembled detail body (~2-5k chars), so we
+        # always overwrite — gated on ``hydrated_positions`` so a
+        # detail fetch that failed doesn't get its sibling's existing
+        # ``jobSummary`` wiped or duplicated.
+        hydrated_desc_by_position: dict[str, str] = {}
         for j in jobs:
             pid = (j.requisition_id or "").split("@")[0]
-            if pid and j.description and pid not in by_position:
-                by_position[pid] = j.description
+            if (
+                pid in hydrated_positions
+                and j.description
+                and pid not in hydrated_desc_by_position
+            ):
+                hydrated_desc_by_position[pid] = j.description
         for j in jobs:
             pid = (j.requisition_id or "").split("@")[0]
-            if pid and not j.description and pid in by_position:
-                j.description = by_position[pid]
+            if pid in hydrated_desc_by_position:
+                j.description = hydrated_desc_by_position[pid]
 
 
 def _extract_js_string_literal(html: str, marker: str) -> str | None:

--- a/src/jobhive/scrapers/apple.py
+++ b/src/jobhive/scrapers/apple.py
@@ -42,10 +42,12 @@ MAX_RETRIES = 3
 RETRY_BASE_DELAY = 1.0
 DETAIL_CONCURRENCY = 25
 DETAIL_TIMEOUT_S = 10.0
-# Regex over the raw HTML — the loader payload is a single huge
-# JSON.parse("…escaped JSON…") expression. We pull the inner string
-# and unescape it before json.loads.
-_LOADER_RE = re.compile(r'JSON\.parse\("(.+?)"\)', re.DOTALL)
+# Marker we walk forward from to extract the JS string literal passed
+# to ``JSON.parse``. Regex non-greedy ``"(.+?)"`` would truncate any
+# payload containing the byte sequence ``")`` inside an escaped string
+# (e.g. ``\"OKRs\")`` in job copy), so we instead scan the JS string
+# character-by-character respecting backslash escapes.
+_LOADER_PREFIX = 'JSON.parse("'
 
 _LOG = logging.getLogger(__name__)
 
@@ -386,18 +388,53 @@ async def _enrich_apple_details(jobs: list[Job], timeout_s: float) -> None:
                 j.description = by_position[pid]
 
 
+def _extract_js_string_literal(html: str, marker: str) -> str | None:
+    """Find ``marker`` in ``html`` and return the JS double-quoted string
+    that immediately follows it. Walks character-by-character respecting
+    backslash escapes so payloads containing ``\\")`` survive intact.
+    Returns the inner (still-escaped) string content without the
+    surrounding quotes, or ``None`` if the marker isn't found or the
+    string is unterminated.
+    """
+    start = html.find(marker)
+    if start < 0:
+        return None
+    i = start + len(marker)
+    n = len(html)
+    body_chars: list[str] = []
+    while i < n:
+        ch = html[i]
+        if ch == "\\":
+            # Take the backslash and the following char as a unit.
+            if i + 1 >= n:
+                return None
+            body_chars.append(ch)
+            body_chars.append(html[i + 1])
+            i += 2
+            continue
+        if ch == '"':
+            return "".join(body_chars)
+        body_chars.append(ch)
+        i += 1
+    return None
+
+
 def _extract_apple_posting(html: str) -> dict[str, Any] | None:
     """Pull the ``posting`` object out of the React loader-data JSON."""
-    m = _LOADER_RE.search(html)
-    if not m:
+    encoded = _extract_js_string_literal(html, _LOADER_PREFIX)
+    if encoded is None:
         return None
-    encoded = m.group(1)
     try:
-        # The loader payload is JSON encoded as a JS string. Decode the
-        # JS string escapes (\n, \", \uXXXX) into the real JSON text.
-        raw_json = encoded.encode("utf-8").decode("unicode_escape")
+        # The loader payload is JSON encoded as a JS string. The JSON
+        # decoder itself handles all JS-string escape sequences (\n,
+        # \", \uXXXX surrogate pairs, etc.) correctly when fed a quoted
+        # string, so we wrap the captured payload in quotes and let
+        # json.loads do the unescape. This avoids the lone-surrogate
+        # bug that ``codecs.decode(..., "unicode_escape")`` exhibits on
+        # supplementary-plane characters (emoji, math symbols, …).
+        raw_json = json.loads('"' + encoded + '"')
         data = json.loads(raw_json)
-    except (UnicodeDecodeError, json.JSONDecodeError):
+    except (ValueError, json.JSONDecodeError):
         return None
 
     loader = data.get("loaderData") or {}

--- a/src/jobhive/scrapers/ashby.py
+++ b/src/jobhive/scrapers/ashby.py
@@ -129,11 +129,15 @@ class AshbyScraper(BaseScraper):
                 elif wp_norm in ("onsite", "inperson", "office"):
                     is_remote = False
 
-        # Description — prefer plain text; HTML is a fallback in case
-        # Ashby ever drops the plaintext field.
+        # Description — prefer ``descriptionHtml`` over ``descriptionPlain``.
+        # The HTML form retains paragraph breaks, bullet lists, and headings
+        # (the plain text concatenates them into a single block); the
+        # post-scrape markdownify step in scripts/normalize_descriptions.py
+        # then converts the HTML into clean markdown. Plain stays as a
+        # last-ditch fallback.
         description = (
-            item.get("descriptionPlain")
-            or item.get("descriptionHtml")
+            item.get("descriptionHtml")
+            or item.get("descriptionPlain")
             or None
         )
 

--- a/src/jobhive/scrapers/builtin.py
+++ b/src/jobhive/scrapers/builtin.py
@@ -298,6 +298,20 @@ class BuiltInScraper(BaseScraper):
         return content
 
 
+def _html_unescape_for_desc(value: object, *, cap: int = 25_000) -> str | None:
+    """Unescape HTML entities and trim/cap, but keep tags intact so the
+    post-scrape markdownify pass can preserve paragraph and list structure.
+    Replaces the legacy _strip_html/_html_to_text path for descriptions
+    only — title/company/salary fields still use the strip variant."""
+    import html as _h
+    if not isinstance(value, str):
+        return None
+    out = _h.unescape(value).strip()
+    if not out:
+        return None
+    return out[:cap]
+
+
 def _strip_html(text: str) -> str:
     cleaned = re.sub(r"<[^>]+>", " ", text)
     cleaned = html.unescape(cleaned)

--- a/src/jobhive/scrapers/builtin.py
+++ b/src/jobhive/scrapers/builtin.py
@@ -172,7 +172,7 @@ class BuiltInScraper(BaseScraper):
         ats_id = match.group("id")
         description = item.get("description") or None
         if isinstance(description, str):
-            description = _strip_html(description) or None
+            description = _html_unescape_for_desc(description) or None
 
         return Job(
             url=url,

--- a/src/jobhive/scrapers/eightfold.py
+++ b/src/jobhive/scrapers/eightfold.py
@@ -215,7 +215,7 @@ class EightfoldScraper(BaseScraper):
         data = payload.get("data") or {}
         desc_html = data.get("jobDescription")
         if isinstance(desc_html, str) and desc_html.strip() and not job.description:
-            job.description = _strip_html(desc_html)[:25_000] or None
+            job.description = _html_unescape_for_desc(desc_html, cap=25_000) or None
 
     async def _fetch_page_httpx(
         self, client: httpx.AsyncClient, *, start: int

--- a/src/jobhive/scrapers/eightfold.py
+++ b/src/jobhive/scrapers/eightfold.py
@@ -429,6 +429,20 @@ def _position_id_from_url(url: object) -> str | None:
     return tail if tail.isdigit() else None
 
 
+def _html_unescape_for_desc(value: object, *, cap: int = 25_000) -> str | None:
+    """Unescape HTML entities and trim/cap, but keep tags intact so the
+    post-scrape markdownify pass can preserve paragraph and list structure.
+    Replaces the legacy _strip_html/_html_to_text path for descriptions
+    only — title/company/salary fields still use the strip variant."""
+    import html as _h
+    if not isinstance(value, str):
+        return None
+    out = _h.unescape(value).strip()
+    if not out:
+        return None
+    return out[:cap]
+
+
 def _strip_html(text: str) -> str:
     text = _TAG_RE_EF.sub(" ", text)
     text = html_mod.unescape(text)

--- a/src/jobhive/scrapers/gem.py
+++ b/src/jobhive/scrapers/gem.py
@@ -342,6 +342,20 @@ def _extract_is_remote(locations: list[dict[str, Any]]) -> bool | None:
     return False if any(isinstance(loc, dict) for loc in locations) else None
 
 
+def _html_unescape_for_desc(value: object, *, cap: int = 25_000) -> str | None:
+    """Unescape HTML entities and trim/cap, but keep tags intact so the
+    post-scrape markdownify pass can preserve paragraph and list structure.
+    Replaces the legacy _strip_html/_html_to_text path for descriptions
+    only — title/company/salary fields still use the strip variant."""
+    import html as _h
+    if not isinstance(value, str):
+        return None
+    out = _h.unescape(value).strip()
+    if not out:
+        return None
+    return out[:cap]
+
+
 def _strip_html(text: str) -> str:
     text = _TAG_RE.sub(" ", text)
     text = html_mod.unescape(text)

--- a/src/jobhive/scrapers/gem.py
+++ b/src/jobhive/scrapers/gem.py
@@ -289,7 +289,7 @@ def _apply_detail_to_job(job: Job, detail: dict[str, Any]) -> None:
     """
     desc_html = detail.get("descriptionHtml")
     if isinstance(desc_html, str) and desc_html.strip():
-        job.description = _strip_html(desc_html)[:25_000] or None
+        job.description = _html_unescape_for_desc(desc_html, cap=25_000) or None
 
     # Posted date — Gem ships ``firstPublishedTsSec`` (epoch seconds) and
     # ``startDateTs`` (epoch seconds, *future* go-live). Prefer the

--- a/src/jobhive/scrapers/google.py
+++ b/src/jobhive/scrapers/google.py
@@ -240,12 +240,28 @@ def _apply_detail_to_job(job: Job, html: str) -> None:
             job.team = value
 
 
-def _extract_full_description(html: str) -> str | None:
-    """Pull the full job-detail body when the page exposes it.
+_GOOGLE_SECTION_HEADINGS = (
+    "About the job",
+    "Minimum qualifications",
+    "Preferred qualifications",
+    "Responsibilities",
+    "Benefits",
+)
 
-    Tries the ``DkhPwc`` container that wraps the focused job's title +
-    icon chips + description sections. Falls back to the page's meta
-    description on parse failure.
+
+def _extract_full_description(html: str) -> str | None:
+    """Pull the full job-detail body, section by section.
+
+    Google's career page splits the description into separate sibling
+    containers (``KwJkGe``-class divs etc.) rather than a single parent
+    that wraps everything. The previous "find one container with all
+    markers" heuristic could match a partial container — typically one
+    holding *About the job* + *Responsibilities* but not the
+    *Minimum/Preferred qualifications* sections — and we were silently
+    publishing incomplete descriptions.
+
+    We now scan for each known h3 heading independently and stitch them
+    together in the order listed in ``_GOOGLE_SECTION_HEADINGS``.
     """
     try:
         from bs4 import BeautifulSoup
@@ -254,34 +270,78 @@ def _extract_full_description(html: str) -> str | None:
 
     soup = BeautifulSoup(html, "html.parser")
 
-    about = soup.find("h3", string=lambda s: s and s.strip() == "About the job")
-    container = None
-    if about is not None:
-        node = about
-        for _ in range(8):
-            node = node.find_parent()
-            if node is None:
-                break
-            text = node.get_text()
-            if (
-                "About the job" in text
-                and "Minimum qualifications" in text
-                and "Responsibilities" in text
-            ):
-                container = node
-                break
+    sections: list[tuple[str, str]] = []
+    for heading_label in _GOOGLE_SECTION_HEADINGS:
+        h = soup.find(
+            "h3",
+            string=lambda s, lbl=heading_label: bool(
+                s and s.strip().rstrip(":").lower() == lbl.lower()
+            ),
+        )
+        if h is None:
+            continue
+        # The section body lives in the h3's nearest enclosing div that
+        # also contains the answer (a sibling ``ul``/``p``/``div``).
+        # Climb up at most 4 ancestors to find a container that contains
+        # both the heading and the body text; otherwise fall back to
+        # collecting all following siblings until the next h3.
+        body_text = _collect_section_body(h)
+        if body_text:
+            sections.append((heading_label, body_text))
 
-    if container is None:
+    if not sections:
         return _meta_description(html)
 
-    # Drop the chips/share-button boilerplate that precedes
-    # "About the job" — slice from the first occurrence of that header.
-    text = container.get_text(separator="\n", strip=True)
-    idx = text.find("About the job")
-    if idx > 0:
-        text = text[idx:]
-    text = re.sub(r"\n{3,}", "\n\n", text).strip()
-    return text or None
+    parts: list[str] = []
+    for label, body in sections:
+        if label == "About the job":
+            parts.append(body)
+        else:
+            parts.append(f"{label}\n{body}")
+    text = "\n\n".join(parts)
+    return re.sub(r"\n{3,}", "\n\n", text).strip() or None
+
+
+def _collect_section_body(heading_node) -> str:
+    """Return the human-readable body text under a section h3.
+
+    Climbs up to find a container that holds both the heading and its
+    answer (lists/paragraphs are usually a sibling div, not a direct
+    child of the h3). Falls back to walking the following siblings of
+    the heading until the next h3 — handles flat layouts where
+    headings + bodies are siblings rather than nested.
+    """
+    # Strategy 1: ancestor that includes a list or paragraph after the h3
+    node = heading_node
+    for _ in range(4):
+        node = node.find_parent()
+        if node is None:
+            break
+        # If this ancestor contains a ul/ol/p after the heading and is
+        # otherwise focused on this one section, use it.
+        lists = node.find_all(["ul", "ol", "p"], recursive=True)
+        if lists:
+            # Only accept ancestors that don't contain another h3 (that
+            # would mean we picked up multiple sections in one ancestor).
+            other_h3 = [h for h in node.find_all("h3", recursive=True) if h is not heading_node]
+            if not other_h3:
+                text = node.get_text(separator="\n", strip=True)
+                # Strip the heading itself from the start
+                heading_text = heading_node.get_text(strip=True)
+                if text.startswith(heading_text):
+                    text = text[len(heading_text):].lstrip(":\n ")
+                return text
+
+    # Strategy 2: walk following-siblings of the heading
+    parts: list[str] = []
+    for sib in heading_node.next_siblings:
+        if getattr(sib, "name", None) == "h3":
+            break
+        if hasattr(sib, "get_text"):
+            t = sib.get_text(separator="\n", strip=True)
+            if t:
+                parts.append(t)
+    return "\n".join(parts).strip()
 
 
 def _meta_description(html: str) -> str | None:

--- a/src/jobhive/scrapers/greenhouse.py
+++ b/src/jobhive/scrapers/greenhouse.py
@@ -161,10 +161,13 @@ class GreenhouseScraper(BaseScraper):
 def _clean_description(value: object) -> str | None:
     if not isinstance(value, str) or not value.strip():
         return None
-    # Greenhouse double-encodes: unescape HTML entities, then strip tags.
-    text = html_mod.unescape(value)
-    text = _TAG_RE.sub(" ", text)
-    text = re.sub(r"\s+", " ", text).strip()
+    # Greenhouse double-encodes ``content``: ``<div>`` shows up as
+    # ``&lt;div&gt;``. Unescape once to recover real HTML; then leave the
+    # tags in place so the post-scrape markdownify step can preserve
+    # paragraph breaks, bullet lists, and headings. The previous brutal
+    # tag-strip collapsed the body into a single space-separated blob,
+    # losing all visual structure.
+    text = html_mod.unescape(value).strip()
     return text[:25_000] or None
 
 

--- a/src/jobhive/scrapers/lever.py
+++ b/src/jobhive/scrapers/lever.py
@@ -147,14 +147,44 @@ class LeverScraper(BaseScraper):
                     employment_type = mapped
                     break
 
-        # Description: ``descriptionPlain`` is the canonical body. Cap
-        # at 25k chars; the schema field allows up to that.
-        description = item.get("descriptionPlain") or item.get("description")
-        description = (
-            description.strip()[:25_000] or None
-            if isinstance(description, str)
-            else None
-        )
+        # Description assembly. Lever's API exposes the body across multiple
+        # fields: ``description`` (intro HTML) plus a separate ``lists``
+        # array carrying the structured sections (Responsibilities,
+        # Requirements, Compensation Details, etc.) as HTML chunks. The
+        # ``descriptionPlain`` text-only field is shorter than ``description``
+        # AND completely omits ``lists`` content, so previously preferring it
+        # silently dropped 50–80% of each posting's body.
+        #
+        # Now we always concatenate the HTML intro with each lists section
+        # (prefixing the section's heading), and rely on the post-scrape
+        # markdownify step in scripts/normalize_descriptions.py to render
+        # the assembled HTML to clean markdown.
+        intro_html = item.get("description") or ""
+        if not isinstance(intro_html, str):
+            intro_html = ""
+        sections = item.get("lists") or []
+        parts: list[str] = []
+        if intro_html.strip():
+            parts.append(intro_html)
+        for section in sections:
+            if not isinstance(section, dict):
+                continue
+            heading = (section.get("text") or "").strip()
+            content = (section.get("content") or "").strip()
+            if not content:
+                continue
+            if heading:
+                parts.append(f"<h3>{heading}</h3>\n{content}")
+            else:
+                parts.append(content)
+        description: str | None = None
+        if parts:
+            assembled = "\n\n".join(parts)
+            description = assembled.strip()[:25_000] or None
+        elif isinstance(item.get("descriptionPlain"), str):
+            # Last-ditch fallback: the legacy plain-text field. Rare —
+            # only fires when both ``description`` and ``lists`` are empty.
+            description = item["descriptionPlain"].strip()[:25_000] or None
 
         raw: dict[str, Any] = {}
         if categories:

--- a/src/jobhive/scrapers/phenom.py
+++ b/src/jobhive/scrapers/phenom.py
@@ -372,7 +372,10 @@ class PhenomScraper(BaseScraper):
             employment_type=employment_type,
             commitment=commitment,
             requisition_id=str(item.get("jobSeqNo")) if item.get("jobSeqNo") else None,
-            description=_clean_description(item.get("descriptionTeaser") or item.get("description")),
+            # Prefer the full ``description`` field. ``descriptionTeaser`` is
+            # a short marketing summary (typically 1-2 sentences) and was
+            # silently truncating each posting to a fraction of its real body.
+            description=_clean_description(item.get("description") or item.get("descriptionTeaser")),
             posted_at=_parse_iso(item.get("postedDate") or item.get("dateCreated") or item.get("createdAt")),
             fetched_at=datetime.now(),
             raw=raw or None,

--- a/src/jobhive/scrapers/pinpoint.py
+++ b/src/jobhive/scrapers/pinpoint.py
@@ -204,7 +204,7 @@ class PinpointScraper(BaseScraper):
             department=department,
             commitment=item.get("schedule") if isinstance(item.get("schedule"), str) else None,
             requisition_id=item.get("reference") if isinstance(item.get("reference"), str) else None,
-            description=_html_to_text(item.get("description")),
+            description=_html_unescape_for_desc(item.get("description")),
             salary_currency=comp_currency,
             salary_min=comp_min,
             salary_max=comp_max,

--- a/src/jobhive/scrapers/pinpoint.py
+++ b/src/jobhive/scrapers/pinpoint.py
@@ -269,6 +269,20 @@ def _extract_is_remote(workplace_type: object) -> bool | None:
     return None
 
 
+def _html_unescape_for_desc(value: object, *, cap: int = 25_000) -> str | None:
+    """Unescape HTML entities and trim/cap, but keep tags intact so the
+    post-scrape markdownify pass can preserve paragraph and list structure.
+    Replaces the legacy _strip_html/_html_to_text path for descriptions
+    only — title/company/salary fields still use the strip variant."""
+    import html as _h
+    if not isinstance(value, str):
+        return None
+    out = _h.unescape(value).strip()
+    if not out:
+        return None
+    return out[:cap]
+
+
 def _html_to_text(value: object) -> str | None:
     if not isinstance(value, str) or not value:
         return None

--- a/src/jobhive/scrapers/recruiterbox.py
+++ b/src/jobhive/scrapers/recruiterbox.py
@@ -215,7 +215,7 @@ class RecruiterboxScraper(BaseScraper):
             ),
             team=item.get("team") or None,
             commitment=item.get("position_type") if isinstance(item.get("position_type"), str) else None,
-            description=_html_to_text(item.get("description")),
+            description=_html_unescape_for_desc(item.get("description")),
             posted_at=_parse_iso(item.get("created_on") or item.get("updated_on")),
             fetched_at=datetime.now(),
             raw=raw or None,

--- a/src/jobhive/scrapers/recruiterbox.py
+++ b/src/jobhive/scrapers/recruiterbox.py
@@ -233,6 +233,20 @@ def _format_location(value: object) -> str | None:
     return ", ".join(parts) or None
 
 
+def _html_unescape_for_desc(value: object, *, cap: int = 25_000) -> str | None:
+    """Unescape HTML entities and trim/cap, but keep tags intact so the
+    post-scrape markdownify pass can preserve paragraph and list structure.
+    Replaces the legacy _strip_html/_html_to_text path for descriptions
+    only — title/company/salary fields still use the strip variant."""
+    import html as _h
+    if not isinstance(value, str):
+        return None
+    out = _h.unescape(value).strip()
+    if not out:
+        return None
+    return out[:cap]
+
+
 def _html_to_text(value: object) -> str | None:
     if not isinstance(value, str) or not value:
         return None

--- a/src/jobhive/scrapers/usajobs.py
+++ b/src/jobhive/scrapers/usajobs.py
@@ -254,7 +254,7 @@ class USAJobsScraper(BaseScraper):
             commitment=emp_name if isinstance(emp_name, str) else None,
             apply_url=apply_uri if apply_uri and apply_uri != url else None,
             requisition_id=ats_id if ats_id else None,
-            description=_html_to_text(description_html),
+            description=_html_unescape_for_desc(description_html),
             salary_min=salary_min,
             salary_max=salary_max,
             salary_currency=salary_currency if salary_min or salary_max else None,

--- a/src/jobhive/scrapers/usajobs.py
+++ b/src/jobhive/scrapers/usajobs.py
@@ -265,6 +265,20 @@ class USAJobsScraper(BaseScraper):
         )
 
 
+def _html_unescape_for_desc(value: object, *, cap: int = 25_000) -> str | None:
+    """Unescape HTML entities and trim/cap, but keep tags intact so the
+    post-scrape markdownify pass can preserve paragraph and list structure.
+    Replaces the legacy _strip_html/_html_to_text path for descriptions
+    only — title/company/salary fields still use the strip variant."""
+    import html as _h
+    if not isinstance(value, str):
+        return None
+    out = _h.unescape(value).strip()
+    if not out:
+        return None
+    return out[:cap]
+
+
 def _html_to_text(value: object) -> str | None:
     if not isinstance(value, str) or not value:
         return None

--- a/tests/test_apple.py
+++ b/tests/test_apple.py
@@ -24,9 +24,19 @@ _SEARCH_URL = "https://jobs.apple.com/api/v1/search"
 
 @pytest.fixture(autouse=True)
 def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Drop sleep delay so retry tests run in <1 s instead of seconds."""
+    """Drop sleep delay so retry tests run in <1 s instead of seconds,
+    and stub out the per-job detail-page enrichment so retry tests
+    that mock only the search API don't have to also mock every
+    job's detail URL. Tests that specifically exercise the detail
+    enrichment can override this with their own _enrich_apple_details.
+    """
     import jobhive.scrapers.apple as m
     monkeypatch.setattr(m, "RETRY_BASE_DELAY", 0.0)
+
+    async def _no_enrich(jobs, timeout_s):  # noqa: ARG001
+        return
+
+    monkeypatch.setattr(m, "_enrich_apple_details", _no_enrich)
 
 
 def _csrf_mock(httpx_mock) -> None:

--- a/tests/test_apple.py
+++ b/tests/test_apple.py
@@ -33,7 +33,7 @@ def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
     import jobhive.scrapers.apple as m
     monkeypatch.setattr(m, "RETRY_BASE_DELAY", 0.0)
 
-    async def _no_enrich(jobs, timeout_s):  # noqa: ARG001
+    async def _no_enrich(jobs, timeout_s):
         return
 
     monkeypatch.setattr(m, "_enrich_apple_details", _no_enrich)

--- a/tests/test_builtin.py
+++ b/tests/test_builtin.py
@@ -113,12 +113,16 @@ def test_parses_listing_with_plain_plus_type_attr(httpx_mock) -> None:
     assert len(BuiltInScraper("any").fetch()) == 1
 
 
-def test_strips_html_from_description(httpx_mock) -> None:
+def test_preserves_html_in_description(httpx_mock) -> None:
+    """Description now keeps HTML tags intact — the post-scrape
+    markdownify pass (scripts/normalize_descriptions.py) converts them
+    to markdown later. Entities are unescaped at scrape time.
+    """
     httpx_mock.add_response(
         url="https://builtin.com/jobs?page=1",
         text=_listing_html([_item(
             position=1, job_id=1, name="Engineer",
-            description="<p>Build <b>things</b>.</p>",
+            description="<p>Build <b>things</b>&nbsp;today.</p>",
         )]),
     )
     httpx_mock.add_response(
@@ -126,7 +130,9 @@ def test_strips_html_from_description(httpx_mock) -> None:
         text=_empty_page(), is_reusable=True,
     )
     j = BuiltInScraper("any").fetch()[0]
-    assert j.description == "Build things ."
+    assert "<b>things</b>" in j.description  # tags survive
+    assert "&nbsp;" not in j.description     # entities decoded
+    assert "&amp;" not in j.description
 
 
 def test_skips_items_with_missing_required_fields(httpx_mock) -> None:

--- a/tests/test_pinpoint.py
+++ b/tests/test_pinpoint.py
@@ -138,12 +138,15 @@ def test_workplace_type_remote_maps_to_is_remote(httpx_mock) -> None:
     assert by_id["h"].is_remote is None  # hybrid: ambiguous
 
 
-def test_html_description_stripped(httpx_mock) -> None:
+def test_html_description_preserved(httpx_mock) -> None:
+    """Description now keeps HTML tags intact for downstream
+    markdownification; only entities are decoded at scrape time."""
     p = _posting()
-    p["description"] = "<div><p>Hello\n\n<b>world</b></p></div>"
+    p["description"] = "<div><p>Hello&nbsp;<b>world</b></p></div>"
     httpx_mock.add_response(url=URL, json={"data": [p]})
     job = PinpointScraper("acme").fetch()[0]
-    assert job.description == "Hello world"
+    assert "<b>world</b>" in job.description
+    assert "&nbsp;" not in job.description  # entity decoded
 
 
 def test_location_falls_back_to_city_when_name_missing(httpx_mock) -> None:

--- a/tests/test_run_pipeline_guards.py
+++ b/tests/test_run_pipeline_guards.py
@@ -477,7 +477,11 @@ def test_load_description_cache_closes_when_load_csv_fails(
     created = []
 
     class FakeCache:
-        def __init__(self) -> None:
+        def __init__(self, *_args, **_kwargs) -> None:
+            # Accept the new ``path=`` and ``compress=`` kwargs the real
+            # DescriptionCache takes — the test doesn't care what they
+            # contain, only that the surrounding open/close protocol
+            # holds when load_csv raises.
             self.closed = False
             created.append(self)
 
@@ -566,7 +570,9 @@ def test_pipeline_closes_description_cache_on_propagating_error(
         raise OSError("disk full")
 
     monkeypatch.setattr(runner, "DATA_ROOT", tmp_path)
-    monkeypatch.setattr(runner, "_load_description_cache", lambda _path: cache)
+    # _load_description_cache now accepts persistent_path / compress /
+    # bootstrap_csv kwargs from the call site; the stub must absorb them.
+    monkeypatch.setattr(runner, "_load_description_cache", lambda _path, **_kw: cache)
     monkeypatch.setattr(runner, "_job_to_row", explode_row)
     monkeypatch.setitem(
         runner.CONFIGS,


### PR DESCRIPTION
## Summary

Audit-driven fix for description capture across the scrapers. 12 scrapers were silently truncating, stripping structure, or picking the wrong field. This PR lands the fixes plus a post-scrape markdownify step and a persistent zstd-compressed cache for Workday.

## Scraper fixes

| ATS | Issue | Fix | Impact |
|---|---|---|---|
| **Lever** | Preferred descriptionPlain (intro-only, no lists[]) | Assemble description + lists[] (Responsibilities/Requirements/Compensation) | **~9× content** per job |
| **Ashby** | Preferred descriptionPlain over descriptionHtml | Prefer HTML; structure preserved for markdownify | +27% length |
| **Phenom** | Used descriptionTeaser (1-2 sentence summary) | Use description (full body) | **~5-10×** content |
| **Greenhouse** | Stripped HTML tags after double-decode | Just unescape entities; keep tags | Structure preserved |
| **builtin, eightfold, gem, pinpoint, recruiterbox, usajobs** | Same strip-HTML pattern | Added per-scraper _html_unescape_for_desc helper | Structure preserved |
| **Apple** | Search API only returns jobSummary (~500 char intro) | Async detail-page enrichment from React loader state | **~5-8×** content |
| **Google** | _extract_full_description required single parent container; sections actually in siblings | Scan each h3 section independently and stitch | Recovers previously-missing Minimum + Preferred qualifications |

## Pipeline (scripts/run_pipeline.py)

- DescriptionCache: optional persistent path + zstd-compressed blobs. WAL journaling.
- Workday config: persistent cache at workday/descriptions.sqlite3 (compressed). skip_description_enrichment flag removed.
- _job_to_row no longer replaces newlines (markdown paragraphs survive CSV round-trip).

## New: scripts/normalize_descriptions.py

Post-scrape pass that streams an ATS jobs.csv, normalizes description per row through a worker pool, atomically rewrites:
- HTML → markdownify → markdown
- plain_dirty (entities or stray tags) → strip + unescape
- clean plain text or existing markdown → fast-path

## Test plan

- [x] All patched scrapers pass AST + import
- [x] Lever sample: ~600c → 5277c
- [x] Ashby sample: 8266c → 10488c
- [x] Apple 5-job sample: ~500c → 2563-3970c with ## Description / Minimum / Preferred sections
- [x] Google: re-extracted previously-broken job now contains Minimum + Preferred qualifications
- [x] DescriptionCache persistent+compress round-trip test passes (set → close → reopen → get)
- [x] Workday cache built from 2026-05 backfill: 668,408 unique URLs, 2.44 GB compressed
- [ ] First daily cron after merge will exercise full pipeline end-to-end

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incomplete job descriptions across 12 scrapers, adds a post-scrape HTML→markdown normalize pass with autolinking, and ships a persistent, zstd-compressed Workday description cache. Also improves Apple detail parsing/broadcast and makes normalization bounded and safe.

- **Bug Fixes**
  - Lever: assemble HTML `description` + `lists[]` into one body.
  - Apple: async detail-page enrichment from loader JSON with robust escaped-quote/unicode handling; broadcasts enriched body to all locations.
  - Google: scan each h3 section independently and stitch; restores Minimum/Preferred qualifications.
  - Ashby + Phenom: prefer `descriptionHtml`; use full `description` over teaser.
  - Greenhouse + `builtin`/`eightfold`/`gem`/`pinpoint`/`recruiterbox`/`usajobs`: stop stripping tags; unescape HTML so structure survives markdownify; add per-scraper `_html_unescape_for_desc`.
  - Normalizer: reject `--chunk 0` / `-j 0`.
  - Pipeline: when fresh and cached descriptions exist, keep the longer and upsert it back to cache; preserve newlines in CSV.

- **New Features**
  - Post-scrape normalizer (`scripts/normalize_descriptions.py`): HTML → `markdownify`; autolinks URLs/emails via `linkify-it-py`; invoked after each scrape (skippable via `skip_normalize`); failures are non-fatal; adds a 2h timeout (tunable) and cleans temp files on failure.
  - Persistent Workday cache: SQLite BLOBs with optional zstd (`zstandard`) and WAL at `workday/descriptions.sqlite3`; seeds from prior CSV; schema guarded via `PRAGMA user_version`.

<sup>Written for commit bd0960256f4e74b416bd86566ab91feb630005c6. Summary will update on new commits. <a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/180?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR audits and fixes description extraction across 12 ATS scrapers, replacing strip-HTML patterns with structure-preserving helpers so a downstream `markdownify` pass can convert HTML to clean markdown. It also introduces a new `normalize_descriptions.py` post-scrape script and a persistent, zstd-compressed `DescriptionCache` for Workday.

- **12 scraper fixes**: Lever now assembles the full HTML intro + `lists[]` sections (~9× more content); Phenom switches from `descriptionTeaser` to `description`; Greenhouse/builtin/eightfold/gem/pinpoint/recruiterbox/usajobs stop stripping HTML; Ashby prefers `descriptionHtml`; Google scans sections independently; Apple adds async detail-page enrichment from the React loader state.
- **Pipeline**: `DescriptionCache` gains a persistent + compressed mode (WAL, NORMAL sync) used by the new Workday config; `_job_to_row` removes the newline→space replacement so markdown paragraphs survive the CSV round-trip.
- **Apple enrichment has a broadcast bug**: multi-location sibling rows are initialised with `jobSummary` (non-`None`), so the `not j.description` guard in the broadcast pass is always `False`, and only the first location row per position ever receives the enriched full description.

<h3>Confidence Score: 3/5</h3>

Safe to merge for all scrapers except Apple, where multi-location jobs will silently receive enriched descriptions only on the first location row.

Ten of the twelve scraper fixes are mechanical and correct. The Workday persistent cache and normalize_descriptions script are well-structured. The Apple enrichment has a logic gap: every job row enters the broadcast pass with a non-None description (jobSummary from the search API), so the not j.description guard never evaluates to True for any sibling row. Apple posts many multi-location roles, so a meaningful fraction of Apple job rows will keep the short summary while others get the full description. The regex and unicode_escape issues degrade gracefully via exception handling but affect a real subset of postings.

src/jobhive/scrapers/apple.py — specifically the broadcast logic in _enrich_apple_details and the _LOADER_RE / unicode_escape decoding in _extract_apple_posting

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/jobhive/scrapers/apple.py | Adds async detail-page enrichment via React loader state; has a bug where the multi-location broadcast never fires (all sibling rows keep jobSummary), plus fragility in the regex and unicode_escape decoding |
| scripts/normalize_descriptions.py | New post-scrape CSV normalizer; uses private pool._processes attribute and does not clean up temp file on early return or exception, though the original CSV is never corrupted |
| scripts/run_pipeline.py | Adds persistent zstd-compressed DescriptionCache with WAL journaling for Workday; removes skip_description_enrichment flag; removes newline-stripping from _job_to_row. Logic is sound. |
| src/jobhive/scrapers/lever.py | Assembles description from HTML intro + lists[] sections instead of the shorter descriptionPlain; correct and well-guarded with a plain-text fallback |
| src/jobhive/scrapers/google.py | Replaces single-container heuristic with per-section heading scan; handles both nested and sibling DOM layouts; section order is deterministic |
| src/jobhive/scrapers/ashby.py | Swaps preference to descriptionHtml over descriptionPlain; correct |
| src/jobhive/scrapers/phenom.py | Prefers full description field over descriptionTeaser; correct single-line fix |
| src/jobhive/scrapers/greenhouse.py | Stops stripping HTML tags after entity unescape so markdownify can preserve structure |
| src/jobhive/scrapers/builtin.py | Switches to _html_unescape_for_desc; correct |
| src/jobhive/scrapers/eightfold.py | Switches to _html_unescape_for_desc with cap parameter; correct |
| src/jobhive/scrapers/gem.py | Switches to _html_unescape_for_desc with cap parameter; correct |
| src/jobhive/scrapers/pinpoint.py | Switches from _html_to_text to _html_unescape_for_desc; correct |
| src/jobhive/scrapers/recruiterbox.py | Switches from _html_to_text to _html_unescape_for_desc; correct |
| src/jobhive/scrapers/usajobs.py | Switches from _html_to_text to _html_unescape_for_desc; correct |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/jobhive/scrapers/apple.py`, line 553-563 ([link](https://github.com/kalil0321/ats-scrapers/blob/87c0134284f34daf692e21b35e28aefba9b20f71/src/jobhive/scrapers/apple.py#L553-L563)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Broadcast never fires for multi-location sibling jobs**

   In `_parse_job`, every job row is initialised with `description = item.get("jobSummary") or None`. The search API always returns a `jobSummary`, so `job.description` is non-`None` for every row. In `hydrate()` only the first job per `position_id` gets the enriched description; the sibling rows keep their `jobSummary`. In the broadcast pass `if pid and not j.description` is therefore always `False` for every sibling, and the full description is never propagated. Multi-location Apple postings end up with the enriched body on the first location row only; all other locations keep the short `jobSummary`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/jobhive/scrapers/apple.py
   Line: 553-563

   Comment:
   **Broadcast never fires for multi-location sibling jobs**

   In `_parse_job`, every job row is initialised with `description = item.get("jobSummary") or None`. The search API always returns a `jobSummary`, so `job.description` is non-`None` for every row. In `hydrate()` only the first job per `position_id` gets the enriched description; the sibling rows keep their `jobSummary`. In the broadcast pass `if pid and not j.description` is therefore always `False` for every sibling, and the full description is never propagated. Multi-location Apple postings end up with the enriched body on the first location row only; all other locations keep the short `jobSummary`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 5 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 5
src/jobhive/scrapers/apple.py:553-563
**Broadcast never fires for multi-location sibling jobs**

In `_parse_job`, every job row is initialised with `description = item.get("jobSummary") or None`. The search API always returns a `jobSummary`, so `job.description` is non-`None` for every row. In `hydrate()` only the first job per `position_id` gets the enriched description; the sibling rows keep their `jobSummary`. In the broadcast pass `if pid and not j.description` is therefore always `False` for every sibling, and the full description is never propagated. Multi-location Apple postings end up with the enriched body on the first location row only; all other locations keep the short `jobSummary`.

### Issue 2 of 5
src/jobhive/scrapers/apple.py:48
The regex `(.+?)` with a plain `"` boundary is fooled by doubly-escaped quotes in the JS string literal. When a job description value contains `")`, the lazy match stops at the wrong `"` and produces a truncated JSON payload. The subsequent `json.JSONDecodeError` is caught and returns `None`, silently falling back to `jobSummary`. A non-backtracking character class that skips `\` escapes avoids this.

```suggestion
_LOADER_RE = re.compile(r'JSON\.parse\("((?:[^"\\]|\\.)*)"\)', re.DOTALL)
```

### Issue 3 of 5
src/jobhive/scrapers/apple.py:396-399
The `encode("utf-8").decode("unicode_escape")` idiom works only for ASCII content. `unicode_escape` interprets the input bytes as Latin-1, so any non-ASCII UTF-8 bytes that appear literally in the matched string (rather than as `\uXXXX` JS escapes) are decoded incorrectly, producing mojibake. Apple job descriptions for non-English roles or with accented names would silently produce a `UnicodeDecodeError` (caught) and fall back to `jobSummary`.

### Issue 4 of 5
scripts/normalize_descriptions.py:142
`pool._processes` is an undocumented private attribute of `multiprocessing.Pool`. Accessing it creates a fragile dependency on CPython internals. Since the worker count is already known from `args.workers` in `main()`, passing it as a parameter to `_process_chunk` avoids the private access entirely.

```suggestion
    n_workers = pool._processes  # noqa: SLF001 – no public API for worker count
```

### Issue 5 of 5
scripts/normalize_descriptions.py:96-131
**Temp file not cleaned up on early exit or exception**

Both `tmp` and `pool` are created before the `try/finally` block. When `return 2` is hit (missing column), the `finally` clause closes but does not delete the temp file, leaving a `.{name}.normalizing.*` file on disk. Similarly, if an exception propagates out of the `try` block the same litter is left behind. The original CSV is never corrupted, but stale temp files accumulate across failed runs.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix description extraction across 12 scr..."](https://github.com/kalil0321/ats-scrapers/commit/87c0134284f34daf692e21b35e28aefba9b20f71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33690616)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->