### PR TITLE
Add 276 live Recruitee boards from crawl discovery

### DIFF
--- a/ats-companies/recruitee.csv
+++ b/ats-companies/recruitee.csv
@@ -2,10 +2,13 @@ name,slug,url
 12Build,12build,https://12build.recruitee.com
 1X Technologies AS,1x,https://1x.recruitee.com
 2am,2am,https://2am.recruitee.com
+3PBIOVIAN,biovian,https://biovian.recruitee.com
 433,by433,https://by433.recruitee.com
 5280 High School,5280highschool,https://5280highschool.recruitee.com
 60 seconds to napoli Holding GmbH,60secondstonapoli,https://60secondstonapoli.recruitee.com
 A-Gas,agaseurope,https://agaseurope.recruitee.com
+A-point,apoint,https://apoint.recruitee.com
+aaff B.V.,aaff,https://aaff.recruitee.com
 ABRIO GmbH,abriogmbh,https://abriogmbh.recruitee.com
 ACE OF PERFORMANCE,aceofperformance,https://aceofperformance.recruitee.com
 AI Digital,aidigital,https://aidigital.recruitee.com
@@ -63,6 +66,8 @@ Attendi,attendi,https://attendi.recruitee.com
 Auditdata,auditdata,https://auditdata.recruitee.com
 Avant Arte,avantarte,https://avantarte.recruitee.com
 BA Logistics GmbH,balogisticsgmbh,https://balogisticsgmbh.recruitee.com
+Baker Street,bakerstreet,https://bakerstreet.recruitee.com
+Bakker Goedhart Brood & Specialiteiten,bakkergoedhartbroodspecialiteiten,https://bakkergoedhartbroodspecialiteiten.recruitee.com
 BAUHAUS Nederland C.V.,bauhausnederlandcv,https://bauhausnederlandcv.recruitee.com
 BC Partners,bcpartners,https://bcpartners.recruitee.com
 BCN Group,bcngroup,https://bcngroup.recruitee.com
@@ -157,6 +162,9 @@ Curotec,curotec,https://curotec.recruitee.com
 Customs Support Group,customssupport,https://customssupport.recruitee.com
 "Cycle Construction Co., LLC",cycle,https://cycle.recruitee.com
 Cyclomedia Technology,cyclomediatechnology,https://cyclomediatechnology.recruitee.com
+D-reizen,dreizen,https://dreizen.recruitee.com
+Dance,dance,https://dance.recruitee.com
+data nation GmbH,datanation,https://datanation.recruitee.com
 DCK Group,dckgroup,https://dckgroup.recruitee.com
 DEINE PHYSIOS,deinephysios,https://deinephysios.recruitee.com
 DEK Deutsche Extrakt Kaffee GmbH,dekdeutscheextraktkaffeegmbh,https://dekdeutscheextraktkaffeegmbh.recruitee.com
@@ -233,6 +241,7 @@ GPV China,gpvchina,https://gpvchina.recruitee.com
 GRID eSports GmbH,grid,https://grid.recruitee.com
 GSB Solutions,gsbsolutions1,https://gsbsolutions1.recruitee.com
 Gain,gain,https://gain.recruitee.com
+GALENIC COSMETICS LABORATORY,galeniccarriererecrutement,https://galeniccarriererecrutement.recruitee.com
 GastroNova GmbH,backspielhaus,https://backspielhaus.recruitee.com
 General Magic,giveth,https://giveth.recruitee.com
 Giovanni RANA Deutschland GmbH,giovanniranadeutschlandgmbh,https://giovanniranadeutschlandgmbh.recruitee.com
@@ -247,6 +256,8 @@ H2R,h2r,https://h2r.recruitee.com
 HG International b.v.,hginternational,https://hginternational.recruitee.com
 HUM Home,humhome,https://humhome.recruitee.com
 Hagener Versorgungs- und Verkehrs-GmbH,hvg,https://hvg.recruitee.com
+Hainmüller Gartengestaltung e.K.,hainmueller,https://hainmueller.recruitee.com
+Halbersbacher Hospitality Group,halbersbacherhospitalitygroup,https://halbersbacherhospitalitygroup.recruitee.com
 Hamelin,hamelin,https://hamelin.recruitee.com
 Happeo,happeo,https://happeo.recruitee.com
 Hauptstadtfloss GmbH,hauptstadtfloss,https://hauptstadtfloss.recruitee.com
@@ -290,13 +301,16 @@ Intersnack IT KG,intersnackitkg,https://intersnackitkg.recruitee.com
 Intersnack Nederland BV,intersnacknederlandbv,https://intersnacknederlandbv.recruitee.com
 Intersnack Procurement BV,intersnackprocurement,https://intersnackprocurement.recruitee.com
 Invest-NL N.V.,investnl,https://investnl.recruitee.com
+JCDECAUX NEDERLAND B.V.,jcdecauxnederland,https://jcdecauxnederland.recruitee.com
 JM Recruiting,apply,https://apply.recruitee.com
+Kaizo,kaizo,https://kaizo.recruitee.com
 KPIT Engineering,primatec,https://primatec.recruitee.com
 KRIEG Industriegeräte GmbH,kriegonline,https://kriegonline.recruitee.com
 Kodland,kodland,https://kodland.recruitee.com
 Kruger NearShore LLC - Rekluti,easyapplyrekluti,https://easyapplyrekluti.recruitee.com
 Krumbholz König & Partner mbB Steuerberater,krumbholzkonigpartnermbbsteuerberater,https://krumbholzkonigpartnermbbsteuerberater.recruitee.com
 Kuok (Singapore) Limited,kuoksingaporelimited,https://kuoksingaporelimited.recruitee.com
+L. Feddersen Baugesellschaft mbH,lfeddersenbaugesellschaftmbh,https://lfeddersenbaugesellschaftmbh.recruitee.com
 LEO der Bäcker & Konditor GmbH & Co. KG,leoderbaecker,https://leoderbaecker.recruitee.com
 LITIT,litit,https://litit.recruitee.com
 LONDIS Ireland,londiscareers,https://londiscareers.recruitee.com
