### PR TITLE
Add 55 live Darwinbox tenants from crawl discovery

### DIFF
--- a/ats-companies/darwinbox.csv
+++ b/ats-companies/darwinbox.csv
@@ -8,63 +8,99 @@ Mygate,mygate,https://mygate.darwinbox.in/ms/candidate/careers
 PwC Asia,pwc.com,https://pwc.darwinbox.com/ms/candidate/careers
 Security Bank Cards (SBC Hero),sbchero.com,https://sbchero.darwinbox.com/ms/candidate/careers
 1mg (Tata 1mg),1mg,https://1mg.darwinbox.in/ms/candidate/careers
+2GO Group,meego.com,https://meego.darwinbox.com/ms/candidate/careers
+2X,2xpeople.com,https://2xpeople.darwinbox.com/ms/candidate/careers
 Aarti Industries,aartiindustries,https://aartiindustries.darwinbox.in/ms/candidate/careers
 ABP Network,abpnetwork,https://abpnetwork.darwinbox.in/ms/candidate/careers
+ADA,adaglobal.com,https://adaglobal.darwinbox.com/ms/candidate/careers
 Addof,addof.com,https://addof.darwinbox.com/ms/candidate/careers
 Affle,affle,https://affle.darwinbox.in/ms/candidate/careers
 AgroStar,agrostar,https://agrostar.darwinbox.in/ms/candidate/careers
+AIS,ais,https://ais.darwinbox.in/ms/candidate/careers
+Akraya Group,akrayagroup.com,https://akrayagroup.darwinbox.com/ms/candidate/careers
 Al Fardan Group,alfardan.com,https://alfardan.darwinbox.com/ms/candidate/careers
 Allcargo,allcargo,https://allcargo.darwinbox.in/ms/candidate/careers
+Arabian Construction Company,accpeoplehr.com,https://accpeoplehr.darwinbox.com/ms/candidate/careers
 Aragen Life Sciences,aragen,https://aragen.darwinbox.in/ms/candidate/careers
 Arvind,arvind,https://arvind.darwinbox.in/ms/candidate/careers
 Ather Energy,atherenergy,https://atherenergy.darwinbox.in/ms/candidate/careers
+AU Small Finance Bank,autalenthub,https://autalenthub.darwinbox.in/ms/candidate/careers
+AXIS Clinicals Limited,axisclinicals,https://axisclinicals.darwinbox.in/ms/candidate/careers
 Bajaj Electricals,bel.com,https://bel.darwinbox.com/ms/candidate/careers
+Bajaj Finserv Direct,hrisbdirect,https://hrisbdirect.darwinbox.in/ms/candidate/careers
 Bank BTPN,btpn.com,https://btpn.darwinbox.com/ms/candidate/careers
 Bharti Airtel Foundation,bhartifoundation,https://bhartifoundation.darwinbox.in/ms/candidate/careers
 Botree Software (HRMS Botree),hrmsbotree,https://hrmsbotree.darwinbox.in/ms/candidate/careers
 Brigade Group,brigadegroup,https://brigadegroup.darwinbox.in/ms/candidate/careers
 BSA,bsa.com,https://bsa.darwinbox.com/ms/candidate/careers
+Bukuwarung,bukuwarung.com,https://bukuwarung.darwinbox.com/ms/candidate/careers
 Busy Bees Asia,busybeesasia.com,https://busybeesasia.darwinbox.com/ms/candidate/careers
 Casagrand,casagrand,https://casagrand.darwinbox.in/ms/candidate/careers
+CBC Group,cbcsynchrone.com,https://cbcsynchrone.darwinbox.com/ms/candidate/careers
 Coding Ninjas,codingninjas,https://codingninjas.darwinbox.in/ms/candidate/careers
+CR3 Group,cr3-care.com,https://cr3-care.darwinbox.com/ms/candidate/careers
 Cure.fit (Curefit Healthcare),curefit,https://curefit.darwinbox.in/ms/candidate/careers
 Darwinbox (dbx),dbx,https://dbx.darwinbox.in/ms/candidate/careers
 Darwinbox Digital Solutions (dbox),dbox,https://dbox.darwinbox.in/ms/candidate/careers
 Deepak Group,deepak,https://deepak.darwinbox.in/ms/candidate/careers
 DMI Unify (DMI Finance),dmiunify,https://dmiunify.darwinbox.in/ms/candidate/careers
