### PR TITLE
Add 57 live Pinpoint companies from crawl discovery

### DIFF
--- a/ats-companies/pinpoint.csv
+++ b/ats-companies/pinpoint.csv
@@ -1,10 +1,9 @@
 name,slug,url
-Anne Arundel Workforce Development Corporation (AAWDC),aawdc,https://aawdc.pinpointhq.com
 Accenture,accenture,https://accenture.pinpointhq.com
-Augustine Consulting Inc.,aciedge,https://aciedge.pinpointhq.com
 ACME candidate 1,acme,https://acme.pinpointhq.com
 Acrobat Talent,acrobat,https://acrobat.pinpointhq.com
 Actica Consulting,actica,https://actica.pinpointhq.com
+Ada Infrastructure,glp,https://glp.pinpointhq.com
 Adaptix,adaptix,https://adaptix.pinpointhq.com
 adm-Indicia,admgroup,https://admgroup.pinpointhq.com
 Advita Ortho,advitaortho,https://advitaortho.pinpointhq.com
@@ -12,10 +11,12 @@ Aeriz,aeriz,https://aeriz.pinpointhq.com
 AgencyAnalytics,agencyanalytics,https://agencyanalytics.pinpointhq.com
 Aireon,aireon,https://aireon.pinpointhq.com
 AirTanker,airtanker,https://airtanker.pinpointhq.com
-Veriforce,alcumus,https://alcumus.pinpointhq.com
+Alcanza Clinical Research,alcanzaclinical,https://alcanzaclinical.pinpointhq.com
 Algomarketing®,algomarketing,https://algomarketing.pinpointhq.com
 Allied Talent Partners,alliedtalentpartners,https://alliedtalentpartners.pinpointhq.com
+Alternative Heat,alternativeheat,https://alternativeheat.pinpointhq.com
 American Veterinary Group,americanveterinarygroup,https://americanveterinarygroup.pinpointhq.com
+Anne Arundel Workforce Development Corporation (AAWDC),aawdc,https://aawdc.pinpointhq.com
 Anthesis Group,anthesisgroup,https://anthesisgroup.pinpointhq.com
 Anthony Collins,anthonycollins,https://anthonycollins.pinpointhq.com
 "APD Engineering & Architecture, PLLC",apd,https://apd.pinpointhq.com
@@ -28,9 +29,14 @@ Arrow Global Group,arrowglobal,https://arrowglobal.pinpointhq.com
 Arthur Cox,arthurcox,https://arthurcox.pinpointhq.com
 Article,article,https://article.pinpointhq.com
 ASC Engineered Solutions,asc-es-reliable,https://asc-es-reliable.pinpointhq.com
+Ascensus Specialties,ascensusspecialties,https://ascensusspecialties.pinpointhq.com
+Aspen Contracting,roofsbyaspen,https://roofsbyaspen.pinpointhq.com
+Aspire Allergy & Sinus,aspireallergy,https://aspireallergy.pinpointhq.com
+Aston Martin F1,astonmartinf1,https://astonmartinf1.pinpointhq.com
 Astorg,astorg,https://astorg.pinpointhq.com
 "Astrana Health, Inc.",astranahealth,https://astranahealth.pinpointhq.com
 Astrolab,astrolab,https://astrolab.pinpointhq.com
+Augustine Consulting Inc.,aciedge,https://aciedge.pinpointhq.com
 Aurora Energy Research,auroraer,https://auroraer.pinpointhq.com
 Bactobio,bactobio,https://bactobio.pinpointhq.com
 Barnet and Southgate College,barnetsouthgate,https://barnetsouthgate.pinpointhq.com
@@ -38,194 +44,243 @@ Bath College,bathcollege,https://bathcollege.pinpointhq.com
 Bath Spa University,bathspa,https://bathspa.pinpointhq.com
 BDO Ireland,bdoireland,https://bdoireland.pinpointhq.com
 Bede Gaming,bedegaming,https://bedegaming.pinpointhq.com
+Bedell Cristin,bedellcristin,https://bedellcristin.pinpointhq.com
 BigHat Biosciences,bighatbiosciences,https://bighatbiosciences.pinpointhq.com
+Biorelate,biorelate,https://biorelate.pinpointhq.com
+Birches Group,birchesgroup,https://birchesgroup.pinpointhq.com
+Blue Cross,bluecross,https://bluecross.pinpointhq.com
 Blue Mantis,bluemantis,https://bluemantis.pinpointhq.com
 Blue Stream Fiber,bluestreamfiber,https://bluestreamfiber.pinpointhq.com
 BMT,bmt,https://bmt.pinpointhq.com
-British Society for Rheumatology,bsr,https://bsr.pinpointhq.com
 Breakthrough New York,btny,https://btny.pinpointhq.com
+Bright,bright,https://bright.pinpointhq.com
+British Society for Rheumatology,bsr,https://bsr.pinpointhq.com
+BSC Analytics,bluesentry,https://bluesentry.pinpointhq.com
+Buckinghamshire Mind,bucksmindcareers,https://bucksmindcareers.pinpointhq.com
 Build A Rocket Boy,buildarocketboy,https://buildarocketboy.pinpointhq.com
+Butlin's,butlins,https://butlins.pinpointhq.com
+C10 Labs,c10labs,https://c10labs.pinpointhq.com
+California Native Plant Society,cnps,https://cnps.pinpointhq.com
 Calligo,calligo,https://calligo.pinpointhq.com
+Careers at Knack,knack,https://knack.pinpointhq.com
+Careers Site | Tripledot Group,tripledotstudios,https://tripledotstudios.pinpointhq.com
 Carma,carma,https://carma.pinpointhq.com
 Carmel College,carmel,https://carmel.pinpointhq.com
 CARTO,carto,https://carto.pinpointhq.com
 CDL Software,cdlsoftware,https://cdlsoftware.pinpointhq.com
 Celnor,celnor,https://celnor.pinpointhq.com
