### PR TITLE
Add 599 live Oracle Recruiting sites from crawl discovery

### DIFF
--- a/ats-companies/oracle.csv
+++ b/ats-companies/oracle.csv
@@ -1,4 +1,11 @@
 name,slug,url
+ACI Worldwide Job Opportunities,ebwg,https://ebwg.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Adara Real Estate Company,fa-etzd-saasfaprod1,https://fa-etzd-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+AirBorneo,airborneo-iacatj,https://airborneo-iacatj.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Allegheny College,alleghenycollege-ibwwjb,https://alleghenycollege-ibwwjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+APP Recruitment,eify/cx_1001,https://eify.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Aspetar Candidate Experience site,eipb/cx_5,https://eipb.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_5
+AustralianSuper,ejjl,https://ejjl.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 ABM US,eiqg,https://eiqg.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 ADES Global,epgv,https://epgv.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 ADIB Candidate Experience site,hciq,https://hciq.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
@@ -31,6 +38,12 @@ Arcor Global,emqm,https://emqm.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/
 Aspire Zone Candidate Experience site,eipb,https://eipb.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Aster DM Healthcare,hcdt,https://hcdt.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 At Home,hdiy,https://hdiy.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+B-Entity Career Site,ejgk/cx_1001,https://ejgk.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Banco Nacional de Costa Rica,ehuk,https://ehuk.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+BAS  Kariyer,elvh,https://elvh.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+BSC,ecge/cx_1003,https://ecge.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1003
+BTN Career Sites,bankbtn-hcis-iaadnf,https://bankbtn-hcis-iaadnf.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Business Operations and Legal,ehpy,https://ehpy.fa.em5.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
 BCBSM Career Section,ejko,https://ejko.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 BDO USA Experienced Career Site,ebqb,https://ebqb.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 BE Careers,iadygs,https://iadygs.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
@@ -44,6 +57,32 @@ Black Box Careers,eoje,https://eoje.fa.us2.oraclecloud.com/hcmUI/CandidateExperi
 Brazos County Career Site,ekzl,https://ekzl.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Bristlecone,iaagiz,https://iaagiz.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Brookdale Senior Living Inc.,ibmwjb,https://ibmwjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Caesars Sportsbook,edmn/cx_6001,https://edmn.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_6001
+Camden,ehap/cx,https://ehap.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Candidate Experience site (CX),ebhu,https://ebhu.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Candidate Experience site (CX),edzt,https://edzt.fa.em4.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Candidate Experience site (CX),eizj,https://eizj.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Candidate Experience site (CX_1001),eieb,https://eieb.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Candidate Experience site (CX_1001),elhr/cx_1001,https://elhr.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Candidate Experience site (MK),ebet,https://ebet.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/MK
+Careers at Myers and Stauffer,ebez/cx_4,https://ebez.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_4
+Careers | BXP,edxn/cx_5001,https://edxn.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_5001
+Cbct,cbct/gallifordtrycareers,https://cbct.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/gallifordtrycareers
+Centrus Global Career Site,eese/centrusenergycareers,https://eese.fa.us8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CentrusEnergyCareers
+Cherokee Nation Businesses,ejvp/cx_4001,https://ejvp.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_4001
+Children\'s Careers,egnx,https://egnx.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Choctaw Nation of Oklahoma,egoh/cx_1001,https://egoh.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+CIMB  Singapore,ejox/cx_6,https://ejox.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_6
+CIMB Cambodia,ejox/cx_2,https://ejox.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+CIMB Vietnam,ejox/cx_11,https://ejox.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_11
+City Of Atlanta Careers,ehxr/city-of-atlanta-careers,https://ehxr.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/City-of-Atlanta-Careers
+City of Greeley -,elvp,https://elvp.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+City of Memphis,eeim,https://eeim.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CMEM
+COPPEL SA DE CV,fa-eqwz-saasfaprod1,https://fa-eqwz-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3001
+Corporate Careers | Trueblue,ehnn/cx,https://ehnn.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Corserv Careers Site,ekzo,https://ekzo.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Cottage Health,eglz/cx,https://eglz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Cva,cva/cx_3,https://cva.fa.us1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3
 CECONY Career Site,ejcu,https://ejcu.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 CIMB Group Malaysia,ejox,https://ejox.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 CLP,iabhtj,https://iabhtj.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
@@ -86,6 +125,10 @@ Corporate Careers | Trueblue,ehnn,https://ehnn.fa.us2.oraclecloud.com/hcmUI/Cand
 Cottage Health,eglz,https://eglz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Cummins Arabia External Career Site,hdjd,https://hdjd.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Cytel,iblyjb,https://iblyjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+DC Water Candidate Experience site,elxb/cx,https://elxb.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+DePaul Talent Acquisition,ekze,https://ekze.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Diebold Nixdorf,eeug/cx,https://eeug.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+DTU Career Site,efzu/cx_2001,https://efzu.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
 DAMAC,ejwe,https://ejwe.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 DC Water Candidate Experience site,elxb,https://elxb.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 DLL Group,iabcbn,https://iabcbn.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
@@ -99,6 +142,126 @@ Diebold Nixdorf,eeug,https://eeug.fa.us6.oraclecloud.com/hcmUI/CandidateExperien
 Digital Realty Global,hdep,https://hdep.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Dubai Holding,esbe,https://esbe.fa.em8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Dubai World Trade Centre -,bun,https://bun.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Ebfr,ebfr,https://ebfr.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/jobs