+DOKU,doku.com,https://doku.darwinbox.com/ms/candidate/careers
 Duroflex Group,duroflex,https://duroflex.darwinbox.in/ms/candidate/careers
 Edelweiss Life Insurance,edelweisslife,https://edelweisslife.darwinbox.in/ms/candidate/careers
 Emeritus,emeritus,https://emeritus.darwinbox.in/ms/candidate/careers
+Enzene,enzenespherenet,https://enzenespherenet.darwinbox.in/ms/candidate/careers
 Excelra,excelra,https://excelra.darwinbox.in/ms/candidate/careers
+Expo City Dubai Authority,ecdhrconnect.com,https://ecdhrconnect.darwinbox.com/ms/candidate/careers
 Galaxy Surfactants,mygalaxy,https://mygalaxy.darwinbox.in/ms/candidate/careers
+GEP Worldwide (NB Ventures INC),geppeoplecentral.com,https://geppeoplecentral.darwinbox.com/ms/candidate/careers
+GirnarSoft Education Services Pvt. Ltd.,collegedekhohrms,https://collegedekhohrms.darwinbox.in/ms/candidate/careers
 Glenmark,glenmark,https://glenmark.darwinbox.in/ms/candidate/careers
+Glenmark | Spring,glenmarkspring.com,https://glenmarkspring.darwinbox.com/ms/candidate/careers
 Great Learning,greatlearning,https://greatlearning.darwinbox.in/ms/candidate/careers
 GYS,gys.com,https://gys.darwinbox.com/ms/candidate/careers
 Hetero,hetero,https://hetero.darwinbox.in/ms/candidate/careers
 HL Mando India,hrmsmandoindia,https://hrmsmandoindia.darwinbox.in/ms/candidate/careers
+HMS Vanguard Sdn Bhd,healthmetrics.com,https://healthmetrics.darwinbox.com/ms/candidate/careers
 HOH / HFS,hoh,https://hoh.darwinbox.in/ms/candidate/careers
+Homevista Decor & Furnishings Private Limited,homelane,https://homelane.darwinbox.in/ms/candidate/careers
 Honasa Consumer (Mamaearth),honasa,https://honasa.darwinbox.in/ms/candidate/careers
+HT Group,htmediagroup,https://htmediagroup.darwinbox.in/ms/candidate/careers
+iQuanti,iquanti,https://iquanti.darwinbox.in/ms/candidate/careers
 ITC Hotels,itchotels,https://itchotels.darwinbox.in/ms/candidate/careers
 JSW (My JSW),myjsw,https://myjsw.darwinbox.in/ms/candidate/careers
+JSW MG Motor India Pvt. Ltd.,mgmhr,https://mgmhr.darwinbox.in/ms/candidate/careers
 Kirloskar Oil Engines,koel,https://koel.darwinbox.in/ms/candidate/careers
 Kissht,ring,https://ring.darwinbox.in/ms/candidate/careers
 Kopi Kenangan,kopikenangan.com,https://kopikenangan.darwinbox.com/ms/candidate/careers
+Kotak Life Insurance,kotaklifeinsurance,https://kotaklifeinsurance.darwinbox.in/ms/candidate/careers
 Kotak Securities,kotaksecurities,https://kotaksecurities.darwinbox.in/ms/candidate/careers
+KPN Corporation,kpncorporation.com,https://kpncorporation.darwinbox.com/ms/candidate/careers
+Leadership Boulevard Pvt. Ltd.,myleadschool,https://myleadschool.darwinbox.in/ms/candidate/careers
 LeadSquared,leadsquaredhrms,https://leadsquaredhrms.darwinbox.in/ms/candidate/careers
+Lendingkart,hrlendingkart,https://hrlendingkart.darwinbox.in/ms/candidate/careers
 Licious,licious,https://licious.darwinbox.in/ms/candidate/careers
+Linfox International Group,linfoxasiahrms.com,https://linfoxasiahrms.darwinbox.com/ms/candidate/careers
+Lionbridge Technologies,lionbridge.com,https://lionbridge.darwinbox.com/ms/candidate/careers
 Mahindra Logistics,nectar,https://nectar.darwinbox.in/ms/candidate/careers
 MatchMove,matchmove.com,https://matchmove.darwinbox.com/ms/candidate/careers
 Maxicare Healthcare (Philippines),onehrad.com,https://onehrad.darwinbox.com/ms/candidate/careers
