### PR TITLE
Company discovery: get_scraper_for_url + find_company

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to **ats-scrapers** are documented here. The project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added — company discovery without ATS knowledge
+
+Nobody knows OpenAI runs on Ashby. Two new package-root entry points
+remove the need to know the `(ats, slug)` pair:
+
+- `get_scraper_for_url("https://jobs.ashbyhq.com/openai")` — builds
+  the right scraper from a public careers URL. Recognizes 20+ ATS URL
+  shapes (path-tenant, subdomain-tenant, and full-URL platforms like
+  Workday/Taleo/iCIMS). `resolve_careers_url(url)` exposes the raw
+  `(ats, slug)` mapping.
+- `find_company("openai")` — case-insensitive name/slug lookup over
+  the hosted companies directory (`Client.companies()`, cached
+  in-process; exact matches rank first).
+
 ## [0.1.0] — 2026-07-22
 
 Initial release of `ats-scrapers`:

--- a/README.md
+++ b/README.md
@@ -70,9 +70,22 @@ for field definitions and normalization rules.
 
 ## Scrape a company
 
+You don't need to know which ATS a company uses. Paste its careers URL:
+
 ```python
+from ats_scrapers import get_scraper_for_url
+
+scraper = get_scraper_for_url("https://jobs.ashbyhq.com/openai")
+jobs = scraper.fetch()
+```
+
+Or look it up by name in the hosted companies directory (63,000+ tenants):
+
+```python
+from ats_scrapers import find_company
 from ats_scrapers.scrapers import get_scraper
 
+find_company("openai")          # → ats="ashby", slug="openai", url=...
 scraper = get_scraper("ashby", "openai")
 jobs = scraper.fetch()
 ```