@@ -384,6 +398,7 @@ OnlineDialog GmbH,onlinedialog,https://onlinedialog.recruitee.com
 Orbem GmbH,orbem,https://orbem.recruitee.com
 Ottawa Safety Council,ottawasafetycouncil,https://ottawasafetycouncil.recruitee.com
 Outbound Operators,outboundoperators,https://outboundoperators.recruitee.com
+P1 Travel,p1travel,https://p1travel.recruitee.com
 PALAZZO VERSACE DUBAI,palazzoversacedubai,https://palazzoversacedubai.recruitee.com
 PMPG,pmpg,https://pmpg.recruitee.com
 PSZ electronic GmbH,pszelectronicgmbh,https://pszelectronicgmbh.recruitee.com
@@ -416,6 +431,8 @@ Pullup Entertainment,focusentertainment,https://focusentertainment.recruitee.com
 PureGym AG,puregymswiss,https://puregymswiss.recruitee.com
 Qualifyze GmbH,qualifyzegmbh,https://qualifyzegmbh.recruitee.com
 Quatra Nederland B.V.,quatra,https://quatra.recruitee.com
+Radish Lab,radishlab,https://radishlab.recruitee.com
+Rail Innovators Group,railinnovatorsgroup,https://railinnovatorsgroup.recruitee.com
 Rent a car - Enterprise,enterprise,https://enterprise.recruitee.com
 Revelator,revelator,https://revelator.recruitee.com
 Riverflex,riverflex,https://riverflex.recruitee.com
@@ -472,6 +489,8 @@ TREUREAL Property Management GmbH,trp,https://trp.recruitee.com
 TSET,tsetsoftware,https://tsetsoftware.recruitee.com
 TYTAN Technologies GmbH,tytantechnologiesgmbh,https://tytantechnologiesgmbh.recruitee.com
 Tabel GmbH,tabelgruppe,https://tabelgruppe.recruitee.com
+Tabel Personalberatung GmbH,tabelpersonal,https://tabelpersonal.recruitee.com
+Taledo GmbH,taledogmbh,https://taledogmbh.recruitee.com
 Talkie sp. z o.o.,talkieai,https://talkieai.recruitee.com
 Tampnet AS,tampnet,https://tampnet.recruitee.com
 Team for the planet,teamfortheplanet1,https://teamfortheplanet1.recruitee.com
@@ -503,6 +522,8 @@ Trusted Shops SE (DE),trustedshops,https://trustedshops.recruitee.com
 Trustfactory - RLV Media GmbH,trustfactory,https://trustfactory.recruitee.com
 Twisto,twisto,https://twisto.recruitee.com
 Tylko,tylko,https://tylko.recruitee.com
+Uhlenhaus GRUPPE,uhlenhaus,https://uhlenhaus.recruitee.com
+Umane,umane,https://umane.recruitee.com
 UP42 GmbH,up42gmbh,https://up42gmbh.recruitee.com
 United Al Saqer Group,unitedalsaqergroup,https://unitedalsaqergroup.recruitee.com
 Unity Communications,unitycommunications,https://unitycommunications.recruitee.com
@@ -528,11 +549,17 @@ Vion Food Group,vionfoodgroup,https://vionfoodgroup.recruitee.com
 VirtualResource,virtualresource,https://virtualresource.recruitee.com
 Visionaries Club,visionariesclub,https://visionariesclub.recruitee.com
 Vitestro,vitestro,https://vitestro.recruitee.com
+Wacom Europe GmbH,wacomeurope,https://wacomeurope.recruitee.com
+Wagenborg Nedlift,wagenborgnedlift,https://wagenborgnedlift.recruitee.com
+Wagenborg Passagiersdiensten,wagenborgpassagiersdiensten,https://wagenborgpassagiersdiensten.recruitee.com
+Wakuli,wakuli,https://wakuli.recruitee.com
+Walibi Holland,walibiholland,https://walibiholland.recruitee.com
 WASABIT株式会社,wasabit,https://wasabit.recruitee.com
 WEBB Traders BV,webbtraders,https://webbtraders.recruitee.com
 WERTCONCEPT Investment Group GmbH,wertconceptinvestmentgroupgmbh,https://wertconceptinvestmentgroupgmbh.recruitee.com
 "WWS Wirtz, Walter, Schmitz GmbH",wwswirtzwalterschmitzgmbh,https://wwswirtzwalterschmitzgmbh.recruitee.com
 Wallarm,wallarm,https://wallarm.recruitee.com
+Warande,warande,https://warande.recruitee.com
 WeSoftYou,wesoftyou2,https://wesoftyou2.recruitee.com
 Wellis,wellis,https://wellis.recruitee.com
 Wiener Institut für Internationale Wirtschaftsvergleiche (wiiw),wiiw,https://wiiw.recruitee.com
@@ -542,12 +569,16 @@ Wizdaa,wizdaa,https://wizdaa.recruitee.com
 Wordbank,wordbank,https://wordbank.recruitee.com
 WÜSTHOF GmbH,wusthof,https://wusthof.recruitee.com
 Württemberger Wohnkonzepte GmbH,wurttembergerwohnkonzeptegmbh,https://wurttembergerwohnkonzeptegmbh.recruitee.com
+xalution,xalution,https://xalution.recruitee.com
 XIAO Beteiligungsgesellschaft mbH,xiaorestaurant,https://xiaorestaurant.recruitee.com
 Xebia Group,xccelerated,https://xccelerated.recruitee.com
 Xebia Group,xebiacareers,https://xebiacareers.recruitee.com
 Xebia sp. z o.o.,xebiapoland,https://xebiapoland.recruitee.com
+xfive,xfive,https://xfive.recruitee.com
+XITE,xite,https://xite.recruitee.com
 Youvia BV,werkenbijyouvia,https://werkenbijyouvia.recruitee.com
 Ypto NV,ypto,https://ypto.recruitee.com
+Z-Catering Mitte GmbH,zteam,https://zteam.recruitee.com
 ZDHC Foundation,zdhcfoundation,https://zdhcfoundation.recruitee.com
 Zelh,zelh,https://zelh.recruitee.com
 Zensai,zensai,https://zensai.recruitee.com
