### PR TITLE
Add 286 live Lever boards from historical crawl discovery

### DIFF
--- a/ats-companies/lever.csv
+++ b/ats-companies/lever.csv
@@ -1,6 +1,8 @@
 name,slug,url
+#paid,hashtagpaid,https://jobs.lever.co/hashtagpaid
 100MS,100ms,https://jobs.lever.co/100ms
 15Five,15five,https://jobs.lever.co/15five
+1840 & Company,1840&company,https://jobs.lever.co/1840&Company
 1inch,1inch,https://jobs.lever.co/1inch
 21st Century Home Health Services Inc.,21hhs,https://jobs.lever.co/21hhs
 2brains,2brains,https://jobs.lever.co/2brains
@@ -10,7 +12,9 @@ name,slug,url
 3E,3eco,https://jobs.lever.co/3eco
 3Pillar,3pillarglobal,https://jobs.lever.co/3pillarglobal
 4Front Ventures,4front,https://jobs.lever.co/4front
+4SIGHT Supply Chain,4sightsupplychain,https://jobs.lever.co/4SIGHTSupplyChain
 90 Seconds,90seconds,https://jobs.lever.co/90seconds
+@hotel,tripscout,https://jobs.lever.co/tripscout
 AIFund,AIFund,https://jobs.lever.co/AIFund
 AMIRI,AMIRI,https://jobs.lever.co/AMIRI
 ABM Industries,ableserve,https://jobs.lever.co/ableserve
@@ -137,6 +141,7 @@ Artera,artera-2,https://jobs.lever.co/artera-2
 Articulate,articulate,https://jobs.lever.co/articulate
 ASAPP,asapp-2,https://jobs.lever.co/asapp-2
 Ashoka,ashoka,https://jobs.lever.co/ashoka
+Faber Work,fabertechnologies,https://jobs.lever.co/fabertechnologies
 Favor,askfavor,https://jobs.lever.co/askfavor
 Assist World,assist-world,https://jobs.lever.co/assist-world
 Ataccama,ataccama,https://jobs.lever.co/ataccama
@@ -438,6 +443,7 @@ Eastern Communications,eastern-communications,https://jobs.lever.co/eastern-comm
 EasyPost,easypost-2,https://jobs.lever.co/easypost-2
 Easy Street Capital,easystreetcap,https://jobs.lever.co/easystreetcap
 ECL,ecldc,https://jobs.lever.co/ecldc
+La Haus,lahaus,https://jobs.lever.co/lahaus
 Lightcast,economicmodeling,https://jobs.lever.co/economicmodeling
 econstruct,econstruct,https://jobs.lever.co/econstruct
 Ecosystem,ecosystem,https://jobs.lever.co/ecosystem
@@ -484,6 +490,7 @@ Equativ,equativ,https://jobs.lever.co/equativ
 ERG,erg,https://jobs.lever.co/erg
 Esalen Institute,esalen,https://jobs.lever.co/esalen
 E-Space,espace,https://jobs.lever.co/espace
+Earth Species Project,earthspecies,https://jobs.lever.co/earthspecies
 Esper,esper,https://jobs.lever.co/esper
 Empire State Realty Trust,esrtreit,https://jobs.lever.co/esrtreit
 Ethena,ethena,https://jobs.lever.co/ethena
@@ -498,6 +505,7 @@ Extreme Networks,extremenetworks,https://jobs.lever.co/extremenetworks
 Eyeline,Eyeline,https://jobs.lever.co/Eyeline
 Factor,factor,https://jobs.lever.co/factor
 Fair Trade Real Estate,FairTradeRealEstate,https://jobs.lever.co/FairTradeRealEstate
+Fairmat,fairmat,https://jobs.lever.co/Fairmat
 Fam,fampay,https://jobs.lever.co/fampay
 Fanatee,fanatee,https://jobs.lever.co/fanatee
 Farfetch,farfetch,https://jobs.lever.co/farfetch
@@ -672,8 +680,11 @@ Humaans,humaans,https://jobs.lever.co/humaans
 Hunger Free America,hungerfreeamerica,https://jobs.lever.co/hungerfreeamerica
 HUSH,hush,https://jobs.lever.co/hush
 Hypebeast,hypebeast,https://jobs.lever.co/hypebeast
+iCodde,icodde,https://jobs.lever.co/iCodde
+Ideas United,ideasunited,https://jobs.lever.co/ideasunited
 IDMWORKS,idmworks,https://jobs.lever.co/idmworks
 IDT,idt,https://jobs.lever.co/idt
+ilek,ilek.fr,https://jobs.lever.co/ilek.fr
 Institute of Foundation Models,ifm-us,https://jobs.lever.co/ifm-us
 Illumination,illumination,https://jobs.lever.co/illumination
 ImageX,imagexmedia,https://jobs.lever.co/imagexmedia
@@ -924,6 +935,8 @@ Moonpig,moonpig,https://jobs.lever.co/moonpig
 Morning Brew Inc.,morningbrew,https://jobs.lever.co/morningbrew
 Morning Consult,morningconsult,https://jobs.lever.co/morningconsult
 M+R,mrss,https://jobs.lever.co/mrss
+Magnify,magnify,https://jobs.lever.co/magnify
+Magnopus,magnopus,https://jobs.lever.co/magnopus
 "MTS Health Partners, L.P.",mtspartners,https://jobs.lever.co/mtspartners
 Mujin,mujininc,https://jobs.lever.co/mujininc
 Mulberry,mulberry,https://jobs.lever.co/mulberry
@@ -1017,8 +1030,10 @@ Outreach,outreach,https://jobs.lever.co/outreach
 Outsight,outsight,https://jobs.lever.co/outsight
 Outsourced Staff,outsourcedstaff,https://jobs.lever.co/outsourcedstaff
 Oxylabs,oxylabs,https://jobs.lever.co/oxylabs
+P3 Veterinary Partners,p3vetpartners,https://jobs.lever.co/p3vetpartners
 Pacific Environment,pacific-environment,https://jobs.lever.co/pacific-environment
 Pacifico Energy,pacificoenergy,https://jobs.lever.co/pacificoenergy
+PackageX,packagex,https://jobs.lever.co/packagex
 Packmatic GmbH,Packmatic,https://jobs.lever.co/Packmatic
 PadSplit,padsplit,https://jobs.lever.co/padsplit
 Palantir Technologies,palantir,https://jobs.lever.co/palantir
