### PR TITLE
Wire Moka into the production pipeline runner

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -66,6 +66,7 @@ from ats_scrapers.scrapers import (
     ManfredScraper,
     MercorScraper,
     MetaScraper,
+    MokaScraper,
     OracleScraper,
     PersonioScraper,
     PhenomScraper,
@@ -251,6 +252,28 @@ def _ashby_slug(row: dict[str, Any]) -> str | None:
             return m.group(1).lower()
     name = (row.get("name") or "").strip()
     return name or None
+
+
+def _moka_slug(row: dict[str, Any]) -> str | None:
+    if (slug := _slug_col(row)):
+        return slug
+    raw = (row.get("url") or "").strip()
+    if raw:
+        parsed = urlparse(raw)
+        host = parsed.netloc.casefold()
+        segments = [segment for segment in parsed.path.split("/") if segment]
+        if (
+            host in {"app.mokahr.com", "hire-r1.mokahr.com"}
+            and len(segments) >= 3
+            and segments[0] in {"social-recruitment", "campus-recruitment"}
+            and segments[2].isdigit()
+        ):
+            prefix = "hire-r1/" if host == "hire-r1.mokahr.com" else ""
+            recruitment_type = (
+                "/campus" if segments[0] == "campus-recruitment" else ""
+            )
+            return f"{prefix}{segments[1]}/{segments[2]}{recruitment_type}"
+    return (row.get("name") or "").strip() or None
 
 
 def _oracle_slug(row: dict[str, Any]) -> str | None:
@@ -478,6 +501,12 @@ CONFIGS: dict[str, dict[str, Any]] = {
         "defer_descriptions_to_cache": True,
         "description_cache_path": "gupy/descriptions.sqlite3",
         "description_cache_compress": True,
+    },
+    "moka": {
+        "scraper": MokaScraper,
+        "slug": _moka_slug,
+        "csv": "ats-companies/moka.csv",
+        "output": "moka/jobs.csv",
     },
     "darwinbox": {
         "scraper": DarwinboxScraper,

--- a/tests/test_run_pipeline_guards.py
+++ b/tests/test_run_pipeline_guards.py
@@ -48,6 +48,24 @@ def test_provider_slug_normalizers_match_current_company_csv_shape() -> None:
     assert runner.CONFIGS["darwinbox"]["slug"](darwinbox_row) == "pwc.com"
     assert runner.CONFIGS["darwinbox"]["output"] == "darwinbox/jobs.csv"
 
+    moka_row = {
+        "name": "Trip.com Group",
+        "slug": "trip/70415",
+        "url": "https://app.mokahr.com/social-recruitment/trip/70415",
+    }
+    assert runner.CONFIGS["moka"]["scraper"] is runner.MokaScraper
+    assert runner.CONFIGS["moka"]["slug"](moka_row) == "trip/70415"
+    assert runner.CONFIGS["moka"]["output"] == "moka/jobs.csv"
+    assert runner.CONFIGS["moka"]["slug"](
+        {
+            "name": "Klook",
+            "url": (
+                "https://hire-r1.mokahr.com/"
+                "campus-recruitment/klook/100008011/jobs"
+            ),
+        }
+    ) == "hire-r1/klook/100008011/campus"
+
     beisen_row = {
         "name": "Mengniu Dairy",
         "slug": "mengniu",


### PR DESCRIPTION
## Summary
- wire the existing Moka scraper and tenant CSV into the production pipeline runner
- preserve explicit compound Moka slugs
- derive missing compound slugs from both `app.mokahr.com` and `hire-r1.mokahr.com` URLs, including campus boards
- add runner guard coverage for explicit and legacy `name,url` rows

## Validation
- `uvx ruff check scripts/run_pipeline.py tests/test_run_pipeline_guards.py`
- focused runner guards: 16 passed
- `pytest -q -m "not live"`: 1,294 passed, 2 skipped, 20 deselected
- `uv build`