--- a/src/ats_scrapers/__init__.py
+++ b/src/ats_scrapers/__init__.py
@@ -15,7 +15,7 @@ directory and is not part of the installable package.
 """
 
 from ats_scrapers._version import __version__
-from ats_scrapers.client import Client, list_ats, search
+from ats_scrapers.client import Client, find_company, list_ats, search
 from ats_scrapers.exceptions import (
     ATSScrapersError,
     CompanyNotFoundError,
@@ -26,6 +26,7 @@ from ats_scrapers.exceptions import (
 from ats_scrapers.fetch import Fetcher, FetchResponse, MalformedJSONError
 from ats_scrapers.manifest import Manifest
 from ats_scrapers.models import ATSType, Company, EmploymentType, Job, Salary, SalaryPeriod
+from ats_scrapers.resolve import ResolvedCareersUrl, get_scraper_for_url, resolve_careers_url
 
 __all__ = [
     "ATSScrapersError",
@@ -40,11 +41,15 @@ __all__ = [
     "MalformedJSONError",
     "Manifest",
     "ManifestError",
+    "ResolvedCareersUrl",
     "Salary",
     "SalaryPeriod",
     "ScraperError",
     "StorageError",
     "__version__",
+    "find_company",
+    "get_scraper_for_url",
     "list_ats",
+    "resolve_careers_url",
     "search",
 ]

--- a/src/ats_scrapers/client.py
+++ b/src/ats_scrapers/client.py
@@ -53,6 +53,7 @@ class Client:
         self._owns_http = http_client is None
         self._manifest: Manifest | None = None
         self._snapshot: pd.DataFrame | None = None
+        self._companies: pd.DataFrame | None = None
 
     def __enter__(self) -> Client:
         return self
@@ -96,6 +97,47 @@ class Client:
             url = self.manifest.url_for_all(prefer_parquet=self._prefer_parquet)
             self._snapshot = _normalize_dataset(self._download(url))
         return self._snapshot
+
+    def companies(self) -> pd.DataFrame:
+        """Load the companies directory (``ats``, ``name``, ``slug``, ``url``).
+
+        One row per tracked tenant. Cached in memory for the client's
+        lifetime — it's a few MB, far smaller than any jobs slice.
+        """
+        if self._companies is None:
+            url = self.manifest.url_for_companies(prefer_parquet=self._prefer_parquet)
+            self._companies = self._download(url)
+        return self._companies
+
+    def find_company(self, name: str, *, limit: int = 10) -> pd.DataFrame:
+        """Find tracked companies by (partial) name or slug.
+
+        Case-insensitive literal substring match — the answer to
+        "which ATS is this company on?" without knowing any ATS
+        exists:
+
+        >>> Client().find_company("openai")
+             ats    name  slug  url
+        0  ashby  OpenAI  openai  https://jobs.ashbyhq.com/openai
+
+        Rows whose slug matches exactly sort first, then exact name
+        matches, then everything else. Feed ``ats``/``slug`` straight
+        into ``get_scraper``.
+        """
+        df = self.companies()
+        needle = name.strip().lower()
+        if not needle:
+            return df.head(0)
+        names = df["name"].fillna("").str.lower()
+        slugs = df["slug"].fillna("").astype(str).str.lower()
+        matches = df[
+            names.str.contains(needle, regex=False) | slugs.str.contains(needle, regex=False)
+        ].copy()
+        rank = (slugs.loc[matches.index] != needle).astype(int) * 2 + (
+            names.loc[matches.index] != needle
+        ).astype(int)
+        matches = matches.loc[rank.sort_values(kind="stable").index]
+        return matches.head(limit).reset_index(drop=True)
 
     def search(
         self,
@@ -248,3 +290,16 @@ def search(
 def list_ats() -> Iterable[str]:
     """Return source names present in the current hosted manifest."""
     return _default_client().manifest.by_ats.keys()
+
+
+def find_company(name: str, *, limit: int = 10) -> pd.DataFrame:
+    """Find tracked companies by (partial) name or slug.
+
+    One-shot wrapper around :meth:`Client.find_company` — answers
+    "which ATS is this company on?" so you can scrape it without
+    knowing the ATS landscape:
+
+    >>> find_company("openai")
+    >>> get_scraper("ashby", "openai")  # from the ats/slug columns
+    """
+    return _default_client().find_company(name, limit=limit)

--- a/src/ats_scrapers/manifest.py
+++ b/src/ats_scrapers/manifest.py
@@ -110,6 +110,12 @@ class Manifest(BaseModel):
             raise ManifestError(f"No snapshot for date {date}")
         return _pick_url(entry, prefer_parquet=prefer_parquet)
 
+    def url_for_companies(self, *, prefer_parquet: bool = True) -> str:
+        """Return the best download URL for the companies directory."""
+        if self.companies is None:
+            raise ManifestError("Manifest has no companies artifact")
+        return _pick_url(self.companies, prefer_parquet=prefer_parquet)
+
 
 def _pick_url(entry: FileEntry, *, prefer_parquet: bool) -> str:
     if prefer_parquet and entry.parquet is not None:

--- a/src/ats_scrapers/resolve.py
+++ b/src/ats_scrapers/resolve.py
@@ -1,0 +1,167 @@
+"""Resolve a careers-page URL to a scraper — no ATS knowledge required.
+
+Almost nobody knows which ATS a company uses ("OpenAI is on Ashby" is
+recruiting-insider trivia), but anyone can Google "<company> careers"
+and paste the URL. Every multi-tenant ATS serves tenants from a
+recognizable URL shape, so the mapping is deterministic and offline:
+
+    >>> from ats_scrapers import get_scraper_for_url
+    >>> scraper = get_scraper_for_url("https://jobs.ashbyhq.com/openai")
+    >>> jobs = scraper.fetch()
+
+Each pattern below mirrors the slug contract documented in the
+corresponding scraper module — path-based tenants (Greenhouse, Lever,
+Ashby, …), subdomain tenants (Recruitee, Teamtailor, Breezy, …), and
+full-URL tenants (Workday, Taleo, and iCIMS variants) where the
+scraper itself wants the whole URL.
+
+Custom-domain career sites (careers.example.com fronting Phenom,
+Avature, or Eightfold) cannot be recognized from the URL alone —
+``resolve_careers_url`` returns ``None`` and
+``get_scraper_for_url`` raises with guidance.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, NamedTuple
+from urllib.parse import urlparse
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType
+
+if TYPE_CHECKING:
+    from ats_scrapers.scrapers.base import BaseScraper
+
+# Tenant slugs interpolated into hostnames/paths must look like DNS
+# labels / board identifiers — this also refuses anything that could
+# escape the intended host when a scraper interpolates the slug into
+# an f-string URL.
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9._\-]*$", re.IGNORECASE)
+
+
+class ResolvedCareersUrl(NamedTuple):
+    """Outcome of :func:`resolve_careers_url`."""
+
+    ats: ATSType
+    slug: str
+
+
+def _first_path_segment(parsed) -> str | None:
+    segments = [s for s in parsed.path.split("/") if s]
+    return segments[0] if segments else None
+
+
+# Path-based tenants: https://{host}/{slug}/...
+_PATH_HOSTS: dict[str, ATSType] = {
+    "boards.greenhouse.io": ATSType.GREENHOUSE,
+    "job-boards.greenhouse.io": ATSType.GREENHOUSE,
+    "boards.eu.greenhouse.io": ATSType.GREENHOUSE,
+    "job-boards.eu.greenhouse.io": ATSType.GREENHOUSE,
+    "jobs.lever.co": ATSType.LEVER,
+    "jobs.eu.lever.co": ATSType.LEVER,
+    "jobs.ashbyhq.com": ATSType.ASHBY,
+    "apply.workable.com": ATSType.WORKABLE,
+    "careers.smartrecruiters.com": ATSType.SMARTRECRUITERS,
+    "jobs.smartrecruiters.com": ATSType.SMARTRECRUITERS,
+    "jobs.gem.com": ATSType.GEM,
+    "ats.rippling.com": ATSType.RIPPLING,
+}
+
+# Subdomain tenants: https://{slug}.{suffix}/...
+_SUBDOMAIN_SUFFIXES: dict[str, ATSType] = {
+    ".recruitee.com": ATSType.RECRUITEE,
+    ".teamtailor.com": ATSType.TEAMTAILOR,
+    ".breezy.hr": ATSType.BREEZY,
+    ".bamboohr.com": ATSType.BAMBOOHR,
+    ".jobs.personio.com": ATSType.PERSONIO,
+    ".jobs.personio.de": ATSType.PERSONIO,
+    ".pinpointhq.com": ATSType.PINPOINT,
+    ".applytojob.com": ATSType.JAZZHR,
+    ".avature.net": ATSType.AVATURE,
+    ".eightfold.ai": ATSType.EIGHTFOLD,
+}
+
+# Full-URL tenants: the scraper's slug IS the careers URL.
+_WORKDAY_HOST_RE = re.compile(r"^[^.]+\.wd\d+\.myworkdayjobs\.com$")
+_TALEO_HOST_RE = re.compile(r"^[^.]+\.tbe\.taleo\.net$")
+_ICIMS_HOST_RE = re.compile(r"^(?P<prefix>[a-z0-9-]+)\.icims\.com$", re.IGNORECASE)
+
+
+def resolve_careers_url(url: str) -> ResolvedCareersUrl | None:
+    """Map a public careers URL to ``(ats, slug)``.
+
+    Returns ``None`` when the URL doesn't match any known ATS shape
+    (typically a custom-domain careers site). The returned slug is in
+    the exact form the matching scraper's constructor expects.
+    """
+    parsed = urlparse(url if "//" in url else f"https://{url}")
+    host = (parsed.hostname or "").lower()
+    if not host:
+        return None
+    if host.startswith("www."):
+        host = host.removeprefix("www.")
+
+    if host in _PATH_HOSTS:
+        slug = _first_path_segment(parsed)
+        if slug and _SLUG_RE.match(slug):
+            return ResolvedCareersUrl(_PATH_HOSTS[host], slug)
+        return None
+
+    # join.com/companies/{slug}
+    if host == "join.com":
+        segments = [s for s in parsed.path.split("/") if s]
+        if len(segments) >= 2 and segments[0] == "companies" and _SLUG_RE.match(segments[1]):
+            return ResolvedCareersUrl(ATSType.JOIN_COM, segments[1])
+        return None
+
+    for suffix, ats in _SUBDOMAIN_SUFFIXES.items():
+        if host.endswith(suffix):
+            slug = host.removesuffix(suffix)
+            if slug and "." not in slug and _SLUG_RE.match(slug):
+                return ResolvedCareersUrl(ats, slug)
+            return None
+
+    if _WORKDAY_HOST_RE.match(host):
+        # WorkdayScraper wants the full careers URL (tenant, wdN
+        # instance, and site name are all load-bearing).
+        return ResolvedCareersUrl(ATSType.WORKDAY, f"https://{host}{parsed.path}")
+
+    if _TALEO_HOST_RE.match(host):
+        # Taleo TBE wants the full search-results URL including query.
+        query = f"?{parsed.query}" if parsed.query else ""
+        return ResolvedCareersUrl(ATSType.TALEO, f"https://{host}{parsed.path}{query}")
+
+    icims = _ICIMS_HOST_RE.match(host)
+    if icims:
+        prefix = icims.group("prefix").lower()
+        if prefix.startswith("careers-"):
+            return ResolvedCareersUrl(ATSType.ICIMS, prefix.removeprefix("careers-"))
+        # Non-standard portal prefixes (uscareers-..., jobs-...): the
+        # scraper accepts the full portal URL verbatim.
+        return ResolvedCareersUrl(ATSType.ICIMS, f"https://{host}")
+
+    return None
+
+
+def get_scraper_for_url(url: str, **kwargs: object) -> BaseScraper:
+    """Build a ready-to-use scraper from a public careers URL.
+
+    Keyword arguments are forwarded to the scraper constructor
+    (``timeout``, ``include_descriptions``, ``proxy``, …).
+
+    Raises :class:`ScraperError` for URLs that don't match a known ATS
+    shape — custom-domain careers sites need the explicit
+    ``get_scraper(ats, slug)`` path.
+    """
+    resolved = resolve_careers_url(url)
+    if resolved is None:
+        raise ScraperError(
+            f"Could not recognize an ATS from {url!r}. Custom-domain careers "
+            f"sites can't be resolved from the URL alone — if you know the "
+            f"platform, use get_scraper(ats, slug), or look the company up "
+            f"with find_company()."
+        )
+    from ats_scrapers.scrapers.base import ScraperRegistry
+
+    return ScraperRegistry.get(resolved.ats)(resolved.slug, **kwargs)  # type: ignore[arg-type]