@@ -1161,6 +1176,7 @@ ROH,ROH,https://jobs.lever.co/ROH
 Rackspace,rackspace,https://jobs.lever.co/rackspace
 Radformation,radformation,https://jobs.lever.co/radformation
 Radical AI,RadicalAI,https://jobs.lever.co/RadicalAI
+"Railroad19, Inc",railroad19,https://jobs.lever.co/railroad19
 Robotics and AI Institute,rai,https://jobs.lever.co/rai
 Raine Group,raine,https://jobs.lever.co/raine
 RainFocus,rainfocus,https://jobs.lever.co/rainfocus
@@ -1552,6 +1568,7 @@ Waabi,waabi,https://jobs.lever.co/waabi
 Wade Trim,wadetrim,https://jobs.lever.co/wadetrim
 Wahed,wahed.com,https://jobs.lever.co/wahed.com
 Wahi,wahi,https://jobs.lever.co/wahi
+WaitWhat,waitwhat,https://jobs.lever.co/waitwhat
 Walker & Company,walkerandcompany,https://jobs.lever.co/walkerandcompany
 Walker Consultants,walkerconsultants,https://jobs.lever.co/walkerconsultants
 WalkMe,walkme,https://jobs.lever.co/walkme
@@ -1591,6 +1608,7 @@ Wisdomai,wisdomai,https://jobs.lever.co/wisdomai
 WISEcode,wisecode,https://jobs.lever.co/wisecode
 Wishpond Technologies,wishpond,https://jobs.lever.co/wishpond
 Warner Music Inc.,wmg,https://jobs.lever.co/wmg
+Waterfall,waterfall,https://jobs.lever.co/waterfall
 Woodard & Curran,woodardcurran,https://jobs.lever.co/woodardcurran
 WorkInProgress,workinprogress,https://jobs.lever.co/workinprogress
 WorkWave,workwave,https://jobs.lever.co/workwave
@@ -1602,8 +1620,12 @@ World Relief,wr,https://jobs.lever.co/wr
 Wristcheck,wristcheck,https://jobs.lever.co/wristcheck
 World Wide Professional Solutions,wwprosolutions,https://jobs.lever.co/wwprosolutions
 Wyetech,wyetechllc,https://jobs.lever.co/wyetechllc
+X by 2,xby2,https://jobs.lever.co/xby2
+Xage Security,xage-security,https://jobs.lever.co/xage-security
 Xcimer Energy,xcimer,https://jobs.lever.co/xcimer
+Xepelin,xepelin,https://jobs.lever.co/xepelin
 Xsolla,xsolla,https://jobs.lever.co/xsolla
+Yardstick,yardstick,https://jobs.lever.co/yardstick
 Yardzen,yardzen,https://jobs.lever.co/yardzen
 Yassir,Yassir,https://jobs.lever.co/Yassir
 Younited,younited,https://jobs.lever.co/younited
@@ -1691,9 +1713,13 @@ BuildingConnected,buildingconnected,https://jobs.lever.co/buildingconnected
 Cambium Networks,cambiumnetworks,https://jobs.lever.co/cambiumnetworks
 candidate.fyi,candidate,https://jobs.lever.co/candidate
 C and L Inspection,candlinspection,https://jobs.lever.co/candlinspection
+Canopyservicing,canopyservicing,https://jobs.lever.co/canopyservicing
 Canvas Forum,canvasforum,https://jobs.lever.co/canvasforum
+Cardiologs,cardiologs,https://jobs.lever.co/cardiologs
 Carelinks ABA,carelinks-aba,https://jobs.lever.co/carelinks-aba
 Carly Rian Group,carlyriangroup,https://jobs.lever.co/carlyriangroup
+Caruso,carusoaffiliated,https://jobs.lever.co/carusoaffiliated
+Catalist,catalist,https://jobs.lever.co/catalist
 Kind Behavioral Health,carolinacenterforaba,https://jobs.lever.co/carolinacenterforaba
 Charcuterie Artisans,charcuterie,https://jobs.lever.co/charcuterie
 Chopra,chopra,https://jobs.lever.co/chopra
@@ -1722,6 +1748,8 @@ CXT Software,cxtsoftware,https://jobs.lever.co/cxtsoftware
 CyberOne Security,cyberonesecurity,https://jobs.lever.co/cyberonesecurity
 Cygnal,cygn,https://jobs.lever.co/cygn
 D-Fend Solutions,d-fendsolutions,https://jobs.lever.co/d-fendsolutions
+"DABS, Inc.",dabsinc,https://jobs.lever.co/dabsinc
+Danti,danti.ai,https://jobs.lever.co/danti.ai
 Lever Demo V2,demo,https://jobs.lever.co/demo
 Dempsey Uniform & Linen Supply,dempseyuniform-2,https://jobs.lever.co/dempseyuniform-2
 Desafío Latam,desafiolatam,https://jobs.lever.co/desafiolatam
@@ -1751,9 +1779,11 @@ Evident ID,evidentid,https://jobs.lever.co/evidentid
 ezCater,ezcater,https://jobs.lever.co/ezcater
 Falcon.io,falcon,https://jobs.lever.co/falcon
 Fantasy,fantasy,https://jobs.lever.co/fantasy
+Farcast,farcast,https://jobs.lever.co/Farcast
 Felix Construction,felix-construction,https://jobs.lever.co/felix-construction
 FEVO,fevo,https://jobs.lever.co/fevo
 Field Fastener,fieldfastener,https://jobs.lever.co/fieldfastener
+Firefly,fireflyon,https://jobs.lever.co/fireflyon
 First American,firstam,https://jobs.lever.co/firstam
 Fitbod,fitbod,https://jobs.lever.co/fitbod
 Fixins Soul Kitchen,fixinssoulkitchen,https://jobs.lever.co/fixinssoulkitchen
@@ -1766,6 +1796,11 @@ Fundrise,fundrise,https://jobs.lever.co/fundrise
 Gamma,gamma,https://jobs.lever.co/gamma
 Collaborative Strategies,getcollaborative,https://jobs.lever.co/getcollaborative
 Five Star Solutions,getfivestar,https://jobs.lever.co/getfivestar
