### PR TITLE
Add 39 live Avature sites from crawl discovery

### DIFF
--- a/ats-companies/avature.csv
+++ b/ats-companies/avature.csv
@@ -1,11 +1,16 @@
 name,slug,url
 Adecco Recruiting,adeccorecruiting,https://adeccorecruiting.avature.net/careers/SearchJobs
+AESC,aesc,https://aesc.avature.net
 Advocate Health,advocateaurorahealth,https://advocateaurorahealth.avature.net/careers/SearchJobs
 Ally Financial,ally,https://ally.avature.net/careers/SearchJobs
 AMS PSR,amspsr,https://amspsr.avature.net/careers/SearchJobs
+Ashfield Healthcare,ashfieldhealthcare,https://ashfieldhealthcare.avature.net
 Astellas Pharma Inc.,astellas,https://astellas.avature.net/careers/SearchJobs
+Astellas Pharma Japan,astellasjapan,https://astellasjapan.avature.net/ja_JP/careers/SearchJobs
 Australia Post,https://jobs.auspost.com.au/en_GB,https://jobs.auspost.com.au/en_GB/careers/SearchJobs
 Avature,avature,https://careers.avature.net/en_US/main/SearchJobs
+BCG Platinion,platinion,https://platinion.avature.net/CareersDeEn/SearchJobs
+Baufest,baufest,https://baufest.avature.net/jobs/SearchJobs
 avanade,avanade,https://avanade.avature.net/careers/SearchJobs
 Berenberg,berenberg,https://berenberg.avature.net/careers/SearchJobs
 Bloomberg,bloomberg,https://bloomberg.avature.net/careers/SearchJobs
@@ -16,38 +21,62 @@ Bravura Solutions Limited,bravura,https://bravura.avature.net/careers/SearchJobs
 Broad Institute,broadinstitute,https://broadinstitute.avature.net/careers/SearchJobs
 Bupa ANZ,bupaanz,https://bupaanz.avature.net/careers/SearchJobs
 CBRE,cbreglobal,https://cbreglobal.avature.net/careers/SearchJobs
+Cicor,cicor,https://cicor.avature.net
+CIUSSS-du-Centre-Ouest-de-l’Île-de-Montréal,ciusss,https://ciusss.avature.net/fr_CA/careers/SearchJobs
+Coca-Cola HBC,cchbc,https://cchbc.avature.net
 Consumer Direct Care Network,cdcn,https://cdcn.avature.net/careers/SearchJobs
 Cycle & Carriage,cyclecarriage,https://cyclecarriage.avature.net/careers/SearchJobs
+DB Group,dbgroup,https://dbgroup.avature.net/jobs/SearchJobs
 Deloitte Belgium,deloittebe,https://deloittebe.avature.net/careers/SearchJobs
+Deloitte Central Europe,deloittece,https://deloittece.avature.net
 Deloitte Central Mediterranean,deloittecm,https://deloittecm.avature.net/careers/SearchJobs
 Deloitte PNG,deloittepng,https://deloittepng.avature.net/careers/SearchJobs
 Deloitte US,deloitteus,https://deloitteus.avature.net/careers/SearchJobs
 Delta,delta,https://delta.avature.net/careers/SearchJobs
+Delta Air Lines,dth,https://dth.avature.net
 DFI Retail Group,dfiretailgroup,https://dfiretailgroup.avature.net/careers/SearchJobs
 DHL Consulting,dhlconsulting,https://dhlconsulting.avature.net/careers/SearchJobs
+DHL Group,dpdhlgroup,https://dpdhlgroup.avature.net/jobs/SearchJobs
+Dubai Holding,dhcareers,https://dhcareers.avature.net/en_US/jumeirahmarketplace/SearchJobs
 Electronic Arts,ea,https://ea.avature.net/careers/SearchJobs
 epic,epic,https://epic.avature.net/careers/SearchJobs
