### PR TITLE
Add 17 live Taleo sites from crawl discovery

### DIFF
--- a/ats-companies/taleo.csv
+++ b/ats-companies/taleo.csv
@@ -13,12 +13,15 @@ KGHM International Ltd,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResu
 "Base-2 Solutions, LLC",https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=BASESOLU&cws=1,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=BASESOLU&cws=1
 "Boeing Intelligence & Analytics, Inc. (BIA)",https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=BIA&cws=1,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=BIA&cws=1
 BSH Home Appliances Corporation,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=BSHHOME&cws=1,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=BSHHOME&cws=1
+Buffalorock,https://phf.tbe.taleo.net/phf02/ats/careers/v2/searchResults?org=BUFFALOROCK&cws=37,https://phf.tbe.taleo.net/phf02/ats/careers/v2/searchResults?org=BUFFALOROCK&cws=37
 Butterball,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=BUTTLLC2&cws=1,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=BUTTLLC2&cws=1
 "C2 Essentials, Inc",https://phh.tbe.taleo.net/phh02/ats/careers/v2/searchResults?org=C2PORTFOLIO&cws=38,https://phh.tbe.taleo.net/phh02/ats/careers/v2/searchResults?org=C2PORTFOLIO&cws=38
 City of Cambridge MA,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=CAMBRIDGEMA&cws=37,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=CAMBRIDGEMA&cws=37
 CARE USA,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=CAREUSA&cws=52,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=CAREUSA&cws=52
 Carley Corporation,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=CARLCORP2&cws=1,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=CARLCORP2&cws=1
+Causcapi,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=CAUSCAPI&cws=37,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=CAUSCAPI&cws=37
 Celestar,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=CELESTAR&cws=1,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=CELESTAR&cws=1
+Centric Consulting LLC,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=CENTCONS&cws=38,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=CENTCONS&cws=38
 City of Burnaby,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CITYBURNABY&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CITYBURNABY&cws=1
 City of Kawartha Lakes,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CITYOFKA&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CITYOFKA&cws=1
 Canadian Nuclear Laboratories,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CNLLTD&cws=37,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CNLLTD&cws=37
@@ -27,6 +30,9 @@ Memorial Health System of Southwest Oklahoma,https://phg.tbe.taleo.net/phg04/ats
 City of St. Catharines,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=COSC&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=COSC&cws=1
 CP Unlimited,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=CPOFNYS&cws=1,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=CPOFNYS&cws=1
 Canadian Red Cross,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CRCS&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CRCS&cws=1
+Canadian Red Cross,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CRCS&cws=75,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CRCS&cws=75
+Candela Medical,https://lde.tbe.taleo.net/lde02/ats/careers/v2/searchResults?org=SYNEMEDI&cws=37,https://lde.tbe.taleo.net/lde02/ats/careers/v2/searchResults?org=SYNEMEDI&cws=37
+Candela Medical,https://lde.tbe.taleo.net/lde02/ats/careers/v2/searchResults?org=SYNEMEDI&cws=48,https://lde.tbe.taleo.net/lde02/ats/careers/v2/searchResults?org=SYNEMEDI&cws=48
 Custom Online,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=CUSTOMONLINE&cws=1,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=CUSTOMONLINE&cws=1
 Custom Online,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=CUSTOMONLINE&cws=37,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=CUSTOMONLINE&cws=37
 "Cydecor, Inc",https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=CYDE&cws=1,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=CYDE&cws=1
@@ -52,6 +58,8 @@ Institute for Defense Analyses,https://phh.tbe.taleo.net/phh01/ats/careers/v2/se
 "INVENSENSE, INC.",https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=INVENSENSE&cws=1,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=INVENSENSE&cws=1
 RealmOne,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=INVXIS&cws=1,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=INVXIS&cws=1
 Sierra-Cedar,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=ITS&cws=1,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=ITS&cws=1
+"Social Impact, Inc.",https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=SOCIIMPA2&cws=39,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=SOCIIMPA2&cws=39
+Sonaca,https://lde.tbe.taleo.net/lde01/ats/careers/v2/searchResults?org=SONACA&cws=38,https://lde.tbe.taleo.net/lde01/ats/careers/v2/searchResults?org=SONACA&cws=38
 "K. Hovnanian Companies, LLC",https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=KHOV&cws=1,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=KHOV&cws=1
 Klohn Crippen Berger,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=KLOHNCRIPPEN&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=KLOHNCRIPPEN&cws=1
 "Leisure Sports, Inc.",https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=LEISURESPORTS&cws=1,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=LEISURESPORTS&cws=1