+Flare Therapeutics,flaretherapeutics,https://jobs.lever.co/FlareTherapeutics
+Flat.mx,flat.mx,https://jobs.lever.co/Flat.mx
+Fliff,fliff,https://jobs.lever.co/Fliff
+Flux Mobility,flux-mobility,https://jobs.lever.co/flux-mobility
+Flytographer,flytographer,https://jobs.lever.co/Flytographer
 Giving Home Health Care,givinghhc,https://jobs.lever.co/givinghhc
 Global Strategy Group,globalstrategygroup,https://jobs.lever.co/globalstrategygroup
 Good Eggs,goodeggs,https://jobs.lever.co/goodeggs
@@ -1776,7 +1811,9 @@ Grand Games,grand,https://jobs.lever.co/grand
 Grant Street Group,grantstreet,https://jobs.lever.co/grantstreet
 Guardsquare,guardsquare,https://jobs.lever.co/guardsquare
 H2 Event Group,h2eventgroup,https://jobs.lever.co/h2eventgroup
+Handoff,handoff,https://jobs.lever.co/handoff
 Happy Health,happy-sleep,https://jobs.lever.co/happy-sleep
+Harmonic Design,harmonicdesign,https://jobs.lever.co/harmonicdesign
 "Hiller Plumbing, Heating, Cooling & Electrical",happyhiller,https://jobs.lever.co/happyhiller
 "Hartizen Homes, LLC",hartizenhomes,https://jobs.lever.co/hartizenhomes
 HavenPoint Health,havenpoint-health,https://jobs.lever.co/havenpoint-health
@@ -1797,25 +1834,39 @@ Hypersonica,hypersonica-prod,https://jobs.lever.co/hypersonica-prod
 Jane Technologies,iheartjane,https://jobs.lever.co/iheartjane
 Immiland Canada Inc.,immiland-canada-inc,https://jobs.lever.co/immiland-canada-inc
 In Compass Health,incompasshealth,https://jobs.lever.co/incompasshealth
+Indebted,indebted,https://jobs.lever.co/indebted
 INFINIT,infinit,https://jobs.lever.co/infinit
 Infobase,infobase,https://jobs.lever.co/infobase
 Innodata,innodata,https://jobs.lever.co/innodata
 Innophos,innophos,https://jobs.lever.co/innophos
+Insight M,insightm,https://jobs.lever.co/InsightM
+Institute for Public Health Innovation,iphi,https://jobs.lever.co/IPHI
+Integra Beauty,integrabeauty,https://jobs.lever.co/integrabeauty
+Integrators services a.s.,integrators.cz,https://jobs.lever.co/integrators.cz
+Interior Marketing Group,interiormarketinggroup,https://jobs.lever.co/InteriorMarketingGroup
 Intrepid College Prep Schools,intrepidcollegeprep,https://jobs.lever.co/intrepidcollegeprep
 Invo Healthcare - Family of Companies,invohealthcare,https://jobs.lever.co/invohealthcare
+Ionic Partners,ionicpartners,https://jobs.lever.co/Ionicpartners
 Ironflow AI,ironflow,https://jobs.lever.co/ironflow
 Iru,iru,https://jobs.lever.co/iru
 Issuu,issuu,https://jobs.lever.co/issuu
+Istari Digital,istaridigital.ai,https://jobs.lever.co/istaridigital.ai
 Jaumo,jaumo,https://jobs.lever.co/jaumo
+Jito Foundation,jito,https://jobs.lever.co/jito
 JMA Wireless,jmawireless,https://jobs.lever.co/jmawireless
+JMI Equity,jmi,https://jobs.lever.co/jmi
+Joyride Autos,joyrideautos,https://jobs.lever.co/joyrideautos
 LinkedIn Test - Senthil,jobvite,https://jobs.lever.co/jobvite
 Formal,joinformal,https://jobs.lever.co/joinformal
+Freeosk,thefreeosk,https://jobs.lever.co/thefreeosk
+Future Motion,rideonewheel,https://jobs.lever.co/rideonewheel
 Jupe,jupe,https://jobs.lever.co/jupe
 Kapwing,kapwing,https://jobs.lever.co/kapwing
 KCAS Bio,kcasbio,https://jobs.lever.co/kcasbio
 Keepsafe,keepsafe,https://jobs.lever.co/keepsafe
 Kestrel Intelligence,kestrel-intelligence,https://jobs.lever.co/kestrel-intelligence
 K Group Companies,kgroupcompanies,https://jobs.lever.co/kgroupcompanies
+KarmaCheck,karmacheck,https://jobs.lever.co/karmacheck
 Kochava,kochava,https://jobs.lever.co/kochava
 Kogniz,kogniz,https://jobs.lever.co/kogniz
 Kolibri Games,kolibrigames,https://jobs.lever.co/kolibrigames
@@ -1823,10 +1874,16 @@ Korro Bio,korrobio,https://jobs.lever.co/korrobio
 Kids on the Move,kotm,https://jobs.lever.co/kotm
 LatchBio,latch,https://jobs.lever.co/latch
 LB Capital,lb-capital,https://jobs.lever.co/lb-capital
+LCBC Church,lcbcchurch,https://jobs.lever.co/lcbcchurch
 Leadership Connect,leadershipconnect,https://jobs.lever.co/leadershipconnect
 Leadspace,leadspace,https://jobs.lever.co/leadspace
+Lean In,sgff.org,https://jobs.lever.co/sgff.org
+Ledger,ledger,https://jobs.lever.co/ledger
 Lever Demo 2,leverdemo,https://jobs.lever.co/leverdemo
 Lever Education,leverdemo50000,https://jobs.lever.co/leverdemo50000
+Lexeo Therapeutics,lexeotx,https://jobs.lever.co/lexeotx
+Liberatii,liberatii,https://jobs.lever.co/Liberatii
+Lillio (formerly HiMama),lillio,https://jobs.lever.co/Lillio
 LinkedIn Partner Sandbox - RSC testing,linkedin,https://jobs.lever.co/linkedin
 Link Rehab and Wellness,linkrehabwellness,https://jobs.lever.co/linkrehabwellness
 "Little Sprouts, LLC",littlesprouts,https://jobs.lever.co/littlesprouts