@@ -578,6 +609,7 @@ Ascension Island Government,ascensionisland,https://ascensionisland.recruitee.co
 ASMPT,asmpthk,https://asmpthk.recruitee.com
 ASTONTEC,astontec,https://astontec.recruitee.com
 Balchem,balchem,https://balchem.recruitee.com
+Ballast Nedam,ballastnedam,https://ballastnedam.recruitee.com
 BALLY’S INTRALOT SA,ballysintralotsa,https://ballysintralotsa.recruitee.com
 BAS Group,basgroup,https://basgroup.recruitee.com
 Willy Bauer KG,bauer,https://bauer.recruitee.com
@@ -633,7 +665,9 @@ e-Luscious,eluscious,https://eluscious.recruitee.com
 eGroup,egroup,https://egroup.recruitee.com
 eXtra Shop,extrashop,https://extrashop.recruitee.com
 E&C,ecconsultants,https://ecconsultants.recruitee.com
+Early Alpine Academy,earlyalpineacademy,https://earlyalpineacademy.recruitee.com
 echourbandesign,echourbandesign,https://echourbandesign.recruitee.com
+Ecocert,ecocert,https://ecocert.recruitee.com
 ecochain,ecochain,https://ecochain.recruitee.com
 edubily GmbH,edubilygmbh,https://edubilygmbh.recruitee.com
 eleQtron GmbH,eleqtron,https://eleqtron.recruitee.com
@@ -655,9 +689,14 @@ exbgroup,exbgroup,https://exbgroup.recruitee.com
 Exeon Analytics,exeon,https://exeon.recruitee.com
 Experiencegift,experiencegift,https://experiencegift.recruitee.com
 Famly,famly,https://famly.recruitee.com
+FARO Gruppe,farogruppe,https://farogruppe.recruitee.com
 Fashion Cloud,fashioncloudgmbh,https://fashioncloudgmbh.recruitee.com
+Fastems,fastems,https://fastems.recruitee.com
 Ferilli's Hospitality Group,ferillis,https://ferillis.recruitee.com
+Ferryscanner,ferryscanner,https://ferryscanner.recruitee.com
+FEST GmbH,festgmbh,https://festgmbh.recruitee.com
 filestage,filestage,https://filestage.recruitee.com
+Fineco Banca Privada Kutxabank,fineco,https://fineco.recruitee.com
 Formo Foods GmbH,formofoodsgmbh,https://formofoodsgmbh.recruitee.com
 forward earth,forwardearth,https://forwardearth.recruitee.com
 FreshMinds,freshminds,https://freshminds.recruitee.com
@@ -666,27 +705,53 @@ Fundamental Hospitality,fundamentalhospitality,https://fundamentalhospitality.re
 FunEx Head Office,funex,https://funex.recruitee.com
 fxth,fxth,https://fxth.recruitee.com
 Gallagher Europe BV,gallaghereurope,https://gallaghereurope.recruitee.com
+Gardec,gardec,https://gardec.recruitee.com
+gemeente Achtkarspelen,gemeenteachtkarspelen,https://gemeenteachtkarspelen.recruitee.com
+Gemeente Lansingerland,gemeentelansingerland,https://gemeentelansingerland.recruitee.com
+GermanZero e.V.,germanzeroev,https://germanzeroev.recruitee.com
+get on top gmbh,getontop,https://getontop.recruitee.com
 "Edwards Health Care Services, Inc.",gemcorehealth,https://gemcorehealth.recruitee.com
+Eerikkilä Sport & Outdoor Resort,eerikkila,https://eerikkila.recruitee.com
 ggz,ggz,https://ggz.recruitee.com
+Giesker & Laakmann GmbH & Co. KG,gieskerlaakmann,https://gieskerlaakmann.recruitee.com
 Ginmon GmbH,ginmon,https://ginmon.recruitee.com
 Glassix,glassix,https://glassix.recruitee.com
+Global Jet Luxembourg,globaljetluxembourg,https://globaljetluxembourg.recruitee.com
+Global Reporting Initiative,gri,https://gri.recruitee.com
 goedemiddag,goedemiddag,https://goedemiddag.recruitee.com
+Golmed GmbH,golmedgmbh,https://golmedgmbh.recruitee.com
 gpvsweden,gpvsweden,https://gpvsweden.recruitee.com
 Hygraph,graphcms,https://graphcms.recruitee.com
 gravity9,gravity9,https://gravity9.recruitee.com
 GRB Gemeinnütziges Rheinisches Bildungszentrum GmbH,grb,https://grb.recruitee.com
 gridscale,gridscale,https://gridscale.recruitee.com
 ELAN Languages,gtn,https://gtn.recruitee.com
+Elanza,elanza,https://elanza.recruitee.com
+Elektro Supersaxo AG,elektrosupersaxoag,https://elektrosupersaxoag.recruitee.com
+Elephant Digital,elephantdigital,https://elephantdigital.recruitee.com
 Hard Rock Digital,hardrockdigital,https://hardrockdigital.recruitee.com
+Hasco NV,hascoinvest,https://hascoinvest.recruitee.com
+HatchTech B.V.,hatchtech,https://hatchtech.recruitee.com
+Haus für Sicherheit,hausfursicherheit,https://hausfursicherheit.recruitee.com
 healthiergeneration,healthiergeneration,https://healthiergeneration.recruitee.com
+HeatTransformers BV,heattransformers,https://heattransformers.recruitee.com
+Heembouw,heembouw,https://heembouw.recruitee.com
+HeinenoordZicht Groep,fidusheinenoord,https://fidusheinenoord.recruitee.com
+HEMERIA,hemeriagroup,https://hemeriagroup.recruitee.com
+HERMOS Gesellschaft für Automatisierungstechnik mbH,hermosautomation,https://hermosautomation.recruitee.com
 Hey Harper,heyharper,https://heyharper.recruitee.com
 High Spirits Hospitality,highspiritshospitality,https://highspiritshospitality.recruitee.com
