### PR TITLE
Match search filters literally, never as regex

### DIFF
--- a/src/ats_scrapers/client.py
+++ b/src/ats_scrapers/client.py
@@ -117,15 +117,25 @@ class Client:
         """
         df = self.load(ats=ats)
 
+        # regex=False everywhere: the documented contract is literal
+        # substring matching, and regex mode on user input is both a
+        # ReDoS vector (catastrophic backtracking) and a correctness
+        # bug — search("c++") would die on an invalid pattern.
         if query:
-            df = df[df["title"].str.contains(query, case=False, na=False)]
+            df = df[df["title"].str.contains(query, case=False, na=False, regex=False)]
         if location:
-            df = df[df["location"].fillna("").str.contains(location, case=False, na=False)]
+            df = df[
+                df["location"].fillna("").str.contains(
+                    location, case=False, na=False, regex=False
+                )
+            ]
         if company:
-            df = df[df["company"].str.contains(company, case=False, na=False)]
+            df = df[df["company"].str.contains(company, case=False, na=False, regex=False)]
         if remote is not None:
             location_remote = (
-                df["location"].fillna("").str.contains("remote", case=False, na=False)
+                df["location"]
+                .fillna("")
+                .str.contains("remote", case=False, na=False, regex=False)
                 if "location" in df.columns
                 else pd.Series(False, index=df.index)
             )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -55,6 +55,21 @@ def test_search_by_title_substring_case_insensitive(stub_client: Client) -> None
     assert set(df["title"]) == {"Senior ML Engineer", "Staff ML Researcher"}
 
 
+def test_search_treats_query_as_literal_text_not_regex(stub_client: Client) -> None:
+    """Regex metacharacters are matched literally (GH-182: user input
+    must never reach pandas' regex engine — ReDoS + crash vector)."""
+    # An invalid regex must not raise — it's just text that matches nothing.
+    assert stub_client.search(query="c++").empty
+    assert stub_client.search(query="(unclosed").empty
+    # Alternation must not act as alternation.
+    assert stub_client.search(query="ML|Sales").empty
+    # A catastrophic-backtracking pattern is inert as literal text.
+    assert stub_client.search(query="(a+)+$" * 5, location="(x)*y").empty
+    # Same for location and company filters.
+    assert stub_client.search(location=".*").empty
+    assert stub_client.search(company="open.i").empty
+
+
 def test_search_by_location(stub_client: Client) -> None:
     df = stub_client.search(location="Paris")
     assert len(df) == 1


### PR DESCRIPTION
Fixes #182.

`pandas.str.contains` defaults to regex mode, so user-supplied `query`/`location`/`company` strings reached the regex engine. That's the reported ReDoS vector (catastrophic backtracking on crafted patterns), and also a plain correctness bug: `search("c++")` crashed on an invalid pattern even though the documented contract is case-insensitive **substring** matching.

Fix: `regex=False` on every filter (including the constant `"remote"` location fallback, for consistency). No behavior change for normal queries; metacharacter queries now match literally instead of crashing or backtracking.

Tests cover invalid patterns (`c++`, unclosed groups), alternation-as-literal, a catastrophic-backtracking pattern, and the location/company filters. Suite: 34 passed in `test_client.py`, full suite green, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDJYTHGuQEFnQDAeZBTJfB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDJYTHGuQEFnQDAeZBTJfB)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Match search filters literally (no regex) by setting `regex=False` in `pandas.Series.str.contains`, preventing ReDoS and crashes on inputs like "c++" and aligning with our substring contract. Fixes #182; covers `query`, `location`, `company`, and the `"remote"` check, with tests for invalid and catastrophic-backtracking patterns.

<sup>Written for commit 22639967e6feab73345cae9f1a15c26cca2ec89d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes search filters match user text literally instead of as regular expressions. The main changes are:

- Adds `regex=False` to title, location, company, and remote-location substring filters.
- Keeps matching case-insensitive while preventing regex parsing of user-supplied filters.
- Adds tests for invalid regex-like input, literal metacharacters, catastrophic-looking patterns, and location/company filters.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrow, matches the documented literal substring contract, and includes focused tests for the reported regex behavior.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Pytest suite for the client filters tests and confirmed all tests passed.
- Ran the Ruff static checks for the client filters module and confirmed all checks passed.

<a href="https://app.greptile.com/trex/runs/15487738/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/ats_scrapers/client.py | Updates all `Client.search` string filters to use literal, case-insensitive substring matching with `regex=False`, including the remote-location fallback. |
| tests/test_client.py | Adds tests showing regex metacharacters and invalid/catastrophic patterns are treated as literal text across query, location, and company filters. |

<sub>Reviews (1): Last reviewed commit: ["Match search filters literally, never as..."](https://github.com/kalil0321/ats-scrapers/commit/22639967e6feab73345cae9f1a15c26cca2ec89d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46460045)</sub>

<!-- /greptile_comment -->