### PR TITLE
Preserve complete structured pipeline data

### DIFF
--- a/pipeline/publisher.py
+++ b/pipeline/publisher.py
@@ -1022,12 +1022,33 @@ def _enrich_lazy(lf: pl.LazyFrame) -> pl.LazyFrame:
             .drop("_salary_parsed")
         )
 
-    if "location" in schema_names and "country_iso" not in schema_names:
-        lf = lf.with_columns(
-            pl.col("location")
-            .map_elements(_country_iso_from_location, return_dtype=pl.String)
-            .alias("country_iso")
+    if "location" in schema_names:
+        derived_country = pl.col("location").map_elements(
+            _country_iso_from_location, return_dtype=pl.String
         )
+        if "country_iso" not in schema_names:
+            lf = lf.with_columns(derived_country.alias("country_iso"))
+        else:
+            current_country = pl.col("country_iso").cast(pl.String)
+            blank_country = current_country.is_null() | (
+                current_country.str.strip_chars().str.len_bytes() == 0
+            )
+            missing_location = (
+                pl.when(blank_country)
+                .then(pl.col("location"))
+                .otherwise(pl.lit(None, dtype=pl.String))
+            )
+            derived_missing = missing_location.map_elements(
+                _country_iso_from_location,
+                return_dtype=pl.String,
+                skip_nulls=True,
+            )
+            lf = lf.with_columns(
+                pl.when(blank_country)
+                .then(derived_missing)
+                .otherwise(current_country)
+                .alias("country_iso")
+            )
 
     return lf
 

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -761,6 +761,7 @@ DATA_ROOT = Path(__file__).resolve().parent.parent  # → repo root
 
 JOB_CSV_FIELDS = [
     "url", "title", "company", "ats_type", "ats_id", "location",
+    "country_iso", "region", "language", "lat", "lon",
     "is_remote", "salary_min", "salary_max", "salary_currency",
     "salary_period", "salary_summary", "employment_type",
     "department", "team", "description", "posted_at",
@@ -1153,6 +1154,11 @@ def _job_to_row(job: Job) -> dict[str, Any]:
         "ats_type": job.ats_type.value,
         "ats_id": job.ats_id,
         "location": job.location or "",
+        "country_iso": job.country_iso or "",
+        "region": job.region or "",
+        "language": job.language or "",
+        "lat": "" if job.lat is None else job.lat,
+        "lon": "" if job.lon is None else job.lon,
         "is_remote": "" if job.is_remote is None else str(job.is_remote).lower(),
         "salary_min": "" if job.salary_min is None else job.salary_min,
         "salary_max": "" if job.salary_max is None else job.salary_max,
@@ -1422,6 +1428,22 @@ async def run(ats: str, concurrency: int, max_tenants: int | None, timeout: floa
         )
 
         failure_threshold = max(1, (len(targets) + 1) // 2)
+        streaming_failure = uses_streaming and counts["error"] > 0
+        if streaming_failure:
+            tmp_output_path.unlink(missing_ok=True)
+            if output_path.exists():
+                print(
+                    f"[{ats}] ACTION keep_previous: streaming scrape failed "
+                    f"after {counts['jobs']:,} jobs; preserved {output_path} "
+                    "instead of publishing a partial dataset."
+                )
+            else:
+                print(
+                    f"[{ats}] ACTION retry: streaming scrape failed after "
+                    f"{counts['jobs']:,} jobs and no previous jobs.csv exists."
+                )
+            return 1
+
         catastrophic_failure = (
             bool(targets)
             and counts["jobs"] == 0

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -160,6 +160,7 @@ def test_publisher_derives_country_iso_column(ats_csv_dir, fake_r2) -> None:
     gh_csv = ats_csv_dir / "greenhouse" / "jobs.csv"
     df = pd.read_csv(gh_csv)
     df.loc[df["location"] == "Paris", "location"] = "Paris, France"
+    df["country_iso"] = ""
     df.to_csv(gh_csv, index=False)
 
     publisher = DatasetPublisher(fake_r2, write_parquet=True)
@@ -173,6 +174,25 @@ def test_publisher_derives_country_iso_column(ats_csv_dir, fake_r2) -> None:
     france_rows = [row for row in rows if row["location"] == "Paris, France"]
     assert france_rows
     assert {row["country_iso"] for row in france_rows} == {"FR"}
+
+
+def test_country_derivation_skips_callback_when_column_is_complete(monkeypatch) -> None:
+    import pipeline.publisher as publisher_module
+
+    frame = publisher_module.pl.DataFrame({
+        "location": ["Paris, France"],
+        "country_iso": ["FR"],
+    }).lazy()
+
+    def fail_if_called(_location):
+        raise AssertionError("country callback should stay on the fast path")
+
+    monkeypatch.setattr(
+        publisher_module, "_country_iso_from_location", fail_if_called,
+    )
+
+    result = publisher_module._enrich_lazy(frame).collect()
+    assert result["country_iso"].to_list() == ["FR"]
 
 
 # --- Manifest patch (read-modify-write) -------------------------------------

--- a/tests/test_run_pipeline_guards.py
+++ b/tests/test_run_pipeline_guards.py
@@ -9,6 +9,30 @@ import scripts.run_pipeline as runner
 from ats_scrapers.models import ATSType, Job
 
 
+def test_job_to_row_preserves_structured_location_metadata() -> None:
+    row = runner._job_to_row(
+        Job(
+            url="https://example.com/jobs/1",
+            title="Engineer",
+            company="Acme",
+            ats_type=ATSType.CUSTOM,
+            ats_id="1",
+            location="กรุงเทพมหานคร",
+            country_iso="TH",
+            region="Asia",
+            language="th",
+            lat=13.7563,
+            lon=100.5018,
+        )
+    )
+
+    assert row["country_iso"] == "TH"
+    assert row["region"] == "Asia"
+    assert row["language"] == "th"
+    assert row["lat"] == 13.7563
+    assert row["lon"] == 100.5018
+
+
 def test_provider_slug_normalizers_match_current_company_csv_shape() -> None:
     sf_row = {
         "name": "Ace1950",
@@ -734,6 +758,50 @@ def test_streaming_pipeline_reuses_sqlite_description_cache(
     assert rc == 0
     rows = list(csv.DictReader(out_path.open(newline="")))
     assert rows[0]["description"] == "cached"
+
+
+def test_streaming_failure_preserves_previous_jobs_csv(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    out_dir = tmp_path / "stream"
+    out_dir.mkdir()
+    out_path = out_dir / "jobs.csv"
+    previous = (
+        "url,title,company,ats_type,ats_id\n"
+        "https://example.com/jobs/old,Old,Acme,custom,old\n"
+    )
+    out_path.write_text(previous, encoding="utf-8")
+
+    class PartiallyFailingStreamingScraper:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        async def fetch_stream(self):
+            yield Job(
+                url="https://example.com/jobs/new",
+                title="New",
+                company="Acme",
+                ats_type=ATSType.CUSTOM,
+                ats_id="new",
+            )
+            raise RuntimeError("page 2 failed")
+
+    monkeypatch.setattr(runner, "DATA_ROOT", tmp_path)
+    monkeypatch.setitem(
+        runner.CONFIGS,
+        "stream",
+        {
+            "scraper": PartiallyFailingStreamingScraper,
+            "singleton": True,
+            "output": "stream/jobs.csv",
+        },
+    )
+
+    rc = asyncio.run(runner.run("stream", concurrency=1, max_tenants=None, timeout=1))
+
+    assert rc == 1
+    assert out_path.read_text(encoding="utf-8") == previous
+    assert not (out_dir / ".jobs.csv.tmp").exists()
 
 
 def test_streaming_pipeline_skips_capped_description_cache(


### PR DESCRIPTION
## Summary

- preserve structured country, region, language, latitude, and longitude fields in pipeline CSV output
- fill only missing country codes during publishing without overwriting source-provided values
- fail closed on interrupted streaming scrapes so partial datasets cannot replace complete ones

## Validation

- `uv run ruff check .`
- `uv run pytest -q` — 1,299 passed, 2 skipped, 20 deselected

This is the small shared safety foundation extracted from #214. No new job-board scraper is included here.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Preserve structured location metadata throughout the publishing pipeline.
- Adds country, region, language, latitude, and longitude fields to generated job CSVs.
- Fills only missing country codes while retaining source-provided values.
- Prevents interrupted streaming scrapes from replacing complete datasets with partial output.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A full pytest run completed with exit code 0, reporting 1,297 passing tests and two skipped credential-free live-site tests.
- Ruff linting completed with exit code 0 and all checks passed.
- Logs from the Pytest and Ruff runs were uploaded for reviewer inspection.

<a href="https://app.greptile.com/trex/runs/15751631/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pipeline/publisher.py | Updates country enrichment to retain existing values and derive only missing or blank entries. |
| scripts/run_pipeline.py | Preserves structured location fields in CSV output and rejects interrupted streaming results before atomic publication. |
| tests/test_publisher.py | Verifies complete country values bypass derivation while missing values remain enrichable. |
| tests/test_run_pipeline_guards.py | Covers structured metadata serialization and preservation of the previous CSV after streaming interruption. |

<sub>Reviews (2): Last reviewed commit: ["Preserve complete structured pipeline da..."](https://github.com/kalil0321/ats-scrapers/commit/f68028dae50531d1ad5975a5a672d049b5dfc1f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47013023)</sub>

<!-- /greptile_comment -->