### PR TITLE
Add 3 live SuccessFactors sites from crawl discovery

### DIFF
--- a/ats-companies/successfactors.csv
+++ b/ats-companies/successfactors.csv
@@ -1161,6 +1161,7 @@ Working at L3Harris Technologies,L3HHCM20,https://jobs.l3harris.com
 Jobs | LEMKEN The Agrovision Company,lemkengmbh,https://jobs.lemken.com
 Letec,srwttec,https://jobs.letec.be
 LIDL,lidlstiftuP2,https://jobs.lidl
+London Government Careers,london-government,https://london-gov.jobs2web.com
 Lopesan,lopesan,https://jobs.lopesan.com
 Jobs at Lake Superior Consulting,lakesuperi,https://jobs.lsconsulting.com
 Jobs at Marvin Group,MECHCM20,https://jobs.marvingroup.com
@@ -1185,6 +1186,7 @@ Careers at SABIC,SABIC,https://jobs.sabic.com
 Safholland,SAFHOLLAND,https://jobs.safholland.com
 Careers with City of San Diego,jobs,https://jobs.sandiego.gov
 Sasol,sasolchemP3,https://jobs.sasol.com
+Saudi Ground Services,saudi-ground-services,https://175102.jobs2web.com
 Saudi Paper Group Career Site,saudipaper,https://jobs.saudipaper.com
 Jobs at Scania | We drive real change,volkswagenP20,https://jobs.scania.com
 Schönmackers Umweltdienste GmbH &Co.KG Careers,schnmacker,https://jobs.schoenmackers.de
@@ -1248,6 +1250,7 @@ Draeger,draegerP,https://recruitment.draeger.jobs
 SCK CEN HR & Academy,centredtud,https://recruitment.sckcen.be
 Tenaris,Tenaris,https://recruitment.tenaris.com
 Bluepharmagroup,bluepharmaP,https://recrutamento.bluepharmagroup.com
+BNSF Railway,bnsf,https://bnsf.jobs2web.com
 Brisa,brisaautoe,https://recrutamento.brisa.pt
 Recrutamento NOS,noscomunic,https://recrutamento.nos.pt
 Novo Banco,novobancos,https://recrutamento.novobanco.pt


### PR DESCRIPTION
## Summary
- add 3 previously unlisted production SuccessFactors Recruiting sites
- expose 114 genuinely new live jobs

## Discovery and validation
- mined `*.jobs2web.com` URLs from `CC-MAIN-2026-25`
- live-tested 20 candidates through the public `sitemal.xml` feed
- excluded all 10 staging hosts even though they exposed jobs
- retained Saudi Ground Services, BNSF Railway, and London Government Careers
- compared all 114 host-scoped job IDs against 291,802 published SuccessFactors jobs
- found zero published overlap and zero candidate-to-candidate overlap
- verified exact CSV additions, no new duplicate groups, `git diff --check`, and focused tests (`18 passed`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added three production SuccessFactors Recruiting sites to `ats-companies/successfactors.csv`, exposing 114 new live jobs with no overlap.
Added: BNSF Railway (`bnsf.jobs2web.com`), London Government Careers (`london-gov.jobs2web.com`), and Saudi Ground Services (`175102.jobs2web.com`); excluded staging hosts and validated via public sitemaps.

<sup>Written for commit 680c599a5527f61f7cac5929bbfe87a3e2c238e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