+Hiltermann Lease BV,werkenbijhiltermann,https://werkenbijhiltermann.recruitee.com
+Hived NV,hived,https://hived.recruitee.com
 Holzland Becker,holzlandbecker,https://holzlandbecker.recruitee.com
 Hometouch,hometouch,https://hometouch.recruitee.com
+HR-Specialist,hrspecialist,https://hrspecialist.recruitee.com
 hued,hued,https://hued.recruitee.com
 hyble,hyble,https://hyble.recruitee.com
 hypepartners,hypepartners,https://hypepartners.recruitee.com
+Hyperion Sales GmbH,gartengold,https://gartengold.recruitee.com
 i-profile GmbH,iprofilegmbh,https://iprofilegmbh.recruitee.com
+ICF Tech Hungary,icftechhungary,https://icftechhungary.recruitee.com
 iChoosr,ichoosr,https://ichoosr.recruitee.com
 iddi,iddi,https://iddi.recruitee.com
 "Illinois Energy Windows and Siding, Inc.",illinoisenergywindowsandsidinginc,https://illinoisenergywindowsandsidinginc.recruitee.com
@@ -699,6 +764,21 @@ International Food Connectors,internationalfoodconnectors,https://internationalf
 Intero Integrity Services,interoeumea,https://interoeumea.recruitee.com
 Intero - The Sniffers,interothesniffers,https://interothesniffers.recruitee.com
 BALLY’S INTRALOT SA,intralot,https://intralot.recruitee.com
+Bambuu,bambuu,https://bambuu.recruitee.com
+BarentsKrans,barentskrans,https://barentskrans.recruitee.com
+BATIT PROTECT,batitprotect,https://batitprotect.recruitee.com
+Batt & Associés,battassocies,https://battassocies.recruitee.com
+Bauer & Söhne GmbH & Co. KG,bauersohnegmbhcokg,https://bauersohnegmbhcokg.recruitee.com
+Bax Metaal,baxmetaal,https://baxmetaal.recruitee.com
+BeingUser,beinguser,https://beinguser.recruitee.com
+Bergman Clinics Nederland B.V.,bergmanclinics,https://bergmanclinics.recruitee.com
+BGH Accountants & Adviseurs B.V.,bghaccountants,https://bghaccountants.recruitee.com
+BIXI Montréal,biximontreal,https://biximontreal.recruitee.com
+Blue Forest,blueforest,https://blueforest.recruitee.com
+Blue Sky Group,blueskygroup,https://blueskygroup.recruitee.com
+BoekenVoordeel Management B.V.,boekenvoordeel,https://boekenvoordeel.recruitee.com
+Bolster Digital,bolster,https://bolster.recruitee.com
+Boschman Advanced Packaging Technology,boschmanadvancedpackagingtechnology,https://boschmanadvancedpackagingtechnology.recruitee.com
 Intuition Staffing,intuitionstaffing,https://intuitionstaffing.recruitee.com
 Iris van Herpen BV,irisvanherpen,https://irisvanherpen.recruitee.com
 isc,isc,https://isc.recruitee.com
@@ -719,6 +799,8 @@ KRING A/S,kring,https://kring.recruitee.com
 kriptomat,kriptomat,https://kriptomat.recruitee.com
 KTI Installatietechniek,kti,https://kti.recruitee.com
 La Veste,laveste,https://laveste.recruitee.com
+Lamm HR GmbH,lammhr,https://lammhr.recruitee.com
+Land Life,landlifecompany,https://landlifecompany.recruitee.com
 Leadership Pathway,leadershippathway,https://leadershippathway.recruitee.com
 "Learn By Doing, Inc.",learnbydoinginc,https://learnbydoinginc.recruitee.com
 LegalFly,legalfly,https://legalfly.recruitee.com
@@ -728,8 +810,10 @@ LOGEX,logex,https://logex.recruitee.com
 SSC,lss,https://lss.recruitee.com
 ltn,ltn,https://ltn.recruitee.com
 MACE Ireland,macecareers,https://macecareers.recruitee.com
+madewithlove BV,madewithlove,https://madewithlove.recruitee.com
 Mainstream,mainstream,https://mainstream.recruitee.com
 Make,make,https://make.recruitee.com
+Manhattan Specialty Care,manhattanspecialtycare,https://manhattanspecialtycare.recruitee.com
 manroland Goss web systems GmbH,manrolandgoss,https://manrolandgoss.recruitee.com
 Maschinenraum GmbH,maschinenraum,https://maschinenraum.recruitee.com
 "Mast Trucking, Inc.",masttrucking,https://masttrucking.recruitee.com
@@ -749,18 +833,34 @@ o2h Group,o2h,https://o2h.recruitee.com
 Normec Sustainability UK,oil,https://oil.recruitee.com
 Olsam Group,olsamgroup,https://olsamgroup.recruitee.com
 O My Bag,omybag,https://omybag.recruitee.com
+OeAD student housing,oeadstudenthousing,https://oeadstudenthousing.recruitee.com
+OeAD-GmbH – Agentur für Bildung und Internationalisierung,oead,https://oead.recruitee.com
+ON2IT B.V.,on2it,https://on2it.recruitee.com
+Online Dialogue,onlinedialogue,https://onlinedialogue.recruitee.com
 Opple Lighting BV,opplebv,https://opplebv.recruitee.com
 paiqo GmbH,paiqo,https://paiqo.recruitee.com
 PALAZZO HOSPITALITY,palazzohospitality,https://palazzohospitality.recruitee.com
+Pale Blue Dot® Recruitment,palebluedotrecruitment,https://palebluedotrecruitment.recruitee.com
+Parte NV,partejobs,https://partejobs.recruitee.com
+Passionfroot,passionfroot,https://passionfroot.recruitee.com
+Payflows,payflows,https://payflows.recruitee.com
+Pels Rijcken,pelsrijcken,https://pelsrijcken.recruitee.com
 Finext B.V.,performancemanagement,https://performancemanagement.recruitee.com
