### PR TITLE
Add 26 discovered Moka boards

### DIFF
--- a/ats-companies/moka.csv
+++ b/ats-companies/moka.csv
@@ -36,7 +36,9 @@ AMEC,amec/28371,https://app.mokahr.com/social-recruitment/amec/28371
 Ant Group,antgroup/47145,https://app.mokahr.com/social-recruitment/antgroup/47145
 Appotronics,ylxinc/140729,https://app.mokahr.com/social-recruitment/ylxinc/140729
 AutoX,autox/6312,https://app.mokahr.com/social-recruitment/autox/6312
+BAAI,baai/42173,https://app.mokahr.com/social-recruitment/baai/42173
 Bairong Inc,100credit/92460,https://app.mokahr.com/social-recruitment/100credit/92460
+BATF Group Campus,batf/144997/campus,https://app.mokahr.com/campus-recruitment/batf/144997
 Bayer,bayer/148387,https://app.mokahr.com/social-recruitment/bayer/148387
 BeiGene,beigene/98934,https://app.mokahr.com/social-recruitment/beigene/98934
 Beijing Bole Technology,bolegames/37642,https://app.mokahr.com/social-recruitment/bolegames/37642
@@ -45,16 +47,21 @@ Biren Technology,biren/44726,https://app.mokahr.com/social-recruitment/biren/447
 Bitget,hire-r1/bitget/100000079,https://hire-r1.mokahr.com/social-recruitment/bitget/100000079
 BYD,byd/40205,https://app.mokahr.com/social-recruitment/byd/40205
 Cambricon,cambricon/1113,https://app.mokahr.com/social-recruitment/cambricon/1113
+Cambricon Campus,cambricon/44201/campus,https://app.mokahr.com/campus-recruitment/cambricon/44201
 Carlsberg China,carlsberg/6730,https://app.mokahr.com/social-recruitment/carlsberg/6730
 CCTV,cctv/19935,https://app.mokahr.com/social-recruitment/cctv/19935
 Chaitin Tech,chaitin/118126,https://app.mokahr.com/social-recruitment/chaitin/118126
+Changyou Campus,cyou-inc/42233/campus,https://app.mokahr.com/campus-recruitment/cyou-inc/42233
 China Datang,datang/29343,https://app.mokahr.com/social-recruitment/datang/29343
 China Telecom,chinatelecom/71984,https://app.mokahr.com/social-recruitment/chinatelecom/71984
 China Vanke,vanke/36266,https://app.mokahr.com/social-recruitment/vanke/36266
+CloudWalk Campus,cloudwalk/4872/campus,https://app.mokahr.com/campus-recruitment/cloudwalk/4872
 Columbia Sportswear,columbia/57872,https://app.mokahr.com/social-recruitment/columbia/57872
 Comau,comau/98393,https://app.mokahr.com/social-recruitment/comau/98393
 Costa Coffee,costa/92534,https://app.mokahr.com/social-recruitment/costa/92534
 Dahua Technology,dahua/55997,https://app.mokahr.com/social-recruitment/dahua/55997
+DeepSeek,high-flyer/140576,https://app.mokahr.com/social-recruitment/high-flyer/140576
+Dianhun Campus,dianhun/55953/campus,https://app.mokahr.com/campus-recruitment/dianhun/55953
 DiDi Global,didiglobal/6222,https://app.mokahr.com/social-recruitment/didiglobal/6222
 DolphinDB,dolphindb/37785,https://app.mokahr.com/social-recruitment/dolphindb/37785
 Douyu,douyu/7622,https://app.mokahr.com/social-recruitment/douyu/7622
@@ -64,6 +71,7 @@ Fapon Biotech,fapon/368,https://app.mokahr.com/social-recruitment/fapon/368
 Fenbi,fenbi/45505,https://app.mokahr.com/social-recruitment/fenbi/45505
 Fiberhome Telecommunication,whfhtx/73921,https://app.mokahr.com/social-recruitment/whfhtx/73921
 First Fun,hire-r1/firstfun/100000617,https://hire-r1.mokahr.com/social-recruitment/firstfun/100000617
+Fourier Intelligence Campus,fftai/147078/campus,https://app.mokahr.com/campus-recruitment/fftai/147078
 Foxconn,foxconn/101965,https://app.mokahr.com/social-recruitment/foxconn/101965
 Fujian Boss Software,bosssoft/68369,https://app.mokahr.com/social-recruitment/bosssoft/68369
 Gaoji Health,gaojihealth/94889,https://app.mokahr.com/social-recruitment/gaojihealth/94889
@@ -71,6 +79,7 @@ Gaotu Techedu,bjhl/92093,https://app.mokahr.com/social-recruitment/bjhl/92093
 Gap China,gap/142160,https://app.mokahr.com/social-recruitment/gap/142160
 GE HealthCare,gehc/142249,https://app.mokahr.com/social-recruitment/gehc/142249
 GenScript,genscript/4000,https://app.mokahr.com/social-recruitment/genscript/4000