+Centellic,lbresearch,https://lbresearch.pinpointhq.com
 CFC,cfc,https://cfc.pinpointhq.com
 CFC,cfcunderwriting,https://cfcunderwriting.pinpointhq.com
 CFRA Research,cfra,https://cfra.pinpointhq.com
 CGT U.S. Limited,cgt,https://cgt.pinpointhq.com
 Chetwood Bank,chetwood-bank,https://chetwood-bank.pinpointhq.com
-Cinven,cinven,https://cinven.pinpointhq.com
 Chuck Latham Associates,clareps,https://clareps.pinpointhq.com
+Cinven,cinven,https://cinven.pinpointhq.com
 ClearlyRated,clearlyrated,https://clearlyrated.pinpointhq.com
 Climate Bonds Initiative,climatebonds,https://climatebonds.pinpointhq.com
 CMap,cmap,https://cmap.pinpointhq.com
+Codec,codec,https://codec.pinpointhq.com
 Codexis Inc,codexis,https://codexis.pinpointhq.com
 Coforma,coforma,https://coforma.pinpointhq.com
 Coleg Sir Gâr and Coleg Ceredigion,colegsirgar,https://colegsirgar.pinpointhq.com
+Columbia Safety & Supply Family of Companies,gmesupply,https://gmesupply.pinpointhq.com
 Company,company,https://company.pinpointhq.com
 Compass Health Network,compasshealthnetwork,https://compasshealthnetwork.pinpointhq.com
+Compassion UK & Ireland,compassionuk,https://compassionuk.pinpointhq.com
 Compre Group,compregroup,https://compregroup.pinpointhq.com
 Confluence Technologies,confluence,https://confluence.pinpointhq.com
+Connected Places Catapult,cpcatapult,https://cpcatapult.pinpointhq.com
 Continental Services,continentalserves,https://continentalserves.pinpointhq.com
 Convex Insurance,convexin,https://convexin.pinpointhq.com
 Convey Law,conveylaw,https://conveylaw.pinpointhq.com
 Cotton Holdings,cottonholdings,https://cottonholdings.pinpointhq.com
 Coursedog,coursedog,https://coursedog.pinpointhq.com
-Connected Places Catapult,cpcatapult,https://cpcatapult.pinpointhq.com
 Crawford Technologies,crawfordtech,https://crawfordtech.pinpointhq.com
 CTI Digital,ctidigital,https://ctidigital.pinpointhq.com
+Cubico Sustainable Investments,cubico,https://cubico.pinpointhq.com
+Current job openings - Wagepoint,wagepoint,https://wagepoint.pinpointhq.com
 Cybernetic Controls Limited,cybernetic-controls,https://cybernetic-controls.pinpointhq.com
-Day One Agency,d1a,https://d1a.pinpointhq.com
 Davies,davies,https://davies.pinpointhq.com
+Day One Agency,d1a,https://d1a.pinpointhq.com
+DAZN,dazn,https://dazn.pinpointhq.com
 DB1,db1group,https://db1group.pinpointhq.com
+dbrand,dbrand,https://dbrand.pinpointhq.com
 DEA Aviation Ltd,dea,https://dea.pinpointhq.com
+Default,instantimpactrecruitment,https://instantimpactrecruitment.pinpointhq.com
+Design Line Construction,designline,https://designline.pinpointhq.com
 Desmos Studio PBC,desmos,https://desmos.pinpointhq.com
 Developer Acme,developers-test,https://developers-test.pinpointhq.com
 Digital Science,digitalscience,https://digitalscience.pinpointhq.com
+Discover What Life at Elliptic is Like & View Our Vacancies,elliptic,https://elliptic.pinpointhq.com
+Disturbia,disturbia,https://disturbia.pinpointhq.com
 Dixon Wilson,dixonwilson,https://dixonwilson.pinpointhq.com
 DMC Healthcare,dmchealthcare,https://dmchealthcare.pinpointhq.com
-Optitex,doradosoftwaregroup,https://doradosoftwaregroup.pinpointhq.com
-Eastlands Venue Services Limited,eastlandsvsl,https://eastlandsvsl.pinpointhq.com
+Driver on Demand,driverondemand,https://driverondemand.pinpointhq.com
 East Bay Community Action Program,ebcap,https://ebcap.pinpointhq.com
+Eastlands Venue Services Limited,eastlandsvsl,https://eastlandsvsl.pinpointhq.com
 Eberjey,eberjey,https://eberjey.pinpointhq.com
 Ebiquity,ebiquity,https://ebiquity.pinpointhq.com
 Elevate Group,elevategroup,https://elevategroup.pinpointhq.com
-Discover What Life at Elliptic is Like & View Our Vacancies,elliptic,https://elliptic.pinpointhq.com
 Embark Student Corp.,embark,https://embark.pinpointhq.com
 Emerald Transformer,emeraldtransformer,https://emeraldtransformer.pinpointhq.com
+Encompass Corporation,encompass,https://encompass.pinpointhq.com
 Endsight,endsight,https://endsight.pinpointhq.com
+Enhance Group,enhance,https://enhance.pinpointhq.com
 Enosis Solutions,enosisbd,https://enosisbd.pinpointhq.com
 Eptura,eptura,https://eptura.pinpointhq.com
-TTEP UK & Ireland,epuki,https://epuki.pinpointhq.com
-Esland,esland,https://esland.pinpointhq.com
 ES Talent Management,estalent,https://estalent.pinpointhq.com
+Esland,esland,https://esland.pinpointhq.com
+ESSS,esss,https://esss.pinpointhq.com
 Eventbase Technology,eventbase,https://eventbase.pinpointhq.com
-IGT,everi,https://everi.pinpointhq.com
 exclaimer,exclaimer,https://exclaimer.pinpointhq.com
 FIDELITONE,fidelitone,https://fidelitone.pinpointhq.com
 FIELD,field,https://field.pinpointhq.com
 Forterro,forterro,https://forterro.pinpointhq.com
