### PR TITLE
Fix PyPI README badges (stale camo cache)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 An open dataset and Python toolkit for job data from ATS platforms and public
 sources.
 
-[![PyPI](https://img.shields.io/pypi/v/ats-scrapers.svg?color=brightgreen)](https://pypi.org/project/ats-scrapers/)
-[![Python](https://img.shields.io/pypi/pyversions/ats-scrapers.svg?color=brightgreen)](https://pypi.org/project/ats-scrapers/)
-[![License](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://github.com/kalil0321/ats-scrapers/blob/main/LICENSE)
+[![PyPI version](https://img.shields.io/pypi/v/ats-scrapers)](https://pypi.org/project/ats-scrapers/)
+[![Python versions](https://img.shields.io/pypi/pyversions/ats-scrapers)](https://pypi.org/project/ats-scrapers/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green)](https://github.com/kalil0321/ats-scrapers/blob/main/LICENSE)
 
 `ats-scrapers` provides two layers:
 


### PR DESCRIPTION
## Problem

The PyPI version and Python-versions badges render **"package or version not found"** even though `ats-scrapers` 0.1.0 is live on PyPI with correct metadata (`requires-python >=3.11`, full Python classifiers — verified against the PyPI JSON API).

## Cause

The badges were added to the README in the rename PR (#186), days before the package was published. GitHub proxies external images through its camo cache; it fetched shields.io's pre-publish **404** and has been serving that stale render since. Nothing is wrong with PyPI or the badge syntax.

## Fix

Changing the badge image URLs makes GitHub mint fresh camo URLs, which re-fetch shields.io's now-valid result. Dropped the `.svg?color=brightgreen` override so the version and pyversions badges show their natural shields.io state.

After merge, the badges resolve on `main`'s README; a browser hard-refresh may be needed to clear a locally cached image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDJYTHGuQEFnQDAeZBTJfB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDJYTHGuQEFnQDAeZBTJfB)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken PyPI badges in the README by updating image URLs so GitHub fetches current data. Also normalizes badge styles and the license label for consistency.

- **Bug Fixes**
  - Updated PyPI version and Python versions badges for `ats-scrapers` to new shields URLs to trigger a fresh GitHub image fetch; removed color overrides to use default styling.
  - Changed the license badge label to "License: MIT" and color to green.

<sup>Written for commit 8c935fb22562834e3886cb4a774bbf454c75fce6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the README badges to refresh GitHub's cached badge images. The main changes are:

- Updated the PyPI version badge URL and label.
- Updated the Python versions badge URL and label.
- Updated the license badge URL and label.

<h3>Confidence Score: 5/5</h3>

This documentation-only PR is safe to merge.

The diff only changes README badge URLs and labels, matching the stated cache-refresh intent. No code, configuration, or runtime behavior is changed.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the pre-change readme\_badges-01-before.log to confirm stale badge URLs and missing PyPI labels.
- Validated the after-state by inspecting readme\_badges-02-after.log and confirming the badge endpoints return HTTP 200 OK and that STALE\_COLOR\_OVERRIDE\_PRESENT is False.
- Verified PyPI metadata in the after state shows version 0.1.0, requires\_python \>=3.11, and classifiers for Python 3.11–3.13.

<a href="https://app.greptile.com/trex/runs/15492763/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Updates README badge image URLs and labels to refresh PyPI/Python version badge rendering without changing package behavior. |

<sub>Reviews (1): Last reviewed commit: ["Fix PyPI README badges (stale camo cache..."](https://github.com/kalil0321/ats-scrapers/commit/8c935fb22562834e3886cb4a774bbf454c75fce6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46472677)</sub>

<!-- /greptile_comment -->