### PR TITLE
Add 29 discovered Beisen tenants

### DIFF
--- a/ats-companies/beisen.csv
+++ b/ats-companies/beisen.csv
@@ -7,6 +7,7 @@ Mindray,mindray,https://mindray.zhiye.com
 Starbucks China,starbucks,https://starbucks.zhiye.com
 Uniqlo China,uniqlo,https://uniqlo.zhiye.com
 Vivo,vivo,https://vivo.zhiye.com
+2345 Network,2345,https://2345.zhiye.com
 360 Group Campus,360campus,https://360campus.zhiye.com
 3SBio,3sbio,https://3sbio.zhiye.com
 51Talk,51talk,https://51talk.zhiye.com
@@ -17,13 +18,17 @@ AUX Group,auxgroup,https://auxgroup.zhiye.com
 BAIC Group,baicgroup,https://baicgroup.zhiye.com
 Bank of Beijing,bankofbeijing,https://bankofbeijing.zhiye.com
 Bank of Suzhou,suzhoubank,https://suzhoubank.zhiye.com
+Beisen,beisen,https://beisen.zhiye.com
+Bestore,lppz,https://lppz.zhiye.com
 Bette Pharmaceutical,btyy,https://btyy.zhiye.com
+BGI Genomics,genomics,https://genomics.zhiye.com
 Biwin Storage,biwin,https://biwin.zhiye.com
 Canon China,canon,https://canon.zhiye.com
 CCD Cabin Design,ccd,https://ccd.zhiye.com
 CETC Chip Technology,cetccq,https://cetccq.zhiye.com
 Changan Auto,changan,https://changan.zhiye.com
 ChangXin Memory (CXMT),cxmt,https://cxmt.zhiye.com
+Chimelong Group,chimelong,https://chimelong.zhiye.com
 China Merchants Group,cmhk,https://cmhk.zhiye.com
 China Unicom,chinaunicom,https://chinaunicom.zhiye.com
 China Unicom (Legacy),unicom,https://unicom.zhiye.com
@@ -33,8 +38,12 @@ CTTQ Pharma,cttq,https://cttq.zhiye.com
 Dahua,dahua,https://dahua.zhiye.com
 Delixi,delixi,https://delixi.zhiye.com
 Denso China,denso,https://denso.zhiye.com
+Digital China Information Service,dcits,https://dcits.zhiye.com
 Dongfeng Nissan,dongfengnissan,https://dongfengnissan.zhiye.com
+Dongwu Securities,dwzq,https://dwzq.zhiye.com
 ENN Group,enn,https://enn.zhiye.com
+Everbright Securities,ebscn,https://ebscn.zhiye.com
+Gejian Semiconductor,gejian-semi,https://gejian-semi.zhiye.com
 Genertec,genertec,https://genertec.zhiye.com
 Goldwind,goldwind,https://goldwind.zhiye.com
 Gotion High-Tech,gotion,https://gotion.zhiye.com
@@ -49,12 +58,21 @@ Hollyland,hollyland,https://hollyland.zhiye.com
 Hudong-Zhonghua Shipbuilding,hudong,https://hudong.zhiye.com
 Huolala (Lalamove),huolala,https://huolala.zhiye.com
 Hupu,hupu,https://hupu.zhiye.com
+iFLYTEK,iflytek,https://iflytek.zhiye.com
+INTSIG,intsig,https://intsig.zhiye.com
+Itcast Education,itcast,https://itcast.zhiye.com
 JAC Motors,jac,https://jac.zhiye.com
 JMC (Jiangling Motors),jmc,https://jmc.zhiye.com
 Kaiyue Group,mu,https://mu.zhiye.com
+KE Holdings Campus,campuske,https://campuske.zhiye.com
+KTC Technology,careerktc,https://careerktc.zhiye.com
+Kylinsoft,kylinos,https://kylinos.zhiye.com
+Leapmotor,leapmotor,https://leapmotor.zhiye.com
 Lvshou,lvshou,https://lvshou.zhiye.com
 Manner Coffee,mannercoffee,https://mannercoffee.zhiye.com
 Michelin China,michelin,https://michelin.zhiye.com
