### PR TITLE
Harden unknown-source handling; add ScraperRegistry.has_scraper (GH-185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ remove the need to know the `(ats, slug)` pair:
   the hosted companies directory (`Client.companies()`, cached
   in-process; exact matches rank first).
 
+### Added — `ScraperRegistry.has_scraper(ats)`
+
+Skip dataset sources this package can't scrape yet without catching
+`ScraperError` (GH-185). The hosted dataset can list a source before a
+matching scraper ships — `search()` already tolerates that; this makes
+the scraper side symmetric.
+
 ## [0.1.0] — 2026-07-22
 
 Initial release of `ats-scrapers`:

--- a/README.md
+++ b/README.md
@@ -112,7 +112,17 @@ Scraper adapters include:
   Welcome to the Jungle, and others.
 
 Run `python -c "from ats_scrapers import list_ats; print(*list_ats())"` for the
-sources currently present in the hosted dataset.
+sources currently present in the hosted dataset. The dataset can list a source
+before this package ships a scraper for it — `search()` still returns those
+rows; only building your own scraper needs one. To skip sources without a
+scraper:
+
+```python
+from ats_scrapers import list_ats
+from ats_scrapers.scrapers import ScraperRegistry, get_scraper
+
+scrapeable = [a for a in list_ats() if ScraperRegistry.has_scraper(a)]
+```
 
 ## Contributing
 

--- a/src/ats_scrapers/scrapers/base.py
+++ b/src/ats_scrapers/scrapers/base.py
@@ -184,6 +184,22 @@ class ScraperRegistry:
     def all(cls) -> dict[ATSType, type[BaseScraper]]:
         return dict(cls._scrapers)
 
+    @classmethod
+    def has_scraper(cls, ats: ATSType | str) -> bool:
+        """Whether a scraper is registered for ``ats``.
+
+        Lets callers skip dataset sources this package can't scrape yet
+        (the hosted dataset can list a source before a scraper ships)
+        instead of catching :class:`ScraperError` from ``get``:
+
+        >>> ats = [a for a in list_ats() if ScraperRegistry.has_scraper(a)]
+        """
+        try:
+            ats_enum = ATSType(ats) if isinstance(ats, str) else ats
+        except ValueError:
+            return False
+        return ats_enum in cls._scrapers
+
 
 def get_scraper(ats: ATSType | str, company_slug: str, **kwargs: object) -> BaseScraper:
     """Convenience: lookup + instantiate in one step."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -213,6 +213,34 @@ def test_load_uses_uuid_for_invalid_legacy_ats_id(stub_client: Client) -> None:
     assert str(UUID(value)) == value
 
 
+# A source name the installed package's ATSType enum does NOT contain.
+# The hosted manifest can list a source before this package ships a
+# matching scraper; that must never break the dataset client (GH-185).
+_UNKNOWN_SOURCE = "futuristic_ats_9000"
+
+
+def test_manifest_validates_with_unknown_source() -> None:
+    """The exact step that crashed in GH-185: validating a live manifest
+    whose ``by_ats`` carries a source the local enum has never heard of."""
+    from ats_scrapers.manifest import Manifest
+    from ats_scrapers.models import ATSType
+
+    assert _UNKNOWN_SOURCE not in {a.value for a in ATSType}
+    manifest = Manifest.model_validate(
+        {
+            "version": "1.0",
+            "generated_at": "2026-07-22T00:00:00+00:00",
+            "stats": {"total_jobs": 1, "total_companies": 1, "ats_count": 1},
+            "all": {"csv": "https://x/all.csv", "rows": 1, "size_bytes": 1},
+            "by_ats": {
+                _UNKNOWN_SOURCE: {"csv": "https://x/f.csv", "rows": 1, "size_bytes": 1},
+            },
+        }
+    )
+    assert _UNKNOWN_SOURCE in manifest.by_ats
+    assert manifest.url_for_ats(_UNKNOWN_SOURCE, prefer_parquet=False) == "https://x/f.csv"
+
+
 def test_load_accepts_manifest_source_not_in_local_enum(
     stub_client: Client,
 ) -> None:
@@ -220,11 +248,26 @@ def test_load_accepts_manifest_source_not_in_local_enum(
         update={
             "by_ats": {
                 **stub_client.manifest.by_ats,
-                "beisen": stub_client.manifest.by_ats["greenhouse"],
+                _UNKNOWN_SOURCE: stub_client.manifest.by_ats["greenhouse"],
             }
         }
     )
-    assert len(stub_client.load(ats="beisen")) == 4
+    assert len(stub_client.load(ats=_UNKNOWN_SOURCE)) == 4
+
+
+def test_search_full_snapshot_tolerates_unknown_ats_rows(stub_client: Client) -> None:
+    """search() over the full snapshot must not choke on rows whose
+    ats_type isn't a known enum member — the beginner's default path."""
+    original = stub_client._download
+
+    def download_with_unknown(url: str) -> pd.DataFrame:
+        df = original(url)
+        df.loc[0, "ats_type"] = _UNKNOWN_SOURCE
+        return df
+
+    stub_client._download = download_with_unknown  # type: ignore[method-assign]
+    result = stub_client.search(query="engineer")
+    assert not result.empty
 
 
 def test_client_defaults_to_csv_without_parquet_engine(

--- a/tests/test_scrapers.py
+++ b/tests/test_scrapers.py
@@ -88,6 +88,16 @@ def test_registry_returns_copy_so_external_mutation_is_safe() -> None:
     assert ATSType.GREENHOUSE in ScraperRegistry.all()
 
 
+def test_has_scraper() -> None:
+    assert ScraperRegistry.has_scraper("greenhouse") is True
+    assert ScraperRegistry.has_scraper(ATSType.GREENHOUSE) is True
+    # A dataset source with no scraper yet (GH-185): known enum member
+    # but unregistered.
+    assert ScraperRegistry.has_scraper("beisen") is False
+    # A source name not even in the enum must not raise.
+    assert ScraperRegistry.has_scraper("futuristic_ats_9000") is False
+
+
 def test_register_decorator_adds_new_scraper() -> None:
     @ScraperRegistry.register(ATSType.CUSTOM)
     class TempScraper(BaseScraper):


### PR DESCRIPTION
Fixes #185.

## Background

`search()` raised a pydantic `ValidationError` because the hosted manifest listed `beisen`, a source the installed `jobhive-py` didn't know. The crash itself is **already fixed** on `main` / in `ats-scrapers` 0.1.0 — the audit changed `Manifest.by_ats` to string keys, so an unknown source no longer fails validation. This PR makes that guarantee durable and implements the issue's feature request.

## Changes

**Regression tests that actually test the thing.** `test_load_accepts_manifest_source_not_in_local_enum` used `"beisen"` — which has since been *added* to the `ATSType` enum, so it no longer exercised the unknown-source path. Retargeted at a genuinely-unknown source (`"futuristic_ats_9000"`) and pinned the tolerance at all three levels touched at runtime:
- `Manifest.model_validate` with an unknown `by_ats` key (the exact step that crashed);
- `Client.load(ats=<unknown>)`;
- `search()` over a snapshot containing unknown `ats_type` rows.

**`ScraperRegistry.has_scraper(ats)`** — the issue asked to "bypass any ATS that does not have a scraper built yet." For the dataset client that's already true (`search()` works regardless). This makes the scraper side symmetric, so iterating sources doesn't require catching `ScraperError`:

```python
scrapeable = [a for a in list_ats() if ScraperRegistry.has_scraper(a)]
```

Returns `False` for both known-but-unregistered sources (`beisen`) and names not even in the enum — never raises. README documents the filter; CHANGELOG updated.

## Testing

Full suite **1167 passed**, 2 skipped, ruff clean.

## Note

The original crash is already resolved in the current release — `pip install -U ats-scrapers` (the project was renamed from `jobhive-py`) picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDJYTHGuQEFnQDAeZBTJfB

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens handling for hosted dataset sources that are not supported by the local scraper package. The main changes are:

- Added `ScraperRegistry.has_scraper(ats)` for checking scraper availability without raising.
- Added tests for unknown ATS values in manifest validation, `Client.load`, `search()`, and the scraper registry.
- Updated the README and changelog with the new scraper-filtering workflow.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The code change is small, localized, and covered by tests for registered, known-unregistered, and unknown ATS values. No runtime, data handling, or security issues were identified in the changed paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the client regression proof by examining the unknown\_client-02-after.log.
- Reviewed the registry regression proof by examining the unknown\_registry-02-after.log.
- Executed the direct smoke test script has\_scraper\_smoke.py and reviewed the results in has\_scraper\_smoke-02-after.log.
- Validated code quality and style by inspecting the Ruff proof in ruff\_changed\_python-02-after.log.

<a href="https://app.greptile.com/trex/runs/15491459/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/ats_scrapers/scrapers/base.py | Adds `ScraperRegistry.has_scraper`, returning `False` for known-unregistered and unknown ATS strings without raising. |
| tests/test_client.py | Expands tests for manifest validation, `Client.load`, and `search()` with an ATS source absent from the local enum. |
| tests/test_scrapers.py | Adds registry tests for `has_scraper` across registered, known-unregistered, and unknown ATS values. |
| README.md | Adds usage guidance for filtering hosted dataset sources to those with registered scrapers. |
| CHANGELOG.md | Documents the new `ScraperRegistry.has_scraper(ats)` addition and unknown dataset-source tolerance. |

<sub>Reviews (1): Last reviewed commit: ["Harden unknown-source handling and add h..."](https://github.com/kalil0321/ats-scrapers/commit/9fedb994376ac99ba64c375132b49153d003cefe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46466602)</sub>

<!-- /greptile_comment -->