+Fivoor,werkenbijfivoor,https://werkenbijfivoor.recruitee.com
+Formelio,formelio,https://formelio.recruitee.com
+Friedrich PICARD GmbH & Co. KG,picard,https://picard.recruitee.com
 Peterson,peterson,https://peterson.recruitee.com
+PEXIN,pexin,https://pexin.recruitee.com
 Plukon Food Group Spain,plukonfoodgroupspain,https://plukonfoodgroupspain.recruitee.com
 policyengineer,policyengineer,https://policyengineer.recruitee.com
 Popcorn Growth,popcorngrowth,https://popcorngrowth.recruitee.com
 Proper Food,properfood,https://properfood.recruitee.com
 qa,qa,https://qa.recruitee.com
+QaamGo Media GmbH,qaamgo,https://qaamgo.recruitee.com
 Raketech Group Limited,raketech,https://raketech.recruitee.com
 RAVO Holding BV,ravo,https://ravo.recruitee.com
+Rcube Professional Services S.A,rcube,https://rcube.recruitee.com
+rebuy,rebuy,https://rebuy.recruitee.com
 Recare Deutschland GmbH,recaregmbh,https://recaregmbh.recruitee.com
 Red Sky,redsky,https://redsky.recruitee.com
 Resato Hydrogen Technology B.V.,resatohydrogentechnology,https://resatohydrogentechnology.recruitee.com
@@ -788,6 +888,9 @@ SpeedlineHub,speedlinehub,https://speedlinehub.recruitee.com
 spoke,spoke,https://spoke.recruitee.com
 SpotLab,spotlab,https://spotlab.recruitee.com
 S-Quantum Engine,sqe,https://sqe.recruitee.com
+SAS LOOK UP SPACE,lookup,https://lookup.recruitee.com
+Silverein,silverein,https://silverein.recruitee.com
+Simvia,simvia,https://simvia.recruitee.com
 Suspicious Antwerp,sspcs,https://sspcs.recruitee.com
 Sterling Fab Tech,sterlingfabricationtechnology,https://sterlingfabricationtechnology.recruitee.com
 "Strategy Engineering & Consulting, LLC.",strategyeng,https://strategyeng.recruitee.com
@@ -800,6 +903,7 @@ swisselect ag,swisselect,https://swisselect.recruitee.com
 Switcho Srl,switchojob,https://switchojob.recruitee.com
 syngenta,syngenta,https://syngenta.recruitee.com
 Talent Heroes (client ATS),talentheroesclientats,https://talentheroesclientats.recruitee.com
+Talk360,talk360,https://talk360.recruitee.com
 Taroko Software,taroko,https://taroko.recruitee.com
 taskus,taskus,https://taskus.recruitee.com
 teccle group GmbH,tecclegroup,https://tecclegroup.recruitee.com
@@ -821,14 +925,21 @@ utrustinsuranceagencyllc,utrustinsuranceagencyllc,https://utrustinsuranceagencyl
 valantic NL,ism,https://ism.recruitee.com
 Valve and Meter,valveandmeter,https://valveandmeter.recruitee.com
 vamatbv,vamatbv,https://vamatbv.recruitee.com
+Van der Valk Hotel Apeldoorn - de Cantharel,werkenbijdecantharel,https://werkenbijdecantharel.recruitee.com
 vandervalk+degroot,vacaturesvandervalk,https://vacaturesvandervalk.recruitee.com
 Veratron AG,veratronag,https://veratronag.recruitee.com
+Vertuoza,vertuoza,https://vertuoza.recruitee.com
+Via Amsterdam,viaamsterdam,https://viaamsterdam.recruitee.com
 vicotx,vicotx,https://vicotx.recruitee.com
 Vilgain s.r.o.,vilgain,https://vilgain.recruitee.com
 vineyardusa,vineyardusa,https://vineyardusa.recruitee.com
 virtual7 GmbH,virtual7jobs,https://virtual7jobs.recruitee.com
 viryah2,viryah2,https://viryah2.recruitee.com
 VLT,vlt,https://vlt.recruitee.com
+vly,vlyfoods,https://vlyfoods.recruitee.com
+VNO-NCW en MKB-Nederland,werkenbijvnoncwmkb,https://werkenbijvnoncwmkb.recruitee.com
+VPteam,vpteam,https://vpteam.recruitee.com
+VrZW,vrzw,https://vrzw.recruitee.com
 VSPARTICLE B.V.,vsparticle,https://vsparticle.recruitee.com
 Wasson-ECE Instrumentation,wassonece,https://wassonece.recruitee.com
 Waterslake Capital,waterslakecapital,https://waterslakecapital.recruitee.com
@@ -839,6 +950,11 @@ WhiteCoat,whitecoatglobal1,https://whitecoatglobal1.recruitee.com
 XMCO,xmco,https://xmco.recruitee.com
 Young & Laramore,youngandlaramore,https://youngandlaramore.recruitee.com
 zackdfilms,zackdfilms,https://zackdfilms.recruitee.com
+ZADRA-Gruppe,zadragruppe,https://zadragruppe.recruitee.com
+zara,zara,https://zara.recruitee.com
+Zero Motorcycles Inc.,zeromotorcycles,https://zeromotorcycles.recruitee.com
+Zonnehuisgroep Amstelland,zonnehuisgroepamstelland,https://zonnehuisgroepamstelland.recruitee.com
+ZPV GmbH & Co. KG,zpvgmbhcokg,https://zpvgmbhcokg.recruitee.com
 Óscala,oscalabv,https://oscalabv.recruitee.com
 agileDSS,agiledss,https://agiledss.recruitee.com
 Apside,apside,https://apside.recruitee.com
@@ -848,42 +964,202 @@ ASVZ,asvz,https://asvz.recruitee.com
 Boulangerie Ange,boulangerieange,https://boulangerieange.recruitee.com
 elmenus technologies,elmenus,https://elmenus.recruitee.com
 weWow,wewow,https://wewow.recruitee.com