+Moore Threads,mthreads,https://mthreads.zhiye.com
+NovaStar,novastar,https://novastar.zhiye.com
 OMRON China,omron,https://omron.zhiye.com
 PICC,picc,https://picc.zhiye.com
 Poly Developments,polycareer,https://polycareer.zhiye.com
@@ -65,27 +83,38 @@ Sansure Biotech,sansurehr,https://sansurehr.zhiye.com
 Sany,sany,https://sany.zhiye.com
 Seven Star (Huachuang Precision),sevenstar,https://sevenstar.zhiye.com
 Shanghai Industrial Investment (SIIC),siic,https://siic.zhiye.com
+SHAREit Group,share,https://share.zhiye.com
 Shenergy,shenergy,https://shenergy.zhiye.com
 Shiseido China,shiseido,https://shiseido.zhiye.com
+SIASUN Robot & Automation,siasun,https://siasun.zhiye.com
 Sinopharm Guoda,guoyao,https://guoyao.zhiye.com
 Sinotrans,sinotrans,https://sinotrans.zhiye.com
 Solar East,solareast,https://solareast.zhiye.com
+Star-net Group,starnet,https://starnet.zhiye.com
+Streamax Technology,streamax,https://streamax.zhiye.com
 Sugon,sugon,https://sugon.zhiye.com
 Sunwoda,sunwoda,https://sunwoda.zhiye.com
+Tmall Auto Care,ncarzonezp,https://ncarzonezp.zhiye.com
 Tongwei,tongwei,https://tongwei.zhiye.com
+TOPSEC,topsec,https://topsec.zhiye.com
 Transsion Holdings,transsion,https://transsion.zhiye.com
 Tsingtao Brewery,tsingtao,https://tsingtao.zhiye.com
+Tuniu,tuniu,https://tuniu.zhiye.com
 UCloud,ucloud,https://ucloud.zhiye.com
 Uni-President China,uni-president,https://uni-president.zhiye.com
 Wasion Electric,wasionelectric,https://wasionelectric.zhiye.com
+WEGO Group,weigao,https://weigao.zhiye.com
 Weichai,weichai,https://weichai.zhiye.com
 Wondershare Campus,wondersharecampus,https://wondersharecampus.zhiye.com
 WuXi AppTec,wuxiapptec,https://wuxiapptec.zhiye.com
 Xinhua Group,xinhua,https://xinhua.zhiye.com
 Yaskawa China,yaskawa,https://yaskawa.zhiye.com
+Yealink,yealink,https://yealink.zhiye.com
+Yiming Food,inm,https://inm.zhiye.com
 YMTC (Yangtze Memory),ymtc,https://ymtc.zhiye.com
 ZCZY,zczy,https://zczy.zhiye.com
 Zhejiang Daily Press Group,zjrbjob,https://zjrbjob.zhiye.com
+Zhejiang Tailong Commercial Bank,zjtlcb,https://zjtlcb.zhiye.com
 Zhenghai Magnetics,zhmag,https://zhmag.zhiye.com
 Zhenghai Tech,zh-tech,https://zh-tech.zhiye.com
 Zongshen,zongshen,https://zongshen.zhiye.com


### PR DESCRIPTION
## Summary
- add 29 previously untracked Beisen tenants discovered from public career-URL references
- keep one canonical `zhiye.com` subdomain per tenant
- exclude empty boards, legacy-only portals, and all PortalId aliases

## Live validation
- fetched every added tenant end-to-end through `BeisenScraper`
- 29/29 tenants returned live jobs
- 5,688 jobs total
- no duplicate job IDs within any tenant
- no PortalId overlap with the 90 existing Beisen tenants
- 119 total CSV rows with unique slugs and URLs

## Scope
- tenant data only: `ats-companies/beisen.csv`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added 29 new Beisen tenants to `ats-companies/beisen.csv`, expanding coverage by 5,688 live jobs.

- **New Features**
  - One canonical `zhiye.com` subdomain per tenant; excluded empty boards, legacy-only portals, and PortalId aliases.
  - Validated via `BeisenScraper`: 29/29 tenants return jobs; no duplicate job IDs; no PortalId overlap with existing tenants.

<sup>Written for commit 042b5d8fb35048e19c14b8b561d1a7106f110059. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