+Mayapada Hospital Group,mayapadahospital.com,https://mayapadahospital.darwinbox.com/ms/candidate/careers
+MHealth,mhealth.com,https://mhealth.darwinbox.com/ms/candidate/careers
 MobiKwik,mobikwik,https://mobikwik.darwinbox.in/ms/candidate/careers
 Modinity Group,modinity.com,https://modinity.darwinbox.com/ms/candidate/careers
+MOL,molit,https://molit.darwinbox.in/ms/candidate/careers
+Moneyview,moneyview,https://moneyview.darwinbox.in/ms/candidate/careers
 Mordor Intelligence,mordorintelligence,https://mordorintelligence.darwinbox.in/ms/candidate/careers
 More Retail,hrmsmoreretail,https://hrmsmoreretail.darwinbox.in/ms/candidate/careers
 MOVIN Express,movin,https://movin.darwinbox.in/ms/candidate/careers
+Muhavra Enterprises Private Limited,bluetokaicoffee,https://bluetokaicoffee.darwinbox.in/ms/candidate/careers
+MyCrisil,mycrisil.com,https://mycrisil.darwinbox.com/ms/candidate/careers
 MyHR,myhr,https://myhr.darwinbox.in/ms/candidate/careers
 Ninjacart,ninjacart,https://ninjacart.darwinbox.in/ms/candidate/careers
 Niva Bupa Health Insurance (Disha),disha,https://disha.darwinbox.in/ms/candidate/careers
 NIVEA India,nivea,https://nivea.darwinbox.in/ms/candidate/careers
 NoBroker,nobroker,https://nobroker.darwinbox.in/ms/candidate/careers
+NOVENTIQ HOLDINGS PLC,noventiq.com,https://noventiq.darwinbox.com/ms/candidate/careers
 OneSource Specialty Pharma (Stelis),stelis,https://stelis.darwinbox.in/ms/candidate/careers
 PDAX (Philippine Digital Asset Exchange),pdax.com,https://pdax.darwinbox.com/ms/candidate/careers
 Piramal,piramal,https://piramal.darwinbox.in/ms/candidate/careers
@@ -72,24 +108,43 @@ Piramal Finance,piramalfinance,https://piramalfinance.darwinbox.in/ms/candidate/
 Pluang,pluanghrms.com,https://pluanghrms.darwinbox.com/ms/candidate/careers
 Polycab,polycab,https://polycab.darwinbox.in/ms/candidate/careers
 Porter,porter,https://porter.darwinbox.in/ms/candidate/careers
+PT. Nippon Indosari Corpindo Tbk.,hrsr.com,https://hrsr.darwinbox.com/ms/candidate/careers
+Quick Heal Technologies Ltd,lifecycleqhtl,https://lifecycleqhtl.darwinbox.in/ms/candidate/careers
+QX Global Group,qxhrms.com,https://qxhrms.darwinbox.com/ms/candidate/careers
 RateGain,rategain.com,https://rategain.darwinbox.com/ms/candidate/careers
+Reserve Bank Information Technology Pvt Ltd,rebithr,https://rebithr.darwinbox.in/ms/candidate/careers
 RustanCoffee (Starbucks Philippines),partnerconnect.com,https://partnerconnect.darwinbox.com/ms/candidate/careers
 SBI Life Insurance,sbilife,https://sbilife.darwinbox.in/ms/candidate/careers
+Sembcorp Group,hrsembcorp.com,https://hrsembcorp.darwinbox.com/ms/candidate/careers
 Shakey's Group,shakeys.com,https://shakeys.darwinbox.com/ms/candidate/careers
+Shalina Group,myshalina.com,https://myshalina.darwinbox.com/ms/candidate/careers
+Shoppers Stop,ss-people,https://ss-people.darwinbox.in/ms/candidate/careers
 Singland,singland.com,https://singland.darwinbox.com/ms/candidate/careers
 Singlife,singlife.com,https://singlife.darwinbox.com/ms/candidate/careers