+Ebqb,ebqb/bdoentrylevelcareers,https://ebqb.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/BDOEntryLevelCareers
+Ebwb,ebwb/cx,https://ebwb.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Ebwh (CX_1001),ebwh/cx_1001,https://ebwh.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Ebwh (CX_1002),ebwh/cx_1002,https://ebwh.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1002
+Ebwv,ebwv/cx_1001,https://ebwv.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Ebxs,ebxs/cx_2,https://ebxs.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Ecwl,ecwl/cx,https://ecwl.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Ecwr,ecwr/work4estes,https://ecwr.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/work4estes
+Edbz,edbz/cx,https://edbz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Ediu,ediu/cx_1013,https://ediu.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1013
+Edyo,edyo/cx,https://edyo.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Edyy,edyy/cx_2002,https://edyy.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2002
+EECOL,eklm/cx_1001,https://eklm.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Eedu,eedu/cx_1003,https://eedu.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1003
+Eeho,eeho/cx_45001,https://eeho.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_45001
+Eeih,eeih,https://eeih.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_6
+Eevd,eevd/cx,https://eevd.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Eexs,eexs/aldersly,https://eexs.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/Aldersly
+Efet,efet,https://efet.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Efuf,efuf,https://efuf.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Efuq,efuq/hiltongrandvacations,https://efuq.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/HiltonGrandVacations
+Egjl,egjl,https://egjl.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Egln,egln/cx,https://egln.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Egug,egug,https://egug.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Egup,egup/cx,https://egup.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Ehpv,ehpv/cx,https://ehpv.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Ehzq,ehzq/cx_4,https://ehzq.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_4
+Eicl,eicl/cx_4001,https://eicl.fa.em5.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_4001
+Eigx,eigx/cx,https://eigx.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Eiqg,eiqg/cx_1001,https://eiqg.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Ejfh,ejfh/stationcasinos,https://ejfh.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/StationCasinos
+Ejhp,ejhp/cx_2,https://ejhp.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Ejis,ejis/cx,https://ejis.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Ejof,ejof/baylorcareers,https://ejof.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/BaylorCareers
+Ejov,ejov/cx,https://ejov.fa.ca2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Ejox (CX_5),ejox/cx_5,https://ejox.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_5
+Ejox (CX_7),ejox/cx_7,https://ejox.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_7
+Ejql,ejql/cx,https://ejql.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Ejrz,ejrz/cx_5001,https://ejrz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_5001
+Ejwl,ejwl/cx,https://ejwl.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Ekaw,ekaw/cx,https://ekaw.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Ekcm,ekcm/cx,https://ekcm.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Ekeq,ekeq,https://ekeq.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3001
+Ekjy,ekjy,https://ekjy.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3007
+Ekkh,ekkh/cx_2002,https://ekkh.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2002
+Eklm,eklm/cx,https://eklm.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Elcn,elcn/cx,https://elcn.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Elij,elij,https://elij.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Eljs,eljs/cx,https://eljs.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Eluq,eluq/cx_2001,https://eluq.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Elxw,elxw/cx_1001,https://elxw.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Elyb,elyb,https://elyb.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Emcm,emcm/cx_4001,https://emcm.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_4001
+Emdz,emdz/cx_2001,https://emdz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Emgi (CX_1001),emgi/cx_1001,https://emgi.fa.ca3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Emgi (CX_3003),emgi/cx_3003,https://emgi.fa.ca3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3003
+Emhm,emhm/cx_1001,https://emhm.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Emit,emit/cx_2001,https://emit.fa.ca3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Emje,emje/cx_1001,https://emje.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Emmr,emmr,https://emmr.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Emor,emor,https://emor.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Empleos ICBC,ejig,https://ejig.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Emqk,emqk,https://emqk.fa.ca3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Emqm,emqm/grupoarcorgl,https://emqm.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/grupoarcorgl
+Emvo,emvo/cx_3002,https://emvo.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3002
+Eney,eney,https://eney.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Enmv,enmv/cx_2001,https://enmv.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Enpf,enpf,https://enpf.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Enpk,enpk/cx_1001,https://enpk.fa.em8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Enre,enre,https://enre.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3001
+Enzj,enzj/cx,https://enzj.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Eoct,eoct,https://eoct.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/careers
+Eodr,eodr/cx_1001,https://eodr.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Eoee,eoee,https://eoee.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Eofb (CX_3001),eofb/cx_3001,https://eofb.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3001
+Eofb (CX_4001),eofb/cx_4001,https://eofb.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_4001
+Eofe,eofe/bny-careers,https://eofe.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/BNY-Careers
+Eoff,eoff,https://eoff.fa.em1.ukg.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Eofh,eofh/cx_3001,https://eofh.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3001
+Eohh,eohh/cx,https://eohh.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Eohm,eohm,https://eohm.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_6004
+Eoiq,eoiq,https://eoiq.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Eoja,eoja,https://eoja.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Eoje,eoje/cx_1001,https://eoje.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Eolj,eolj,https://eolj.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Eord,eord,https://eord.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Eour,eour,https://eour.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Eozs (CX_1),eozs/cx_1,https://eozs.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Eozs (CX_11),eozs/cx_11,https://eozs.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_11
+Eozs (CX_21),eozs/cx_21,https://eozs.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_21
+Eozs (CX_30),eozs/cx_30,https://eozs.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_30
+Eozs (CX_4),eozs/cx_4,https://eozs.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_4
+Eozs (CX_6),eozs/cx_6,https://eozs.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_6
+Epdj,epdj,https://epdj.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Epej,epej/churchemployment,https://epej.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/ChurchEmployment
+Epin,epin,https://epin.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Epiw,epiw,https://epiw.fa.la1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Epix,epix,https://epix.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Eppr,eppr/cx_2,https://eppr.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Epvw,epvw,https://epvw.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Epyc (CLH-CA),epyc/clh-ca,https://epyc.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CLH-CA
+Epyc (CX_1001),epyc/cx_1001,https://epyc.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Eqtm,eqtm,https://eqtm.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/fmolhs-careers
+Erel,erel,https://erel.fa.em8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Ertd,ertd,https://ertd.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Ertr,ertr/cx_3001,https://ertr.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3001
+Erzb,erzb,https://erzb.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Esbe,esbe/dubai-holding,https://esbe.fa.em8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/Dubai-Holding
+ESEC Experience site,ebfi/cx_1001,https://ebfi.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Esgj,esgj,https://esgj.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Estm (CX_2003),estm/cx_2003,https://estm.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2003
+Estm (CX_3001),estm/cx_3001,https://estm.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3001
+Estm (CX_5001),estm/cx_5001,https://estm.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_5001
+Eswt,eswt/cx_1001,https://eswt.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Etgi,etgi/cx_4005,https://etgi.fa.us8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_4005
+Etvy,etvy,https://etvy.fa.ap2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Euroclear,don/cx_1003,https://don.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1003
+Ewvl,ewvl,https://ewvl.fa.us8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Exzj,exzj,https://exzj.fa.us8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 ELCA Global Career site,iaaras,https://iaaras.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 EMAAR,emhm,https://emhm.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 EMSS,eism,https://eism.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
@@ -146,12 +309,258 @@ Erey,erey,https://erey.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites
 Euroclear,don,https://don.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Explore RH Careers,hcqq,https://hcqq.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 External Site,ekez,https://ekez.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Ekwr Saasfaprod1,fa-ekwr-saasfaprod1,https://fa-ekwr-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Ekzu Saasfaprod1,fa-ekzu-saasfaprod1,https://fa-ekzu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Fa Elpm Saasfaprod1,fa-elpm-saasfaprod1,https://fa-elpm-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Fa Elwc Saasfaprod1,fa-elwc-saasfaprod1,https://fa-elwc-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Fa Elxu Saasfaprod1 (CX_1001),fa-elxu-saasfaprod1/cx_1001,https://fa-elxu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Elxu Saasfaprod1 (CX_1012),fa-elxu-saasfaprod1/cx_1012,https://fa-elxu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1012