@@ -1836,6 +1893,10 @@ LTA Research,ltaresearch,https://jobs.lever.co/ltaresearch
 Lucas Museum of Narrative Art,lucasmuseum,https://jobs.lever.co/lucasmuseum
 Rainmaker Technology Corporation,make-rain,https://jobs.lever.co/make-rain
 Makpar,makpar,https://jobs.lever.co/makpar
+Malbon,malbongolf,https://jobs.lever.co/malbongolf
+Mammoth Biosciences,mammothbiosci,https://jobs.lever.co/mammothbiosci
+MantaNetwork,mantanetwork,https://jobs.lever.co/MantaNetwork
+Maquette Virtuelle,maquettevirtuelle,https://jobs.lever.co/maquettevirtuelle
 Marquette Associates,marquetteassociates,https://jobs.lever.co/marquetteassociates
 Marshall Reddick Real Estate,marshallreddick,https://jobs.lever.co/marshallreddick
 Mastery Charter Schools,masterycharter,https://jobs.lever.co/masterycharter
@@ -1866,6 +1927,8 @@ Ubiquity Retirement and Savings (dba Decimal Inc),myubiquity,https://jobs.lever.
 Nango,nango,https://jobs.lever.co/nango
 NAVISITE - Part of Accenture,navisite,https://jobs.lever.co/navisite
 Nelnet Community Engagement,nce,https://jobs.lever.co/nce
+New Jersey Innovation Authority,njstateofficeofinnovation,https://jobs.lever.co/NJStateOfficeofInnovation
+nexos.ai,nexos,https://jobs.lever.co/Nexos
 NFX,nfx,https://jobs.lever.co/nfx
 Nimbus,nimbus,https://jobs.lever.co/nimbus
 NOBULL,nobullproject,https://jobs.lever.co/nobullproject
@@ -1881,16 +1944,26 @@ O'Donnell/Snider Construction,odonnellsnider,https://jobs.lever.co/odonnellsnide
 Okendo,okendo,https://jobs.lever.co/okendo
 Oktopost,oktopost,https://jobs.lever.co/oktopost
 Oliver Wyman Labs,oliverwyman,https://jobs.lever.co/oliverwyman
+Onehouse,onehouse,https://jobs.lever.co/Onehouse
 Oomnitza,oomnitza,https://jobs.lever.co/oomnitza
 Optimus SBR,optimussbr,https://jobs.lever.co/optimussbr
 OPYS,opys,https://jobs.lever.co/opys
+OraSure Technologies Inc.,dnagenotek,https://jobs.lever.co/dnagenotek
 Orb Aerospace,orbaerospace,https://jobs.lever.co/orbaerospace
+Orbitalsidekick,orbitalsidekick,https://jobs.lever.co/orbitalsidekick
 Ordr,ordr,https://jobs.lever.co/ordr
+"Orijin, a public benefit corporation",orijin,https://jobs.lever.co/orijin
+OTI Lumionics Inc.,otilumionics,https://jobs.lever.co/otilumionics
+OU Education Services,ou-education-services,https://jobs.lever.co/ou-education-services
+OutcomesAI,outcomesai,https://jobs.lever.co/outcomesai
 Overcast,overcast,https://jobs.lever.co/overcast
+Overclock Labs,akashnetwork,https://jobs.lever.co/AkashNetwork
 Overmind,overmind,https://jobs.lever.co/overmind
 Paradigm Health,paradigm-health,https://jobs.lever.co/paradigm-health
 Paramedic Services of Illinois,paramedicservices,https://jobs.lever.co/paramedicservices
 Parnall Law,parnalllaw,https://jobs.lever.co/parnalllaw
+Pathpoint,pathpoint,https://jobs.lever.co/pathpoint
+Pavement Coffeehouse,pavementcoffee,https://jobs.lever.co/pavementcoffee
 Paytm Payments Services,paytmpayments,https://jobs.lever.co/paytmpayments
 Penrod,penrodsoftware,https://jobs.lever.co/penrodsoftware
 Perr&Knight,perrknight,https://jobs.lever.co/perrknight
@@ -1927,12 +2000,16 @@ Proxima,proxima,https://jobs.lever.co/proxima
 Blood,pslove-pte,https://jobs.lever.co/pslove-pte
 Pyka,pyka,https://jobs.lever.co/pyka
 Q Bio,qbio,https://jobs.lever.co/qbio
+Qover,qover,https://jobs.lever.co/Qover
+Quandri,quandri,https://jobs.lever.co/quandri
 Quilted Health,quilted-health,https://jobs.lever.co/quilted-health
 Quiq,quiq,https://jobs.lever.co/quiq
 Quixel,quixel,https://jobs.lever.co/quixel
+Quokka,quokka,https://jobs.lever.co/quokka
 Range Energy,rangeenergy,https://jobs.lever.co/rangeenergy
 RapidDeploy,rapiddeploy,https://jobs.lever.co/rapiddeploy
 Rapid Micro Biosystems,rapidmicrobio,https://jobs.lever.co/rapidmicrobio
+Rapt Studio,raptstudio,https://jobs.lever.co/RaptStudio
 RAVL,ravl_io,https://jobs.lever.co/ravl_io
 rbanw,rbanw,https://jobs.lever.co/rbanw
 RECESS,recess,https://jobs.lever.co/recess
@@ -1947,7 +2024,9 @@ Rocket Communications,rocketcommunications,https://jobs.lever.co/rocketcommunica
 Cooper for NC,roy-cooper,https://jobs.lever.co/roy-cooper
 Rupa Health,rupa,https://jobs.lever.co/rupa
 Safran.AI,safran-ai,https://jobs.lever.co/safran-ai
+Saga,saga-xyz,https://jobs.lever.co/saga-xyz
 Sapling - Partner,sapling,https://jobs.lever.co/sapling
+Sauce,sauce,https://jobs.lever.co/Sauce
 Scott Logic,scottlogic,https://jobs.lever.co/scottlogic
 Seattle Art Museum,seattleartmuseum,https://jobs.lever.co/seattleartmuseum
 Sequel Med Tech,sequel-med-tech,https://jobs.lever.co/sequel-med-tech