+Giant Network Campus,ztgame/92438/campus,https://app.mokahr.com/campus-recruitment/ztgame/92438
 GigaDevice,gigadevice/100227,https://app.mokahr.com/social-recruitment/gigadevice/100227
 Glodon,glodon/1751,https://app.mokahr.com/social-recruitment/glodon/1751
 GSK,gsk/148067,https://app.mokahr.com/social-recruitment/gsk/148067
@@ -86,6 +95,7 @@ HEYTEA,hire-r1/heytea/100000206,https://hire-r1.mokahr.com/social-recruitment/he
 High-Flyer Quant,high-flyer/4604,https://app.mokahr.com/social-recruitment/high-flyer/4604
 Hikvision,hikvision/58021,https://app.mokahr.com/social-recruitment/hikvision/58021
 Huaqin Technology,huaqin/41745,https://app.mokahr.com/social-recruitment/huaqin/41745
+Huaqin Technology Campus,hq/44757/campus,https://app.mokahr.com/campus-recruitment/hq/44757
 HUTCHMED,hutchmed/140975,https://app.mokahr.com/social-recruitment/hutchmed/140975
 Huxiu,huxiu/40603,https://app.mokahr.com/social-recruitment/huxiu/40603
 Hytech,hire-r1/hytech/100008074,https://hire-r1.mokahr.com/social-recruitment/hytech/100008074
@@ -103,12 +113,14 @@ KCareers,hire-r1/kcareers/100000192,https://hire-r1.mokahr.com/social-recruitmen
 KEENON Robotics,keenon/24672,https://app.mokahr.com/social-recruitment/keenon/24672
 Kering,kering/144484,https://app.mokahr.com/social-recruitment/kering/144484
 Kingnet,kingnet/2247,https://app.mokahr.com/social-recruitment/kingnet/2247
+Kingsoft Office Campus,wps/41436/campus,https://app.mokahr.com/campus-recruitment/wps/41436
 KORRUN Group,korrun/147968,https://app.mokahr.com/social-recruitment/korrun/147968
 KPMG,kpmg/74216,https://app.mokahr.com/social-recruitment/kpmg/74216
 Li-Ning,lining/166080,https://app.mokahr.com/social-recruitment/lining/166080
 Mammotion Technology,hire-r1/inter-mammotion/100008071,https://hire-r1.mokahr.com/social-recruitment/inter-mammotion/100008071
 Master Kong (Tingyi),masterkong/25435,https://app.mokahr.com/social-recruitment/masterkong/25435
 Medbanks,medbanks/150528,https://app.mokahr.com/social-recruitment/medbanks/150528
+MEGVII Campus,megviihr/38642/campus,https://app.mokahr.com/campus-recruitment/megviihr/38642
 MGCC,mgcc/37697,https://app.mokahr.com/social-recruitment/mgcc/37697
 Michael Kors China,mk/148379,https://app.mokahr.com/social-recruitment/mk/148379
 Mindray,mindray/44475,https://app.mokahr.com/social-recruitment/mindray/44475
@@ -133,24 +145,35 @@ SANY Group,sany/7588,https://app.mokahr.com/social-recruitment/sany/7588
 Sanyuan Foods,sanyuan/73995,https://app.mokahr.com/social-recruitment/sanyuan/73995
 SEER Robotics,seer/41526,https://app.mokahr.com/social-recruitment/seer/41526
 Servyou Software,servyou/42864,https://app.mokahr.com/social-recruitment/servyou/42864
+Shanghai Integrated Circuit R&D Center Campus,icrd/126587/campus,https://app.mokahr.com/campus-recruitment/icrd/126587
+SHEIN Campus,shein/2932/campus,https://app.mokahr.com/campus-recruitment/shein/2932
+Shiyue Network,shiyuehr/72054,https://app.mokahr.com/social-recruitment/shiyuehr/72054
 Shokz,aftershokzhr/40779,https://app.mokahr.com/social-recruitment/aftershokzhr/40779
+Shokz Campus,aftershokzhr/36940/campus,https://app.mokahr.com/campus-recruitment/aftershokzhr/36940
 Shuqu Huyu,shuquhuyu/146521,https://app.mokahr.com/social-recruitment/shuquhuyu/146521
 Sigma,sigma/24905,https://app.mokahr.com/social-recruitment/sigma/24905
 Sina,sina/43535,https://app.mokahr.com/social-recruitment/sina/43535