--- a/src/ats_scrapers/resolve.py
+++ b/src/ats_scrapers/resolve.py
@@ -162,6 +162,9 @@ def get_scraper_for_url(url: str, **kwargs: object) -> BaseScraper:
             f"platform, use get_scraper(ats, slug), or look the company up "
             f"with find_company()."
         )
-    from ats_scrapers.scrapers.base import ScraperRegistry
+    # Import the scrapers package (not just .base): importing it runs
+    # every @ScraperRegistry.register decorator, so the registry is
+    # populated even when the caller only imported the package root.
+    from ats_scrapers.scrapers import get_scraper
 
-    return ScraperRegistry.get(resolved.ats)(resolved.slug, **kwargs)  # type: ignore[arg-type]
+    return get_scraper(resolved.ats, resolved.slug, **kwargs)

--- a/tests/test_find_company.py
+++ b/tests/test_find_company.py
@@ -1,0 +1,106 @@
+"""Tests for the companies directory lookup (`Client.find_company`)."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ats_scrapers.client import Client
+from ats_scrapers.exceptions import ManifestError
+
+COMPANIES = pd.DataFrame(
+    [
+        {"ats": "ashby", "name": "OpenAI", "slug": "openai",
+         "url": "https://jobs.ashbyhq.com/openai"},
+        {"ats": "greenhouse", "name": "Anthropic", "slug": "anthropic",
+         "url": "https://boards.greenhouse.io/anthropic"},
+        {"ats": "lever", "name": "OpenAI Research Partners", "slug": "openai-research",
+         "url": "https://jobs.lever.co/openai-research"},
+        {"ats": "workday", "name": "Open Assistance Intl", "slug": None,
+         "url": "https://oai.wd1.myworkdayjobs.com/jobs"},
+    ]
+)
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> Client:
+    c = Client()
+    monkeypatch.setattr(Client, "companies", lambda self: COMPANIES.copy())
+    return c
+
+
+def test_exact_slug_match_ranks_first(client: Client) -> None:
+    result = client.find_company("openai")
+    assert not result.empty
+    assert result.iloc[0]["slug"] == "openai"
+    assert result.iloc[0]["ats"] == "ashby"
+    # The partial match is still included, after the exact one.
+    assert "openai-research" in set(result["slug"])
+
+
+def test_name_match_is_case_insensitive(client: Client) -> None:
+    result = client.find_company("ANTHROPIC")
+    assert len(result) == 1
+    assert result.iloc[0]["ats"] == "greenhouse"
+
+
+def test_substring_matches_name_with_null_slug(client: Client) -> None:
+    result = client.find_company("open assistance")
+    assert len(result) == 1
+    assert result.iloc[0]["ats"] == "workday"
+
+
+def test_no_match_returns_empty(client: Client) -> None:
+    assert client.find_company("definitely-not-a-company").empty
+
+
+def test_blank_query_returns_empty(client: Client) -> None:
+    assert client.find_company("   ").empty
+
+
+def test_limit_is_applied(client: Client) -> None:
+    assert len(client.find_company("o", limit=2)) == 2
+
+
+def test_companies_download_uses_manifest_entry(
+    monkeypatch: pytest.MonkeyPatch, httpx_mock,
+) -> None:
+    from ats_scrapers.manifest import FileEntry, Manifest, ManifestStats
+
+    manifest = Manifest(
+        version="1.0",
+        generated_at="2026-07-22T00:00:00+00:00",
+        stats=ManifestStats(total_jobs=1, total_companies=1, ats_count=1),
+        all=FileEntry(csv="https://example.com/all.csv", rows=1, size_bytes=1),
+        companies=FileEntry(
+            csv="https://example.com/companies.csv", rows=1, size_bytes=1
+        ),
+    )
+    httpx_mock.add_response(
+        url="https://example.com/companies.csv",
+        text="ats,name,slug,url\nashby,OpenAI,openai,https://jobs.ashbyhq.com/openai\n",
+    )
+    client = Client(prefer_parquet=False)
+    monkeypatch.setattr(Client, "manifest", property(lambda self: manifest))
+    df = client.companies()
+    assert list(df.columns) == ["ats", "name", "slug", "url"]
+    # Cached: second call must not re-download.
+    client.companies()
+    assert len(httpx_mock.get_requests()) == 1
+
+
+def test_companies_without_manifest_entry_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from ats_scrapers.manifest import FileEntry, Manifest, ManifestStats
+
+    manifest = Manifest(
+        version="1.0",
+        generated_at="2026-07-22T00:00:00+00:00",
+        stats=ManifestStats(total_jobs=1, total_companies=1, ats_count=1),
+        all=FileEntry(csv="https://example.com/all.csv", rows=1, size_bytes=1),
+    )
+    client = Client()
+    monkeypatch.setattr(Client, "manifest", property(lambda self: manifest))
+    with pytest.raises(ManifestError, match="companies"):
+        client.companies()

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -113,3 +113,22 @@ def test_get_scraper_for_url_builds_scraper() -> None:
 def test_get_scraper_for_url_raises_with_guidance() -> None:
     with pytest.raises(ScraperError, match="Could not recognize"):
         get_scraper_for_url("https://careers.example.com/jobs")
+
+
+def test_get_scraper_for_url_from_fresh_interpreter() -> None:
+    """Root-level import alone must suffice — the registry has to be
+    populated by the call itself, not by earlier scraper imports in
+    the calling process (regression for the empty-registry bug)."""
+    import subprocess
+    import sys
+
+    code = (
+        "from ats_scrapers import get_scraper_for_url; "
+        "s = get_scraper_for_url('https://jobs.ashbyhq.com/openai'); "
+        "print(type(s).__name__, s.company_slug)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "AshbyScraper openai"

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,0 +1,115 @@
+"""Tests for careers-URL resolution (`ats_scrapers.resolve`)."""
+
+from __future__ import annotations
+
+import pytest
+
+from ats_scrapers import get_scraper_for_url, resolve_careers_url
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType
+from ats_scrapers.scrapers import (
+    AshbyScraper,
+    GreenhouseScraper,
+    WorkdayScraper,
+)
+
+RESOLVES = [
+    # Path-based tenants
+    ("https://jobs.ashbyhq.com/openai", ATSType.ASHBY, "openai"),
+    ("https://jobs.ashbyhq.com/openai/some-posting-id", ATSType.ASHBY, "openai"),
+    ("https://boards.greenhouse.io/anthropic", ATSType.GREENHOUSE, "anthropic"),
+    ("https://job-boards.greenhouse.io/anthropic/jobs/123", ATSType.GREENHOUSE, "anthropic"),
+    ("https://boards.eu.greenhouse.io/acme", ATSType.GREENHOUSE, "acme"),
+    ("https://jobs.lever.co/palantir", ATSType.LEVER, "palantir"),
+    ("https://jobs.eu.lever.co/acme", ATSType.LEVER, "acme"),
+    ("https://apply.workable.com/0x/", ATSType.WORKABLE, "0x"),
+    ("https://careers.smartrecruiters.com/10Pearls", ATSType.SMARTRECRUITERS, "10Pearls"),
+    ("https://jobs.gem.com/accel", ATSType.GEM, "accel"),
+    ("https://ats.rippling.com/acme/jobs", ATSType.RIPPLING, "acme"),
+    ("https://join.com/companies/acme", ATSType.JOIN_COM, "acme"),
+    # Subdomain tenants
+    ("https://12build.recruitee.com", ATSType.RECRUITEE, "12build"),
+    ("https://1komma5.teamtailor.com/jobs", ATSType.TEAMTAILOR, "1komma5"),
+    ("https://acme.breezy.hr", ATSType.BREEZY, "acme"),
+    ("https://10web.bamboohr.com/careers", ATSType.BAMBOOHR, "10web"),
+    ("https://10xfounders.jobs.personio.com", ATSType.PERSONIO, "10xfounders"),
+    ("https://aawdc.pinpointhq.com", ATSType.PINPOINT, "aawdc"),
+    ("https://acme.applytojob.com/apply", ATSType.JAZZHR, "acme"),
+    ("https://bloomberg.avature.net/careers", ATSType.AVATURE, "bloomberg"),
+    ("https://nvidia.eightfold.ai/careers", ATSType.EIGHTFOLD, "nvidia"),
+    # Scheme-less input is tolerated
+    ("jobs.ashbyhq.com/openai", ATSType.ASHBY, "openai"),
+    ("www.jobs.lever.co/acme", ATSType.LEVER, "acme"),
+    # iCIMS standard portal prefix -> bare slug
+    ("https://careers-peraton.icims.com/jobs/search", ATSType.ICIMS, "peraton"),
+]
+
+
+@pytest.mark.parametrize(("url", "ats", "slug"), RESOLVES)
+def test_resolves(url: str, ats: ATSType, slug: str) -> None:
+    resolved = resolve_careers_url(url)
+    assert resolved is not None, f"expected {url} to resolve"
+    assert resolved.ats is ats
+    assert resolved.slug == slug
+
+
+def test_workday_slug_is_full_url() -> None:
+    resolved = resolve_careers_url(
+        "https://2020companies.wd1.myworkdayjobs.com/external_careers"
+    )
+    assert resolved is not None
+    assert resolved.ats is ATSType.WORKDAY
+    assert resolved.slug == "https://2020companies.wd1.myworkdayjobs.com/external_careers"
+
+
+def test_taleo_slug_keeps_query() -> None:
+    url = "https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=UH9TY5&cws=41"
+    resolved = resolve_careers_url(url)
+    assert resolved is not None
+    assert resolved.ats is ATSType.TALEO
+    assert resolved.slug == url
+
+
+def test_icims_nonstandard_prefix_keeps_full_url() -> None:
+    resolved = resolve_careers_url("https://uscareers-rws.icims.com/jobs/search")
+    assert resolved is not None
+    assert resolved.ats is ATSType.ICIMS
+    assert resolved.slug == "https://uscareers-rws.icims.com"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://careers.example.com/jobs",       # custom domain
+        "https://www.linkedin.com/jobs/view/1",   # aggregator
+        "https://jobs.ashbyhq.com",               # no slug in path
+        "https://join.com/about",                 # join.com non-company path
+        "https://evil.recruitee.com.attacker.io", # suffix-spoofing host
+        "not a url at all",
+    ],
+)
+def test_unrecognized_urls_return_none(url: str) -> None:
+    assert resolve_careers_url(url) is None
+
+
+def test_get_scraper_for_url_builds_scraper() -> None:
+    scraper = get_scraper_for_url(
+        "https://jobs.ashbyhq.com/openai", include_descriptions=False
+    )
+    assert isinstance(scraper, AshbyScraper)
+    assert scraper.company_slug == "openai"
+    assert scraper.include_descriptions is False
+
+    assert isinstance(
+        get_scraper_for_url("https://boards.greenhouse.io/anthropic"),
+        GreenhouseScraper,
+    )
+    workday = get_scraper_for_url(
+        "https://2020companies.wd1.myworkdayjobs.com/external_careers"
+    )
+    assert isinstance(workday, WorkdayScraper)
+
+
+def test_get_scraper_for_url_raises_with_guidance() -> None:
+    with pytest.raises(ScraperError, match="Could not recognize"):
+        get_scraper_for_url("https://careers.example.com/jobs")


### PR DESCRIPTION
## What

Removes the biggest UX wall in the scraping API: users had to know the `(ats, slug)` pair — and nobody outside recruiting-tech knows OpenAI runs on Ashby. Two new zero-knowledge entry points, both exported at the package root.

## `get_scraper_for_url(url)` — paste a careers URL

```python
scraper = get_scraper_for_url("https://jobs.ashbyhq.com/openai")
jobs = scraper.fetch()
```

New `ats_scrapers.resolve` module maps 20+ known ATS URL shapes to `(ats, slug)`:

- **Path tenants**: Greenhouse (incl. `job-boards.` and EU hosts), Lever (+EU), Ashby, Workable, SmartRecruiters, Gem, Rippling, join.com
- **Subdomain tenants**: Recruitee, Teamtailor, Breezy, BambooHR, Personio (.com/.de), Pinpoint, JazzHR, Avature, Eightfold
- **Full-URL platforms**: Workday (`*.wdN.myworkdayjobs.com`), Taleo TBE (query string preserved), iCIMS (standard `careers-{slug}` portals → bare slug; non-standard portals → full URL, both forms the scraper already accepts)

Every pattern mirrors the slug contract documented in its scraper module. Slugs are shape-validated (DNS-label regex), and suffix-spoofing hosts (`evil.recruitee.com.attacker.io`) are rejected. Custom-domain careers sites resolve to `None` / raise with guidance. `resolve_careers_url(url)` exposes the raw mapping.

## `find_company(name)` — look it up by name

```python
find_company("openai")   # → ats="ashby", slug="openai", url=...
```

Backed by the hosted companies directory the pipeline already publishes (`ats,name,slug,url`, 63k+ tenants): new `Client.companies()` (downloaded once, cached in-process; `Manifest.url_for_companies()` added) with case-insensitive literal name/slug matching, exact matches ranked first.

## Also

- README's scraping section now leads with the no-ATS-knowledge paths.
- CHANGELOG `[Unreleased]` entry.

## Testing

- 46 new tests (`tests/test_resolve.py` table-driven across all URL shapes + negatives; `tests/test_find_company.py` incl. manifest-driven download/caching) — all offline.
- Full suite: **1079 passed**, 2 skipped, 20 live-e2e deselected; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDJYTHGuQEFnQDAeZBTJfB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDJYTHGuQEFnQDAeZBTJfB)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add zero-knowledge company discovery: `get_scraper_for_url(url)` builds the right scraper from a careers URL, and `find_company(name)` looks up ATS and slug by name. This removes the need to know `(ats, slug)` to start scraping.

- **New Features**
  - `get_scraper_for_url(url)` builds a scraper from a public careers URL; `resolve_careers_url(url)` returns `(ats, slug)`. Supports path-tenant, subdomain-tenant, and full-URL platforms (incl. Workday, Taleo, iCIMS); validates slugs and rejects spoofed hosts; custom domains return guidance.
  - `find_company(name)` queries the hosted companies directory (63k+). Case-insensitive name/slug match with exact matches ranked first; backed by `Client.companies()` (cached) and `Manifest.url_for_companies()`.

- **Bug Fixes**
  - Fixed empty registry when importing only from the package root: `get_scraper_for_url` now routes through `ats_scrapers.scrapers.get_scraper` so scraper registrations are loaded. Added a fresh-interpreter regression test.

<sup>Written for commit 1b91e6e77282fddf8182a12ea73af96a07fd861e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds company discovery APIs so callers can scrape without knowing the ATS and slug first. The main changes are:

- Package-root exports for `get_scraper_for_url`, `resolve_careers_url`, and `find_company`.
- URL shape resolution for path-based, subdomain-based, and full-URL ATS platforms.
- Companies-directory loading and cached lookup through `Client.companies()` and `Client.find_company()`.
- README, changelog, and offline tests for the new discovery flows.

<h3>Confidence Score: 4/5</h3>

One contained bug affects the new scraper-construction entry point.

URL resolution and company lookup are otherwise straightforward, but `get_scraper_for_url` can fail in the documented root-import workflow.

src/ats_scrapers/resolve.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a fresh-interpreter import harness for get\_scraper\_for\_url to verify the scraper registry was loaded before the entry point was invoked.
- In the root-import-only scenario, AshbyScraper was constructed for https://jobs.ashbyhq.com/openai without a No scraper registered error and without calling fetch(), and the same construction occurred when importing ats\_scrapers.scrapers first in the contrast path.
- Collected and summarized execution logs showing the discovery-focused pytest run with EXIT\_CODE 0 and the import/API smoke run with EXIT\_CODE 0 after fixing an initial shell issue.
- The discovery-smoke log shows imports\_ok Client True True and resolved ashby openai, with EXIT\_CODE: 0.

<a href="https://app.greptile.com/trex/runs/15487253/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/ats_scrapers/resolve.py | Adds ATS URL shape resolution and scraper construction, but scraper construction can fail from the documented package-root import path because registry registration is not triggered. |
| src/ats_scrapers/client.py | Adds companies-directory loading and cached case-insensitive company lookup. |
| src/ats_scrapers/manifest.py | Adds manifest URL selection for the companies directory artifact. |
| src/ats_scrapers/__init__.py | Exports the new company discovery and careers URL resolution APIs from the package root. |
| tests/test_resolve.py | Adds URL resolution tests across supported ATS shapes, but the scraper-construction test imports scraper classes first and masks the package-root registry issue. |
| tests/test_find_company.py | Adds offline tests for company lookup ranking, caching, manifest integration, and missing companies artifacts. |
| README.md | Updates scraping examples to lead with URL-based and name-based discovery flows. |
| CHANGELOG.md | Adds an Unreleased entry documenting the new URL resolution and company discovery APIs. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/ats_scrapers/resolve.py:163-165
**Load scraper registrations**
`get_scraper_for_url` only imports `ScraperRegistry` from `ats_scrapers.scrapers.base`, so a root-level usage like `from ats_scrapers import get_scraper_for_url` reaches an empty registry because the scraper modules have not been imported and their `@ScraperRegistry.register(...)` decorators have not run. The documented entry point then raises `No scraper registered` for valid URLs unless the caller separately imports `ats_scrapers.scrapers` first.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add company discovery: get\_scraper\_for\_u..."](https://github.com/kalil0321/ats-scrapers/commit/a9e9706470024f0636017654e5333d2cb2dcc7a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46459209)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->