+Fa Elxu Saasfaprod1 (CX_1016),fa-elxu-saasfaprod1/cx_1016,https://fa-elxu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1016
+Fa Elxu Test Saasfaprod1,fa-elxu-test-saasfaprod1,https://fa-elxu-test-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Elzs Saasfaprod1 (CX),fa-elzs-saasfaprod1/cx,https://fa-elzs-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Fa Elzs Saasfaprod1 (CX_1001),fa-elzs-saasfaprod1/cx_1001,https://fa-elzs-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Emad Saasfaprod1,fa-emad-saasfaprod1,https://fa-emad-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_6001
+Fa Emkq Saasfaprod1,fa-emkq-saasfaprod1,https://fa-emkq-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Fa Emmq Saasfaprod1,fa-emmq-saasfaprod1,https://fa-emmq-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Fa Emqf Saasfaprod1,fa-emqf-saasfaprod1,https://fa-emqf-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1004
+Fa Emqh Saasfaprod1,fa-emqh-saasfaprod1,https://fa-emqh-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Emsb Saasfaprod1,fa-emsb-saasfaprod1,https://fa-emsb-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Emza Saasfaprod1,fa-emza-saasfaprod1,https://fa-emza-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3001
+Fa Enfw Saasfaprod1,fa-enfw-saasfaprod1,https://fa-enfw-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_4003
+Fa Enlf Saasfaprod1,fa-enlf-saasfaprod1,https://fa-enlf-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Fa Enmi Saasfaprod1,fa-enmi-saasfaprod1,https://fa-enmi-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3001
+Fa Enor Saasfaprod1,fa-enor-saasfaprod1,https://fa-enor-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Fa Enru Saasfaprod1,fa-enru-saasfaprod1,https://fa-enru-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Fa Eocc Saasfaprod1,fa-eocc-saasfaprod1,https://fa-eocc-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1007
+Fa Eoic Saasfaprod1,fa-eoic-saasfaprod1/cx_12001,https://fa-eoic-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_12001
+Fa Eolw Saasfaprod1,fa-eolw-saasfaprod1,https://fa-eolw-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Fa Eomf Saasfaprod1,fa-eomf-saasfaprod1,https://fa-eomf-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1002
+Fa Eomj Saasfaprod1,fa-eomj-saasfaprod1,https://fa-eomj-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Eoqj Saasfaprod1,fa-eoqj-saasfaprod1,https://fa-eoqj-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/Juilliard
+Fa Eosd Saasfaprod1,fa-eosd-saasfaprod1,https://fa-eosd-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Eotc Saasfaprod1,fa-eotc-saasfaprod1,https://fa-eotc-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Eowa Saasfaprod1,fa-eowa-saasfaprod1,https://fa-eowa-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CSXCareers
+Fa Eozc Saasfaprod1,fa-eozc-saasfaprod1,https://fa-eozc-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_6001
+Fa Epcb Saasfaprod1,fa-epcb-saasfaprod1,https://fa-epcb-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Fa Epec Saasfaprod1,fa-epec-saasfaprod1,https://fa-epec-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Epmd Saasfaprod1,fa-epmd-saasfaprod1,https://fa-epmd-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3001
+Fa Epod Saasfaprod1,fa-epod-saasfaprod1,https://fa-epod-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Fa Epop Saasfaprod1,fa-epop-saasfaprod1,https://fa-epop-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Eptm Saasfaprod1,fa-eptm-saasfaprod1,https://fa-eptm-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_4001
+Fa Epvs Saasfaprod1,fa-epvs-saasfaprod1,https://fa-epvs-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Epxe Saasfaprod1,fa-epxe-saasfaprod1,https://fa-epxe-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Epxn Saasfaprod1,fa-epxn-saasfaprod1,https://fa-epxn-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Epzg Saasfaprod1,fa-epzg-saasfaprod1,https://fa-epzg-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Eqai Saasfaprod1,fa-eqai-saasfaprod1,https://fa-eqai-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Eqbh Saasfaprod1,fa-eqbh-saasfaprod1,https://fa-eqbh-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_7001
+Fa Eqcd Saasfaprod1,fa-eqcd-saasfaprod1,https://fa-eqcd-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Eqdg Saasfaprod1,fa-eqdg-saasfaprod1,https://fa-eqdg-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Eqgc Saasfaprod1,fa-eqgc-saasfaprod1,https://fa-eqgc-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_9
+Fa Eqgp Saasfaprod1,fa-eqgp-saasfaprod1,https://fa-eqgp-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Eqhn Saasfaprod1,fa-eqhn-saasfaprod1,https://fa-eqhn-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Fa Eqid Saasfaprod1,fa-eqid-saasfaprod1,https://fa-eqid-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Eqie Saasfaprod1,fa-eqie-saasfaprod1,https://fa-eqie-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Eqnr Saasfaprod1,fa-eqnr-saasfaprod1,https://fa-eqnr-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1020
+Fa Eqto Saasfaprod1,fa-eqto-saasfaprod1,https://fa-eqto-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Equm Saasfaprod1,fa-equm-saasfaprod1,https://fa-equm-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Eqvg Saasfaprod1,fa-eqvg-saasfaprod1,https://fa-eqvg-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_4001
+Fa Eqzr Saasfaprod1,fa-eqzr-saasfaprod1,https://fa-eqzr-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Fa Erav Saasfaprod1,fa-erav-saasfaprod1,https://fa-erav-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/SEW-jobs-and-career
+Fa Erjf Saasfaprod1,fa-erjf-saasfaprod1,https://fa-erjf-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Erjt Saasfaprod1,fa-erjt-saasfaprod1,https://fa-erjt-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3001
+Fa Ermg Saasfaprod1,fa-ermg-saasfaprod1,https://fa-ermg-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Erno Saasfaprod1,fa-erno-saasfaprod1,https://fa-erno-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Ernw Saasfaprod1,fa-ernw-saasfaprod1,https://fa-ernw-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Fa Erqb Saasfaprod1,fa-erqb-saasfaprod1,https://fa-erqb-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Erqf Saasfaprod1,fa-erqf-saasfaprod1,https://fa-erqf-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Errt Saasfaprod1,fa-errt-saasfaprod1,https://fa-errt-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Fa Ertb Saasfaprod1,fa-ertb-saasfaprod1,https://fa-ertb-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Fa Ertg Saasfaprod1,fa-ertg-saasfaprod1,https://fa-ertg-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Eryf Saasfaprod1,fa-eryf-saasfaprod1,https://fa-eryf-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Esau Saasfaprod1,fa-esau-saasfaprod1,https://fa-esau-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/crawco-jobs
+Fa Esbv Saasfaprod1,fa-esbv-saasfaprod1,https://fa-esbv-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Esfc Saasfaprod1,fa-esfc-saasfaprod1,https://fa-esfc-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Esgu Saasfaprod1,fa-esgu-saasfaprod1,https://fa-esgu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Eshb Saasfaprod1,fa-eshb-saasfaprod1,https://fa-eshb-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1003
+Fa Eslq Saasfaprod1,fa-eslq-saasfaprod1,https://fa-eslq-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Esms Saasfaukgovprod1,fa-esms-saasfaukgovprod1,https://fa-esms-saasfaukgovprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Esmz Saasfaprod1,fa-esmz-saasfaprod1,https://fa-esmz-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Esow Saasfaprod1,fa-esow-saasfaprod1,https://fa-esow-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Espf Saasfaprod1,fa-espf-saasfaprod1,https://fa-espf-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Espx Saasfaprod1,fa-espx-saasfaprod1,https://fa-espx-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Essf Saasfaprod1,fa-essf-saasfaprod1,https://fa-essf-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Esta Saasfaprod1,fa-esta-saasfaprod1,https://fa-esta-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Esth Saasfaprod1,fa-esth-saasfaprod1,https://fa-esth-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Esti Saasfaprod1,fa-esti-saasfaprod1,https://fa-esti-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Esyi Saasfaprod1,fa-esyi-saasfaprod1,https://fa-esyi-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Etbx Saasfaprod1,fa-etbx-saasfaprod1/cx_1001,https://fa-etbx-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Etjb Saasfaprod1,fa-etjb-saasfaprod1,https://fa-etjb-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Etnf Saasfaprod1,fa-etnf-saasfaprod1,https://fa-etnf-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Etnv Saasfaprod1,fa-etnv-saasfaprod1,https://fa-etnv-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/healthpartners
+Fa Etqd Saasfaprod1,fa-etqd-saasfaprod1,https://fa-etqd-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Etqo Saasfaprod1,fa-etqo-saasfaprod1,https://fa-etqo-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Etrb Saasfaprod1,fa-etrb-saasfaprod1,https://fa-etrb-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/weber-county-careers
+Fa Etum Saasfaprod1,fa-etum-saasfaprod1,https://fa-etum-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Etus Saasfaprod1,fa-etus-saasfaprod1,https://fa-etus-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Fa Etvl Saasfaprod1,fa-etvl-saasfaprod1,https://fa-etvl-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Etwq Saasfaprod1,fa-etwq-saasfaprod1,https://fa-etwq-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Etxt Saasfaprod1,fa-etxt-saasfaprod1,https://fa-etxt-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_5
+Fa Etxx Saasfaprod1,fa-etxx-saasfaprod1,https://fa-etxx-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Etyi Saasfaprod1,fa-etyi-saasfaprod1,https://fa-etyi-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Etyr Saasfaprod1,fa-etyr-saasfaprod1,https://fa-etyr-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2003
+Fa Eudi Saasfaprod1,fa-eudi-saasfaprod1,https://fa-eudi-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Eufk Saasfaprod1,fa-eufk-saasfaprod1,https://fa-eufk-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Eugn Saasfaprod1,fa-eugn-saasfaprod1,https://fa-eugn-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/UniSuperCareers
+Fa Eugp Saasfaprod1,fa-eugp-saasfaprod1,https://fa-eugp-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/career-synlab
+Fa Eugs Saasfaprod1,fa-eugs-saasfaprod1,https://fa-eugs-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2002
+Fa Eugx Saasfaprod1,fa-eugx-saasfaprod1,https://fa-eugx-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Euhj Saasfaukgovprod1,fa-euhj-saasfaukgovprod1,https://fa-euhj-saasfaukgovprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Euii Saasfaprod1,fa-euii-saasfaprod1,https://fa-euii-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/careers
+Fa Eujk Saasfaprod1,fa-eujk-saasfaprod1,https://fa-eujk-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Eujo Saasfaprod1,fa-eujo-saasfaprod1,https://fa-eujo-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Eukq Saasfaprod1,fa-eukq-saasfaprod1,https://fa-eukq-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Eunv Saasfaprod1,fa-eunv-saasfaprod1,https://fa-eunv-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Euok Saasfaprod1,fa-euok-saasfaprod1,https://fa-euok-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Eups Saasfaprod1,fa-eups-saasfaprod1,https://fa-eups-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/ULSolutionsCareers
+Fa Eupt Saasfaprod1,fa-eupt-saasfaprod1,https://fa-eupt-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Euru Saasfaprod1,fa-euru-saasfaprod1,https://fa-euru-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/External
+Fa Eute Saasfaprod1,fa-eute-saasfaprod1,https://fa-eute-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Eutm Saasfaprod1 (CX_1),fa-eutm-saasfaprod1/cx_1,https://fa-eutm-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Eutm Saasfaprod1 (CX_2),fa-eutm-saasfaprod1/cx_2,https://fa-eutm-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Fa Eutv Saasfaprod1 (CX_1),fa-eutv-saasfaprod1/cx_1,https://fa-eutv-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Eutv Saasfaprod1 (CX_1001),fa-eutv-saasfaprod1/cx_1001,https://fa-eutv-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Eutv Saasfaprod1 (CX_6007),fa-eutv-saasfaprod1/cx_6007,https://fa-eutv-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_6007
+Fa Euuc Saasfaprod1,fa-euuc-saasfaprod1,https://fa-euuc-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Fa Euud Saasfaprod1,fa-euud-saasfaprod1,https://fa-euud-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Euum Saasfaprod1,fa-euum-saasfaprod1,https://fa-euum-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Euup Saasfaprod1,fa-euup-saasfaprod1,https://fa-euup-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Euwx Saasfaprod1,fa-euwx-saasfaprod1,https://fa-euwx-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Euxc Saasfaprod1,fa-euxc-saasfaprod1,https://fa-euxc-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Euxi Saasfaukgovprod1,fa-euxi-saasfaukgovprod1,https://fa-euxi-saasfaukgovprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Euxy Saasfaprod1,fa-euxy-saasfaprod1,https://fa-euxy-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Euyk Saasfaprod1,fa-euyk-saasfaprod1,https://fa-euyk-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3
+Fa Euyo Saasfaprod1,fa-euyo-saasfaprod1,https://fa-euyo-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_4
+Fa Euzi Saasfaprod1,fa-euzi-saasfaprod1,https://fa-euzi-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Evav Saasfaprod1,fa-evav-saasfaprod1,https://fa-evav-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/connecticutchildrenscareers
+Fa Evax Saasfaprod1,fa-evax-saasfaprod1,https://fa-evax-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Evcg Saasfaprod1,fa-evcg-saasfaprod1,https://fa-evcg-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Evdi Saasfaprod1,fa-evdi-saasfaprod1,https://fa-evdi-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/WarbyParkerCareers
+Fa Evdq Saasfaprod1,fa-evdq-saasfaprod1/cx_2001,https://fa-evdq-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Fa Evem Saasfaprod1,fa-evem-saasfaprod1,https://fa-evem-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Evfm Saasfaprod1,fa-evfm-saasfaprod1,https://fa-evfm-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1029
+Fa Evge Saasfaprod1,fa-evge-saasfaprod1,https://fa-evge-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Evib Saasfaprod1,fa-evib-saasfaprod1,https://fa-evib-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Evjm Saasfaprod1 (CX_1003),fa-evjm-saasfaprod1/cx_1003,https://fa-evjm-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1003
+Fa Evjm Saasfaprod1 (CX_4001),fa-evjm-saasfaprod1/cx_4001,https://fa-evjm-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_4001
+Fa Evlb Saasfaprod1 (CX_1),fa-evlb-saasfaprod1/cx_1,https://fa-evlb-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Evlb Saasfaprod1 (CX_2001),fa-evlb-saasfaprod1/cx_2001,https://fa-evlb-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Fa Evlf Saasfaprod1,fa-evlf-saasfaprod1,https://fa-evlf-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Evlp Saasfaprod1,fa-evlp-saasfaprod1,https://fa-evlp-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Evly Saasfaprod1,fa-evly-saasfaprod1,https://fa-evly-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Evmm Saasfaprod1,fa-evmm-saasfaprod1,https://fa-evmm-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Evng Saasfaprod1,fa-evng-saasfaprod1,https://fa-evng-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/LBWF
+Fa Evpg Saasfaeuraprod1,fa-evpg-saasfaeuraprod1,https://fa-evpg-saasfaeuraprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Evra Saasfaprod1,fa-evra-saasfaprod1,https://fa-evra-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/SARB
+Fa Evrg Saasfaprod1,fa-evrg-saasfaprod1,https://fa-evrg-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Evvx Saasfaprod1,fa-evvx-saasfaprod1,https://fa-evvx-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/The-Redpath-Group
+Fa Evwo Saasfaprod1 (CX_1),fa-evwo-saasfaprod1/cx_1,https://fa-evwo-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Evwo Saasfaprod1 (CX_1001),fa-evwo-saasfaprod1/cx_1001,https://fa-evwo-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Evwo Saasfaprod1 (CX_2001),fa-evwo-saasfaprod1/cx_2001,https://fa-evwo-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Fa Evwo Saasfaprod1 (CX_2003),fa-evwo-saasfaprod1/cx_2003,https://fa-evwo-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2003
+Fa Evwo Saasfaprod1 (CX_3),fa-evwo-saasfaprod1/cx_3,https://fa-evwo-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3
+Fa Evwo Saasfaprod1 (CX_5),fa-evwo-saasfaprod1/cx_5,https://fa-evwo-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_5
+Fa Evxn Saasfaukgovprod1,fa-evxn-saasfaukgovprod1,https://fa-evxn-saasfaukgovprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Evxo Saasfaprod1,fa-evxo-saasfaprod1,https://fa-evxo-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Evxv Saasfaprod1,fa-evxv-saasfaprod1,https://fa-evxv-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Fa Evzn Saasfaukgovprod1,fa-evzn-saasfaukgovprod1,https://fa-evzn-saasfaukgovprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/UKRI-Careers
+Fa Evzu Saasfaprod1,fa-evzu-saasfaprod1,https://fa-evzu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Ewab Saasfaprod1,fa-ewab-saasfaprod1,https://fa-ewab-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Ewca Saasfaprod1,fa-ewca-saasfaprod1,https://fa-ewca-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Ewcd Saasfaprod1,fa-ewcd-saasfaprod1,https://fa-ewcd-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/JGCGroup
+Fa Ewci Saasfaprod1,fa-ewci-saasfaprod1,https://fa-ewci-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Ewcy Saasfaprod1,fa-ewcy-saasfaprod1,https://fa-ewcy-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Ewdg Saasfaprod1,fa-ewdg-saasfaprod1,https://fa-ewdg-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CynclyJobs
+Fa Ewfi Saasfaprod1,fa-ewfi-saasfaprod1,https://fa-ewfi-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Ewgu Saasfaprod1,fa-ewgu-saasfaprod1,https://fa-ewgu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Fa Ewic Saasfaprod1,fa-ewic-saasfaprod1,https://fa-ewic-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Ewje Saasfaprod1,fa-ewje-saasfaprod1,https://fa-ewje-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Ewji Saasfaprod1,fa-ewji-saasfaprod1,https://fa-ewji-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Ewjt Saasfaprod1,fa-ewjt-saasfaprod1,https://fa-ewjt-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Fa Ewkd Dev1 Saasfaprod1,fa-ewkd-dev1-saasfaprod1,https://fa-ewkd-dev1-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/USF
+Fa Ewkd Saasfaprod1,fa-ewkd-saasfaprod1,https://fa-ewkd-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/USF
+Fa Ewle Saasfaprod1,fa-ewle-saasfaprod1,https://fa-ewle-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Ewmp Saasfaprod1,fa-ewmp-saasfaprod1,https://fa-ewmp-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Ewmw Saasfaprod1,fa-ewmw-saasfaprod1,https://fa-ewmw-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Fa Ewmy Saasfaprod1,fa-ewmy-saasfaprod1,https://fa-ewmy-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Ewnb Saasfaprod1,fa-ewnb-saasfaprod1,https://fa-ewnb-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3001
+Fa Ewnv Saasfaprod1,fa-ewnv-saasfaprod1,https://fa-ewnv-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/BIBANCA-Lavora-Con-Noi
+Fa Ewnx Saasfaprod1,fa-ewnx-saasfaprod1,https://fa-ewnx-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Ewnz Saasfaprod1,fa-ewnz-saasfaprod1,https://fa-ewnz-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Ewpe Saasfaprod1,fa-ewpe-saasfaprod1,https://fa-ewpe-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Ewph Saasfaprod1,fa-ewph-saasfaprod1,https://fa-ewph-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Ewqm Saasfaprod1,fa-ewqm-saasfaprod1,https://fa-ewqm-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Ewqq Saasfaprod1,fa-ewqq-saasfaprod1,https://fa-ewqq-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/hkbu
+Fa Ewto Saasfaprod1,fa-ewto-saasfaprod1,https://fa-ewto-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Ewub Saasfaprod1,fa-ewub-saasfaprod1,https://fa-ewub-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_26
+Fa Ewur Saasfaprod1,fa-ewur-saasfaprod1,https://fa-ewur-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3
+Fa Ewwt Saasfaprod1,fa-ewwt-saasfaprod1,https://fa-ewwt-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/Americold-Careers
+Fa Ewwx Saasfaprod1,fa-ewwx-saasfaprod1,https://fa-ewwx-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Ewxl Saasfaprod1,fa-ewxl-saasfaprod1,https://fa-ewxl-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Ewye Saasfaprod1,fa-ewye-saasfaprod1,https://fa-ewye-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/AkosomboHotelsLtd
+Fa Ewzu Saasfaprod1,fa-ewzu-saasfaprod1,https://fa-ewzu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Ewzx Saasfaprod1,fa-ewzx-saasfaprod1,https://fa-ewzx-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Exci Saasfaprod1,fa-exci-saasfaprod1,https://fa-exci-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Fa Exco Saasfaprod1,fa-exco-saasfaprod1,https://fa-exco-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/MinnesotaJudicialBranch
+Fa Exdf Saasfaprod1,fa-exdf-saasfaprod1,https://fa-exdf-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Exdu Saasfaprod1,fa-exdu-saasfaprod1,https://fa-exdu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Exer Saasfaprod1,fa-exer-saasfaprod1,https://fa-exer-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Exew Saasfaprod1,fa-exew-saasfaprod1,https://fa-exew-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Exhh Saasfaprod1 (CX_2001),fa-exhh-saasfaprod1/cx_2001,https://fa-exhh-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Fa Exhh Saasfaprod1 (StaplesCanada),fa-exhh-saasfaprod1/staplescanada,https://fa-exhh-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/StaplesCanada
+Fa Exhj Saasfaprod1,fa-exhj-saasfaprod1,https://fa-exhj-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Exki Saasfaprod1 (CX_1),fa-exki-saasfaprod1/cx_1,https://fa-exki-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Exki Saasfaprod1 (CX_2001),fa-exki-saasfaprod1/cx_2001,https://fa-exki-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Fa Exkk Saasfaprod1,fa-exkk-saasfaprod1,https://fa-exkk-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Exna Saasfaprod1,fa-exna-saasfaprod1,https://fa-exna-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Exnu Saasfaprod1 (CX_1),fa-exnu-saasfaprod1/cx_1,https://fa-exnu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Exnu Saasfaprod1 (CX_2),fa-exnu-saasfaprod1/cx_2,https://fa-exnu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Fa Expc Saasfaprod1,fa-expc-saasfaprod1,https://fa-expc-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Expf Saasfaeuraprod1,fa-expf-saasfaeuraprod1,https://fa-expf-saasfaeuraprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Expo Saasfaprod1,fa-expo-saasfaprod1,https://fa-expo-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Exqb Saasfaprod1,fa-exqb-saasfaprod1,https://fa-exqb-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1003
+Fa Exrr Saasfaprod1,fa-exrr-saasfaprod1,https://fa-exrr-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/abbott
+Fa Exru Saasfaukgovprod1,fa-exru-saasfaukgovprod1,https://fa-exru-saasfaukgovprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Extu Saasfaprod1,fa-extu-saasfaprod1,https://fa-extu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Exty Saasfaprod1,fa-exty-saasfaprod1,https://fa-exty-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Exvn Saasfaprod1,fa-exvn-saasfaprod1,https://fa-exvn-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Exvu Saasfaprod1 (CX_1),fa-exvu-saasfaprod1/cx_1,https://fa-exvu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Exvu Saasfaprod1 (CX_1003),fa-exvu-saasfaprod1/cx_1003,https://fa-exvu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1003
+Fa Exxd Saasfaprod1,fa-exxd-saasfaprod1,https://fa-exxd-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3
+Fa Exxm Saasfaprod1,fa-exxm-saasfaprod1,https://fa-exxm-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_4
+Fa Exxn Saasfaprod1,fa-exxn-saasfaprod1,https://fa-exxn-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Fa Eyau Saasfaprod1,fa-eyau-saasfaprod1,https://fa-eyau-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/Argano-Careers
+Fa Eygi Saasfaprod1,fa-eygi-saasfaprod1,https://fa-eygi-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Eygo Saasfaprod1,fa-eygo-saasfaprod1,https://fa-eygo-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Fa Eyip Saasfaprod1,fa-eyip-saasfaprod1,https://fa-eyip-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_4001
+Fa Eykz Saasfaprod1,fa-eykz-saasfaprod1,https://fa-eykz-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fa Eylc Saasfaeuraprod1,fa-eylc-saasfaeuraprod1,https://fa-eylc-saasfaeuraprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fda,fda,https://fda.fa.us1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Fife Council Jobs and Careers,ekmu/cx_6009,https://ekmu.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_6009
+Forward,eguq/movingyouforward,https://eguq.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/MovingYouForward
 FAB |,ehjd,https://ehjd.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Fife Council Jobs and Careers,ekmu,https://ekmu.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Ford Global Career Site,efds,https://efds.fa.em5.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Fortive Careers,ejta,https://ejta.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Forward,eguq,https://eguq.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Fujifilm Business Innovation APAC,hcjq,https://hcjq.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_17