+Fortify Health,fortifyhealth,https://fortifyhealth.pinpointhq.com
 Foxconn WI,foxconnwi,https://foxconnwi.pinpointhq.com
 Franklin Electric,franklin-electric,https://franklin-electric.pinpointhq.com
 Frazil,frazil,https://frazil.pinpointhq.com
 Fremont Group,fremontgroup,https://fremontgroup.pinpointhq.com
 Frontline,frontline,https://frontline.pinpointhq.com
+FS-Curtis,fscurtis,https://fscurtis.pinpointhq.com
+FS-Elliott,fs-elliott,https://fs-elliott.pinpointhq.com
 Fulwell Entertainment,fulwellentertainment,https://fulwellentertainment.pinpointhq.com
 FundApps,fundapps,https://fundapps.pinpointhq.com
 Future Group,futuregroup,https://futuregroup.pinpointhq.com
 GAIN,gainuk,https://gainuk.pinpointhq.com
 Gameplay Galaxy,gameplaygalaxy,https://gameplaygalaxy.pinpointhq.com
+Gaming Innovation Group,gig,https://gig.pinpointhq.com
 Gappify,gappify,https://gappify.pinpointhq.com
 Gardiner and Theobald LLP,gardiner,https://gardiner.pinpointhq.com
 GEEIQ,geeiq,https://geeiq.pinpointhq.com
 Gemba Advantage,gembaadvantage,https://gembaadvantage.pinpointhq.com
-Gaming Innovation Group,gig,https://gig.pinpointhq.com
 Girls on the Run,girlsontherun,https://girlsontherun.pinpointhq.com
 GLORY,gloryglobal,https://gloryglobal.pinpointhq.com
-Columbia Safety & Supply Family of Companies,gmesupply,https://gmesupply.pinpointhq.com
 Gordon Murray Group,gordonmurraygroup,https://gordonmurraygroup.pinpointhq.com
+Grant Thornton Channel Islands,gtci,https://gtci.pinpointhq.com
+Grasshopper Bank,grasshopper,https://grasshopper.pinpointhq.com
 Gravity Global,gravityglobal,https://gravityglobal.pinpointhq.com
 Greenergy,greenergy,https://greenergy.pinpointhq.com
 Greenwood Project,greenwoodproject,https://greenwoodproject.pinpointhq.com
 Group GTI,groupgti,https://groupgti.pinpointhq.com
 Group O,groupo,https://groupo.pinpointhq.com
 GS1 Canada,gs1ca,https://gs1ca.pinpointhq.com
+Guernsey Electricity,guernseyelectricity,https://guernseyelectricity.pinpointhq.com
 Harmeny Education Trust,harmeny,https://harmeny.pinpointhq.com
 Harnham,harnham,https://harnham.pinpointhq.com
 Hazelcast,hazelcast,https://hazelcast.pinpointhq.com
+HC Brands,hcbrands,https://hcbrands.pinpointhq.com
+Headkount,headkount,https://headkount.pinpointhq.com
+Health Staff Recruitment,medical,https://medical.pinpointhq.com
 Herr Foods Inc.,herrs,https://herrs.pinpointhq.com
+HNC,huddnewcoll,https://huddnewcoll.pinpointhq.com
 Holland America Line & Seabourn,hollandamericagroup,https://hollandamericagroup.pinpointhq.com
 Holland America/Princess Alaska-Yukon Land Operations,hollandamericaprincess,https://hollandamericaprincess.pinpointhq.com
 Hooli,hooli,https://hooli.pinpointhq.com
+Hopwood Hall,hopwood,https://hopwood.pinpointhq.com
 Hugh Baird College,hughbaird,https://hughbaird.pinpointhq.com
+Human8,wearehuman8,https://wearehuman8.pinpointhq.com
+Icario,icario,https://icario.pinpointhq.com
 IFX Payments,ifx,https://ifx.pinpointhq.com
+IGT,everi,https://everi.pinpointhq.com
+Imagemaker,imagemaker,https://imagemaker.pinpointhq.com
 ImpactAssets,impactassets,https://impactassets.pinpointhq.com
 Impulse Space,impulsespace,https://impulsespace.pinpointhq.com
+In Tandem,intandem,https://intandem.pinpointhq.com
 inDrive,indrive,https://indrive.pinpointhq.com
 inMusic,inmusicbrands,https://inmusicbrands.pinpointhq.com
 Innovetive Petcare,innovetivepetcare,https://innovetivepetcare.pinpointhq.com
-Default,instantimpactrecruitment,https://instantimpactrecruitment.pinpointhq.com
+Instant Impact,instant-impact,https://instant-impact.pinpointhq.com
 intelliHR,intellihr,https://intellihr.pinpointhq.com
 Intermedia Intelligent Communications,intermedia,https://intermedia.pinpointhq.com
+International WELL Building Institute (IWBI),iwbi,https://iwbi.pinpointhq.com
+interop.io,interopio,https://interopio.pinpointhq.com
 InvestorHub,investorhub,https://investorhub.pinpointhq.com
 Invictus Capital Partners / Verus Mortgage Capital,invictus-verus,https://invictus-verus.pinpointhq.com
+Ipsos,ipsos,https://ipsos.pinpointhq.com
 ISG,isginc,https://isginc.pinpointhq.com
 ITVET,itvet,https://itvet.pinpointhq.com
 iVenture Solutions,iventure,https://iventure.pinpointhq.com
 Jaguar Building Services,jbs-ltd,https://jbs-ltd.pinpointhq.com
-The Jed Foundation,jed,https://jed.pinpointhq.com
+Jersey Electricity,jec,https://jec.pinpointhq.com
 "Jimerson Birr, P.A.",jimersonfirm,https://jimersonfirm.pinpointhq.com
 Joe's Test Platform,joe-testing,https://joe-testing.pinpointhq.com
 Join Parachute,joinparachute,https://joinparachute.pinpointhq.com
 joveo dev sandbox,joveo-sandbox,https://joveo-sandbox.pinpointhq.com