@@ -1957,6 +2036,24 @@ Service Wire,servicewire,https://jobs.lever.co/servicewire
 Shadow,shadow,https://jobs.lever.co/shadow
 Showcase IDX,showcaseidx,https://jobs.lever.co/showcaseidx
 Acme,sigma-squared,https://jobs.lever.co/sigma-squared
+Acselhealth,acselhealth,https://jobs.lever.co/acselhealth
+Actriv,actriv,https://jobs.lever.co/actriv
+Ad Hoc Labs,adhoclabs,https://jobs.lever.co/adhoclabs
+Advanced Agrilytics,advancedagrilytics,https://jobs.lever.co/advancedagrilytics
+AE,ae-2,https://jobs.lever.co/ae-2
+AFAR,afarmedia,https://jobs.lever.co/AfarMedia
+Agerpoint,agerpoint,https://jobs.lever.co/Agerpoint
+Aicrete,aicrete,https://jobs.lever.co/aicrete
+Aizon,aizon,https://jobs.lever.co/aizon
+All Ears Veterinary,allears-vet,https://jobs.lever.co/allears-vet
+Allworknow,allworknow,https://jobs.lever.co/allworknow
+Altarum,altarum,https://jobs.lever.co/altarum
+Altoida,altoida,https://jobs.lever.co/Altoida
+Ambergroup,ambergroup,https://jobs.lever.co/ambergroup
+Ambi Robotics,ambirobotics,https://jobs.lever.co/ambirobotics
+Ampeco Ltd,ampeco-global,https://jobs.lever.co/ampeco-global
+AmSty,amsty,https://jobs.lever.co/amsty
+AntiCapital,anticapital,https://jobs.lever.co/AntiCapital
 Sila,silasg,https://jobs.lever.co/silasg
 DNAM Brands,silhouette,https://jobs.lever.co/silhouette
 SimonMed Imaging,simonmed,https://jobs.lever.co/simonmed
@@ -1991,6 +2088,8 @@ Technology Advancement Group,tag,https://jobs.lever.co/tag
 Talkwalker,talkwalker,https://jobs.lever.co/talkwalker
 Thomas & Hutton,tandh,https://jobs.lever.co/tandh
 Tangram,tangram,https://jobs.lever.co/tangram
+TDA_Boulder,tdaboulder,https://jobs.lever.co/tdaboulder
+TeamBuilders Behavioral Health,teambuilders,https://jobs.lever.co/teambuilders
 Tekton,tekton,https://jobs.lever.co/tekton
 Tenna,tenna,https://jobs.lever.co/tenna
 Terminus,terminus,https://jobs.lever.co/terminus
@@ -2018,12 +2117,17 @@ True Zero Technologies,truezerotech,https://jobs.lever.co/truezerotech
 Tusker,tusker,https://jobs.lever.co/tusker
 UATX,uaustin,https://jobs.lever.co/uaustin
 Uberflip,uberflip,https://jobs.lever.co/uberflip
+Ubiminds,ubiminds,https://jobs.lever.co/Ubiminds
 UCSF,ucsf,https://jobs.lever.co/ucsf
 Ullico,ullico,https://jobs.lever.co/ullico
 UQUAL,uqual,https://jobs.lever.co/uqual
 Util-Assist Inc.,util-assist,https://jobs.lever.co/util-assist
 Vail Systems Inc.,vailsys,https://jobs.lever.co/vailsys
+Valarian Technologies Limited,valarian,https://jobs.lever.co/valarian
+VALPEO,valpeo.com,https://jobs.lever.co/valpeo.com
 Veda Tech Labs,vedatechlabs,https://jobs.lever.co/vedatechlabs
+VeeFriends,veefriends,https://jobs.lever.co/VeeFriends
+Veeva Systems,veeva,https://jobs.lever.co/veeva
 Velo3D,velo3d,https://jobs.lever.co/velo3d
 Venus Aerospace,venusaero,https://jobs.lever.co/venusaero
 "Via Separations, Inc.",viaseparations,https://jobs.lever.co/viaseparations
@@ -2036,8 +2140,11 @@ Vohra Physicians,vohra,https://jobs.lever.co/vohra
 Vrify Trial,vrify,https://jobs.lever.co/vrify
 VTG,vtg,https://jobs.lever.co/vtg
 Wavicle Data Solutions,wavicledata,https://jobs.lever.co/wavicledata
+Wayground (formerly Quizizz),wayground,https://jobs.lever.co/Wayground
 Welo Global,weloglobal,https://jobs.lever.co/weloglobal
+WeSalute,wesalute,https://jobs.lever.co/WeSalute
 Western Aircraft,westair,https://jobs.lever.co/westair
+Westminster-Canterbury of the Blue Ridge,wc-br,https://jobs.lever.co/wc-br
 Monster Tree Service,whymonster,https://jobs.lever.co/whymonster
 Williamsburg Learning,williamsburglearning,https://jobs.lever.co/williamsburglearning
 Wisr,wisr,https://jobs.lever.co/wisr
@@ -2047,68 +2154,247 @@ Worldscape Technology Inc.,worldscape-technology,https://jobs.lever.co/worldscap
 XTB Trial,xtb,https://jobs.lever.co/xtb
 Yonex USA,yonexusa,https://jobs.lever.co/yonexusa
 Z1 Tech,z1tech,https://jobs.lever.co/z1tech
+Zadara,zadara,https://jobs.lever.co/Zadara
 Zambezi,zambezi,https://jobs.lever.co/zambezi
 Zazzle,zazzle,https://jobs.lever.co/zazzle
 Zeiss,zeiss,https://jobs.lever.co/zeiss
+Zeller,zeller,https://jobs.lever.co/Zeller
 Zilliz,zilliz,https://jobs.lever.co/zilliz
 Zingtree,zingtree,https://jobs.lever.co/zingtree
 Zinier Trial,zinier,https://jobs.lever.co/zinier
+Zinovo,zinovo,https://jobs.lever.co/zinovo
 Channel Corp.,zoyi,https://jobs.lever.co/zoyi
 APCO Holdings,apcoholdings,https://jobs.lever.co/apcoholdings
+APEX Investigation,apexpi,https://jobs.lever.co/apexpi
 AppSamurai,appsamurai,https://jobs.lever.co/appsamurai
 Apryse,apryse,https://jobs.lever.co/apryse