@@ -68,6 +76,7 @@ NuAxis Innovations,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?
 Oaks Christian School,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=OAKSCHRISTIAN&cws=1,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=OAKSCHRISTIAN&cws=1
 ORBIS Inc,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=ORBIS&cws=1,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=ORBIS&cws=1
 "OUTSOURCE Consulting Services, Inc.",https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=OSOURCE&cws=1,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=OSOURCE&cws=1
+PACO Group,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=AYYRW5&cws=37,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=AYYRW5&cws=37
 "Potawatomi Federal Solutions, LLC",https://phf.tbe.taleo.net/phf01/ats/careers/v2/searchResults?org=PFS&cws=1,https://phf.tbe.taleo.net/phf01/ats/careers/v2/searchResults?org=PFS&cws=1
 Philadelphia Corporation for Aging,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=PHILADELPHIACORP&cws=1,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=PHILADELPHIACORP&cws=1
 Phoenix Industrial,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=PHXIND&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=PHXIND&cws=1
@@ -78,6 +87,7 @@ City of New Westminster,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchRes
 Radiology Partners,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=RADIPART&cws=1,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=RADIPART&cws=1
 SE Health,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=SAINTELIZABETH&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=SAINTELIZABETH&cws=1
 St. Joseph's Healthcare Hamilton,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=STJOSHAM&cws=1,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=STJOSHAM&cws=1
+"System Studies and Simulation, Inc.",https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=S3INC&cws=48,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=S3INC&cws=48
 Toronto Community Housing Corporation,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=TCHC&cws=45,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=TCHC&cws=45
 "TSG Ski & Golf, LLC",https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=TELRIDE&cws=1,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=TELRIDE&cws=1
 TerpSys,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=TERPSYS&cws=1,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=TERPSYS&cws=1
@@ -96,6 +106,8 @@ Yukon-Kuskokwim Health Corporation,https://phh.tbe.taleo.net/phh01/ats/careers/v
 YMCA of the USA,https://phf.tbe.taleo.net/phf01/ats/careers/v2/searchResults?org=YMCAUSA&cws=1,https://phf.tbe.taleo.net/phf01/ats/careers/v2/searchResults?org=YMCAUSA&cws=1
 Freedom House,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=FREEHOUS&cws=39,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=FREEHOUS&cws=39
 Mediacom Communications Corporation,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=MEDIACOMCC&cws=46,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=MEDIACOMCC&cws=46
+Medicaid And Chip Payment and Access Commission,https://phf.tbe.taleo.net/phf03/ats/careers/v2/searchResults?org=MACPAC&cws=37,https://phf.tbe.taleo.net/phf03/ats/careers/v2/searchResults?org=MACPAC&cws=37
+Melbourne Grammar School,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=MELBGRAM&cws=50,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=MELBGRAM&cws=50
 Pinellas Suncoast Transit Authority,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=UH9TY5&cws=41,https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=UH9TY5&cws=41
 Caidya,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=CLINIPACE&cws=41,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=CLINIPACE&cws=41
 Meruelo Group,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=GRANDSIERRARESORT&cws=54,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=GRANDSIERRARESORT&cws=54
@@ -105,6 +117,7 @@ Costco,https://phf.tbe.taleo.net/phf02/ats/careers/v2/searchResults?org=COSTCO&c
 Empire Today,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=EMPITODA&cws=37,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=EMPITODA&cws=37
 Graniterock,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=GRANITEROCK&cws=42,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=GRANITEROCK&cws=42
 "M. J. Electric, LLC",https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=UT62VN&cws=37,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=UT62VN&cws=37
+Madison Gas and Electric Company,https://phf.tbe.taleo.net/phf01/ats/careers/v2/searchResults?org=MGE&cws=38,https://phf.tbe.taleo.net/phf01/ats/careers/v2/searchResults?org=MGE&cws=38
 City of Artesia,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=ARTESIA&cws=40,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=ARTESIA&cws=40
 Conservation International,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=CONSERVATION&cws=39,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=CONSERVATION&cws=39
 DCS Corporation,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=DCSCORP2&cws=37,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=DCSCORP2&cws=37