+JT,jtglobal,https://jtglobal.pinpointhq.com
 Judge & Priestley LLP,judge-priestley,https://judge-priestley.pinpointhq.com
 Karp Strategies,karpstrategies,https://karpstrategies.pinpointhq.com
 Kempinski Hotels,kempinski,https://kempinski.pinpointhq.com
 Kenway Consulting,kenwayconsulting,https://kenwayconsulting.pinpointhq.com
-Careers at Knack,knack,https://knack.pinpointhq.com
+Kharon,kharon,https://kharon.pinpointhq.com
 Kreston Reeves,krestonreeves,https://krestonreeves.pinpointhq.com
-The Lancashire Group,lancashire-group,https://lancashire-group.pinpointhq.com
-Centellic,lbresearch,https://lbresearch.pinpointhq.com
-Leading Edge Aviation,leadingedgeaviation,https://leadingedgeaviation.pinpointhq.com
+L'OCCITANE EN PROVENCE,loccitane,https://loccitane.pinpointhq.com
 Le Ski,leski,https://leski.pinpointhq.com
+Leading Edge Aviation,leadingedgeaviation,https://leadingedgeaviation.pinpointhq.com
+Lendable,lendable,https://lendable.pinpointhq.com
 Lichfields,lichfields,https://lichfields.pinpointhq.com
 Lingoda,lingoda,https://lingoda.pinpointhq.com
 LiveLink,livelink,https://livelink.pinpointhq.com
-L'OCCITANE EN PROVENCE,loccitane,https://loccitane.pinpointhq.com
 London Hire Group,londonhireltd,https://londonhireltd.pinpointhq.com
 London Youth,londonyouth,https://londonyouth.pinpointhq.com
 Lush,lush,https://lush.pinpointhq.com
-Made Tech,made-tech,https://made-tech.pinpointhq.com
+LV Care Group,lvcaregroup,https://lvcaregroup.pinpointhq.com
 Mad Fish Digital,madfishdigital,https://madfishdigital.pinpointhq.com
+Made Tech,made-tech,https://made-tech.pinpointhq.com
 "Magic, Inc",magic,https://magic.pinpointhq.com
 Main Street Anesthesia,mainstreetanesthesia,https://mainstreetanesthesia.pinpointhq.com
 Malaa,malaa,https://malaa.pinpointhq.com
+MAPP,wearemapp,https://wearemapp.pinpointhq.com
+Marketing Pros,marketingpros,https://marketingpros.pinpointhq.com
 Marlborough Highways,marlboroughhighways,https://marlboroughhighways.pinpointhq.com
 Matter,matter,https://matter.pinpointhq.com
 Maverick Games,maverick-games,https://maverick-games.pinpointhq.com
+McBains,mcbains,https://mcbains.pinpointhq.com
+Mechanism Ventures,mechanismventures,https://mechanismventures.pinpointhq.com
+MedTrust,mymedtrust,https://mymedtrust.pinpointhq.com
 Menzies LLP,menzies,https://menzies.pinpointhq.com
 MidKent College,midkent,https://midkent.pinpointhq.com
+MIGSO-PCUBED,migso-pcubed,https://migso-pcubed.pinpointhq.com
+Mimeo US,mimeo,https://mimeo.pinpointhq.com
 Mole Valley Farmers Limited,moleonline,https://moleonline.pinpointhq.com
+Monkey Puzzle Day Nurseries,mpdn,https://mpdn.pinpointhq.com
 Moore Kingston Smith,mooreks,https://mooreks.pinpointhq.com
 Mosaic Veterinary Partners,mosaicvet,https://mosaicvet.pinpointhq.com
 Mountain Warehouse,mountainwarehouse,https://mountainwarehouse.pinpointhq.com
-Monkey Puzzle Day Nurseries,mpdn,https://mpdn.pinpointhq.com
 MPLC,mplc,https://mplc.pinpointhq.com
 Multiplier,multiplier-careers,https://multiplier-careers.pinpointhq.com
 myInterview - Staging,myinterview,https://myinterview.pinpointhq.com
-MedTrust,mymedtrust,https://mymedtrust.pinpointhq.com
+N Family Club,nfamilyclub,https://nfamilyclub.pinpointhq.com
 Naim Audio,naimaudio,https://naimaudio.pinpointhq.com
 Napier AI,napier,https://napier.pinpointhq.com
 Nasstar,nasstar,https://nasstar.pinpointhq.com
-the National Centre for Social Research,natcen,https://natcen.pinpointhq.com
 Navigate Power & Verde Solutions,navigatepower,https://navigatepower.pinpointhq.com
 NCH Europe,ncheurope,https://ncheurope.pinpointhq.com
 Network Plus,networkplus,https://networkplus.pinpointhq.com
 Newfire Global Partners,newfireglobal,https://newfireglobal.pinpointhq.com
-N Family Club,nfamilyclub,https://nfamilyclub.pinpointhq.com
-The Nursing and Midwifery Council,nmc,https://nmc.pinpointhq.com
 Nodal Exchange,nodalexchange,https://nodalexchange.pinpointhq.com
 Northcoders Group,northcodersgroup,https://northcodersgroup.pinpointhq.com
 Northern Bedrock Historic Preservation Corps,northernbedrockcorps,https://northernbedrockcorps.pinpointhq.com
 Not On The High Street,notonthehighstreet,https://notonthehighstreet.pinpointhq.com
 Nüvitek,nuvitek,https://nuvitek.pinpointhq.com
-The New York Public Library,nypl,https://nypl.pinpointhq.com
 Ohio Valley Electric Corporation / Indiana - Kentucky Electric Corporation,ohiovalleyelectriccorporation,https://ohiovalleyelectriccorporation.pinpointhq.com
 Oil Change International,oilchange,https://oilchange.pinpointhq.com
 "OneApp, Inc.",oneapp,https://oneapp.pinpointhq.com
 OnePlan Solutions,oneplan,https://oneplan.pinpointhq.com
 Online River,onlineriver,https://onlineriver.pinpointhq.com