+"Arundel Lodge, Inc.",arundellodge,https://jobs.lever.co/arundellodge
 Asendia Inc,asendia,https://jobs.lever.co/asendia
+Aurora Labs,aurora-dev,https://jobs.lever.co/aurora-dev
 Avenues Recovery,avenuesrecovery,https://jobs.lever.co/avenuesrecovery
+AVIA,aviahealth,https://jobs.lever.co/aviahealth
 Balbix,balbix,https://jobs.lever.co/balbix
+base | flowa,base-flowa,https://jobs.lever.co/base-flowa
+Beem,beemenergy,https://jobs.lever.co/BeemEnergy
+Bekk,bekk,https://jobs.lever.co/bekk
+Bellese,bellese,https://jobs.lever.co/bellese
+Belong,belong,https://jobs.lever.co/belong
+BioBus,biobus.org,https://jobs.lever.co/biobus.org
 BioCatch,biocatch,https://jobs.lever.co/biocatch
+Biodigital,biodigital,https://jobs.lever.co/biodigital
 BizAway Trial,bizaway,https://jobs.lever.co/bizaway
+BLEN,blencorp,https://jobs.lever.co/blencorp
+Blue Coding,bluecoding,https://jobs.lever.co/bluecoding
+"BrainStorm, Inc.",brainstorminc,https://jobs.lever.co/brainstorminc
+Branch,branch.gg,https://jobs.lever.co/branch.gg
+Breakwater Technology,breakwatertech,https://jobs.lever.co/BreakwaterTech
+Brooklyn Investment Group,bkln,https://jobs.lever.co/bkln
+Brotherhood Crusade,brotherhoodcrusade,https://jobs.lever.co/brotherhoodcrusade
+Burro,burro,https://jobs.lever.co/Burro
 Cheerz,cheerz,https://jobs.lever.co/cheerz
 ClickTime,clicktime,https://jobs.lever.co/clicktime
 "CopilotKit, Inc.",copilotkit,https://jobs.lever.co/copilotkit
 dermalogica,dermalogica,https://jobs.lever.co/dermalogica
+Designetics,designetics,https://jobs.lever.co/designetics
+Dimension,getdimension,https://jobs.lever.co/getdimension
+Dioxycle,dioxycle,https://jobs.lever.co/Dioxycle
 Distru,distru,https://jobs.lever.co/distru
 Doonails,doonails,https://jobs.lever.co/doonails
+DoubleDown Interactive,doubledown,https://jobs.lever.co/doubledown
 Draslovka,draslovka,https://jobs.lever.co/draslovka
 Easy Agile,easyagile,https://jobs.lever.co/easyagile
 Edera,edera,https://jobs.lever.co/edera
 EDR,edr,https://jobs.lever.co/edr
+Electrified Thermal,electrifiedthermalsolutions,https://jobs.lever.co/ElectrifiedThermalSolutions
+Eliyan,eliyan,https://jobs.lever.co/eliyan
 Ellevation,ellevationeducation,https://jobs.lever.co/ellevationeducation
+Elroy Air,elroyair,https://jobs.lever.co/elroyair
+Empirico,empiricotx,https://jobs.lever.co/empiricotx
+Encore Renewable Energy,encore-renewable-energy,https://jobs.lever.co/encore-renewable-energy
+Energy Vault,energyvault,https://jobs.lever.co/EnergyVault
+Engine Ventures,engine-ventures,https://jobs.lever.co/engine-ventures
+Espresso,espresso,https://jobs.lever.co/Espresso
+Eternal,eternal,https://jobs.lever.co/eternal
+EV Realty,evrealty-us,https://jobs.lever.co/evrealty-us
+Evergreen Strategy Group,evergreenstrategygroup,https://jobs.lever.co/evergreenstrategygroup
 Exploding Kittens,explodingkittens,https://jobs.lever.co/explodingkittens
 "Galatea Bio, Inc.",galatea,https://jobs.lever.co/galatea
+Gantri,gantri,https://jobs.lever.co/Gantri
+Glue,gluegroups,https://jobs.lever.co/gluegroups
+Gobrightside,gobrightside,https://jobs.lever.co/gobrightside
 Circuit,getcircuit,https://jobs.lever.co/getcircuit
 goFluent,gofluent,https://jobs.lever.co/gofluent
+GR0,gr0,https://jobs.lever.co/gr0
+Graviticsspace,graviticsspace,https://jobs.lever.co/graviticsspace
+Gurobi Optimization,gurobioptimization,https://jobs.lever.co/GurobiOptimization
+Gursey,gursey,https://jobs.lever.co/gursey
 Harmony,harmony,https://jobs.lever.co/harmony
+Havenpark Communities,havenparkcommunities,https://jobs.lever.co/havenparkcommunities
+HDVI,hdvi,https://jobs.lever.co/HDVI
 Healthmark Group Trial,healthmark-group,https://jobs.lever.co/healthmark-group
 Heetch,heetch,https://jobs.lever.co/heetch
 Hellotickets,hellotickets,https://jobs.lever.co/hellotickets
 Hero Cosmetics,herocosmetics,https://jobs.lever.co/herocosmetics
+Hgen,hgen,https://jobs.lever.co/hgen
+Highbar Physical Therapy,highbarhealth,https://jobs.lever.co/highbarhealth
+Highland Electric Fleets,highlandfleets-2,https://jobs.lever.co/highlandfleets-2
+Highlight,highlight,https://jobs.lever.co/Highlight
 HiHello,hihello,https://jobs.lever.co/hihello
 Hiring Our Heroes,hiringourheroes,https://jobs.lever.co/hiringourheroes
+Hively,hively,https://jobs.lever.co/Hively
+HowGood,howgood,https://jobs.lever.co/HowGood
+Humata,humata,https://jobs.lever.co/humata
+"Hydrow, Inc.",hydrow,https://jobs.lever.co/Hydrow
 Center For Humane Technology,humanetech,https://jobs.lever.co/humanetech
