### PR TITLE
Validate tenant slugs before hostname interpolation

### DIFF
--- a/src/ats_scrapers/scrapers/_slug.py
+++ b/src/ats_scrapers/scrapers/_slug.py
@@ -21,6 +21,7 @@ clear message instead of producing a request to the wrong host.
 
 from __future__ import annotations
 
+import ipaddress
 import re
 from urllib.parse import urlparse
 
@@ -49,12 +50,22 @@ def require_host_label(slug: str, *, provider: str) -> str:
 
 
 def require_http_url(url: str, *, provider: str) -> str:
-    """Return ``url`` stripped, or raise if it isn't a plain http(s) URL.
+    """Return ``url`` stripped, or raise if it isn't a public http(s) URL.
 
     For scrapers whose slug contract accepts a full careers URL
     (custom-domain tenants). Enforces scheme and the presence of a
-    hostname; rejects embedded credentials, which are a classic
-    URL-confusion vector.
+    hostname, rejects embedded credentials (a classic URL-confusion
+    vector), and refuses targets that statically identify internal
+    infrastructure: literal non-public IPs (loopback, RFC-1918,
+    link-local incl. 169.254.169.254 cloud metadata, reserved),
+    obfuscated numeric hosts, ``localhost``, single-label internal
+    hostnames, and ``.internal`` / ``.local`` names.
+
+    DNS-based checks (a public hostname *resolving* to a private IP —
+    rebinding) are out of scope for a client library: they'd require
+    resolution at validation time and are only meaningfully enforced
+    at connect time. Operators feeding untrusted tenant lists into a
+    privileged network position should additionally sandbox egress.
     """
     cleaned = url.strip()
     parsed = urlparse(cleaned)
@@ -67,4 +78,33 @@ def require_http_url(url: str, *, provider: str) -> str:
         raise ScraperError(
             f"{provider}: careers URL {url!r} must not contain credentials."
         )
+    reason = _disallowed_host(parsed.hostname.lower())
+    if reason:
+        raise ScraperError(
+            f"{provider}: careers URL {url!r} refused — {reason}. Only "
+            f"public hostnames are valid scrape targets."
+        )
     return cleaned
+
+
+def _disallowed_host(host: str) -> str | None:
+    """Return a refusal reason for hosts that identify internal targets."""
+    bare = host.rstrip(".")
+    if bare == "localhost" or bare.endswith(".localhost"):
+        return "localhost is not a public host"
+    if bare.endswith((".internal", ".local")):
+        return f"{bare!r} is an internal-network name"
+    try:
+        ip = ipaddress.ip_address(bare)
+    except ValueError:
+        # Not a well-formed IP literal. Hosts made only of digits/dots/
+        # colons/hex markers (e.g. "0177.0.0.1", "2130706433") are IP
+        # obfuscations that inet_aton-style resolvers still parse.
+        if re.fullmatch(r"[0-9xX.:]+", bare):
+            return f"{bare!r} looks like an obfuscated IP address"
+        if "." not in bare:
+            return f"single-label hostname {bare!r} is not a public name"
+        return None
+    if not ip.is_global:
+        return f"IP {bare} is not publicly routable"
+    return None

--- a/src/ats_scrapers/scrapers/_slug.py
+++ b/src/ats_scrapers/scrapers/_slug.py
@@ -1,0 +1,70 @@
+"""Tenant-identifier validation for URL construction (GH-181).
+
+Scrapers interpolate ``company_slug`` into URLs — most dangerously into
+*hostnames* (``f"https://{slug}.recruitee.com"``). Without validation a
+"slug" like ``"evil.com/x?y="`` produces a request whose host is
+``evil.com``: server-side request forgery when slugs come from
+untrusted input (e.g. community-contributed tenant CSVs run by the
+publish pipeline).
+
+Two validators, matching the two slug contracts scrapers document:
+
+- :func:`require_host_label` for bare tenant slugs that become a DNS
+  label of a fixed ATS domain;
+- :func:`require_http_url` for scrapers that accept a full careers URL
+  (custom-domain tenants) — scheme restricted to http(s) so a slug
+  can't smuggle ``file://`` or other schemes into the HTTP client.
+
+Call them at scraper construction time: bad input fails fast with a
+clear message instead of producing a request to the wrong host.
+"""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import urlparse
+
+from ats_scrapers.exceptions import ScraperError
+
+# One DNS label: letters/digits with inner hyphens, max 63 chars.
+# Deliberately no dots — a dot is exactly how a slug escapes the
+# intended parent domain.
+_HOST_LABEL_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$", re.IGNORECASE)
+
+
+def require_host_label(slug: str, *, provider: str) -> str:
+    """Return ``slug`` stripped, or raise if it can't be a DNS label.
+
+    For scrapers that build ``https://{slug}.<ats-domain>`` URLs.
+    """
+    cleaned = slug.strip()
+    if not _HOST_LABEL_RE.match(cleaned):
+        raise ScraperError(
+            f"{provider}: invalid tenant slug {slug!r} — expected a bare "
+            f"tenant name (letters, digits, hyphens), e.g. 'acme'. Slugs "
+            f"containing dots, slashes, or other separators would change "
+            f"the request host."
+        )
+    return cleaned
+
+
+def require_http_url(url: str, *, provider: str) -> str:
+    """Return ``url`` stripped, or raise if it isn't a plain http(s) URL.
+
+    For scrapers whose slug contract accepts a full careers URL
+    (custom-domain tenants). Enforces scheme and the presence of a
+    hostname; rejects embedded credentials, which are a classic
+    URL-confusion vector.
+    """
+    cleaned = url.strip()
+    parsed = urlparse(cleaned)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        raise ScraperError(
+            f"{provider}: invalid careers URL {url!r} — expected an "
+            f"http(s) URL like 'https://careers.example.com'."
+        )
+    if parsed.username or parsed.password:
+        raise ScraperError(
+            f"{provider}: careers URL {url!r} must not contain credentials."
+        )
+    return cleaned

--- a/src/ats_scrapers/scrapers/avature.py
+++ b/src/ats_scrapers/scrapers/avature.py
@@ -42,6 +42,7 @@ import httpx
 
 from ats_scrapers.exceptions import CompanyNotFoundError, ScraperError
 from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers._slug import require_host_label, require_http_url
 from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
 
 if TYPE_CHECKING:
@@ -138,6 +139,26 @@ class AvatureScraper(BaseScraper):
     for tenants on custom domains (``"https://careers.ibm.com/en_US"``)."""
 
     ats = ATSType.AVATURE
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        include_descriptions: bool = True,
+        proxy: str | None = None,
+    ) -> None:
+        super().__init__(
+            company_slug,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        slug = company_slug.strip()
+        if slug.startswith(("http://", "https://")):
+            self.company_slug = require_http_url(slug, provider="AvatureScraper")
+        else:
+            self.company_slug = require_host_label(slug, provider="AvatureScraper")
 
     def get_description(self, job: Job) -> str | None:
         if job.description:

--- a/src/ats_scrapers/scrapers/bamboohr.py
+++ b/src/ats_scrapers/scrapers/bamboohr.py
@@ -41,6 +41,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 from ats_scrapers.exceptions import ScraperError
 from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers._slug import require_host_label
 from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
 
 if TYPE_CHECKING:
@@ -124,6 +125,24 @@ class BambooHRScraper(BaseScraper):
     ats = ATSType.BAMBOOHR
 
     default_headers: ClassVar[dict[str, str]] = {"User-Agent": "Mozilla/5.0"}
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        include_descriptions: bool = True,
+        proxy: str | None = None,
+    ) -> None:
+        super().__init__(
+            company_slug,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        self.company_slug = require_host_label(
+            company_slug, provider="BambooHRScraper"
+        )
 
     def get_description(self, job: Job) -> str | None:
         if job.description:

--- a/src/ats_scrapers/scrapers/breezy.py
+++ b/src/ats_scrapers/scrapers/breezy.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, ClassVar
 from ats_scrapers import fetch as fetch_layer
 from ats_scrapers.exceptions import CompanyNotFoundError, ScraperError
 from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers._slug import require_host_label
 from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
 
 if TYPE_CHECKING:
@@ -76,6 +77,22 @@ class BreezyScraper(BaseScraper):
     ats = ATSType.BREEZY
 
     default_headers: ClassVar[dict[str, str] | None] = {"User-Agent": "Mozilla/5.0"}
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        include_descriptions: bool = True,
+        proxy: str | None = None,
+    ) -> None:
+        super().__init__(
+            company_slug,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        self.company_slug = require_host_label(company_slug, provider="BreezyScraper")
 
     def get_description(self, job: Job) -> str | None:
         if job.description:

--- a/src/ats_scrapers/scrapers/cornerstone.py
+++ b/src/ats_scrapers/scrapers/cornerstone.py
@@ -30,6 +30,7 @@ from urllib.parse import urlparse
 
 from ats_scrapers.exceptions import ScraperError
 from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers._slug import require_host_label, require_http_url
 from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
 
 if TYPE_CHECKING:
@@ -219,6 +220,9 @@ def _resolve_career_url(slug_or_url: str, site_id: int) -> tuple[str, str, int]:
     requests instead of silently using the constructor default.
     """
     if slug_or_url.startswith(("http://", "https://")):
+        # Full URL (custom career site): validate the target host before
+        # it becomes a fetch target — bare slugs land in {slug}.csod.com.
+        slug_or_url = require_http_url(slug_or_url, provider="CornerstoneScraper")
         # Try to extract slug from the URL's `?c=` query param or hostname.
         m = re.search(r"[?&]c=([^&#]+)", slug_or_url)
         if m:
@@ -229,7 +233,7 @@ def _resolve_career_url(slug_or_url: str, site_id: int) -> tuple[str, str, int]:
         site_match = re.search(r"/careersite/(\d+)/", slug_or_url)
         resolved_site_id = int(site_match.group(1)) if site_match else site_id
         return slug_or_url, slug, resolved_site_id
-    slug = slug_or_url
+    slug = require_host_label(slug_or_url, provider="CornerstoneScraper")
     return (
         f"https://{slug}.csod.com/ux/ats/careersite/{site_id}/home?c={slug}",
         slug,

--- a/src/ats_scrapers/scrapers/eightfold.py
+++ b/src/ats_scrapers/scrapers/eightfold.py
@@ -34,6 +34,7 @@ import httpx
 
 from ats_scrapers.exceptions import ScraperError
 from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers._slug import require_host_label, require_http_url
 from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
 
 if TYPE_CHECKING:
@@ -88,6 +89,10 @@ class EightfoldScraper(BaseScraper):
             include_descriptions=include_descriptions,
             proxy=proxy,
         )
+        company_slug = require_host_label(company_slug, provider="EightfoldScraper")
+        self.company_slug = company_slug
+        if base_url is not None:
+            base_url = require_http_url(base_url, provider="EightfoldScraper")
         self.base_url = (base_url or f"https://{company_slug}.eightfold.ai").rstrip("/")
         self.domain = domain or f"{company_slug}.com"
         self.company_name = company_name or company_slug.replace("-", " ").title()

--- a/src/ats_scrapers/scrapers/icims.py
+++ b/src/ats_scrapers/scrapers/icims.py
@@ -49,6 +49,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 from ats_scrapers.exceptions import ScraperError
 from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers._slug import require_host_label, require_http_url
 from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
 
 if TYPE_CHECKING:
@@ -147,7 +148,12 @@ class iCIMSScraper(BaseScraper):  # noqa: N801  matches public iCIMS branding
             include_descriptions=include_descriptions,
             proxy=proxy,
         )
-        self.base_url = self._resolve_base_url(company_slug)
+        slug = company_slug.strip()
+        if slug.startswith(("http://", "https://")):
+            self.company_slug = require_http_url(slug, provider="iCIMSScraper")
+        else:
+            self.company_slug = require_host_label(slug, provider="iCIMSScraper")
+        self.base_url = self._resolve_base_url(self.company_slug)
 
     def get_description(self, job: Job) -> str | None:
         if job.description:

--- a/src/ats_scrapers/scrapers/jazzhr.py
+++ b/src/ats_scrapers/scrapers/jazzhr.py
@@ -44,6 +44,7 @@ import httpx
 
 from ats_scrapers.exceptions import CompanyNotFoundError, ScraperError
 from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers._slug import require_host_label
 from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
 
 if TYPE_CHECKING:
@@ -136,6 +137,7 @@ class JazzHRScraper(BaseScraper):
             include_descriptions=include_descriptions,
             proxy=proxy,
         )
+        self.company_slug = require_host_label(company_slug, provider="JazzHRScraper")
         self.client_kind: ClientKind = client_kind
 
     def get_description(self, job: Job) -> str | None:

--- a/src/ats_scrapers/scrapers/personio.py
+++ b/src/ats_scrapers/scrapers/personio.py
@@ -27,6 +27,7 @@ from urllib.parse import urlparse
 
 from ats_scrapers.exceptions import CompanyNotFoundError, ScraperError
 from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers._slug import require_host_label, require_http_url
 from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
 
 if TYPE_CHECKING:
@@ -76,6 +77,26 @@ _EMPLOYMENT_TYPE_PATTERNS = {
 @ScraperRegistry.register(ATSType.PERSONIO)
 class PersonioScraper(BaseScraper):
     ats = ATSType.PERSONIO
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        include_descriptions: bool = True,
+        proxy: str | None = None,
+    ) -> None:
+        super().__init__(
+            company_slug,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        slug = company_slug.strip()
+        if slug.startswith(("http://", "https://")):
+            self.company_slug = require_http_url(slug, provider="PersonioScraper")
+        else:
+            self.company_slug = require_host_label(slug, provider="PersonioScraper")
 
     async def afetch(self) -> list[Job]:
         base = self._resolve_base_url()

--- a/src/ats_scrapers/scrapers/pinpoint.py
+++ b/src/ats_scrapers/scrapers/pinpoint.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 from ats_scrapers.exceptions import CompanyNotFoundError, ScraperError
 from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers._slug import require_host_label
 from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
 
 if TYPE_CHECKING:
@@ -83,6 +84,24 @@ class PinpointScraper(BaseScraper):
         "User-Agent": "Mozilla/5.0",
         "Accept": "application/json",
     }
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        include_descriptions: bool = True,
+        proxy: str | None = None,
+    ) -> None:
+        super().__init__(
+            company_slug,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        self.company_slug = require_host_label(
+            company_slug, provider="PinpointScraper"
+        )
 
     async def afetch(self) -> list[Job]:
         url = API_TEMPLATE.format(slug=self.company_slug)

--- a/src/ats_scrapers/scrapers/recruitee.py
+++ b/src/ats_scrapers/scrapers/recruitee.py
@@ -6,10 +6,10 @@ Recruitee exposes a clean public JSON API per tenant:
 
 Returns a single payload with every active offer — no pagination, full
 description and requirements inline. Custom domains are also supported by
-passing the bare hostname or full URL as `company_slug`.
+passing the full careers URL as `company_slug`.
 
     >>> RecruiteeScraper("monzo").fetch()
-    >>> RecruiteeScraper("careers.acme.com").fetch()
+    >>> RecruiteeScraper("https://careers.acme.com").fetch()
 """
 
 from __future__ import annotations
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 from ats_scrapers.exceptions import ScraperError
 from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers._slug import require_host_label, require_http_url
 from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
 
 if TYPE_CHECKING:
@@ -39,6 +40,26 @@ class RecruiteeScraper(BaseScraper):
     ats = ATSType.RECRUITEE
 
     default_headers: ClassVar[dict[str, str]] = {"User-Agent": "Mozilla/5.0", "Accept": "application/json"}
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        include_descriptions: bool = True,
+        proxy: str | None = None,
+    ) -> None:
+        super().__init__(
+            company_slug,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        slug = company_slug.strip()
+        if slug.startswith(("http://", "https://")):
+            self.company_slug = require_http_url(slug, provider="RecruiteeScraper")
+        else:
+            self.company_slug = require_host_label(slug, provider="RecruiteeScraper")
 
     async def afetch(self) -> list[Job]:
         api_url = self._resolve_api_url()

--- a/src/ats_scrapers/scrapers/teamtailor.py
+++ b/src/ats_scrapers/scrapers/teamtailor.py
@@ -24,6 +24,7 @@ from xml.etree import ElementTree as ET
 
 from ats_scrapers.exceptions import ScraperError
 from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers._slug import require_host_label
 from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
 
 if TYPE_CHECKING:
@@ -47,6 +48,24 @@ class TeamtailorScraper(BaseScraper):
         "User-Agent": "Mozilla/5.0",
         "Accept": "application/rss+xml, text/xml",
     }
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        include_descriptions: bool = True,
+        proxy: str | None = None,
+    ) -> None:
+        super().__init__(
+            company_slug,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        self.company_slug = require_host_label(
+            company_slug, provider="TeamtailorScraper"
+        )
 
     async def afetch(self) -> list[Job]:
         url = RSS_TEMPLATE.format(slug=self.company_slug)

--- a/tests/test_slug_validation.py
+++ b/tests/test_slug_validation.py
@@ -15,6 +15,7 @@ from ats_scrapers.scrapers import (
     AvatureScraper,
     BambooHRScraper,
     BreezyScraper,
+    CornerstoneScraper,
     EightfoldScraper,
     JazzHRScraper,
     PersonioScraper,
@@ -38,6 +39,7 @@ SLUG_OR_URL_SCRAPERS = [
     PersonioScraper,
     AvatureScraper,
     iCIMSScraper,
+    CornerstoneScraper,
 ]
 ALL_PATCHED_SCRAPERS = BARE_SLUG_SCRAPERS + SLUG_OR_URL_SCRAPERS
 

--- a/tests/test_slug_validation.py
+++ b/tests/test_slug_validation.py
@@ -1,0 +1,164 @@
+"""Tenant-slug validation tests (GH-181 SSRF fix).
+
+Scrapers that interpolate ``company_slug`` into a URL *hostname* must
+reject slugs that would change the request host (dots, slashes, query
+strings, credentials, non-http schemes). Validation happens at
+construction time via :mod:`ats_scrapers.scrapers._slug`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.scrapers import (
+    AvatureScraper,
+    BambooHRScraper,
+    BreezyScraper,
+    EightfoldScraper,
+    JazzHRScraper,
+    PersonioScraper,
+    PinpointScraper,
+    RecruiteeScraper,
+    TeamtailorScraper,
+    iCIMSScraper,
+)
+from ats_scrapers.scrapers._slug import require_host_label, require_http_url
+
+BARE_SLUG_SCRAPERS = [
+    TeamtailorScraper,
+    BreezyScraper,
+    BambooHRScraper,
+    PinpointScraper,
+    JazzHRScraper,
+    EightfoldScraper,
+]
+SLUG_OR_URL_SCRAPERS = [
+    RecruiteeScraper,
+    PersonioScraper,
+    AvatureScraper,
+    iCIMSScraper,
+]
+ALL_PATCHED_SCRAPERS = BARE_SLUG_SCRAPERS + SLUG_OR_URL_SCRAPERS
+
+
+# --- require_host_label ------------------------------------------------------
+
+
+@pytest.mark.parametrize("slug", ["acme", "ACME", "a", "10-4-truck-recruiting", "1komma5"])
+def test_host_label_accepts_valid_slugs(slug: str) -> None:
+    assert require_host_label(slug, provider="X") == slug
+
+
+def test_host_label_strips_whitespace() -> None:
+    assert require_host_label("  acme  ", provider="X") == "acme"
+
+
+@pytest.mark.parametrize(
+    "slug",
+    [
+        "evil.com",  # dot escapes the parent domain
+        "evil.com/x?y=",  # dot + path + query
+        "a/b",  # slash
+        "a?b",  # query
+        "",  # empty
+        "   ",  # whitespace only
+        "-leading",  # hyphen at edge
+        "trailing-",
+        "a" * 64,  # longer than one DNS label
+        "user:pass@host",
+        "a b",  # inner whitespace
+    ],
+)
+def test_host_label_rejects_bad_slugs(slug: str) -> None:
+    with pytest.raises(ScraperError):
+        require_host_label(slug, provider="X")
+
+
+def test_host_label_error_names_provider() -> None:
+    with pytest.raises(ScraperError, match="RecruiteeScraper"):
+        require_host_label("evil.com", provider="RecruiteeScraper")
+
+
+# --- require_http_url --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://careers.example.com",
+        "http://careers.example.com",
+        "https://careers.example.com/en_US/SearchJobs",
+    ],
+)
+def test_http_url_accepts_plain_http_urls(url: str) -> None:
+    assert require_http_url(url, provider="X") == url
+
+
+def test_http_url_strips_whitespace() -> None:
+    assert (
+        require_http_url("  https://a.example.com ", provider="X")
+        == "https://a.example.com"
+    )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "file:///etc/passwd",  # non-http scheme
+        "ftp://example.com",
+        "https://",  # no hostname
+        "https://user:pass@host",  # embedded credentials
+        "https://user@host",  # username only
+        "",  # empty
+        "evil.com",  # no scheme
+    ],
+)
+def test_http_url_rejects_bad_urls(url: str) -> None:
+    with pytest.raises(ScraperError):
+        require_http_url(url, provider="X")
+
+
+# --- construction-time enforcement per scraper -------------------------------
+
+
+@pytest.mark.parametrize("scraper_cls", ALL_PATCHED_SCRAPERS)
+def test_hostile_slug_rejected_at_construction(scraper_cls: type) -> None:
+    with pytest.raises(ScraperError):
+        scraper_cls("evil.com/x?y=")
+
+
+@pytest.mark.parametrize("scraper_cls", SLUG_OR_URL_SCRAPERS)
+def test_file_scheme_rejected(scraper_cls: type) -> None:
+    with pytest.raises(ScraperError):
+        scraper_cls("file:///etc/passwd")
+
+
+@pytest.mark.parametrize("scraper_cls", SLUG_OR_URL_SCRAPERS)
+def test_credentialed_url_rejected(scraper_cls: type) -> None:
+    with pytest.raises(ScraperError):
+        scraper_cls("https://user:pass@host")
+
+
+@pytest.mark.parametrize("scraper_cls", ALL_PATCHED_SCRAPERS)
+def test_normal_slug_constructs(scraper_cls: type) -> None:
+    scraper = scraper_cls("acme")
+    assert scraper.company_slug == "acme"
+
+
+@pytest.mark.parametrize("scraper_cls", SLUG_OR_URL_SCRAPERS)
+def test_full_url_slug_constructs(scraper_cls: type) -> None:
+    scraper = scraper_cls("https://careers.example.com")
+    assert scraper.company_slug == "https://careers.example.com"
+
+
+def test_eightfold_base_url_validated() -> None:
+    with pytest.raises(ScraperError):
+        EightfoldScraper("acme", base_url="file:///etc/passwd")
+    with pytest.raises(ScraperError):
+        EightfoldScraper("acme", base_url="https://user:pass@host")
+
+
+def test_eightfold_valid_base_url_constructs() -> None:
+    s = EightfoldScraper("acme", base_url="https://apply.careers.example.com")
+    assert s.base_url == "https://apply.careers.example.com"

--- a/tests/test_slug_validation.py
+++ b/tests/test_slug_validation.py
@@ -119,6 +119,36 @@ def test_http_url_rejects_bad_urls(url: str) -> None:
         require_http_url(url, provider="X")
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:8080/admin",          # loopback
+        "http://[::1]/",                        # IPv6 loopback
+        "http://169.254.169.254/latest/meta-data/",  # cloud metadata
+        "http://10.0.0.5/",                     # RFC-1918
+        "http://172.16.3.4/",                   # RFC-1918
+        "http://192.168.1.1/",                  # RFC-1918
+        "http://0.0.0.0/",                      # unspecified
+        "http://localhost/x",                   # localhost by name
+        "http://foo.localhost/",                # .localhost suffix
+        "http://metadata.google.internal/",     # .internal name
+        "http://printer.local/",                # .local name
+        "http://intranet/",                     # single-label host
+        "http://0177.0.0.1/",                   # octal-obfuscated 127.0.0.1
+        "http://2130706433/",                   # decimal-obfuscated 127.0.0.1
+    ],
+)
+def test_http_url_rejects_internal_targets(url: str) -> None:
+    """GH-181's explicit ask: private ranges and metadata endpoints
+    must not be reachable through the full-URL slug contract."""
+    with pytest.raises(ScraperError, match="refused"):
+        require_http_url(url, provider="X")
+
+
+def test_http_url_accepts_public_ip_literal() -> None:
+    assert require_http_url("https://8.8.8.8/jobs", provider="X")
+
+
 # --- construction-time enforcement per scraper -------------------------------
 
 


### PR DESCRIPTION
Fixes #181.

## The vector

Ten scrapers interpolate `company_slug` into request **hostnames** (`f"https://{slug}.recruitee.com"` and friends). A "slug" like `"evil.com/x?y="` produced a request whose actual host is `evil.com` — SSRF when slugs come from untrusted input, which they do: the publish pipeline runs community-contributed CSV rows server-side.

## The fix

New `scrapers/_slug.py`, applied at construction time so bad input fails fast with a clear message:

- **`require_host_label`** — bare tenant slugs must be a single DNS label (letters/digits/inner hyphens, ≤63 chars, **no dots** — a dot is exactly how a slug escapes the intended parent domain). Applied to teamtailor, breezy, bamboohr, pinpoint, jazzhr, eightfold.
- **`require_http_url`** — slug contracts that accept a full careers URL (custom-domain tenants): http(s) scheme enforced (no `file://` smuggling), hostname required, embedded credentials rejected. Applied to the URL branch of personio, avature, icims, and recruitee — recruitee was reclassified as slug-or-URL during implementation because its custom-domain tenants legitimately pass full URLs (existing tests and the pipeline's `_recruitee_slug` depend on it). Eightfold's explicit `base_url` parameter is validated the same way.

Deliberately out of scope: slug interpolation into URL *paths* on fixed ATS hosts (greenhouse, lever, ashby, …) — it cannot change the request host. Workday and Taleo already validate their full-URL slugs.

Also corrects recruitee's docstring example: the documented bare dotted-hostname form (`RecruiteeScraper("careers.acme.com")`) always produced a broken `careers.acme.com.recruitee.com` URL — custom domains take the full https URL.

## Verified against real data

All tenant CSVs under `ats-companies/` were checked against the new rules: every bare slug in use is a clean host label; recruitee's 11 custom-domain rows and avature's 3 URL-form rows go through the URL branch exactly as the pipeline already passes them.

## Testing

New `tests/test_slug_validation.py`: validator unit tests (dots/slashes/query/empty/credentials/`file://`/oversized rejected), parametrized malicious-slug construction across all 10 scrapers, `file:///etc/passwd` + credential-URL rejection for the slug-or-URL group, and positive constructions for every scraper. Full suite on the rebased branch: **1144 passed**, 2 skipped; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDJYTHGuQEFnQDAeZBTJfB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDJYTHGuQEFnQDAeZBTJfB)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened SSRF protection by validating tenant slugs and full-URL inputs at construction and rejecting private/internal targets. Added Cornerstone validation; Recruitee custom-domain tenants now require a full https URL.

- **Bug Fixes**
  - Added `require_host_label` and `require_http_url` in `ats_scrapers/scrapers/_slug.py` to validate DNS labels and plain http(s) URLs (no dots in labels, hostname required, no credentials, no non-http schemes). The URL validator now also refuses internal targets: localhost/loopback (v4/v6), RFC1918 ranges, `169.254.169.254`, single-label hosts, `.internal`/`.local` names, and obfuscated IPs; public hosts and public IP literals are allowed.
  - Applied `require_host_label` to `TeamtailorScraper`, `BreezyScraper`, `BambooHRScraper`, `PinpointScraper`, `JazzHRScraper`, `EightfoldScraper`, and `CornerstoneScraper`; applied `require_http_url` to URL-accepting paths in `PersonioScraper`, `AvatureScraper`, `iCIMSScraper`, `RecruiteeScraper`, and `CornerstoneScraper`. Validates `EightfoldScraper`’s `base_url` too.
  - Updated Recruitee docs: custom domains must pass a full `https://` careers URL. Expanded `tests/test_slug_validation.py` to cover internal-target rejection, Cornerstone, and positive cases.

- **Migration**
  - If you pass a custom domain to `RecruiteeScraper`, use the full URL (e.g., `https://careers.example.com`) instead of a bare hostname. No other changes required.

<sup>Written for commit a6f901a55ff6e1cd4cadb746725d584787ef2b9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds validation for scraper tenant slugs and URL-form inputs. The main changes are:

- Added shared helpers for single-label tenant slugs and public `http(s)` careers URLs.
- Applied validation across the affected hostname-interpolating scrapers.
- Updated Recruitee custom-domain usage to require a full careers URL.
- Added tests for malicious slugs, unsafe URL schemes, credentialed URLs, internal targets, and valid construction cases.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changed code consistently validates bare hostname labels and URL-form inputs before constructing fetch targets. The tests cover the original host-escape vector and the previously discussed internal-target cases. No blocking correctness or security issues were found.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Pytest suite for slug validation and confirmed all tests executed with exit code 0; 350 tests were collected and 350 passed, including malicious slug/URL rejection cases.
- Ran the Ruff linter on slug validation and confirmed the run finished with exit code 0 and All checks passed.

<a href="https://app.greptile.com/trex/runs/15490377/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/ats_scrapers/scrapers/_slug.py | Adds shared host-label and public `http(s)` URL validators; no blocking issues found. |
| src/ats_scrapers/scrapers/cornerstone.py | Validates Cornerstone full career-site URLs and bare `csod` slugs before constructing fetch targets; no blocking issues found. |
| src/ats_scrapers/scrapers/eightfold.py | Validates Eightfold subdomain slugs and optional base URLs before using them as request targets; no blocking issues found. |
| src/ats_scrapers/scrapers/recruitee.py | Validates Recruitee bare slugs versus full custom-domain URLs and updates the docstring example; no blocking issues found. |
| tests/test_slug_validation.py | Adds validator and scraper construction tests for malicious slugs and unsafe URL inputs; no blocking issues found. |

<sub>Reviews (2): Last reviewed commit: ["Validate Cornerstone slugs too (GH-181)"](https://github.com/kalil0321/ats-scrapers/commit/a6f901a55ff6e1cd4cadb746725d584787ef2b9a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46462429)</sub>

<!-- /greptile_comment -->