-Under Secretary of War for Research & Engineering,ouswre,https://ouswre.pinpointhq.com
+Optitex,doradosoftwaregroup,https://doradosoftwaregroup.pinpointhq.com
 Overland Partners,overlandpartners,https://overlandpartners.pinpointhq.com
 Oxford International Education Group,oxfordinternational,https://oxfordinternational.pinpointhq.com
+Oxford Metrics Plc,oxfordmetrics,https://oxfordmetrics.pinpointhq.com
 Partners for HOME,partnersforhome,https://partnersforhome.pinpointhq.com
 Pathify,pathify,https://pathify.pinpointhq.com
+Payroll Software & Services Group,pssg,https://pssg.pinpointhq.com
 Peninsula,peninsula360,https://peninsula360.pinpointhq.com
 Penrose Health,penrosehealth,https://penrosehealth.pinpointhq.com
 PEX,pexcard,https://pexcard.pinpointhq.com
 Pinnacle Bank/Bank of Colorado,pinnbank,https://pinnbank.pinpointhq.com
+Pinpoint,workwithus,https://workwithus.pinpointhq.com
 PipeDreams,pipedreams,https://pipedreams.pinpointhq.com
 Pipeworks Studios,pipeworks,https://pipeworks.pinpointhq.com
 Pod,pod-point,https://pod-point.pinpointhq.com
@@ -235,38 +290,41 @@ Portakabin,portakabin,https://portakabin.pinpointhq.com
 Portnox,portnox,https://portnox.pinpointhq.com
 Ports of Jersey,ports,https://ports.pinpointhq.com
 Precision Neuroscience,precisionneuro,https://precisionneuro.pinpointhq.com
-The Premier League,premierleague,https://premierleague.pinpointhq.com
 Price Brothers,pricebrotherskc,https://pricebrotherskc.pinpointhq.com
 Princess Cruises,princesscruises,https://princesscruises.pinpointhq.com
 Project Canary,projectcanary,https://projectcanary.pinpointhq.com
 Propeller,propelleraero,https://propelleraero.pinpointhq.com
-Payroll Software & Services Group,pssg,https://pssg.pinpointhq.com
 px Group,pxlimited,https://pxlimited.pinpointhq.com
-Queen Alexandra Charity,qac,https://qac.pinpointhq.com
 "Qellus, LLC",qellus,https://qellus.pinpointhq.com
 QualityLogic,qualitylogic,https://qualitylogic.pinpointhq.com
+Queen Alexandra Charity,qac,https://qac.pinpointhq.com
 Rangeline Group,rangeline,https://rangeline.pinpointhq.com
 Ravelin Technology,ravelin,https://ravelin.pinpointhq.com
 Recentive Analytics,recentive,https://recentive.pinpointhq.com
 Reconomy,reconomy,https://reconomy.pinpointhq.com
-RRS,recycle,https://recycle.pinpointhq.com
 Reimagined Parking,reimaginedcareers,https://reimaginedcareers.pinpointhq.com
 Rethink Priorities,rethinkpriorities,https://rethinkpriorities.pinpointhq.com
 Reward Gateway,rewardgateway,https://rewardgateway.pinpointhq.com
+Rider Levett Bucknall,rlb,https://rlb.pinpointhq.com
 Riipen,riipen,https://riipen.pinpointhq.com
 Rivalry,rivalry,https://rivalry.pinpointhq.com
-Rider Levett Bucknall,rlb,https://rlb.pinpointhq.com
+Rockborne,rockborne,https://rockborne.pinpointhq.com
 Rowden,rowdentech,https://rowdentech.pinpointhq.com
+RRS,recycle,https://recycle.pinpointhq.com
+Ruffwear,ruffwear,https://ruffwear.pinpointhq.com
 RWDI,rwdi,https://rwdi.pinpointhq.com
 Sabio Group,sabio,https://sabio.pinpointhq.com
 SafetyWing,safetywing,https://safetywing.pinpointhq.com
 Saffery Trust,saffery,https://saffery.pinpointhq.com
+SandpiperCI,sandpiperci,https://sandpiperci.pinpointhq.com
 SANS Institute,sans,https://sans.pinpointhq.com
-Somerset Bridge Group,sbgl,https://sbgl.pinpointhq.com
+Savanna Institute,savannainstitute,https://savannainstitute.pinpointhq.com
 scandiweb,scandiweb,https://scandiweb.pinpointhq.com
 Scottish Football Association,scottishfa,https://scottishfa.pinpointhq.com
 Securian Canada,securiancanada,https://securiancanada.pinpointhq.com
+Serefin,serefin,https://serefin.pinpointhq.com
 Seven Points Capital,sevenpointscapital,https://sevenpointscapital.pinpointhq.com
+Seymour Hotels,seymourhotels,https://seymourhotels.pinpointhq.com
 Shield,shieldtp,https://shieldtp.pinpointhq.com
 simpleclub,simpleclub,https://simpleclub.pinpointhq.com
 SKIMS,skims,https://skims.pinpointhq.com
@@ -274,8 +332,11 @@ SkinSpirit,skinspirit,https://skinspirit.pinpointhq.com
 SmartThings,smartthings,https://smartthings.pinpointhq.com
 Snap Analytics,snapanalytics,https://snapanalytics.pinpointhq.com
 Soben part of Accenture,sobencc,https://sobencc.pinpointhq.com
+Somerset Bridge Group,sbgl,https://sbgl.pinpointhq.com
 Spektrix,spektrix,https://spektrix.pinpointhq.com
 Spiralyze,spiralyze,https://spiralyze.pinpointhq.com
+Sport 54,weare54,https://weare54.pinpointhq.com
+St Petrocs,stpetrocs,https://stpetrocs.pinpointhq.com
 Stratom,stratom,https://stratom.pinpointhq.com
 Summit K12,summitk12,https://summitk12.pinpointhq.com
 Sun King,sunking,https://sunking.pinpointhq.com