+Fletcher Building,fb,https://fb.avature.net
+FM Logistic,fmlogistic,https://fmlogistic.avature.net/fr_FR/careers/SearchJobs
 Fonterra,fonterrakf,https://fonterrakf.avature.net/careers/SearchJobs
 Fortress,fortress,https://fortress.avature.net/careers/SearchJobs
+Forvis Mazars,forvis,https://forvis.avature.net/campuscareers/SearchJobs
 Frequentis,frequentis,https://frequentis.avature.net/careers/SearchJobs
 Genpact,genpact,https://genpact.avature.net/careers/SearchJobs
+giffgaff,virginmediao2,https://virginmediao2.avature.net/en_US/giffgaffcareers/SearchJobs
 GPS Hospitality,gpshospitality,https://gpshospitality.avature.net/careers/SearchJobs
 HARMAN,harmanglobal,https://harmanglobal.avature.net/careers/SearchJobs
+Healthfirst,healthfirst,https://healthfirst.avature.net/careers/SearchJobs
+In-N-Out Burger,ino,https://ino.avature.net
 infor,infor,https://infor.avature.net/careers/SearchJobs
 Insperity,insperity,https://insperity.avature.net/careers/SearchJobs
 Intercare Therapy,intercaretherapy,https://intercaretherapy.avature.net/careers/SearchJobs
 Jack Henry,jackhenry,https://jackhenry.avature.net/careers/SearchJobs
+Jakala,jakala,https://jakala.avature.net
 Jardine Matheson,jardinematheson,https://jardinematheson.avature.net/careers/SearchJobs
 JRG,jrg,https://jrg.avature.net/careers/SearchJobs
 KPMG Ireland,kpmgireland,https://kpmgireland.avature.net/careers/SearchJobs
+Koch,koch,https://koch.avature.net
 L'Oreal,loa,https://loa.avature.net/careers/SearchJobs
+Land O'Lakes Venture37,lol,https://lol.avature.net
+LaplandUK,laplanduk,https://laplanduk.avature.net/careersmarketplace/SearchJobs
+Lawson Products,lawson,https://lawson.avature.net/en_US/KentCareers/SearchJobs
 Lenovo,lenovo,https://lenovo.avature.net/careers/SearchJobs
+Leonard Cheshire,leonardcheshire,https://leonardcheshire.avature.net/en_GB/careersmarketplace/SearchJobs
+Lindner Group,lindner,https://lindner.avature.net
 lululemon,lululemoninc,https://lululemoninc.avature.net/careers/SearchJobs
+ManpowerGroup Colombia,manpowergroupco,https://manpowergroupco.avature.net/es_CO/careers/SearchJobs
+ManpowerGroup Talent Solutions,workmyway,https://workmyway.avature.net
 ManTech,mantech,https://mantech.avature.net/careers/SearchJobs
 Maximus,maximus,https://maximus.avature.net/careers/SearchJobs
 McLaren,mclaren,https://mclaren.avature.net/careers/SearchJobs
 Mercadona,mercadona,https://mercadona.avature.net/careers/SearchJobs
 Metrobank,metrobank,https://metrobank.avature.net/amazingcareers/SearchJobs
+METTLER TOLEDO,mt,https://mt.avature.net
 Ministry of Justice,justicejobs,https://justicejobs.avature.net/careers/SearchJobs
 Missionpethealth,missionpethealth,https://missionpethealth.avature.net/careers/SearchJobs
 Monadelphous,monadelphous,https://monadelphous.avature.net/careers/SearchJobs
@@ -64,20 +93,30 @@ Primero,primero,https://primero.avature.net/careers/SearchJobs
 Radiology Partners,radpartners,https://radpartners.avature.net/careers/SearchJobs
 Regis,regis,https://regis.avature.net/careers/SearchJobs
 ResourceBank,resourcebank,https://resourcebank.avature.net/careers/SearchJobs
+Rohde & Schwarz,rohdeschwarz,https://rohdeschwarz.avature.net
 Rosewood Hotel Group,rhg,https://rhg.avature.net/careers/SearchJobs