+Garrett Advancing Motion,ehth/cx_2001,https://ehth.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+GCI Careers,edqv/cx,https://edqv.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Geduglobal Iabmbn,geduglobal-iabmbn,https://geduglobal-iabmbn.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+GFSL Career Site,ejdm,https://ejdm.fa.em1.ukg.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Gka,gka/cx,https://gka.fa.us1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Global Careers,ekpl/cx_3001,https://ekpl.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3001
+Gowling WLG Careers,ehjc,https://ehjc.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_17
+Grupo Werthein,egky,https://egky.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_5001
 GCAA,elon,https://elon.fa.em8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 GCI Careers,edqv,https://edqv.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 GP Strategies Career Site,eetz,https://eetz.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
@@ -163,6 +572,70 @@ Global Careers,ekpl,https://ekpl.fa.us6.oraclecloud.com/hcmUI/CandidateExperienc
 Golden Goose,iaagmj,https://iaagmj.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Grant Thornton - US,ehzq,https://ehzq.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Guthrie Careers,elfw,https://elfw.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Harmonic Inc.,egmn,https://egmn.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Havering Candidate Experience Site,elfy,https://elfy.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Hbcp,hbcp,https://hbcp.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Hcal,hcal/cx_1001,https://hcal.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Hcas,hcas,https://hcas.fa.us1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Hcbt,hcbt/cx,https://hcbt.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Hccz,hccz/cx_2,https://hccz.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Hcdtgccprod Iayeqy,hcdtgccprod-iayeqy,https://hcdtgccprod-iayeqy.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Hcex,hcex,https://hcex.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/careers-telamon