@@ -283,39 +344,53 @@ Superside: Your creative team’s creative team™,superside,https://superside.p
 Surgo Health,surgohealth,https://surgohealth.pinpointhq.com
 Systematica Investments,systematica,https://systematica.pinpointhq.com
 Tabby,tabby,https://tabby.pinpointhq.com
+Tails.com,tails,https://tails.pinpointhq.com
+Tandym,tandym,https://tandym.pinpointhq.com
+Tata Chemicals Europe,tatachemicals,https://tatachemicals.pinpointhq.com
 Teacher Apprenticeship Network,teacherapprenticeship,https://teacherapprenticeship.pinpointhq.com
 "Teaching Strategies, LLC",teaching-strategies,https://teaching-strategies.pinpointhq.com
 TeachMichigan,teachmichigan,https://teachmichigan.pinpointhq.com
 TeleSolv Consulting,telesolvconsulting,https://telesolvconsulting.pinpointhq.com
 The Arch Company,thearchco,https://thearchco.pinpointhq.com
 The Bulwark,thebulwark,https://thebulwark.pinpointhq.com
-Theiagen Genomics,theiagen,https://theiagen.pinpointhq.com
+The Christian Reformed Church in North America,crcna,https://crcna.pinpointhq.com
+The Duke of Edinburgh's Award,dofe,https://dofe.pinpointhq.com
+The Jed Foundation,jed,https://jed.pinpointhq.com
+The Lancashire Group,lancashire-group,https://lancashire-group.pinpointhq.com
 The Misch Group,themischgroup,https://themischgroup.pinpointhq.com
-TMC,therapymgmt,https://therapymgmt.pinpointhq.com
+the National Centre for Social Research,natcen,https://natcen.pinpointhq.com
+The New York Public Library,nypl,https://nypl.pinpointhq.com
+The Nursing and Midwifery Council,nmc,https://nmc.pinpointhq.com
+The Premier League,premierleague,https://premierleague.pinpointhq.com
 The Ready,theready,https://theready.pinpointhq.com
+Theiagen Genomics,theiagen,https://theiagen.pinpointhq.com
 Thompsons Solicitors,thompsonslaw,https://thompsonslaw.pinpointhq.com
 Thorne,thorne,https://thorne.pinpointhq.com
 Tithely,tithely,https://tithely.pinpointhq.com
+TMC,therapymgmt,https://therapymgmt.pinpointhq.com
+Torbay Council,torbaycouncil,https://torbaycouncil.pinpointhq.com
 Trading Technologies,tradingtechnologies,https://tradingtechnologies.pinpointhq.com
 Transform,transformuk,https://transformuk.pinpointhq.com
 Trilon Group,trilongroup,https://trilongroup.pinpointhq.com
 Trinidad Benham,trinidadbenham,https://trinidadbenham.pinpointhq.com
-Careers Site | Tripledot Group,tripledotstudios,https://tripledotstudios.pinpointhq.com
 Trivandi,trivandi,https://trivandi.pinpointhq.com
 Truly Good Foods,trulygoodfoods,https://trulygoodfoods.pinpointhq.com
+TTEP UK & Ireland,epuki,https://epuki.pinpointhq.com
 Twinings Ovaltine,twiningsovocareers,https://twiningsovocareers.pinpointhq.com
 UKTV,uktv,https://uktv.pinpointhq.com
+Under Secretary of War for Research & Engineering,ouswre,https://ouswre.pinpointhq.com
 Upway,upway,https://upway.pinpointhq.com
 Utilities One,utilitiesone,https://utilitiesone.pinpointhq.com
-Vena Solutions,vena,https://vena.pinpointhq.com
 V.Group,vgroup,https://vgroup.pinpointhq.com
+Vaiie,vaiie,https://vaiie.pinpointhq.com
+Vena Solutions,vena,https://vena.pinpointhq.com
+Veriforce,alcumus,https://alcumus.pinpointhq.com
+Virtual Staffing Solutions,virtualstaffing,https://virtualstaffing.pinpointhq.com
 Vital Bio,vitalbio,https://vitalbio.pinpointhq.com
-Current job openings - Wagepoint,wagepoint,https://wagepoint.pinpointhq.com
+W.E. O'Neil Construction,weoneil,https://weoneil.pinpointhq.com
 Wanstor,wanstor,https://wanstor.pinpointhq.com
 Waymark,waymark,https://waymark.pinpointhq.com
 Wealth Wizards,wealthwizards,https://wealthwizards.pinpointhq.com
-MAPP,wearemapp,https://wearemapp.pinpointhq.com
-W.E. O'Neil Construction,weoneil,https://weoneil.pinpointhq.com
 White Swan Data,whiteswandata,https://whiteswandata.pinpointhq.com
 Windward Energy Group,windward-energy,https://windward-energy.pinpointhq.com
 WMH,wmhsolutions,https://wmhsolutions.pinpointhq.com
@@ -328,81 +403,6 @@ Xeneta,xeneta,https://xeneta.pinpointhq.com
 YMCA of Greater Boston,ymcaboston,https://ymcaboston.pinpointhq.com
 YNAB,ynab,https://ynab.pinpointhq.com
 Zencargo,zencargo,https://zencargo.pinpointhq.com