+Whello B.V.,whello,https://whello.recruitee.com
+WJ-Gruppe,wjgruppe,https://wjgruppe.recruitee.com
+WONINGBORG TOETSING EN TOEZICHT B.V.,wtt,https://wtt.recruitee.com
+Woonplus Schiedam,woonplusschiedam,https://woonplusschiedam.recruitee.com
+Woonzorg Nederland,woonzorgnederland,https://woonzorgnederland.recruitee.com
 Budget Thuis,nutsgroep,https://werkenbijbudgetthuis.nl
+BUKO Infrasupport,bukoinfrasupport,https://bukoinfrasupport.recruitee.com
+BURG Bedrijven,burgbedrijven,https://burgbedrijven.recruitee.com
+BV Peak Coaching,jobspeakcoaching,https://jobspeakcoaching.recruitee.com
+Bäcker Müller GmbH & Co KG,baeckermueller,https://baeckermueller.recruitee.com
 Kapten & Son,kaptenandson,https://karriere.kapten-son.com
+KB | nationale bibliotheek,kb,https://kb.recruitee.com
+Kieser,kiesertrainingag,https://kiesertrainingag.recruitee.com
+KLA,kimlundgrenassociatesinc,https://kimlundgrenassociatesinc.recruitee.com
 Livestorm,livestorm,https://jobs.livestorm.co
 Marks and Spencer Greece,marksandspencer,https://careers.marksandspencergreece.com
+Massimo Dutti,massimodutti,https://massimodutti.recruitee.com
 Merz Schule gGmbH,mbw,https://mbw.recruitee.com
 Bäckerei Salzbäcker,salzbacker,https://salzbacker.recruitee.com
+BÖCKELS Beste GmbH,karriereboeckelsbestede,https://karriereboeckelsbestede.recruitee.com
 Sircle Collection,sirclecollection,https://careers.sirclecollection.com
+Solvinity,solvinity,https://solvinity.recruitee.com
+SPLETNIK d.o.o,spletnik,https://spletnik.recruitee.com
+Spotzer Digital,spotzer,https://spotzer.recruitee.com
+SPS Schaltanlagentechnik,spsschaltanlagentechnik,https://spsschaltanlagentechnik.recruitee.com
+Stacvalley,stacvalley,https://stacvalley.recruitee.com
+status C AG,statuscag,https://statuscag.recruitee.com
+Stibbe,stibbebv,https://stibbebv.recruitee.com
+Stichting Kwintes,stichtingkwintes,https://stichtingkwintes.recruitee.com
+Stichting Sprank,stichtingsprank,https://stichtingsprank.recruitee.com
+Stichting Voor ieder 1,stichtingvoorieder1,https://stichtingvoorieder1.recruitee.com
+Strict B.V.,strictbv,https://strictbv.recruitee.com
+Student Works Management Program,studentworks,https://studentworks.recruitee.com
+SuccessDay,successday,https://successday.recruitee.com
+Sveriges a-kassor,sverigesakassor,https://sverigesakassor.recruitee.com
+SW Logistics,swlog,https://swlog.recruitee.com
+Symvaro GmbH,symvaro,https://symvaro.recruitee.com
+Südstärke GmbH,sudstarkegmbh,https://sudstarkegmbh.recruitee.com
 Xylos,xylos,https://xylos.recruitee.com
 Landbot,landbot,https://jobs.landbot.io
+Lassner Metallbau & Zerspanungstechnik GmbH & Co. KG,lassnerkarriere,https://lassnerkarriere.recruitee.com
+LayerScale Advisory,layerscaleadvisory,https://layerscaleadvisory.recruitee.com
+Leeruniek,leeruniek,https://leeruniek.recruitee.com
+Lenskart,lenskartcareers,https://lenskartcareers.recruitee.com
+LessonUp,lessonup,https://lessonup.recruitee.com
+Lister,lister,https://lister.recruitee.com
 KP Snacks,kpsnacks,https://kpsnacks.recruitee.com
 Atiba,jobs.atiba.com,https://jobs.atiba.com
 PIAGROUP Netherlands Beheer B.V.,piagroupnetherlands,https://piagroupnetherlands.recruitee.com
+pladis France,pladisfrance,https://pladisfrance.recruitee.com
+Polaroid,polaroid,https://polaroid.recruitee.com
+Pragmatic Coders,pragmaticcoders,https://pragmaticcoders.recruitee.com
+Priestley Management Company,priestley,https://priestley.recruitee.com
+Primo Marine,primomarine,https://primomarine.recruitee.com
+Prinsenstichting,prinsenstichting,https://prinsenstichting.recruitee.com
 DB Financial,career.dbfinancial.ae,https://career.dbfinancial.ae
+De Piergroep,depiergroep,https://depiergroep.recruitee.com
+De'Longhi Group,delonghigroup,https://delonghigroup.recruitee.com
+DeepSea Technologies,deepsea,https://deepsea.recruitee.com
+Deerns Groep BV,jobsdeerns,https://jobsdeerns.recruitee.com
+DemoUp Cliplister,demoupcliplister,https://demoupcliplister.recruitee.com
+Dienst Dommelvallei,dommelvallei,https://dommelvallei.recruitee.com
+DocCheck AG,doccheckgroup,https://doccheckgroup.recruitee.com
+Doctena S.A.,doctenasa,https://doctenasa.recruitee.com
 John Howard Society of Okanagan & Kootenay,johnhowardsocietyofokanagankootenay,https://johnhowardsocietyofokanagankootenay.recruitee.com
+JOHO Group GmbH,johogroup,https://johogroup.recruitee.com
+Julius Berger International GmbH,juliusbergerinternationalgmbh,https://juliusbergerinternationalgmbh.recruitee.com
+Juno,junolegal,https://junolegal.recruitee.com
+Just Russel,justrussel,https://justrussel.recruitee.com
 MaxGrip B.V.,maxgrip,https://maxgrip.recruitee.com
 N.V. Juva,nvjuva,https://nvjuva.recruitee.com