+Hcfa (AmnealCareers),hcfa/amnealcareers,https://hcfa.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/AmnealCareers
+Hcfa (CX),hcfa/cx,https://hcfa.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Hcfa (CX_5001),hcfa/cx_5001,https://hcfa.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_5001
+Hchx,hchx,https://hchx.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hcib,hcib/cx_1001,https://hcib.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Hckg,hckg,https://hckg.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hcml,hcml/aeo-careers,https://hcml.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/AEO-Careers
+Hcnq,hcnq,https://hcnq.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Hcog (CX_2),hcog/cx_2,https://hcog.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Hcog (CX_2001),hcog/cx_2001,https://hcog.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Hcor,hcor,https://hcor.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hcpo,hcpo,https://hcpo.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Hcps,hcps,https://hcps.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hcqq,hcqq/cx_5004,https://hcqq.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_5004
+Hcqr,hcqr,https://hcqr.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2005
+Hcqt,hcqt,https://hcqt.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/Reale-Group
+Hcrb,hcrb,https://hcrb.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/BostonBeerCareers
+Hcre (CX_1),hcre/cx_1,https://hcre.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hcre (CX_3001),hcre/cx_3001,https://hcre.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3001
+Hcrg,hcrg,https://hcrg.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hcrw,hcrw,https://hcrw.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hctq,hctq,https://hctq.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hctz,hctz/cx_1001,https://hctz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Hcug,hcug/cx_2001,https://hcug.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Hcvk,hcvk,https://hcvk.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_16
+Hcwp,hcwp/cx_8001,https://hcwp.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_8001
+Hcwx (CX_15),hcwx/cx_15,https://hcwx.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_15
+Hcwx (CX_19),hcwx/cx_19,https://hcwx.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_19
+Hcwx (CX_2),hcwx/cx_2,https://hcwx.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Hcwx (CX_3001),hcwx/cx_3001,https://hcwx.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3001
+Hcwx (CX_5),hcwx/cx_5,https://hcwx.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_5
+Hcwx (CX_8),hcwx/cx_8,https://hcwx.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_8
+Hcyc,hcyc,https://hcyc.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hczf,hczf,https://hczf.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hczw,hczw/cx_1001,https://hczw.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Hdat,hdat,https://hdat.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Hdde,hdde,https://hdde.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Hddl,hddl,https://hddl.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Hdeh,hdeh,https://hdeh.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hdep,hdep/cx,https://hdep.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Hdga,hdga/lucyelectric,https://hdga.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/Lucyelectric
+Hdhe,hdhe/cx,https://hdhe.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Hdhf,hdhf,https://hdhf.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Hdix,hdix,https://hdix.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hdiy,hdiy/cx,https://hdiy.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Hdjm,hdjm/cx_5,https://hdjm.fa.ca2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_5
+Hdkk,hdkk/cx_2001,https://hdkk.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Hdks,hdks,https://hdks.fa.ca2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hdnn,hdnn/cx,https://hdnn.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Hdow (CX_1001),hdow/cx_1001,https://hdow.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Hdow (CX_1003),hdow/cx_1003,https://hdow.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1003
+Hdpc,hdpc/campushiring,https://hdpc.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CampusHiring
+Hdrc,hdrc/cx_3001,https://hdrc.fa.ca3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3001
+Hoffman Specialty Contracting,efsp/cx_4,https://efsp.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_4
+HUS Urasivusto,ejnv,https://ejnv.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 HBL People,hdcs,https://hdcs.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Hand Protection,emdm,https://emdm.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Harrah's Cherokee Casino Resort,epgr,https://epgr.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
@@ -181,6 +654,61 @@ Hoffman Construction Company,efsp,https://efsp.fa.us6.oraclecloud.com/hcmUI/Cand
 Hologic Careers,ebwb,https://ebwb.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Home Page,hdhy,https://hdhy.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Honeywell,ibqbjb,https://ibqbjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Iaacnf,iaacnf,https://iaacnf.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/Current-Opportunities