-Zinc,zincwork,https://zincwork.pinpointhq.com
-Alternative Heat,alternativeheat,https://alternativeheat.pinpointhq.com
-Buckinghamshire Mind,bucksmindcareers,https://bucksmindcareers.pinpointhq.com
-Codec,codec,https://codec.pinpointhq.com
-MIGSO-PCUBED,migso-pcubed,https://migso-pcubed.pinpointhq.com
-Pinpoint,workwithus,https://workwithus.pinpointhq.com
-Blue Cross,bluecross,https://bluecross.pinpointhq.com
-Butlin's,butlins,https://butlins.pinpointhq.com
-DAZN,dazn,https://dazn.pinpointhq.com
-International WELL Building Institute (IWBI),iwbi,https://iwbi.pinpointhq.com
-Tata Chemicals Europe,tatachemicals,https://tatachemicals.pinpointhq.com
-Icario,icario,https://icario.pinpointhq.com
-Lendable,lendable,https://lendable.pinpointhq.com
-Sport 54,weare54,https://weare54.pinpointhq.com
-Tails.com,tails,https://tails.pinpointhq.com
-BSC Analytics,bluesentry,https://bluesentry.pinpointhq.com
-Aston Martin F1,astonmartinf1,https://astonmartinf1.pinpointhq.com
-Imagemaker,imagemaker,https://imagemaker.pinpointhq.com
-Virtual Staffing Solutions,virtualstaffing,https://virtualstaffing.pinpointhq.com
-interop.io,interopio,https://interopio.pinpointhq.com
-Mechanism Ventures,mechanismventures,https://mechanismventures.pinpointhq.com
-Ada Infrastructure,glp,https://glp.pinpointhq.com
-Alcanza Clinical Research,alcanzaclinical,https://alcanzaclinical.pinpointhq.com
-Ascensus Specialties,ascensusspecialties,https://ascensusspecialties.pinpointhq.com
-Aspen Contracting,roofsbyaspen,https://roofsbyaspen.pinpointhq.com
-Aspire Allergy & Sinus,aspireallergy,https://aspireallergy.pinpointhq.com
-Bedell Cristin,bedellcristin,https://bedellcristin.pinpointhq.com
-Biorelate,biorelate,https://biorelate.pinpointhq.com
-Birches Group,birchesgroup,https://birchesgroup.pinpointhq.com
-Bright,bright,https://bright.pinpointhq.com
-C10 Labs,c10labs,https://c10labs.pinpointhq.com
-California Native Plant Society,cnps,https://cnps.pinpointhq.com
-Compassion UK & Ireland,compassionuk,https://compassionuk.pinpointhq.com
-Cubico Sustainable Investments,cubico,https://cubico.pinpointhq.com
-dbrand,dbrand,https://dbrand.pinpointhq.com
-Design Line Construction,designline,https://designline.pinpointhq.com
-Disturbia,disturbia,https://disturbia.pinpointhq.com
-Driver on Demand,driverondemand,https://driverondemand.pinpointhq.com
-Encompass Corporation,encompass,https://encompass.pinpointhq.com
-Enhance Group,enhance,https://enhance.pinpointhq.com
-ESSS,esss,https://esss.pinpointhq.com
-Fortify Health,fortifyhealth,https://fortifyhealth.pinpointhq.com
-FS-Curtis,fscurtis,https://fscurtis.pinpointhq.com
-FS-Elliott,fs-elliott,https://fs-elliott.pinpointhq.com
-Grant Thornton Channel Islands,gtci,https://gtci.pinpointhq.com
-Grasshopper Bank,grasshopper,https://grasshopper.pinpointhq.com
-Guernsey Electricity,guernseyelectricity,https://guernseyelectricity.pinpointhq.com
-HC Brands,hcbrands,https://hcbrands.pinpointhq.com
-Headkount,headkount,https://headkount.pinpointhq.com
-Health Staff Recruitment,medical,https://medical.pinpointhq.com
-HNC,huddnewcoll,https://huddnewcoll.pinpointhq.com
-Hopwood Hall,hopwood,https://hopwood.pinpointhq.com
-Human8,wearehuman8,https://wearehuman8.pinpointhq.com
-In Tandem,intandem,https://intandem.pinpointhq.com
-Instant Impact,instant-impact,https://instant-impact.pinpointhq.com
-Ipsos,ipsos,https://ipsos.pinpointhq.com
-Jersey Electricity,jec,https://jec.pinpointhq.com
-JT,jtglobal,https://jtglobal.pinpointhq.com
-Kharon,kharon,https://kharon.pinpointhq.com
-LV Care Group,lvcaregroup,https://lvcaregroup.pinpointhq.com
-Marketing Pros,marketingpros,https://marketingpros.pinpointhq.com
-McBains,mcbains,https://mcbains.pinpointhq.com
-Mimeo US,mimeo,https://mimeo.pinpointhq.com
-Oxford Metrics Plc,oxfordmetrics,https://oxfordmetrics.pinpointhq.com
-Rockborne,rockborne,https://rockborne.pinpointhq.com
-Ruffwear,ruffwear,https://ruffwear.pinpointhq.com
-SandpiperCI,sandpiperci,https://sandpiperci.pinpointhq.com
-Savanna Institute,savannainstitute,https://savannainstitute.pinpointhq.com
-Serefin,serefin,https://serefin.pinpointhq.com
-Seymour Hotels,seymourhotels,https://seymourhotels.pinpointhq.com
-St Petrocs,stpetrocs,https://stpetrocs.pinpointhq.com
-Tandym,tandym,https://tandym.pinpointhq.com
-The Christian Reformed Church in North America,crcna,https://crcna.pinpointhq.com
-The Duke of Edinburgh's Award,dofe,https://dofe.pinpointhq.com
-Torbay Council,torbaycouncil,https://torbaycouncil.pinpointhq.com
-Vaiie,vaiie,https://vaiie.pinpointhq.com
 Zenergi,zenergi,https://zenergi.pinpointhq.com
 Zevo Health,zevohealth,https://zevohealth.pinpointhq.com
+Zinc,zincwork,https://zincwork.pinpointhq.com

--- a/ats-companies/pinpoint.csv
+++ b/ats-companies/pinpoint.csv
@@ -349,3 +349,60 @@ Imagemaker,imagemaker,https://imagemaker.pinpointhq.com
 Virtual Staffing Solutions,virtualstaffing,https://virtualstaffing.pinpointhq.com
 interop.io,interopio,https://interopio.pinpointhq.com
 Mechanism Ventures,mechanismventures,https://mechanismventures.pinpointhq.com