+SMC Group,mysmcdbx,https://mysmcdbx.darwinbox.in/ms/candidate/careers
+SMN Group,protelindo.com,https://protelindo.darwinbox.com/ms/candidate/careers
+Spark Minda Group,sparkminda-hris,https://sparkminda-hris.darwinbox.in/ms/candidate/careers
 Spinzone,spinzone,https://spinzone.darwinbox.in/ms/candidate/careers
 SPML Infra,spml,https://spml.darwinbox.in/ms/candidate/careers
 SteriScience Specialties,steriscience.com,https://steriscience.darwinbox.com/ms/candidate/careers
 Strides Pharma Science,strides,https://strides.darwinbox.in/ms/candidate/careers
 Suzlon,suzlon,https://suzlon.darwinbox.in/ms/candidate/careers
+Synamedia,synamedia.com,https://synamedia.darwinbox.com/ms/candidate/careers
+Synergy Marine Group,synergymarinegroup.com,https://synergymarinegroup.darwinbox.com/ms/candidate/careers
 TBO.com,tbo,https://tbo.darwinbox.in/ms/candidate/careers
+Tessolve Semiconductor Private Limited,tessolve.com,https://tessolve.darwinbox.com/ms/candidate/careers
+The Guardians India,theguardiansindia,https://theguardiansindia.darwinbox.in/ms/candidate/careers
+Thermax Group,thermaxglobal,https://thermaxglobal.darwinbox.in/ms/candidate/careers
 Times Internet,timesinternet,https://timesinternet.darwinbox.in/ms/candidate/careers
+Tripatra,tripatra.com,https://tripatra.darwinbox.com/ms/candidate/careers
 TV9 Network (ABCPL),tv9,https://tv9.darwinbox.in/ms/candidate/careers
+UEM Sunrise,uemsunrise.com,https://uemsunrise.darwinbox.com/ms/candidate/careers
 Unacademy,unacademy,https://unacademy.darwinbox.in/ms/candidate/careers
 Upstox,upstox,https://upstox.darwinbox.in/ms/candidate/careers
 Vedanta,vhr,https://vhr.darwinbox.in/ms/candidate/careers
+Visteon,visteon-panorama.com,https://visteon-panorama.darwinbox.com/ms/candidate/careers
 Vivriti Capital,vivriti,https://vivriti.darwinbox.in/ms/candidate/careers
+Y-Axis,y-axis,https://y-axis.darwinbox.in/ms/candidate/careers
 Yashoda Hospitals Group,yashoda,https://yashoda.darwinbox.in/ms/candidate/careers
 YES Bank,yesforyou,https://yesforyou.darwinbox.in/ms/candidate/careers
 Yotta Infrastructure,yotta,https://yotta.darwinbox.in/ms/candidate/careers


### PR DESCRIPTION
## Summary
- add 55 live production Darwinbox tenants
- expose 2,015 new live jobs

## Discovery and validation
- mined exact `*.darwinbox.in` and `*.darwinbox.com` hosts across `CC-MAIN-2026-25`, `2025-47`, `2025-38`, `2025-30`, and `2024-51`
- extracted 147 unique Darwinbox tenant hosts and removed all 96 hosts already present in the inventory
- excluded marketing, demo, test, staging, UAT, and other non-production hosts before validation
- live-tested 110 candidates through the existing `DarwinboxScraper` careers-page and `candidateapi/job/alljobs` flow
- found 56 live boards with 2,171 jobs, then excluded the ambiguous 156-job multi-client `smileshrms` board
- retained 55 company-specific boards with 2,015 unique Darwinbox job IDs and zero candidate-to-candidate overlap
- verified the live manifest currently has no Darwinbox dataset entry, so there are zero published Darwinbox overlaps
- verified no duplicate CSV slugs/URLs, no exact existing company-name matches, `git diff --check`, focused tests (`20 passed`), and the full suite (`1,294 passed, 2 skipped`)

The Darwinbox scraper and focused tests are already present on `main`; this PR only expands `ats-companies/darwinbox.csv`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 55 live Darwinbox tenants to `ats-companies/darwinbox.csv`, exposing 2,015 new live jobs from company-specific boards. No scraper changes; this expands ATS coverage only.

- **New Features**
  - Added validated `*.darwinbox.in` and `*.darwinbox.com` tenants discovered via crawl; excluded non-prod and multi-client boards.
  - Checked careers pages and `candidateapi/job/alljobs`; ensured no duplicate slugs, URLs, or job ID overlaps.

<sup>Written for commit 22aa39dc082bded74cf46d31d5ac11441d60ff82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