+Iaagiz,iaagiz/bristlecone-careers,https://iaagiz.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/bristlecone-careers
+Iaagmj,iaagmj/gg,https://iaagmj.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/GG
+Iaajtj,iaajtj,https://iaajtj.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Iaaley,iaaley,https://iaaley.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Iaamcp,iaamcp,https://iaamcp.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CSB
+Iaaqbn,iaaqbn,https://iaaqbn.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Iaaras,iaaras/cx_2,https://iaaras.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Iaavas,iaavas,https://iaavas.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Iaavey,iaavey,https://iaavey.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Iaayzv,iaayzv,https://iaayzv.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/SIGA
+Iabdgs,iabdgs,https://iabdgs.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/Finland
+Iabeey,iabeey,https://iabeey.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Iabhtj,iabhtj/clp-recruitment-system,https://iabhtj.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CLP-Recruitment-System
+Iaboey,iaboey/cx_2,https://iaboey.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Iabwey,iabwey,https://iabwey.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Iabxas,iabxas,https://iabxas.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Iabzbn,iabzbn,https://iabzbn.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Iacrgs,iacrgs,https://iacrgs.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Iadugs,iadugs,https://iadugs.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Iadyup,iadyup/cx_4001,https://iadyup.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_4001
+Iaejup,iaejup,https://iaejup.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/UOA-Careers
+Iaetme,iaetme,https://iaetme.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/Standard
+Iagime,iagime,https://iagime.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Iagjme,iagjme/cx_1005,https://iagjme.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1005
+Iagvme,iagvme,https://iagvme.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CITBCareers
+Iahtgs,iahtgs,https://iahtgs.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Iaings,iaings/sinchcareer,https://iaings.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/SinchCareer
+Ialime,ialime,https://ialime.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/jobsattatasteeluk
+Ialmme,ialmme,https://ialmme.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/ciklum-career
+Iaotqy,iaotqy,https://iaotqy.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Iapiqy,iapiqy,https://iapiqy.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Iascqy,iascqy,https://iascqy.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Iawmqy,iawmqy/careers,https://iawmqy.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/careers
+Iaymqy,iaymqy,https://iaymqy.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Iayzqy,iayzqy,https://iayzqy.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Ibaeqy,ibaeqy,https://ibaeqy.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Ibanqy,ibanqy,https://ibanqy.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_4
+Ibcjqy,ibcjqy,https://ibcjqy.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/jobsmymlc
+Iblyjb,iblyjb/cytel,https://iblyjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cytel
+Ibmdjb,ibmdjb,https://ibmdjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Ibmxjb,ibmxjb,https://ibmxjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Ibqajb,ibqajb,https://ibqajb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Ibqbjb,ibqbjb/honeywell,https://ibqbjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/Honeywell
+Ibqmjb,ibqmjb/monro-careers,https://ibqmjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/Monro-Careers
+Ibqzjb,ibqzjb,https://ibqzjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Ibvcjb,ibvcjb,https://ibvcjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2002
+Ibwsjb,ibwsjb,https://ibwsjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Ibyrjb,ibyrjb,https://ibyrjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/ACCJobs
+Ibzbjb,ibzbjb,https://ibzbjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/MLC
+Icbpjb,icbpjb,https://icbpjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/LazardProfessionalCareers
+Icczjb,icczjb,https://icczjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Icfcjb,icfcjb/aerospace,https://icfcjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/Aerospace
+Inland Revenue Career Site,ekfu,https://ekfu.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Ipsos,ecqf/cx_2001,https://ecqf.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
 IB,ejst,https://ejst.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 IFM Investors,enlc,https://enlc.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
 INSEAD,iablgs,https://iablgs.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