@@ -126,11 +139,13 @@ IFPRI,https://phf.tbe.taleo.net/phf04/ats/careers/v2/searchResults?org=IFPRI&cws
 NVR Inc,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=NVRINC&cws=65,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=NVRINC&cws=65
 Palouse Brand,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=PALOBRAN&cws=40,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=PALOBRAN&cws=40
 DHL eCommerce,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=DHLECOMMERCE&cws=43,https://phg.tbe.taleo.net/phg03/ats/careers/v2/searchResults?org=DHLECOMMERCE&cws=43
+"Dierbergs Markets, Inc.",https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=DIERGERGS&cws=43,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=DIERGERGS&cws=43
 Great Hearts Academies,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=GREATHEARTS&cws=40,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=GREATHEARTS&cws=40
 Federal Home Loan Bank of Boston,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=FHLBBOSTON&cws=38,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=FHLBBOSTON&cws=38
 Dyno Nobel,https://phh.tbe.taleo.net/phh02/ats/careers/v2/searchResults?org=DYNONOBEL&cws=43,https://phh.tbe.taleo.net/phh02/ats/careers/v2/searchResults?org=DYNONOBEL&cws=43
 Sierra Nevada Brewing Co,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=SIERRANEVADABREWINGCO&cws=39,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=SIERRANEVADABREWINGCO&cws=39
 Wagman,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=WAGMAN&cws=37,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=WAGMAN&cws=37
+Wagner,https://phf.tbe.taleo.net/phf04/ats/careers/v2/searchResults?org=WAGNER&cws=37,https://phf.tbe.taleo.net/phf04/ats/careers/v2/searchResults?org=WAGNER&cws=37
 Defence Construction Canada,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=DEFENCECONSTRUCTIONCANADA&cws=47,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=DEFENCECONSTRUCTIONCANADA&cws=47
 Hamilton Island Enterprises Limited,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=HAMILTONISLAND&cws=42,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=HAMILTONISLAND&cws=42
 Wilco,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=WILCO&cws=37,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=WILCO&cws=37
@@ -144,8 +159,10 @@ Telecon Inc,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=TEL
 Town of Oakville,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=TOWNOFOA&cws=43,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=TOWNOFOA&cws=43
 Aurora Flight Sciences,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=AURORA&cws=37,https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=AURORA&cws=37
 Systems Technologies (Systek),https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=SYSTEK&cws=42,https://phh.tbe.taleo.net/phh04/ats/careers/v2/searchResults?org=SYSTEK&cws=42
+Tassal Group Limited,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=TASSALGROUP&cws=41,https://phe.tbe.taleo.net/phe03/ats/careers/v2/searchResults?org=TASSALGROUP&cws=41
 Alakaina Family of Companies,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=AKIMEKATECH&cws=43,https://phg.tbe.taleo.net/phg04/ats/careers/v2/searchResults?org=AKIMEKATECH&cws=43
 ActionLink,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=ACTIONLINK&cws=41,https://phh.tbe.taleo.net/phh01/ats/careers/v2/searchResults?org=ACTIONLINK&cws=41
 Canadian Air Transport Security Authority,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=CATSA&cws=46,https://phe.tbe.taleo.net/phe02/ats/careers/v2/searchResults?org=CATSA&cws=46
+Canadian Museum of History,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CMCC&cws=54,https://tre.tbe.taleo.net/tre01/ats/careers/v2/searchResults?org=CMCC&cws=54
 David Evans and Associates,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=DEAINC&cws=51,https://phh.tbe.taleo.net/phh03/ats/careers/v2/searchResults?org=DEAINC&cws=51
 Punahou School,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=PUNAHOU&cws=39,https://phg.tbe.taleo.net/phg02/ats/careers/v2/searchResults?org=PUNAHOU&cws=39


### PR DESCRIPTION
## Summary
- add 17 live Oracle Taleo Business Edition career sites
- expose 134 genuinely new live jobs

## Discovery and validation
- mined exact `*.tbe.taleo.net/*/ats/careers/v2/searchResults` URLs from `CC-MAIN-2026-25`
- removed all existing Taleo `(host, instance, org, cws)` combinations before live probing
- live-tested 36 canonical candidates; 27 returned jobs
- compared 200 unique org-scoped requisition IDs against 1,072 published Taleo jobs
- removed 60 published overlaps and cross-site duplicate requisitions
- excluded three partially overlapping mirror boards because CSV inventory would publish all 28 jobs rather than only their 6 unseen records
- retained 17 sites contributing 134 net-new jobs
- verified exactly 17 CSV additions, no removals, no duplicate slugs/URLs, `git diff --check`, and focused tests (`13 passed`)