+Nedcargo,werkenbijnedcargo,https://werkenbijnedcargo.recruitee.com
+Newelec,newelec,https://newelec.recruitee.com
+NIC Systemhaus GmbH,nicsystemhausgmbh,https://nicsystemhausgmbh.recruitee.com
+Nictiz,nictiz,https://nictiz.recruitee.com
+NIKIN AG,nikin,https://nikin.recruitee.com
+Normec Talentpool,normectalentpool,https://normectalentpool.recruitee.com
+Novritsch Trading,novritschtrading,https://novritschtrading.recruitee.com
+NVM,nvm,https://nvm.recruitee.com
+NWB Bank,nwbbank,https://nwbbank.recruitee.com
+nyra health,nyrahealth,https://nyrahealth.recruitee.com
 Pääkaupunkiseudun Kaupunkiliikenne Oy,kaupunkiliikenne,https://kaupunkiliikenne.recruitee.com
 Good Seed Community Development Corporation,goodseedcommunitydevelopmentcorporation,https://goodseedcommunitydevelopmentcorporation.recruitee.com
+GPV Finland,gpvfinland,https://gpvfinland.recruitee.com
+GPV Germany GmbH,gpvgermany,https://gpvgermany.recruitee.com
+GPV Slovakia (Nova) s.r.o.,gpvslovakia,https://gpvslovakia.recruitee.com
+GPV Switzerland SA,gpvswitzerland,https://gpvswitzerland.recruitee.com
+Greenpeace Belgium,greenpeacebelgium,https://greenpeacebelgium.recruitee.com
+"Griffin Funding, Inc.",griffinfundinginc,https://griffinfundinginc.recruitee.com
 RW Group,rwg,https://rwg.recruitee.com
 OPUS,opus,https://opus.recruitee.com
 Avedo - Eine Marke der Ströer X GmbH,avedo,https://avedo.recruitee.com
 Copaco Nederland BV,nl.werkenbijcopaco.com,https://nl.werkenbijcopaco.com
 Master English,masterenglish,https://masterenglish.recruitee.com
+Mavie Next GmbH,mavienextgmbh,https://mavienextgmbh.recruitee.com
+Mayflower,mayflower,https://mayflower.recruitee.com
+MEDACTA FRANCE SAS,medactafrance,https://medactafrance.recruitee.com
+Medecins Sans Frontières-WaCA,medecinssansfrontiereswaca,https://medecinssansfrontiereswaca.recruitee.com
+Mega Group International S.A.,megagroupinternational,https://megagroupinternational.recruitee.com
+Mei architects and planners,meiarchitectsplanners,https://meiarchitectsplanners.recruitee.com
+Metzgerei Jedowski GmbH & Co.KG,jedowski,https://jedowski.recruitee.com
+Médecins Sans Frontières Suisse,medecinssansfrontieressuisse,https://medecinssansfrontieressuisse.recruitee.com
+Médialo Inc.,medialo,https://medialo.recruitee.com
 Universe Group,universegroup,https://universegroup.recruitee.com
+Utility Profit,utilityprofit,https://utilityprofit.recruitee.com
 Aalberts Surface Technologies GmbH,jobs.aalberts-st.com,https://jobs.aalberts-st.com
+Ab Närpes Trä & Metall,ntm,https://ntm.recruitee.com
+Ackermans & van Haaren,ackermansvanhaaren,https://ackermansvanhaaren.recruitee.com
 Group Jansen,kansenbijjansen.be,https://kansenbijjansen.be
+Groupe LG2,lg2,https://lg2.recruitee.com
+Grow Progress,growprogress,https://growprogress.recruitee.com
+GTO Wizard,gtowizard,https://gtowizard.recruitee.com
+Gérard Bertrand,gerardbertrand,https://gerardbertrand.recruitee.com
 pro4dynamix GmbH,pro4dynamixgmbh,https://pro4dynamixgmbh.recruitee.com
+Prodigi Group,prodigigroup,https://prodigigroup.recruitee.com
+Protect Democracy,protectdemocracy,https://protectdemocracy.recruitee.com
 Fulcrum,fulcrum,https://fulcrum.recruitee.com
 Yellowstone Local,jobs.yellowstonelocal.com,https://jobs.yellowstonelocal.com
+Yellowtail Conclusion,yellowtail,https://yellowtail.recruitee.com
 Kodify,kodify,https://kodify.recruitee.com
 Carano Software Solutions GmbH,carano,https://carano.recruitee.com
+CarbonBetter,carbonbetter,https://carbonbetter.recruitee.com
+CARE EXPERT B.V.,careexpert,https://careexpert.recruitee.com
+CB,cb,https://cb.recruitee.com
+CCM Europe,ccmeurope,https://ccmeurope.recruitee.com
+CENTRALE LYON,ecolecentraledelyon,https://ecolecentraledelyon.recruitee.com
+CH Media,chmedia,https://chmedia.recruitee.com
+Chow Co ApS,chowco,https://chowco.recruitee.com
+cigus GmbH,cigusgmbh,https://cigusgmbh.recruitee.com
+"Civiltec Engineering, Inc",civiltecengineering,https://civiltecengineering.recruitee.com
+Claus Group,claus,https://claus.recruitee.com
+Clay Hospitality,clay,https://clay.recruitee.com
+Climeworks,climeworks,https://climeworks.recruitee.com
+Club Pierre Charron (MARVAL),groupemarval,https://groupemarval.recruitee.com
+Commodity Hero,buildofarm,https://buildofarm.recruitee.com
+Comtest Engineering,comtest,https://comtest.recruitee.com
+Confo Therapeutics,confotherapeutics,https://confotherapeutics.recruitee.com
+connect people & company GmbH,connectpeople,https://connectpeople.recruitee.com
+Context&,contextand,https://contextand.recruitee.com
+Context& Finland Oy,sulavaoy,https://sulavaoy.recruitee.com
+Coppens Metaal-techniek B.V.,coppensmetaaltechniek,https://coppensmetaaltechniek.recruitee.com
+CoverWorks Group,coverworks,https://coverworks.recruitee.com
+Craftzing,craftzing,https://craftzing.recruitee.com
+Crunch Analytics,crunchanalyticscareers,https://crunchanalyticscareers.recruitee.com
+CSC – IT Center for Science,cscfi,https://cscfi.recruitee.com
+CTICC,cticc,https://cticc.recruitee.com
+CURRENTA Gruppe Ausbildung,azubi,https://azubi.recruitee.com
 livedepartment crew support GmbH,jobs.livedepartment.com,https://jobs.livedepartment.com