+CesiumAstro,cesiumastro,https://jobs.lever.co/CesiumAstro
+Chamber of Progress,chamberofprogress,https://jobs.lever.co/ChamberofProgress
+ChannelApe,channelape,https://jobs.lever.co/channelape
+Chargezoom,chargezoom,https://jobs.lever.co/chargezoom
+ChefRobotics,chefrobotics,https://jobs.lever.co/ChefRobotics
+Church at the Park,churchatthepark,https://jobs.lever.co/churchatthepark
+CITCON USA LLC,citcon,https://jobs.lever.co/citcon
+Civitta,civitta,https://jobs.lever.co/Civitta
+ClearEdge,clearedge,https://jobs.lever.co/clearedge
+Clearer.io,clearer,https://jobs.lever.co/Clearer
+Clozd,clozd,https://jobs.lever.co/Clozd
+CNM LLP,cnmllp,https://jobs.lever.co/cnmllp
+co:collective,cocollective,https://jobs.lever.co/cocollective
+Cobaltrobotics,cobaltrobotics,https://jobs.lever.co/cobaltrobotics
+Cofactr,cofactr,https://jobs.lever.co/Cofactr
+Collectly,collectlyinc,https://jobs.lever.co/CollectlyInc
+CommunityBoost,communityboost,https://jobs.lever.co/CommunityBoost
+Component Repair Technologies,componentrepairtechnologies,https://jobs.lever.co/componentrepairtechnologies
+confluera,confluera,https://jobs.lever.co/confluera
+Connext Network,connext-network,https://jobs.lever.co/connext-network
+"Constellation Technologies, Inc",cti-md,https://jobs.lever.co/cti-md
+ContactOut,contactout,https://jobs.lever.co/ContactOut
+Copia Automation,copia,https://jobs.lever.co/copia
+Craftwater,craftwater,https://jobs.lever.co/craftwater
+Crossing Minds Recruiting,crossing-minds,https://jobs.lever.co/crossing-minds
+CruxOCM,cruxocm,https://jobs.lever.co/cruxocm
+Cubegroup,cubegroup,https://jobs.lever.co/cubegroup
+Curio Research,curio.gg,https://jobs.lever.co/curio.gg
 iyzico,iyzico,https://jobs.lever.co/iyzico
 Katten Muchin Rosenman LLP,katten,https://jobs.lever.co/katten
+Ketch,ketch,https://jobs.lever.co/Ketch
+Kitman Labs,kitmanlabs,https://jobs.lever.co/kitmanlabs
 Lincoln Institute of Land Policy,lincolninst,https://jobs.lever.co/lincolninst
 Lovepop,lovepop,https://jobs.lever.co/lovepop
 Loyal,loyalhealth,https://jobs.lever.co/loyalhealth
+Lumary,lumary,https://jobs.lever.co/Lumary
+Luminary Labs,luminary-labs,https://jobs.lever.co/luminary-labs
+LumiQ,lumiq-learn,https://jobs.lever.co/lumiq-learn
+LUUM,luumlash,https://jobs.lever.co/luumlash
+Lyra Collective,lyracollective,https://jobs.lever.co/LyraCollective
 Lyrebird Health,lyrebirdhealth,https://jobs.lever.co/lyrebirdhealth
 Markham LLC,markham,https://jobs.lever.co/markham
+Mast Reforestation,mastreforestation,https://jobs.lever.co/MastReforestation
+Matters,matters,https://jobs.lever.co/Matters
+Maureen Joy Charter School,joycharter,https://jobs.lever.co/joycharter
+McChrystal Group,mcchrystalgroup,https://jobs.lever.co/mcchrystalgroup
+MedCare Pediatric,medcarepediatric,https://jobs.lever.co/medcarepediatric
+Mediafly,mediafly,https://jobs.lever.co/Mediafly
+Medical Outsourcing Solutions,medical-outsourcing-solutions,https://jobs.lever.co/medical-outsourcing-solutions
+MedRhythms,medrhythms,https://jobs.lever.co/medrhythms
+Metawealth,metawealth,https://jobs.lever.co/metawealth
+Milo,milocredit,https://jobs.lever.co/milocredit
+MIRAI FOODS AG,mirai-foods,https://jobs.lever.co/mirai-foods
+Mirastar FCU,mirastarfcu,https://jobs.lever.co/mirastarfcu
+Mission Graduates,missiongraduates,https://jobs.lever.co/missiongraduates
+MO,mostudio,https://jobs.lever.co/MOstudio
+MobileAction,mobile-action,https://jobs.lever.co/mobile-action
+Modern Intelligence,modernintelligence,https://jobs.lever.co/ModernIntelligence
+Modern Life,modernlife,https://jobs.lever.co/modernlife
+Molten Industries,moltenindustries,https://jobs.lever.co/moltenindustries
+Moneytree,moneytree,https://jobs.lever.co/moneytree
+Monterey Technologies Inc,mti-inc,https://jobs.lever.co/mti-inc
+Motif,motifsystems,https://jobs.lever.co/motifsystems
 NOBODY,nobody,https://jobs.lever.co/nobody
+Nomagic,nomagic,https://jobs.lever.co/Nomagic
+Nova,ioconnectservices.com,https://jobs.lever.co/ioconnectservices.com
 Owlet,owletcare,https://jobs.lever.co/owletcare
 Payactiv,payactiv,https://jobs.lever.co/payactiv
+Pison,pison,https://jobs.lever.co/pison
+Planned Parenthood Keystone,ppkeystone,https://jobs.lever.co/ppkeystone
+Planned Parenthood South Atlantic,ppsat,https://jobs.lever.co/ppsat
 PlayVS,playvs,https://jobs.lever.co/playvs
+PocketHealth,pockethealth,https://jobs.lever.co/PocketHealth
+Portoro,portoro,https://jobs.lever.co/portoro
+Premier Truck Group,premiertruck,https://jobs.lever.co/premiertruck
+Pretto,pretto,https://jobs.lever.co/Pretto
 Primate Labs Inc.,primatelabs,https://jobs.lever.co/primatelabs
+Prime Electric,primee,https://jobs.lever.co/primee
 Prime Fiber,primefiber,https://jobs.lever.co/primefiber
+Probius,probiusdx,https://jobs.lever.co/ProbiusDx
+Product Ventures,productventures,https://jobs.lever.co/productventures
+Progressive Physician Associates,ppa,https://jobs.lever.co/PPA
+Project Kitty Hawk,projectkittyhawk,https://jobs.lever.co/projectkittyhawk
+Promesa Academy,promesaacademy,https://jobs.lever.co/promesaacademy
+Prominent Edge LLC,prominentedge,https://jobs.lever.co/prominentedge
+Protect Environmental,protectenvironmental,https://jobs.lever.co/protectenvironmental
+Purple Team,purple-technology,https://jobs.lever.co/purple-technology
 Qwoted,qwoted,https://jobs.lever.co/qwoted
 RealWork Labs,realworklabs,https://jobs.lever.co/realworklabs