+Santos,santos,https://santos.avature.net
 Siemens Healthineers,https://jobs.siemens-healthineers.com/en_US/searchjobs/SearchJobs,https://jobs.siemens-healthineers.com/en_US/searchjobs/SearchJobs
 Skanska,skanska,https://skanska.avature.net/careers/SearchJobs
 Smurfit Westrock,smurfitwestrockta,https://smurfitwestrockta.avature.net/careers/SearchJobs
+Spark,sparknz,https://sparknz.avature.net
+St. Jude,https://talent.stjude.org/careers/SearchJobs,https://talent.stjude.org/careers/SearchJobs
+St. Luke's Health System,slhs,https://slhs.avature.net/careersmarketplace/SearchJobs
 Synopsys,synopsys,https://synopsys.avature.net/careers/SearchJobs
 Tesco,tesco,https://tesco.avature.net/careers/SearchJobs
 Tesco Bank,tescoinsuranceandmoneyservices,https://tescoinsuranceandmoneyservices.avature.net/careers/SearchJobs
 The a2 Milk Company,a2milkkf,https://a2milkkf.avature.net/careers/SearchJobs
+TMF,tmf,https://tmf.avature.net/careersmarketplace/SearchJobs
+Total Quality Logistics,tql,https://tql.avature.net/en_US/TQLexternalcareers/SearchJobs
 Trader Joe's,traderjoes,https://traderjoes.avature.net/careers/SearchJobs
 Transcom,transcom,https://transcom.avature.net/careers/SearchJobs
+Travis Perkins,travisperkins,https://travisperkins.avature.net
 UCLA Health,uclahealth,https://uclahealth.avature.net/careers/SearchJobs
 Unifi,unifi,https://unifi.avature.net/careers/SearchJobs
+University of Colorado Boulder,colorado,https://colorado.avature.net/jobs/SearchJobs
 UOP,uop,https://uop.avature.net/careers/SearchJobs
 Uskpmgats,uskpmgats,https://uskpmgats.avature.net/careers/SearchJobs
+Van Oord,vanoord,https://vanoord.avature.net/en_US/careersmarketplace/SearchJobs
 Virgin Media O2,https://jobs.virginmediao2.co.uk/en_US/careersmarketplace/SearchJobs,https://jobs.virginmediao2.co.uk/en_US/careersmarketplace/SearchJobs
 Voutiqueintegrations,voutiqueintegrations,https://voutiqueintegrations.avature.net/careers/SearchJobs
 Walmartsourcingeu,walmartsourcingeu,https://walmartsourcingeu.avature.net/careers/SearchJobs


### PR DESCRIPTION
## Summary
- add 39 live production Avature career sites
- expose 905 genuinely new live jobs

## Discovery and validation
- mined `*.avature.net/*` across `CC-MAIN-2026-25` plus three 2025 crawl snapshots
- removed existing Avature hosts and slugs before live probing
- tested 181 canonical candidates through exact crawled search paths plus bounded default-path fallbacks
- retained 39 production sites contributing 905 live jobs
- compared host-scoped job IDs against 3,084 published Avature rows and found zero exact overlap
- excluded sandbox/UAT/test hosts and one portal explicitly marked `do not use`
- resolved generic display names from live metadata and public company mappings
- verified exactly 39 CSV additions, no removals, no duplicate slugs/URLs, `git diff --check`, and focused tests (`23 passed`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added 39 live Avature career sites from crawl discovery to expand coverage and surface 905 new live jobs. CSV-only change with no removals or duplicates.

- **New Features**
  - Sourced from `CC-MAIN-2026-25` + 2025 snapshots; validated 181; kept prod only.
  - Deduped vs 3,084 Avature rows; excluded sandbox/UAT/test and one “do not use”.
  - Names from live metadata; no slug/URL dupes; focused tests passed.

<sup>Written for commit 094519390702d5f6a7092be37b319385b93e3536. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