@@ -203,17 +731,35 @@ Inova,elar,https://elar.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/site
 Inspira Health,ernh,https://ernh.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Intertek US,hcog,https://hcog.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Ipsos,ecqf,https://ecqf.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Jobs @ Carmeuse,ekiz,https://ekiz.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
 Jefferies,hdid,https://hdid.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Job Opportunities | MCB Group,ekbd,https://ekbd.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Jobs at Acosta,eczy,https://eczy.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+King Ranch,eeof,https://eeof.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/King-Ranch
+KLDiscovery,ekug/cx_1001,https://ekug.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+KPMG,elzw/cx_1001,https://elzw.fa.em8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+KPMG Delivery Network India 1,ejgk/cx_3001,https://ejgk.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3001
 KPMG,elzw,https://elzw.fa.em8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 KPMG India,ejgk,https://ejgk.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Kroll,hcxs,https://hcxs.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+LBC ORC Career Site,ecum,https://ecum.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Leejam Official Career Site New,ebpy,https://ebpy.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Leicestershire County Council,eism/lcc,https://eism.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/lcc
+Local Truck Driving Jobs | Centerline Drivers,ehnn/cx_10,https://ehnn.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_10
+Lorain County Community College,ccyj,https://ccyj.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
 LANDMARK GROUP,efhi,https://efhi.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Lewisham Career Site,efuy,https://efuy.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 LifeView Group,etud,https://etud.fa.us8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Loma Linda,egln,https://egln.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Lucy Group,hdga,https://hdga.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Masimo,egcu/cx,https://egcu.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Mattson,eidg,https://eidg.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Messiah Ibvrjb,messiah-ibvrjb,https://messiah-ibvrjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+MHRA,eckx/mhracareers,https://eckx.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/MHRACareers
+Mountaire Jobs,ebtg/career-site,https://ebtg.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/Career-Site
+Multiconsult Group Iacabn,multiconsult-group-iacabn,https://multiconsult-group-iacabn.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/Multiconsult
+Mycronic Job Openings,ehtv,https://ehtv.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+MyHR Candidate Experience site,emvz,https://emvz.fa.em1.ukg.oraclecloud.com/hcmUI/CandidateExperience/en/sites/des-jobs
 MAS Holdings,egmh,https://egmh.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 MBC Group,ehff,https://ehff.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 MHRA,eckx,https://eckx.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
@@ -235,6 +781,13 @@ Monro,ibqmjb,https://ibqmjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/
 Motherson_North America Careers,hcnh,https://hcnh.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Mountaire Jobs,ebtg,https://ebtg.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Mouser,eabw,https://eabw.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Namos Solutions,edfl,https://edfl.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+National Highways,ehcu,https://ehcu.fa.em1.ukg.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_13
+National Pen,eihb,https://eihb.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+NatureScot,ejki,https://ejki.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+NHC Innovation,eghj,https://eghj.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_6001
+NMT Career Site,ejvr,https://ejvr.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+NRC NORCAP Careers,ekum/cx_2019,https://ekum.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2019
 NFL Career Site,hdmm,https://hdmm.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 NMC,eiby,https://eiby.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Nokia,fa-evmr-saasfaprod1,https://fa-evmr-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
@@ -247,21 +800,47 @@ National Bank of Kenya,eoin,https://eoin.fa.em3.oraclecloud.com/hcmUI/CandidateE
 NemoursCareerSite,epyz,https://epyz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Northwell Career Site,eppr,https://eppr.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Notified,eclz,https://eclz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Omicron Iadzgs,omicron-iadzgs,https://omicron-iadzgs.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/OmicronCareers