+Red Canyon Engineering & Software,redcanyonsoftware,https://jobs.lever.co/redcanyonsoftware
+Red Dog Media,reddogmedia,https://jobs.lever.co/reddogmedia
 redbee,redbee,https://jobs.lever.co/redbee
+REEKON Tools,reekon-tools,https://jobs.lever.co/reekon-tools
+Regrello,regrello,https://jobs.lever.co/regrello
+Relay Commerce,relay-commerce,https://jobs.lever.co/relay-commerce
+Relay Robotics,relayrobotics.com,https://jobs.lever.co/relayrobotics.com
+Remedyproductstudio,remedyproductstudio,https://jobs.lever.co/remedyproductstudio
+Resiliencelab,resiliencelab,https://jobs.lever.co/resiliencelab
+Richards Services,richards-services,https://jobs.lever.co/richards-services
+Riptide Technology,riptidetech,https://jobs.lever.co/RiptideTech
+Riverdale Country School,riverdale,https://jobs.lever.co/riverdale
+Rocket Partners,rocketpartners,https://jobs.lever.co/rocketpartners
+Roofstacks,roofstacks,https://jobs.lever.co/roofstacks
+RouteThis,routethis,https://jobs.lever.co/RouteThis
 Ruby Play,rubyplay,https://jobs.lever.co/rubyplay
+Rylo,rylo,https://jobs.lever.co/rylo
 sbz,sbz,https://jobs.lever.co/sbz
+Scale Microgrid Solutions,scalemicrogridsolutions,https://jobs.lever.co/ScaleMicrogridSolutions
 Schedule Engine,scheduleengine,https://jobs.lever.co/scheduleengine
+Scoperecruiting,scoperecruiting,https://jobs.lever.co/scoperecruiting
+Seedify Fund,seedify-fund,https://jobs.lever.co/seedify-fund
+Shiru,shiru,https://jobs.lever.co/shiru
+Silverback Strategies,silverbackstrategies,https://jobs.lever.co/silverbackstrategies
+Simpleventures,simpleventures,https://jobs.lever.co/simpleventures
+Skip,skipscooters,https://jobs.lever.co/skipscooters
+Skyral Group,skyralio,https://jobs.lever.co/skyralio
+"Skyward IT Solutions, LLC",skywarditsolutions,https://jobs.lever.co/skywarditsolutions
+Slangai,slangai,https://jobs.lever.co/slangai
+Smile.io,smile.io,https://jobs.lever.co/Smile.io
+SOLFL,solfl,https://jobs.lever.co/solfl
 Solutions Journalism Network,solutionsjournalism,https://jobs.lever.co/solutionsjournalism
+Sonrai Security,sonrai-security,https://jobs.lever.co/sonrai-security
+Spruce Street Compliance,sprucestreetcomp,https://jobs.lever.co/sprucestreetcomp
 Squire Patton Boggs,squirepb,https://jobs.lever.co/squirepb
+Stackblitz,stackblitz,https://jobs.lever.co/stackblitz
 StarCompliance,starcompliance,https://jobs.lever.co/starcompliance
+Storygrounds,storygrounds,https://jobs.lever.co/Storygrounds
+Studion,gostudion,https://jobs.lever.co/gostudion
+Swiftly,swiftlysystems,https://jobs.lever.co/SwiftlySystems
 Tech Nation,technation,https://jobs.lever.co/technation
+Technexus,technexus,https://jobs.lever.co/technexus
+Terraformation,terraformation,https://jobs.lever.co/Terraformation
+The Upright Project,uprightproject,https://jobs.lever.co/uprightproject
+"Therma-Tron-X, Inc.",ttxinc,https://jobs.lever.co/ttxinc
+Titan Electric,titanelectric-ga,https://jobs.lever.co/titanelectric-ga
+Tonsser,tonsser,https://jobs.lever.co/tonsser
+Topl,topl,https://jobs.lever.co/Topl
+Tribe Payments,tribe-payments,https://jobs.lever.co/tribe-payments
+Trilogy Federal,trilogyfederal,https://jobs.lever.co/TrilogyFederal
+Trinity Hunt Partners,trinityhunt,https://jobs.lever.co/trinityhunt
+TXI,txidigital,https://jobs.lever.co/txidigital
 Universal Electronics Inc.,uei,https://jobs.lever.co/uei
+Unlikely,unlikely,https://jobs.lever.co/unlikely
+Unstructuredtechnologies,unstructuredtechnologies,https://jobs.lever.co/unstructuredtechnologies
+UpMetrics,upmetrics,https://jobs.lever.co/UpMetrics
 Velocity Global,velocityglobal,https://jobs.lever.co/velocityglobal
+Venteur,venteur,https://jobs.lever.co/venteur
+Verkor,verkor,https://jobs.lever.co/verkor
 Viome Life Sciences,viome,https://jobs.lever.co/viome
 WisdomTree,wisdomtree,https://jobs.lever.co/wisdomtree
+Wisdomtree UK,wisdomtree-2,https://jobs.lever.co/wisdomtree-2
+"WRA, Inc.",wra-ca,https://jobs.lever.co/wra-ca


### PR DESCRIPTION
## Summary
- add 286 previously unlisted Lever boards
- expose 3,325 genuinely new live jobs

## Discovery and validation
- mined high-coverage 2025 Common Crawl snapshots because current Lever board pages are robots-limited
- normalized board URLs and removed all 2,113 existing Lever slugs and URLs
- live-tested 871 candidates through the public Lever postings API; 288 returned jobs
- excluded the `salesdemo-jr` sales demo and `xmlexample` partner example feed after AI review
- compared the remaining 3,325 candidate job IDs against 67,379 published Lever job IDs
- found zero published overlap and zero candidate-to-candidate ID overlap
- normalized public slugs to the lowercase identifiers used by the production pipeline
- verified exact CSV additions, unique slugs and URLs, `git diff --check`, and focused tests (`8 passed`)