+Ada Infrastructure,glp,https://glp.pinpointhq.com
+Alcanza Clinical Research,alcanzaclinical,https://alcanzaclinical.pinpointhq.com
+Ascensus Specialties,ascensusspecialties,https://ascensusspecialties.pinpointhq.com
+Aspen Contracting,roofsbyaspen,https://roofsbyaspen.pinpointhq.com
+Aspire Allergy & Sinus,aspireallergy,https://aspireallergy.pinpointhq.com
+Bedell Cristin,bedellcristin,https://bedellcristin.pinpointhq.com
+Biorelate,biorelate,https://biorelate.pinpointhq.com
+Birches Group,birchesgroup,https://birchesgroup.pinpointhq.com
+Bright,bright,https://bright.pinpointhq.com
+C10 Labs,c10labs,https://c10labs.pinpointhq.com
+California Native Plant Society,cnps,https://cnps.pinpointhq.com
+Compassion UK & Ireland,compassionuk,https://compassionuk.pinpointhq.com
+Cubico Sustainable Investments,cubico,https://cubico.pinpointhq.com
+dbrand,dbrand,https://dbrand.pinpointhq.com
+Design Line Construction,designline,https://designline.pinpointhq.com
+Disturbia,disturbia,https://disturbia.pinpointhq.com
+Driver on Demand,driverondemand,https://driverondemand.pinpointhq.com
+Encompass Corporation,encompass,https://encompass.pinpointhq.com
+Enhance Group,enhance,https://enhance.pinpointhq.com
+ESSS,esss,https://esss.pinpointhq.com
+Fortify Health,fortifyhealth,https://fortifyhealth.pinpointhq.com
+FS-Curtis,fscurtis,https://fscurtis.pinpointhq.com
+FS-Elliott,fs-elliott,https://fs-elliott.pinpointhq.com
+Grant Thornton Channel Islands,gtci,https://gtci.pinpointhq.com
+Grasshopper Bank,grasshopper,https://grasshopper.pinpointhq.com
+Guernsey Electricity,guernseyelectricity,https://guernseyelectricity.pinpointhq.com
+HC Brands,hcbrands,https://hcbrands.pinpointhq.com
+Headkount,headkount,https://headkount.pinpointhq.com
+Health Staff Recruitment,medical,https://medical.pinpointhq.com
+HNC,huddnewcoll,https://huddnewcoll.pinpointhq.com
+Hopwood Hall,hopwood,https://hopwood.pinpointhq.com
+Human8,wearehuman8,https://wearehuman8.pinpointhq.com
+In Tandem,intandem,https://intandem.pinpointhq.com
+Instant Impact,instant-impact,https://instant-impact.pinpointhq.com
+Ipsos,ipsos,https://ipsos.pinpointhq.com
+Jersey Electricity,jec,https://jec.pinpointhq.com
+JT,jtglobal,https://jtglobal.pinpointhq.com
+Kharon,kharon,https://kharon.pinpointhq.com
+LV Care Group,lvcaregroup,https://lvcaregroup.pinpointhq.com
+Marketing Pros,marketingpros,https://marketingpros.pinpointhq.com
+McBains,mcbains,https://mcbains.pinpointhq.com
+Mimeo US,mimeo,https://mimeo.pinpointhq.com
+Oxford Metrics Plc,oxfordmetrics,https://oxfordmetrics.pinpointhq.com
+Rockborne,rockborne,https://rockborne.pinpointhq.com
+Ruffwear,ruffwear,https://ruffwear.pinpointhq.com
+SandpiperCI,sandpiperci,https://sandpiperci.pinpointhq.com
+Savanna Institute,savannainstitute,https://savannainstitute.pinpointhq.com
+Serefin,serefin,https://serefin.pinpointhq.com
+Seymour Hotels,seymourhotels,https://seymourhotels.pinpointhq.com
+St Petrocs,stpetrocs,https://stpetrocs.pinpointhq.com
+Tandym,tandym,https://tandym.pinpointhq.com
+The Christian Reformed Church in North America,crcna,https://crcna.pinpointhq.com
+The Duke of Edinburgh's Award,dofe,https://dofe.pinpointhq.com
+Torbay Council,torbaycouncil,https://torbaycouncil.pinpointhq.com
+Vaiie,vaiie,https://vaiie.pinpointhq.com
+Zenergi,zenergi,https://zenergi.pinpointhq.com
+Zevo Health,zevohealth,https://zevohealth.pinpointhq.com


### PR DESCRIPTION
## Summary
- add 57 live production Pinpoint company boards
- expose 576 genuinely new live jobs

## Discovery and validation
- mined exact `*.pinpointhq.com` tenants across `CC-MAIN-2026-25`, `2025-38`, and `2025-30`
- extracted 252 unique crawl slugs and removed all slugs/hosts already present in the 350-company inventory
- live-tested 138 remaining candidates through the same public `postings.json` surface used by `PinpointScraper`
- excluded stale, redirected, empty, and malformed boards
- conservatively excluded all nine boards whose postings spanned multiple embedded organizations, including internship programs and multi-client boards
- retained 57 company-specific boards with 576 unique Pinpoint job IDs and zero candidate-to-candidate overlap
- compared against 10,877 published Pinpoint job IDs and found zero published overlap
- verified no duplicate CSV slugs/URLs, no exact existing company-name matches, `git diff --check`, focused tests (`15 passed`), and the full suite (`1,294 passed, 2 skipped`)

The Pinpoint scraper and focused tests are already present on `main`; this PR only expands `ats-companies/pinpoint.csv`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 57 live Pinpoint company boards to `ats-companies/pinpoint.csv` and alphabetize the inventory by company name. This exposes 576 new live jobs that the existing `PinpointScraper` will ingest automatically.

<sup>Written for commit 18f85a974a72830119dbf003dabd8bb2cc7145a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