+Onity External Career Site,ebhz/onity,https://ebhz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/Onity
+Otsuka ICU Med Careers,eduu/cx_1001,https://eduu.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
 Onity External Career Site,ebhz,https://ebhz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Online @ Air Selangor,egek,https://egek.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Opus,iaaxiz,https://iaaxiz.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Oracle,eeho,https://eeho.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Oxford Nanopore Technologies,ejnh,https://ejnh.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Pella Windows & Doors,ebgj,https://ebgj.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/Pella-Careers
+Phoenix,egeg,https://egeg.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Pittsburg State University Career Site Minimal,ebyf,https://ebyf.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
 People First Bank,hcyt,https://hcyt.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
 Proskauer,dfa,https://dfa.fa.us1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Providence,evac,https://evac.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Pyxus,iahome,https://iahome.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Quest Diagnostics Careers,hdox,https://hdox.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Resideo,ehtl/cx,https://ehtl.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Riyadh Schools,ejpi/cx_5001,https://ejpi.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_5001
+Rjcorphcm Iacbiz,rjcorphcm-iacbiz,https://rjcorphcm-iacbiz.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Rockland Trust Career Site,eehb,https://eehb.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3001
 R+L Carriers,erhk,https://erhk.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 REDCON - Candidate Career site,eiej,https://eiej.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Resideo,ehtl,https://ehtl.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Rice University Minimal Template External Career Site,emdz,https://emdz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Ricoh Careers,cbha,https://cbha.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+S&C Minimal Career Site,ejia/cx_1001,https://ejia.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+"Samuel, Son & Co. 1855",ebct,https://ebct.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3002
+Sana Klinikum Lichtenberg,fa-eycl-saasfaeuraprod1,https://fa-eycl-saasfaeuraprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_4025
+SBC,egsd,https://egsd.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Schroders Referral,ekbq/cx_1001,https://ekbq.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Securitas Canada,ekaw/cx_1001,https://ekaw.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Sedgman,elgl,https://elgl.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2004
+Setonhill Ibtwjb,setonhill-ibtwjb,https://setonhill-ibtwjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+SLAB_Careersite,efpb,https://efpb.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1003
+Smith Mechanical Electric Plumbing,ekkt/cx_4001,https://ekkt.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_4001
+Specialized Rehabilitation Hospital,eftr,https://eftr.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Springfield Clinic,eify/cx_1004,https://eify.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1004
+St. Croix County Career Section,efff,https://efff.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Sumitomo SHI FW Career,eiox,https://eiox.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Sunflower,ecvu,https://ecvu.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/SunflowerCareers
+Synlait External Careers Site,ekvx,https://ekvx.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
 S&C Minimal Career Site,ejia,https://ejia.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 SAIL BSL,iabaiz,https://iabaiz.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 SALIC Career Site,hen,https://hen.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
@@ -289,6 +868,13 @@ Subaru,hcal,https://hcal.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sit
 Suffolk Jobs Direct,eoce,https://eoce.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Sun River Health,edvy,https://edvy.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Sundt Careers,eewl,https://eewl.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+TForce Freight,efjm,https://efjm.fa.ca2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/TForceFreight
+The Fedcap Group,eckb/cx_1001,https://eckb.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Thurrock Council,egst,https://egst.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Travelport Candidate Experience site,ejzg,https://ejzg.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Trincore Ibvxjb,trincore-ibvxjb,https://trincore-ibvxjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Tulane Ibqejb (CX_1),tulane-ibqejb/cx_1,https://tulane-ibqejb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Tulane Ibqejb (CX_1001),tulane-ibqejb/cx_1001,https://tulane-ibqejb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
 T.EN Career Site,hcxg,https://hcxg.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 TG_WFSJobs,iaboey,https://iaboey.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 TTX,ejjc,https://ejjc.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
@@ -307,6 +893,10 @@ The Fedcap Group,eckb,https://eckb.fa.us2.oraclecloud.com/hcmUI/CandidateExperie
 The Kroger Co.,eluq,https://eluq.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Tiffany,eljs,https://eljs.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Trillium Health Partners,iadyup,https://iadyup.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+University of Waikato Careers,elhs,https://elhs.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+University of Wollongong,ejgl,https://ejgl.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/UOW
+UoB Employee,edzz,https://edzz.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_6001
+Utulsa Ibvjjb,utulsa-ibvjjb,https://utulsa-ibvjjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
 UC Health Career Site,eswt,https://eswt.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 UNDP,estm,https://estm.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 URUS Group,hdjm,https://hdjm.fa.ca2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
@@ -314,11 +904,20 @@ USS,icbajb,https://icbajb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/si
 UW Health,eimy,https://eimy.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 UnitedLex,ekkk,https://ekkk.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 University of Edinburgh,elxw,https://elxw.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Valaris,efqq,https://efqq.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1008
 VDOT Careers Site,etgi,https://etgi.fa.us8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 VITAS Healthcare,ejrz,https://ejrz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Vanderbilt University,ecsr,https://ecsr.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Vertiv,egup,https://egup.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Vodafone Qatar,elat,https://elat.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Walsall Council,ejti,https://ejti.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/WMBC
+Wam Iabkey,wam-iabkey,https://wam-iabkey.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Wearememorial Ibrkjb,wearememorial-ibrkjb,https://wearememorial-ibrkjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/Careers
+Werken bij Profource,eccs,https://eccs.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/werkenbij
+West Midlands Police,ecwz/wmp,https://ecwz.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/WMP
+Westpac Group,ebuu/cx,https://ebuu.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Work with us | Copa Airlines - NEW,ejom,https://ejom.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Worthington Steel,cbdt,https://cbdt.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/WorthingtonSteelCareers
 WM,emcm,https://emcm.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 WSP,emit,https://emit.fa.ca3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 WTW External Careers Site,eedu,https://eedu.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1


### PR DESCRIPTION
## Summary
- add 599 previously unlisted Oracle Recruiting career sites
- expose 59,851 genuinely new live jobs after host-scoped deduplication

## Discovery and validation
- mined the latest Common Crawl index (`CC-MAIN-2026-25`)
- normalized CandidateExperience URLs and removed existing site URLs before probing
- live-tested 774 candidates through Oracle’s public recruiting API; 709 initially returned jobs
- fully extracted host-scoped requisition IDs, then removed aliases and overlap
- compared against 220,025 published Oracle jobs
- excluded 39,249 already-published jobs and 105 boards that contributed no new jobs
- retained 599 sites contributing 59,851 unique new jobs
- verified candidate URLs are unique and no new slug collision groups were introduced
- `git diff --ignore-space-at-eol` is exactly 599 additions; 21 existing CRLF context lines are represented as EOL-only changes by the patch tooling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 599 live Oracle Recruiting career sites, surfacing 59,851 unique new jobs after host-scoped deduplication.

- **New Features**
  - Added 599 sites to `ats-companies/oracle.csv` (patch shows +620/−21 due to EOL normalization).
  - Mined Common Crawl `CC-MAIN-2026-25`, normalized `CandidateExperience` URLs, and validated via Oracle’s public recruiting API; excluded 39,249 already-published jobs and 105 sites with no net new.
  - De-aliased requisition IDs and checked for slug collisions; none introduced.

<sup>Written for commit a3ec30cc862eee5d3a7518d05320e53ef3d60059. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