+Livio,livio,https://livio.recruitee.com
+Loyalty Key A/S,loyaltykey,https://loyaltykey.recruitee.com
 REIZ TECH UAB,reiztech,https://reiztech.recruitee.com
+REPLOID Group AG,reploidgroupag,https://reploidgroupag.recruitee.com
 Resumedia,careers.resumedia.com,https://careers.resumedia.com
+RH Partners,rhpartners,https://rhpartners.recruitee.com
+Rooyse Wissel,rooysewissel,https://rooysewissel.recruitee.com
 Adarga,adarga,https://adarga.recruitee.com
+ADHESE,adhese,https://adhese.recruitee.com
+Adstronauts GmbH,adstronauts,https://adstronauts.recruitee.com
+aedifion GmbH,aedifion,https://aedifion.recruitee.com
+Affidea Greece,affideagreece,https://affideagreece.recruitee.com
+ahc GmbH,ahcgmbh,https://ahcgmbh.recruitee.com
+Alliade,alliade,https://alliade.recruitee.com
+apotal,apotal,https://apotal.recruitee.com
+Applus+,applus,https://applus.recruitee.com
+ATASS Sports,atasssports,https://atasssports.recruitee.com
+ATLANTIC GmbH,atlanticgmbh,https://atlanticgmbh.recruitee.com
+Atostek Oy,atostek,https://atostek.recruitee.com
+Autohaus Dünnes & Sohn GmbH,autohausduennes,https://autohausduennes.recruitee.com
+Autoriteit Financiele Markten,werkenbijdeafm,https://werkenbijdeafm.recruitee.com
+Aux Merveilleux de Fred,auxmerveilleuxcarriere,https://auxmerveilleuxcarriere.recruitee.com
+Avante Bouwprocessen,avantebouwprocessen,https://avantebouwprocessen.recruitee.com
+Aveniq AG,aveniq,https://aveniq.recruitee.com
 Knuddels GmbH & Co. KG,jobs.knuddels.de,https://jobs.knuddels.de
+Koninklijk Theater Carré,koninklijktheatercarre,https://koninklijktheatercarre.recruitee.com
+Koninklijke Niestern Sander,koninklijkeniesternsander,https://koninklijkeniesternsander.recruitee.com
+Kurparkklinik Dr. Lauterbach Klinik GmbH,jobsdrlauterbachklinik,https://jobsdrlauterbachklinik.recruitee.com
+kybun Joya Retail,kybunjoyaretail,https://kybunjoyaretail.recruitee.com
+KÖ-KLINIK GmbH,koklinikgmbh,https://koklinikgmbh.recruitee.com
 Tereos Starch & Sweeteners Belgium NV,tereos,https://tereos.recruitee.com
+testimonials.de GmbH,testimonials,https://testimonials.recruitee.com
+TFH Holland Beheer BV.,werkenbijons,https://werkenbijons.recruitee.com
+The Career Centre,thecareersteam,https://thecareersteam.recruitee.com
+The Landbanking Group,thelandbankinggroup,https://thelandbankinggroup.recruitee.com
+The Mortgage Talent Network,themortgagetalentnetwork,https://themortgagetalentnetwork.recruitee.com
+The Safety Network,thesafetynetwork,https://thesafetynetwork.recruitee.com
+The Sales Centre co,thesalescentre,https://thesalescentre.recruitee.com
+timeout Stiftung gGmbH,timeoutstiftungggmbh,https://timeoutstiftungggmbh.recruitee.com
+Transferz,transferz,https://transferz.recruitee.com
+True North Partners LLP,tnp,https://tnp.recruitee.com
+Tweede Kamer,tweedekamer,https://tweedekamer.recruitee.com
 Online Payment Platform,jobs.onlinepaymentplatform.com,https://jobs.onlinepaymentplatform.com
+OPEN.nl Software Group,opennl,https://opennl.recruitee.com
+OpenTag,opentag,https://opentag.recruitee.com
 OpenVPN,careers.openvpn.net,https://careers.openvpn.net
+Opernhaus Graz GmbH,opergraz,https://opergraz.recruitee.com
+Organisation internationale de la Francophonie,francophoniecarrieres,https://francophoniecarrieres.recruitee.com
+Otovo,otovo,https://otovo.recruitee.com
+Otsuka Pharma GmbH,otsukapharmagmbh,https://otsukapharmagmbh.recruitee.com
+ÖJAB – Österreichische JungArbeiterBewegung,oejab,https://oejab.recruitee.com


### PR DESCRIPTION
## Summary
- add 276 previously unlisted Recruitee boards
- expose 3,790 genuinely new live jobs

## Discovery and validation
- mined `*.recruitee.com/o/*` from `CC-MAIN-2026-25`
- removed all 888 existing Recruitee slugs and URLs before probing
- live-tested 382 candidates through the public offers API; 277 returned jobs
- compared all 3,795 tenant-scoped candidate jobs against 13,249 published Recruitee rows
- removed 5 published overlaps and one board that contributed no new jobs
- retained 276 boards contributing 3,790 net-new jobs
- sourced company names from the live API
- verified exact CSV additions, no new duplicate groups, `git diff --check`, and focused tests (`7 passed`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 276 previously unlisted Recruitee boards and surfaces 3,790 net-new live jobs. Updates only `ats-companies/recruitee.csv`.

- **New Features**
  - Discovered candidates via `CC-MAIN-2026-25` crawl of `*.recruitee.com/o/*`; API-validated 382 and kept 276 with jobs.
  - De-duplicated against 888 existing slugs and 13,249 published rows; removed overlaps and empty sources to keep net-new jobs only.
  - Company names pulled from the live API; CSV verified (no new duplicate groups) and focused tests passed.

<sup>Written for commit 418ce8bb05217d61c107a29f274e9213ad561242. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