+Sina Campus,sina/43536/campus,https://app.mokahr.com/campus-recruitment/sina/43536
 Sinopharm,sinopharm/56224,https://app.mokahr.com/social-recruitment/sinopharm/56224
 Sinovac,sinovac/4915,https://app.mokahr.com/social-recruitment/sinovac/4915
 SmartMore,smartmore/40505,https://app.mokahr.com/social-recruitment/smartmore/40505
 Smoore International,smoore/126055,https://app.mokahr.com/social-recruitment/smoore/126055
 Sohu,sohu/43256,https://app.mokahr.com/social-recruitment/sohu/43256
 SolaX Power,solaxpower/151400,https://app.mokahr.com/social-recruitment/solaxpower/151400
+SpacemiT,space-t1/67915,https://app.mokahr.com/social-recruitment/space-t1/67915
 State Power Investment Corporation,spic/45565,https://app.mokahr.com/social-recruitment/spic/45565
 StepFun (Jieyue Xingchen),step/94904,https://app.mokahr.com/social-recruitment/step/94904
+StepFun Campus,step/141903/campus,https://app.mokahr.com/campus-recruitment/step/141903
 STO Express,sto/42337,https://app.mokahr.com/social-recruitment/sto/42337
 SUNDA International,hire-r1/sunda/100000130,https://hire-r1.mokahr.com/social-recruitment/sunda/100000130
+Sungrow Campus,sungrow/94416/campus,https://app.mokahr.com/campus-recruitment/sungrow/94416
 Tengden,tengden/45126,https://app.mokahr.com/social-recruitment/tengden/45126
 Tesla China,tesla/46129,https://app.mokahr.com/social-recruitment/tesla/46129
+Tesla China Campus,tesla/41460/campus,https://app.mokahr.com/campus-recruitment/tesla/41460
+Tesla Japan,hire-r1/tesla/100004135,https://hire-r1.mokahr.com/social-recruitment/tesla/100004135
 Texas Instruments,ti/143985,https://app.mokahr.com/social-recruitment/ti/143985
 Tianma Microelectronics,tianma/143383,https://app.mokahr.com/social-recruitment/tianma/143383
+Tianyan Capital,tianyancapital/98901,https://app.mokahr.com/social-recruitment/tianyancapital/98901
 Tigermed,hire-r1/tigermed/100004122,https://hire-r1.mokahr.com/social-recruitment/tigermed/100004122
 Topsec,topsec/24131,https://app.mokahr.com/social-recruitment/topsec/24131
 TotalEnergies,totalenergies/100441,https://app.mokahr.com/social-recruitment/totalenergies/100441
@@ -165,9 +188,12 @@ Xiaochuan Keji,xiaochuankeji/116068,https://app.mokahr.com/social-recruitment/xi
 Xtep,xtep/148870,https://app.mokahr.com/social-recruitment/xtep/148870
 Xueqiu (Snowball),xueqiu/3591,https://app.mokahr.com/social-recruitment/xueqiu/3591
 Xunlei,xunlei/26599,https://app.mokahr.com/social-recruitment/xunlei/26599
+YITU Technology,yitu-inc/3701,https://app.mokahr.com/social-recruitment/yitu-inc/3701
 Yoka Games,yokagames/41939,https://app.mokahr.com/social-recruitment/yokagames/41939
 Yoozoo Games,yoozoo/91950,https://app.mokahr.com/social-recruitment/yoozoo/91950
+Zhihu Campus,zhihu/68321/campus,https://app.mokahr.com/campus-recruitment/zhihu/68321
 Zijin Mining Group,zijinmining/72010,https://app.mokahr.com/social-recruitment/zijinmining/72010
 Zijin Mining Group (alt),zijin/47703,https://app.mokahr.com/social-recruitment/zijin/47703
 Zoomlion,zoomlion/38183,https://app.mokahr.com/social-recruitment/zoomlion/38183
+ZTE Campus,zte/46903/campus,https://app.mokahr.com/campus-recruitment/zte/46903
 Zuoyebang,zuoyebang/41328,https://app.mokahr.com/social-recruitment/zuoyebang/41328


### PR DESCRIPTION
## Summary
- add 26 previously untracked live Moka boards discovered from public career-URL references
- cover social, campus, and `hire-r1` board formats
- exclude empty/rejected boards and two boards whose public pages are explicitly shut down

## Live validation
- fetched every added board end-to-end through `MokaScraper`
- 26/26 boards returned live jobs
- 1,414 jobs total
- no duplicate job IDs within any board
- no overlap with 30,737 job IDs from the 172 existing Moka boards
- no job-ID overlap between the 26 candidates
- 198 total CSV rows with unique slugs and URLs

## Scope
- tenant data only: `ats-companies/moka.csv`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 26 newly discovered live Moka boards to ats-companies/moka.csv, spanning social, campus, and `hire-r1` formats to expand coverage. All were validated via `MokaScraper` (1,414 live jobs) with no ID overlap against the 172 existing boards; empty or shut‑down boards were excluded.

<sup>Written for commit 13061991e3ccadb3f8fcd97750b711f46a9cb74f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

