### PR TITLE
Add Latin American credential-free job boards

### DIFF
--- a/ats-companies/bumeran.csv
+++ b/ats-companies/bumeran.csv
@@ -1,0 +1,5 @@
+name,slug,url
+Bumeran Argentina,ar,https://www.bumeran.com.ar
+Bumeran Peru,pe,https://www.bumeran.com.pe
+Bumeran Venezuela,ve,https://www.bumeran.com.ve
+Multitrabajos,ec-multitrabajos,https://www.multitrabajos.com

--- a/ats-companies/elempleo.csv
+++ b/ats-companies/elempleo.csv
@@ -1,0 +1,2 @@
+name,slug,url
+Elempleo,elempleo,https://www.elempleo.com

--- a/ats-companies/infojobs_br.csv
+++ b/ats-companies/infojobs_br.csv
@@ -1,0 +1,2 @@
+name,slug,url
+InfoJobs Brasil,infojobs_br,https://www.infojobs.com.br

--- a/pipeline/publisher.py
+++ b/pipeline/publisher.py
@@ -547,6 +547,9 @@ ATS_DEDUP_PRIORITY: dict[str, int] = {
     "tiktok": 1, "uber": 1,
     # Hybrid jobboards
     "welcometothejungle": 3, "mercor": 3, "gem": 3,
+    # Direct-posting job boards. Prefer canonical employer ATS rows when
+    # the same opening is syndicated to one of these marketplaces.
+    "bumeran": 4, "elempleo": 4, "infojobs_br": 4,
     # Sourcing/matching layer that mirrors others
     "eightfold": 5,
     # National public-sector aggregators — government-curated but the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "httpx>=0.27",
     "pydantic>=2.6",
     "pandas>=2.0",
+    "tzdata>=2022.1",
 ]
 
 [project.optional-dependencies]

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -47,16 +47,19 @@ from ats_scrapers.scrapers import (
     BeisenScraper,
     BreezyScraper,
     BuiltInScraper,
+    BumeranScraper,
     BundesagenturScraper,
     CornerstoneScraper,
     DarwinboxScraper,
     EightfoldScraper,
+    ElempleoScraper,
     EuresScraper,
     GemScraper,
     GetOnBrdScraper,
     GoogleScraper,
     GreenhouseScraper,
     GupyScraper,
+    InfoJobsBrasilScraper,
     InfoJobsSpainScraper,
     JazzHRScraper,
     JobsChScraper,
@@ -664,6 +667,24 @@ CONFIGS: dict[str, dict[str, Any]] = {
         # InfoJobs Spain - Spanish direct-posting job board. ~70k live.
         "scraper": InfoJobsSpainScraper, "singleton": True,
         "output": "infojobs_es/jobs.csv",
+    },
+    "bumeran": {
+        "scraper": BumeranScraper,
+        "slug": lambda r: _slug_col(r) or None,
+        "csv": "ats-companies/bumeran.csv",
+        "output": "bumeran/jobs.csv",
+        "fail_closed_on_any_error": True,
+        "fail_closed_on_empty": True,
+    },
+    "elempleo": {
+        "scraper": ElempleoScraper, "singleton": True,
+        "output": "elempleo/jobs.csv",
+        "fail_closed_on_empty": True,
+    },
+    "infojobs_br": {
+        "scraper": InfoJobsBrasilScraper, "singleton": True,
+        "output": "infojobs_br/jobs.csv",
+        "fail_closed_on_empty": True,
     },
     "jobs_cz": {
         # jobs.cz - Czech Republic's largest direct-posting board. ~10k live via seeded search.
@@ -1441,6 +1462,47 @@ async def run(ats: str, concurrency: int, max_tenants: int | None, timeout: floa
                 print(
                     f"[{ats}] ACTION retry: streaming scrape failed after "
                     f"{counts['jobs']:,} jobs and no previous jobs.csv exists."
+                )
+            return 1
+
+        empty_output_failure = (
+            bool(cfg.get("fail_closed_on_empty"))
+            and bool(targets)
+            and counts["jobs"] == 0
+        )
+        if empty_output_failure:
+            tmp_output_path.unlink(missing_ok=True)
+            if output_path.exists():
+                print(
+                    f"[{ats}] ACTION keep_previous: required scrape returned "
+                    f"0 jobs; preserved {output_path} instead of publishing "
+                    "an empty dataset."
+                )
+            else:
+                print(
+                    f"[{ats}] ACTION retry: required scrape returned 0 jobs "
+                    "and no previous jobs.csv exists."
+                )
+            return 1
+
+        sharded_failure = (
+            bool(cfg.get("fail_closed_on_any_error"))
+            and counts["error"] > 0
+        )
+        if sharded_failure:
+            tmp_output_path.unlink(missing_ok=True)
+            if output_path.exists():
+                print(
+                    f"[{ats}] ACTION keep_previous: {counts['error']}/"
+                    f"{len(targets)} required shards failed after "
+                    f"{counts['jobs']:,} jobs; preserved {output_path} "
+                    "instead of publishing a partial dataset."
+                )
+            else:
+                print(
+                    f"[{ats}] ACTION retry: {counts['error']}/"
+                    f"{len(targets)} required shards failed and no previous "
+                    "jobs.csv exists."
                 )
             return 1
 

--- a/src/ats_scrapers/models.py
+++ b/src/ats_scrapers/models.py
@@ -87,6 +87,9 @@ class ATSType(StrEnum):
     YCOMBINATOR = "ycombinator"
     WELLFOUND = "wellfound"
     INFOJOBSES = "infojobs_es"
+    BUMERAN = "bumeran"
+    ELEMPLEO = "elempleo"
+    INFOJOBSBR = "infojobs_br"
     # Additional multi-tenant ATSes (post-0.1)
     BAMBOOHR = "bamboohr"
     BREEZY = "breezy"

--- a/src/ats_scrapers/scrapers/__init__.py
+++ b/src/ats_scrapers/scrapers/__init__.py
@@ -19,10 +19,12 @@ from ats_scrapers.scrapers.beisen import BeisenScraper
 from ats_scrapers.scrapers.beisen_legacy import BeisenLegacyScraper
 from ats_scrapers.scrapers.breezy import BreezyScraper
 from ats_scrapers.scrapers.builtin import BuiltInScraper
+from ats_scrapers.scrapers.bumeran import BumeranScraper
 from ats_scrapers.scrapers.bundesagentur import BundesagenturScraper
 from ats_scrapers.scrapers.cornerstone import CornerstoneScraper
 from ats_scrapers.scrapers.darwinbox import DarwinboxScraper
 from ats_scrapers.scrapers.eightfold import EightfoldScraper
+from ats_scrapers.scrapers.elempleo import ElempleoScraper
 from ats_scrapers.scrapers.eures import EuresScraper
 from ats_scrapers.scrapers.gem import GemScraper
 from ats_scrapers.scrapers.getonbrd import GetOnBrdScraper
@@ -30,6 +32,7 @@ from ats_scrapers.scrapers.google import GoogleScraper
 from ats_scrapers.scrapers.greenhouse import GreenhouseScraper
 from ats_scrapers.scrapers.gupy import GupyScraper
 from ats_scrapers.scrapers.icims import iCIMSScraper
+from ats_scrapers.scrapers.infojobs_br import InfoJobsBrasilScraper
 from ats_scrapers.scrapers.infojobs_es import InfoJobsSpainScraper
 from ats_scrapers.scrapers.jazzhr import JazzHRScraper
 from ats_scrapers.scrapers.jobs_cz import JobsCzScraper
@@ -78,16 +81,19 @@ __all__ = [
     "BeisenScraper",
     "BreezyScraper",
     "BuiltInScraper",
+    "BumeranScraper",
     "BundesagenturScraper",
     "CornerstoneScraper",
     "DarwinboxScraper",
     "EightfoldScraper",
+    "ElempleoScraper",
     "EuresScraper",
     "GemScraper",
     "GetOnBrdScraper",
     "GoogleScraper",
     "GreenhouseScraper",
     "GupyScraper",
+    "InfoJobsBrasilScraper",
     "InfoJobsSpainScraper",
     "JazzHRScraper",
     "JobsChScraper",

--- a/src/ats_scrapers/scrapers/bumeran.py
+++ b/src/ats_scrapers/scrapers/bumeran.py
@@ -430,9 +430,7 @@ class BumeranScraper(BaseScraper):
 
     @property
     def _request_timeout(self) -> float:
-        """Return timeout units expected by the selected transport."""
-        if self.client_kind == "httpcloak":
-            return self.timeout * 1_000
+        """Return the per-request timeout in seconds."""
         return self.timeout
 
     # --- parsing ------------------------------------------------------------

--- a/src/ats_scrapers/scrapers/bumeran.py
+++ b/src/ats_scrapers/scrapers/bumeran.py
@@ -1,0 +1,584 @@
+"""Bumeran / Navent (LATAM family) — multi-country jobboard scraper.
+
+Bumeran is the consumer brand of Navent, a regional jobboard platform
+that serves 5+ Spanish-speaking Latin American countries from a single
+shared backend. The same React/SPA frontend and same ``/api/avisos/...``
+JSON API power every regional site — only the brand, ``x-site-id``
+header, and country in the data differ. The sister brands
+``zonajobs.com.ar`` (Argentina) and ``multitrabajos.com`` (Ecuador)
+also ride on the same backend.
+
+Public JSON API at ``POST /api/avisos/searchV2`` — no auth, no API key.
+The request is gated by Cloudflare's bot manager: a bare ``httpx``
+request returns 403, but TLS+h2 fingerprint impersonation via
+``httpcloak`` (already in the ``scrapers`` extra) plus a one-shot
+landing-page GET to acquire the ``__cf_*`` cookies is enough to clear
+the WAF for the full session. The same pattern is documented in
+``builtin.py`` / ``jazzhr.py``.
+
+API contract reverse-engineered from
+``/candidate/static/js/main.<hash>.js`` on the live frontend:
+
+    POST /api/avisos/searchV2?pageSize=<n>&page=<p>&sort=RELEVANTES
+    Headers:
+      x-site-id: BMAR | BMPE | BMEC | BMVE | ZJAR | ...
+      Origin / Referer: matching site
+      Content-Type: application/json
+    Body: { "filtros": [], "query": "", "internacional": false }
+    Response: { number, size, total, content: [aviso, ...], ... }
+
+Each ``aviso`` in ``content`` ships ``id``, ``titulo``, ``detalle``
+(plain-text body, ~10kB), ``empresa``, ``localizacion``,
+``fechaHoraPublicacion`` (``"DD-MM-YYYY HH:MM:SS"``), ``tipoTrabajo``
+(``Full-time``/``Part-time``/...), ``modalidadTrabajo``
+(``Presencial``/``Remoto``/``Hibrido``), plus ``idArea`` / ``idSubarea``
+classification ids. We map the structured fields to the canonical
+``Job`` schema and keep the area / portal / modality on ``raw`` so the
+downstream pipeline doesn't lose Navent-specific signal.
+
+``company_slug`` picks the region — one of ``ar``, ``pe``, ``ec``,
+``ve``, ``ar-zonajobs``, ``ec-multitrabajos``. The ``cl`` (Chile) and
+``pe-konzerta`` aliases are recognised in the region table but the
+underlying Trabajando.com / Konzerta stacks don't share this API; they
+fall through to an empty result with a logged warning rather than
+crashing the publish pipeline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html as _html
+import json
+import logging
+import re
+from datetime import UTC, datetime
+from importlib.util import find_spec
+from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo
+
+import httpx
+
+from ats_scrapers.exceptions import CompanyNotFoundError, ScraperError
+from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+log = logging.getLogger(__name__)
+
+# Per-region: base URL, site-id header value, ISO 3166-1 alpha-2 country,
+# ISO 4217 currency (best-effort — the API rarely exposes salary).
+# Order matters for the public-API docstring but not for behaviour.
+REGIONS: dict[str, tuple[str, str, str, str, str]] = {
+    # company_slug -> (base_url, x_site_id, country_iso, language, currency)
+    "ar": ("https://www.bumeran.com.ar", "BMAR", "AR", "es", "ARS"),
+    "pe": ("https://www.bumeran.com.pe", "BMPE", "PE", "es", "PEN"),
+    "ec": ("https://www.bumeran.com.ec", "BMEC", "EC", "es", "USD"),
+    "ve": ("https://www.bumeran.com.ve", "BMVE", "VE", "es", "VES"),
+    "cl": ("https://www.bumeran.cl", "BMCL", "CL", "es", "CLP"),
+    "ar-zonajobs": ("https://www.zonajobs.com.ar", "ZJAR", "AR", "es", "ARS"),
+    "pe-konzerta": ("https://www.konzerta.com.pe", "BMPE", "PE", "es", "PEN"),
+    # multitrabajos shares the BMEC site-id with bumeran.com.ec — same
+    # backend tenant, different brand surface.
+    "ec-multitrabajos": ("https://www.multitrabajos.com", "BMEC", "EC", "es", "USD"),
+}
+REGION_TIMEZONES = {
+    "ar": "America/Argentina/Buenos_Aires",
+    "ar-zonajobs": "America/Argentina/Buenos_Aires",
+    "pe": "America/Lima",
+    "pe-konzerta": "America/Lima",
+    "ec": "America/Guayaquil",
+    "ec-multitrabajos": "America/Guayaquil",
+    "ve": "America/Caracas",
+    "cl": "America/Santiago",
+}
+
+# Sites whose backend isn't on the shared searchV2 API. The scraper
+# accepts the slug (so the caller can keep a uniform config) but logs a
+# warning and returns an empty list. Move out once a working endpoint
+# is documented.
+_UNSUPPORTED_SLUGS: frozenset[str] = frozenset({"cl", "pe-konzerta"})
+
+PAGE_SIZE = 100  # API hard-caps at 100; lower values just paginate more.
+DEFAULT_MAX_PAGES = 5_000  # 500k jobs/region at PAGE_SIZE; fail closed above.
+MAX_RETRIES = 4
+RETRY_BASE_DELAY = 2.0
+# Cloudflare rate-limits aggressive bursts on the same edge cookie.
+# Three concurrent page fetches finishes a 100k-row country in ~5min.
+MAX_CONCURRENCY = 3
+
+# Per ``tipoTrabajo`` value -> canonical EmploymentType. Lowercased
+# before lookup so "Full-time" / "FULL_TIME" / "full-time" all match.
+_TIPO_TRABAJO_MAP: dict[str, str] = {
+    "full-time": "FULL_TIME",
+    "full time": "FULL_TIME",
+    "tiempo completo": "FULL_TIME",
+    "part-time": "PART_TIME",
+    "part time": "PART_TIME",
+    "medio tiempo": "PART_TIME",
+    "tiempo parcial": "PART_TIME",
+    "freelance": "CONTRACT",
+    "contractor": "CONTRACT",
+    "por hora": "CONTRACT",
+    "temporario": "TEMPORARY",
+    "temporal": "TEMPORARY",
+    "pasantia": "INTERN",
+    "pasantía": "INTERN",
+    "practicas": "INTERN",
+    "prácticas": "INTERN",
+    "internship": "INTERN",
+    "becario": "INTERN",
+    "primer empleo": "FULL_TIME",
+}
+
+_TAG_RE = re.compile(r"<[^>]+>")
+# Bumeran's API ships ``fechaHoraPublicacion`` as ``DD-MM-YYYY HH:MM:SS``
+# in the site's local time. We only have date-level granularity for
+# matching, so the time part is best-effort.
+_DATE_FMT = "%d-%m-%Y %H:%M:%S"
+_DATE_ONLY_FMT = "%d-%m-%Y"
+
+
+@ScraperRegistry.register(ATSType.BUMERAN)
+class BumeranScraper(BaseScraper):
+    """Bumeran / Navent (LATAM family) — multi-country jobboard.
+
+    ``company_slug`` selects the country / brand. Recognised values:
+
+    - ``ar`` — bumeran.com.ar (Argentina)
+    - ``pe`` — bumeran.com.pe (Peru)
+    - ``ec`` — bumeran.com.ec (Ecuador)
+    - ``ve`` — bumeran.com.ve (Venezuela)
+    - ``cl`` — bumeran.cl (Chile) — *not on shared API; returns []*
+    - ``ar-zonajobs`` — zonajobs.com.ar (Argentina alt brand)
+    - ``pe-konzerta`` — konzerta.com.pe (Peru alt brand) — *unreachable*
+    - ``ec-multitrabajos`` — multitrabajos.com (Ecuador alt brand)
+
+    Optional knobs:
+
+    - ``max_pages`` — optional explicit pagination cap for bounded probes;
+      production defaults to the full reported catalogue.
+    - ``client_kind`` — ``"httpcloak"`` (default) uses TLS+h2
+      impersonation to clear Cloudflare; ``"httpx"`` skips httpcloak
+      for diagnostic comparison and will 403 in production.
+    - ``proxy`` / ``include_descriptions`` — standard scraper options,
+      forwarded to the selected transport and parser respectively.
+
+    The class raises :class:`ScraperError` when ``httpcloak`` isn't
+    installed so production cannot replace a complete regional dataset
+    with an empty successful run.
+    """
+
+    ats = ATSType.BUMERAN
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        max_pages: int | None = None,
+        include_descriptions: bool = True,
+        proxy: str | None = None,
+        client_kind: str = "httpcloak",
+    ) -> None:
+        super().__init__(
+            company_slug,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        if company_slug not in REGIONS:
+            raise CompanyNotFoundError(
+                f"Bumeran: unknown region {company_slug!r}. "
+                f"Known: {sorted(REGIONS)}"
+            )
+        if max_pages is not None and max_pages < 1:
+            raise ScraperError(
+                f"Bumeran max_pages must be positive, got {max_pages}"
+            )
+        self._full_catalogue = max_pages is None
+        self.max_pages = min(max_pages or DEFAULT_MAX_PAGES, DEFAULT_MAX_PAGES)
+        if client_kind not in {"httpcloak", "httpx"}:
+            raise ValueError("client_kind must be 'httpcloak' or 'httpx'")
+        self.client_kind = client_kind
+        self._timezone = ZoneInfo(REGION_TIMEZONES[company_slug])
+        (
+            self._base_url,
+            self._site_id,
+            self._country_iso,
+            self._language,
+            self._currency,
+        ) = REGIONS[company_slug]
+
+    async def afetch(self) -> list[Job]:
+        if self.company_slug in _UNSUPPORTED_SLUGS:
+            log.warning(
+                "Bumeran: region %r is recognised but its backend is not "
+                "on the shared searchV2 API yet — returning [].",
+                self.company_slug,
+            )
+            return []
+        if self.client_kind == "httpcloak" and find_spec("httpcloak") is None:
+            raise ScraperError(
+                "Bumeran: httpcloak is required to clear Cloudflare on "
+                "Navent's API — install with `pip install ats_scrapers[scrapers]`"
+            )
+        return await self._fetch_async()
+
+    def fetch(self) -> list[Job]:
+        return self._run_sync(self.afetch())
+
+    # --- listing fetch ------------------------------------------------------
+
+    async def _fetch_async(self) -> list[Job]:
+        # Establish a single httpcloak session for the whole scrape. The
+        # landing-page GET seeds Cloudflare's __cf_* cookies that the
+        # subsequent /api/avisos/searchV2 POSTs need to pass the WAF.
+        session = await asyncio.to_thread(self._open_session)
+        try:
+            return await self._fetch_with_session(session)
+        finally:
+            close = getattr(session, "close", None)
+            if callable(close):
+                await asyncio.to_thread(close)
+
+    async def _fetch_with_session(self, session: Any) -> list[Job]:
+        first = await asyncio.to_thread(self._search_page, session, 0)
+        total = int(first.get("total") or 0)
+        size = int(first.get("size") or PAGE_SIZE)
+        if size <= 0:
+            size = PAGE_SIZE
+        # ``size`` from the API is the number of rows actually returned
+        # on this page, not the requested pageSize — when only a handful
+        # of jobs exist, ``size`` is small but the math still holds.
+        reported_pages = (total + size - 1) // size if total else 1
+        if self._full_catalogue and reported_pages > DEFAULT_MAX_PAGES:
+            raise ScraperError(
+                f"Bumeran ({self.company_slug}) reported {reported_pages} pages, "
+                f"above the {DEFAULT_MAX_PAGES}-page safety limit"
+            )
+        total_pages = min(self.max_pages, reported_pages)
+
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        raw_rows = 0
+        parsed_rows = 0
+        lock = asyncio.Lock()
+
+        async def absorb(payload: dict[str, Any]) -> None:
+            nonlocal raw_rows, parsed_rows
+            content = payload.get("content")
+            if not isinstance(content, list) or not all(
+                isinstance(item, dict) for item in content
+            ):
+                raise ScraperError(
+                    f"Bumeran ({self.company_slug}): expected content to be "
+                    "a list of objects"
+                )
+            parsed = [self._parse_job(item) for item in content]
+            usable = [job for job in parsed if job is not None]
+            if self._full_catalogue and len(usable) != len(content):
+                raise ScraperError(
+                    f"Bumeran ({self.company_slug}): parsed {len(usable)} of "
+                    f"{len(content)} rows on page {payload.get('number', '?')}"
+                )
+            if self._full_catalogue and total > 0 and not content:
+                raise ScraperError(
+                    f"Bumeran ({self.company_slug}): page "
+                    f"{payload.get('number', '?')} was empty while the API "
+                    f"reported {total} jobs"
+                )
+            async with lock:
+                raw_rows += len(content)
+                parsed_rows += len(usable)
+                for job in usable:
+                    if job.ats_id in seen:
+                        continue
+                    seen.add(job.ats_id)
+                    jobs.append(job)
+
+        await absorb(first)
+        if total_pages > 1:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+
+            async def per_page(page: int) -> None:
+                async with sem:
+                    payload = await asyncio.to_thread(
+                        self._search_page, session, page,
+                    )
+                await absorb(payload)
+
+            await asyncio.gather(*(per_page(p) for p in range(1, total_pages)))
+        if self._full_catalogue and (
+            raw_rows < total or parsed_rows < raw_rows
+        ):
+            raise ScraperError(
+                f"Bumeran ({self.company_slug}): catalogue validation failed "
+                f"(reported={total}, fetched={raw_rows}, parsed={parsed_rows})"
+            )
+        return jobs
+
+    # --- httpcloak transport ------------------------------------------------
+
+    def _open_session(self) -> Any:
+        """Create an httpcloak Session, prime it with the landing page so
+        Cloudflare drops the right cookies, and return it."""
+        if self.client_kind == "httpx":
+            session: Any = httpx.Client(
+                proxy=self.proxy,
+                follow_redirects=True,
+            )
+        else:
+            import httpcloak
+
+            session = (
+                httpcloak.Session(proxy=self.proxy)
+                if self.proxy
+                else httpcloak.Session()
+            )
+        landing = f"{self._base_url}/empleos.html"
+        try:
+            response = session.get(landing, timeout=self._request_timeout)
+        except Exception as exc:
+            close = getattr(session, "close", None)
+            if callable(close):
+                close()
+            raise ScraperError(
+                f"Bumeran ({self.company_slug}): landing-page fetch "
+                f"failed: {exc}"
+            ) from exc
+        if response.status_code != 200:
+            close = getattr(session, "close", None)
+            if callable(close):
+                close()
+            raise ScraperError(
+                f"Bumeran ({self.company_slug}): landing returned "
+                f"{response.status_code} (expected 200)"
+            )
+        return session
+
+    def _search_page(self, session: Any, page: int) -> dict[str, Any]:
+        url = (
+            f"{self._base_url}/api/avisos/searchV2"
+            f"?pageSize={PAGE_SIZE}&page={page}&sort=RELEVANTES"
+        )
+        body = {"filtros": [], "query": "", "internacional": False}
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/plain, */*",
+            "Accept-Language": "es-AR,es;q=0.9,en;q=0.8",
+            "Origin": self._base_url,
+            "Referer": f"{self._base_url}/empleos.html",
+            "x-site-id": self._site_id,
+        }
+
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                response = session.post(
+                    url, headers=headers, json=body,
+                    timeout=self._request_timeout,
+                )
+            except Exception as exc:
+                last_exc = exc
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Bumeran ({self.company_slug}) page {page}: "
+                        f"transport failed: {exc}"
+                    ) from exc
+                _sleep(RETRY_BASE_DELAY * attempt)
+                continue
+            status = int(getattr(response, "status_code", 0))
+            text = _response_text(response)
+            if status == 200:
+                try:
+                    payload = json.loads(text)
+                except ValueError as exc:
+                    # Cloudflare sometimes returns 200 + HTML challenge
+                    # body on transient flaky edges — retry rather than
+                    # surface a misleading parse error.
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"Bumeran ({self.company_slug}) page {page}: "
+                            f"non-JSON 200 body: {exc}"
+                        ) from exc
+                    _sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+                if not isinstance(payload, dict):
+                    raise ScraperError(
+                        f"Bumeran ({self.company_slug}) page {page}: "
+                        f"expected object, got {type(payload).__name__}"
+                    )
+                return payload
+            if status == 403 or status == 429 or 500 <= status < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Bumeran ({self.company_slug}) page {page}: "
+                        f"status {status} after {MAX_RETRIES} retries"
+                    )
+                _sleep(RETRY_BASE_DELAY * (2 ** attempt))
+                continue
+            raise ScraperError(
+                f"Bumeran ({self.company_slug}) page {page}: "
+                f"unexpected status {status}"
+            )
+        raise ScraperError(
+            f"Bumeran ({self.company_slug}) page {page}: "
+            f"exhausted retries: {last_exc}"
+        )
+
+    @property
+    def _request_timeout(self) -> float:
+        """Return timeout units expected by the selected transport."""
+        if self.client_kind == "httpcloak":
+            return self.timeout * 1_000
+        return self.timeout
+
+    # --- parsing ------------------------------------------------------------
+
+    def _parse_job(self, item: dict[str, Any]) -> Job | None:
+        raw_id = item.get("id")
+        if raw_id is None:
+            return None
+        ats_id = str(raw_id)
+        title = (item.get("titulo") or "").strip()
+        if not ats_id or not title:
+            return None
+
+        # Synthesize the canonical detail URL — Bumeran's frontend uses
+        # ``/empleos/<slug>-<id>.html`` and accepts ``aviso-<id>.html``
+        # as an alias (verified live: 200 with the SPA shell, which
+        # then bootstraps the same detail data we already have from the
+        # listing). Use the alias so we don't have to slugify titles
+        # with diacritics.
+        url = f"{self._base_url}/empleos/aviso-{ats_id}.html"
+
+        company_name = (item.get("empresa") or "").strip()
+        # Bumeran flags confidential listings — keep the empty company
+        # value visible as "Confidencial" so downstream rows don't
+        # silently fall back to a numeric employer id.
+        if item.get("confidencial") and not company_name:
+            company_name = "Confidencial"
+        if not company_name:
+            company_name = "Unknown"
+
+        location = (item.get("localizacion") or "").strip() or None
+
+        modalidad = (item.get("modalidadTrabajo") or "").strip()
+        is_remote: bool | None = None
+        if modalidad:
+            mlow = modalidad.lower()
+            if "remoto" in mlow or "remote" in mlow or "home office" in mlow:
+                is_remote = True
+            elif "presencial" in mlow:
+                is_remote = False
+            # Hybrid / mixed leaves is_remote=None — the downstream
+            # enrichment can decide once it sees the description.
+
+        tipo = (item.get("tipoTrabajo") or "").strip()
+        employment_type = _TIPO_TRABAJO_MAP.get(tipo.lower())
+
+        description = (
+            _clean_description(item.get("detalle"))
+            if self.include_descriptions
+            else None
+        )
+
+        posted_at = _parse_datetime(
+            item.get("fechaHoraPublicacion") or item.get("fechaPublicacion"),
+            timezone=self._timezone,
+        )
+
+        raw: dict[str, Any] = {}
+        for key in (
+            "idArea", "idSubarea", "idEmpresa", "idPais",
+            "portal", "planPublicacion", "modalidadTrabajo",
+            "tipoTrabajo", "tipoAviso", "cantidadVacantes",
+            "aptoDiscapacitado", "confidencial", "empresaPro",
+            "postulacionRapida",
+        ):
+            v = item.get(key)
+            if v not in (None, "", []):
+                raw[key] = v
+        raw["country_alias"] = self.company_slug
+        raw["site_id"] = self._site_id
+
+        return Job(
+            url=url,
+            title=title,
+            company=company_name,
+            ats_type=ATSType.BUMERAN,
+            ats_id=ats_id,
+            location=location,
+            country_iso=self._country_iso,
+            region="South America",
+            is_remote=is_remote,
+            employment_type=employment_type,
+            commitment=tipo or None,
+            description=description,
+            posted_at=posted_at,
+            fetched_at=datetime.now(tz=UTC),
+            language=self._language,
+            raw=raw or None,
+        )
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+def _response_text(response: Any) -> str:
+    """Return response body as text, tolerating httpcloak's variable API."""
+    text = getattr(response, "text", None)
+    if isinstance(text, str):
+        return text
+    content = getattr(response, "content", b"")
+    if isinstance(content, bytes):
+        return content.decode("utf-8", errors="replace")
+    return str(content)
+
+
+def _sleep(seconds: float) -> None:
+    """Synchronous sleep used inside the httpcloak (blocking) path. We
+    can't call ``asyncio.sleep`` here because the function runs inside
+    ``asyncio.to_thread`` so the event loop is on another thread."""
+    import time
+
+    time.sleep(seconds)
+
+
+def _clean_description(value: object) -> str | None:
+    """Bumeran's ``detalle`` ships as plain text but with HTML entities
+    (``&#x1f50e;``, ``&amp;``) interleaved. Decode entities, strip any
+    stray tags, collapse whitespace, and truncate to the canonical
+    ~10kB description budget."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    cleaned = _html.unescape(value)
+    cleaned = _TAG_RE.sub(" ", cleaned)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    if not cleaned:
+        return None
+    return cleaned[:10_000]
+
+
+def _parse_datetime(
+    value: object,
+    *,
+    timezone: ZoneInfo,
+) -> datetime | None:
+    """Parse Bumeran's ``DD-MM-YYYY HH:MM:SS`` (and date-only fallback).
+
+    The API ships local time without a zone, so interpret it in the
+    selected regional timezone and normalize to UTC."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    s = value.strip()
+    for fmt in (_DATE_FMT, _DATE_ONLY_FMT):
+        try:
+            return datetime.strptime(s, fmt).replace(
+                tzinfo=timezone,
+            ).astimezone(UTC)
+        except ValueError:
+            continue
+    return None

--- a/src/ats_scrapers/scrapers/elempleo.py
+++ b/src/ats_scrapers/scrapers/elempleo.py
@@ -1,0 +1,561 @@
+"""elempleo.com — Colombia's largest direct-posting job board.
+
+elempleo serves Colombia primarily (10k+ live postings across every
+sector — tech is a small slice, the bulk is operations, healthcare,
+sales, manufacturing). Companies post directly through the site,
+which makes coverage high-signal for the CO market that LinkedIn
+under-indexes.
+
+The listing pages at ``https://www.elempleo.com/co/ofertas-empleo?Page=N``
+are server-rendered HTML. Each card carries enough fields that we
+don't need to fetch detail pages:
+
+  - title — ``<a class="… js-offer-title …">``
+  - company — ``<span class="… js-offer-company …">``
+  - city — ``<span class="… js-offer-city …">``
+  - salary — first ``<div class="text-blue-petrol-dark">`` above
+    ``<div class="small-text … ">Salario</div>``
+  - contract type, modality (Presencial / Híbrido / Remoto)  —
+    same labelled-pair pattern
+  - posted date — ``<span class="… js-offer-date …">`` shows relative
+    labels such as ``Hoy``, ``Ayer``, or ``Hace 2 días``; unresolved
+    ``{{publishDateInfo}}`` template placeholders are ignored
+  - id — trailing number in the detail URL slug
+    (``/co/ofertas-trabajo/some-title-1886709556`` → ``1886709556``).
+    The same id is also embedded as ``data-offer-id`` on the share
+    button, which is what we anchor the parser on for robustness.
+
+Pagination uses ``?Page=N`` (capital P matters); pages past the live
+tail return HTTP 200 with zero job cards rather than 404, so the
+scraper terminates after two consecutive empty pages.
+
+Single-source scraper: ``company_slug`` is ignored — the scraper
+sweeps the entire site.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import re
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo
+
+import httpx
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+API_ROOT = "https://www.elempleo.com"
+DEFAULT_MAX_PAGES = 1500  # 20 jobs/page × 1500 = 30,000 max — covers
+                          # the entire live inventory (~21.7k) with headroom.
+                          # Pagination still stops early on the empty-page tail.
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 4
+RETRY_BASE_DELAY = 2.0
+_BOGOTA_TZ = ZoneInfo("America/Bogota")
+
+# Each result-item is a top-level wrapper card. The class includes a
+# trailing space in the live HTML — match flexibly. We use the
+# data-offer-id present on the share button inside the card as the
+# canonical id; that's the same numeric trailing chunk in the slug
+# URL but extracting it from a dedicated attribute is more robust
+# than re-parsing the URL.
+_CARD_RE = re.compile(
+    r'<div class="col-md-12 result-item mb-3 bg-white\s*"(?P<body>.*?)'
+    r'(?=<div class="col-md-12 result-item mb-3 bg-white\s*"|<div class="text-center pt-3"|<footer)',
+    re.DOTALL,
+)
+_EMPTY_PAGE_MARKERS = (
+    'class="no-results"',
+    "class='no-results'",
+    'class="text-center pt-3"',
+    "class='text-center pt-3'",
+)
+_OFFER_ID_RE = re.compile(r'data-offer-id="(?P<id>\d+)"')
+_DETAIL_HREF_RE = re.compile(
+    r'href="(?P<href>/co/ofertas-trabajo/[a-z0-9-]+-(?P<id>\d+))"'
+)
+_TITLE_RE = re.compile(
+    r'class="[^"]*js-offer-title[^"]*"[^>]*title="(?P<t>[^"]+)"'
+)
+_COMPANY_RE = re.compile(
+    r'class="[^"]*js-offer-company[^"]*"[^>]*>\s*(?P<v>[^<]+?)\s*</span>'
+)
+_CITY_RE = re.compile(
+    r'class="[^"]*js-offer-city[^"]*"[^>]*>\s*(?P<v>[^<]+?)\s*</span>'
+)
+# Labelled-pair pattern: a <div class="text-blue-petrol-dark"> with
+# the value, followed by a <div class="small-text …">LABEL</div>.
+_LABELLED_VALUE_RE = re.compile(
+    r'<div class="text-blue-petrol-dark">\s*(?P<v>[^<]+?)\s*</div>\s*'
+    r'<div class="small-text[^"]*">\s*(?P<label>[^<{]+?)\s*</div>',
+    re.DOTALL,
+)
+# js-offer-date wraps the publish hint in a <span> with an icon
+# in front; capture whatever text follows the </i>. ``Hoy`` = today.
+# Anything else is a Mustache placeholder rendered by JS (``{{…}}``)
+# which we ignore.
+_DATE_RE = re.compile(
+    r'class="[^"]*js-offer-date[^"]*"[^>]*>\s*'
+    r'(?:<i[^>]*></i>\s*)?(?P<v>[^<]+?)\s*</span>',
+    re.DOTALL,
+)
+_RELATIVE_DATE_RE = re.compile(r"^hace\s+(?P<days>\d+)\s+dias?$")
+# Description fallback: the share modal embeds the full posting body
+# as data-offer-description="…". HTML-escaped, multi-line.
+_DESCRIPTION_RE = re.compile(
+    r'data-offer-description="(?P<v>[^"]*)"', re.DOTALL,
+)
+
+# elempleo contract-type → canonical ``EmploymentType`` enum.
+#
+# Colombian labour-contract terminology:
+#   - "Indefinido"             — open-ended permanent contract → FULL_TIME
+#   - "Definido" / "Termino fijo" — fixed-term contract → TEMPORARY
+#   - "Por obra o labor"       — project / task-based → CONTRACT
+#   - "Prestacion de Servicios"— independent contractor → CONTRACT
+#   - "Contrato de aprendizaje"— apprenticeship → INTERN
+#   - "Practicas"              — internship → INTERN
+#   - "Temporal"               — temp agency → TEMPORARY
+_EMPLOYMENT_MAP: dict[str, str | None] = {
+    "indefinido": "FULL_TIME",
+    "termino indefinido": "FULL_TIME",
+    "definido": "TEMPORARY",
+    "termino fijo": "TEMPORARY",
+    "termino definido": "TEMPORARY",
+    "temporal": "TEMPORARY",
+    "por obra o labor": "CONTRACT",
+    "prestacion de servicios": "CONTRACT",
+    "freelance": "CONTRACT",
+    "contrato de aprendizaje": "INTERN",
+    "practicas": "INTERN",
+    "otro": None,  # surfaced via commitment, no canonical mapping
+}
+
+# Modality (work arrangement) → is_remote signal.
+_MODALITY_REMOTE: dict[str, bool] = {
+    "remoto": True,
+    "presencial": False,
+    "hibrido": False,
+    "híbrido": False,
+}
+
+
+@ScraperRegistry.register(ATSType.ELEMPLEO)
+class ElempleoScraper(BaseScraper):
+    """elempleo.com — Colombian national job board.
+
+    Single-source: ``company_slug`` is ignored. Pass anything
+    (``"any"``, ``""``) — the scraper paginates the entire board.
+
+    Knobs:
+    - ``max_pages`` — optional pagination cap for bounded probes. A
+      production fetch defaults to a fail-closed 1500-page safety limit.
+    """
+
+    ats = ATSType.ELEMPLEO
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        include_descriptions: bool = True,
+        proxy: str | None = None,
+        max_pages: int | None = None,
+    ) -> None:
+        super().__init__(
+            company_slug,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        self._full_catalogue = max_pages is None
+        self.max_pages = min(max_pages or DEFAULT_MAX_PAGES, DEFAULT_MAX_PAGES)
+
+    async def afetch(self) -> list[Job]:
+        return await self._fetch_async()
+
+    def fetch(self) -> list[Job]:
+        return self._run_sync(self.afetch())
+
+    async def _fetch_async(self) -> list[Job]:
+        seen_ids: set[str] = set()
+        jobs: list[Job] = []
+
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True, proxy=self.proxy,
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+            # Pages out of range return HTTP 200 with zero job cards
+            # (rather than 404). Walk until we see two consecutive
+            # empty pages — a single empty page in the middle would
+            # otherwise be a brittle stop signal if the site ever
+            # ships a transient render glitch.
+            consecutive_empty = 0
+            page = 1
+            while page <= self.max_pages and consecutive_empty < 2:
+                page_jobs = await self._fetch_page(client, sem, page)
+                new_count = 0
+                for job in page_jobs:
+                    if job.ats_id in seen_ids:
+                        continue
+                    seen_ids.add(job.ats_id or "")
+                    jobs.append(job)
+                    new_count += 1
+                if new_count == 0:
+                    consecutive_empty += 1
+                else:
+                    consecutive_empty = 0
+                page += 1
+        if self._full_catalogue and not jobs:
+            raise ScraperError(
+                "elempleo full-catalogue scrape returned no parseable jobs"
+            )
+        if self._full_catalogue and consecutive_empty < 2:
+            raise ScraperError(
+                f"elempleo reached its {DEFAULT_MAX_PAGES}-page safety limit "
+                "before detecting the end of results"
+            )
+        return jobs
+
+    async def _fetch_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        page: int,
+    ) -> list[Job]:
+        url = f"{API_ROOT}/co/ofertas-empleo?Page={page}"
+        text = await self._request_html(client, sem, url)
+        jobs = list(self._parse_listing(text))
+        card_count = sum(1 for _ in _CARD_RE.finditer(text))
+        if len(jobs) != card_count:
+            raise ScraperError(
+                f"elempleo page={page} contained {card_count} job cards "
+                f"but parsed {len(jobs)}"
+            )
+        if card_count == 0 and not any(
+            marker in text for marker in _EMPTY_PAGE_MARKERS
+        ):
+            raise ScraperError(
+                f"elempleo page={page} lacked jobs and end-of-results markup"
+            )
+        return jobs
+
+    async def _request_html(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        url: str,
+    ) -> str:
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(
+                        url, headers={
+                            "User-Agent": (
+                                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                                "Chrome/120.0.0.0 Safari/537.36"
+                            ),
+                            "Accept": "text/html,*/*",
+                            "Accept-Language": "es-CO,es;q=0.9,en;q=0.5",
+                        },
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"elempleo fetch failed for {url}: {exc}"
+                        ) from exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if response.status_code == 200:
+                return response.text
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"elempleo returned {response.status_code} for "
+                        f"{url} after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"elempleo returned {response.status_code} for {url}"
+            )
+        raise ScraperError(
+            f"elempleo exhausted retries for {url}: {last_exc}"
+        )
+
+    def _parse_listing(self, text: str):
+        for match in _CARD_RE.finditer(text):
+            body = match.group("body")
+            job = self._parse_card(body)
+            if job is not None:
+                yield job
+
+    def _parse_card(self, body: str) -> Job | None:
+        # Prefer the explicit data-offer-id (anchored to the share
+        # button); fall back to the trailing-id slug of the detail
+        # URL if the share button isn't rendered for some variant.
+        id_match = _OFFER_ID_RE.search(body)
+        href_match = _DETAIL_HREF_RE.search(body)
+        if not href_match:
+            return None
+        ats_id = id_match.group("id") if id_match else href_match.group("id")
+        if not ats_id:
+            return None
+
+        title_match = _TITLE_RE.search(body)
+        if not title_match:
+            return None
+        title = html.unescape(title_match.group("t")).strip()
+        if not title:
+            return None
+
+        company_match = _COMPANY_RE.search(body)
+        company = (
+            html.unescape(company_match.group("v")).strip()
+            if company_match else "Confidencial"
+        )
+
+        # Labelled fields — walk the (value, label) pairs once.
+        salary_raw: str | None = None
+        contract_raw: str | None = None
+        modality_raw: str | None = None
+        for pair in _LABELLED_VALUE_RE.finditer(body):
+            value = html.unescape(pair.group("v")).strip()
+            label = pair.group("label").strip().lower()
+            if value.startswith("{{") or not value:
+                continue
+            if label.startswith("salario") and salary_raw is None:
+                salary_raw = value
+            elif label.startswith("tipo de contrato") and contract_raw is None:
+                contract_raw = value
+            elif label.startswith("modalidad laboral") and modality_raw is None:
+                modality_raw = value
+
+        # City — js-offer-city span; some postings (remote, multi-city)
+        # leave it blank. Fall back to ``Colombia`` only when truly
+        # absent so country_iso stays accurate.
+        city_match = _CITY_RE.search(body)
+        city = (
+            html.unescape(city_match.group("v")).strip()
+            if city_match else ""
+        )
+        location = (
+            f"{city}, Colombia" if city else "Colombia"
+        )
+
+        # Modality drives is_remote — listing exposes this directly
+        # rather than via the JSON-LD ``jobLocationType`` flag.
+        is_remote: bool | None = None
+        if modality_raw:
+            is_remote = _MODALITY_REMOTE.get(
+                _strip_accents(modality_raw).lower()
+            )
+
+        # Contract type → normalized employment_type + verbatim commitment.
+        employment_type: str | None = None
+        commitment: str | None = None
+        if contract_raw:
+            commitment = contract_raw
+            key = _strip_accents(contract_raw).lower()
+            employment_type = _EMPLOYMENT_MAP.get(key)
+
+        # Salary — ``$X a $Y millones`` → COP/month range; confidential
+        # and unparseable placeholders remain available only in raw.
+        salary_min, salary_max, salary_currency, salary_period = (
+            _parse_salary(salary_raw)
+        )
+
+        # Posted date — listing uses relative Colombian labels. Ignore
+        # unresolved Mustache placeholders rather than inventing a date.
+        posted_at = None
+        date_match = _DATE_RE.search(body)
+        if date_match:
+            label = html.unescape(date_match.group("v")).strip()
+            posted_at = _parse_relative_date(label)
+
+        # Description — pulled from the share modal's data attribute
+        # so listings already carry the body. Keep this defensive:
+        # the attribute is HTML-escaped and may contain entities.
+        description = None
+        desc_match = _DESCRIPTION_RE.search(body)
+        if desc_match:
+            description = _normalize_description(desc_match.group("v"))
+
+        raw: dict[str, Any] = {}
+        if salary_raw:
+            raw["salary_text"] = salary_raw
+        if modality_raw:
+            raw["modality"] = modality_raw
+        if contract_raw:
+            raw["contract_type"] = contract_raw
+
+        return Job(
+            url=f"{API_ROOT}{href_match.group('href')}",
+            title=title,
+            company=company,
+            ats_type=ATSType.ELEMPLEO,
+            ats_id=ats_id,
+            location=location,
+            country_iso="CO",
+            region="South America",
+            is_remote=is_remote,
+            salary_currency=salary_currency,
+            salary_period=salary_period,
+            salary_summary=salary_raw if salary_currency else None,
+            salary_min=salary_min,
+            salary_max=salary_max,
+            employment_type=employment_type,
+            commitment=commitment,
+            description=description if self.include_descriptions else None,
+            posted_at=posted_at,
+            fetched_at=datetime.now(tz=UTC),
+            language="es",
+            raw=raw or None,
+        )
+
+
+# --- module-level helpers ---------------------------------------------------
+
+
+_ACCENT_RE = re.compile(r"[áéíóúñÁÉÍÓÚÑ]")
+_ACCENT_MAP = str.maketrans(
+    "áéíóúñÁÉÍÓÚÑ",
+    "aeiounAEIOUN",
+)
+
+
+def _strip_accents(text: str) -> str:
+    """ASCII-fold for case-insensitive lookups against the
+    ``_EMPLOYMENT_MAP`` / ``_MODALITY_REMOTE`` keys (which are stored
+    accent-free for stability — the live HTML may render ``Híbrido``
+    with or without the accent depending on encoding)."""
+    if not text:
+        return ""
+    return text.translate(_ACCENT_MAP)
+
+
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _normalize_description(raw: str) -> str | None:
+    """Decode HTML entities, drop residual tags, collapse whitespace,
+    truncate to the schema's ~10kB budget."""
+    if not raw:
+        return None
+    decoded = html.unescape(raw)
+    cleaned = _TAG_RE.sub(" ", decoded)
+    cleaned = re.sub(r"[\r\n]+", "\n", cleaned)
+    cleaned = re.sub(r"[ \t]+", " ", cleaned).strip()
+    return cleaned[:10_000] or None
+
+
+def _parse_relative_date(
+    label: str,
+    *,
+    now: datetime | None = None,
+) -> datetime | None:
+    """Parse elempleo relative labels at midnight in Colombia."""
+    normalized = _strip_accents(label).strip().lower()
+    if normalized == "hoy":
+        days_ago = 0
+    elif normalized == "ayer":
+        days_ago = 1
+    else:
+        match = _RELATIVE_DATE_RE.fullmatch(normalized)
+        if not match:
+            return None
+        days_ago = int(match.group("days"))
+    local_now = (now or datetime.now(tz=_BOGOTA_TZ)).astimezone(_BOGOTA_TZ)
+    return (
+        local_now.replace(hour=0, minute=0, second=0, microsecond=0)
+        - timedelta(days=days_ago)
+    ).astimezone(UTC)
+
+
+# ``$1,5 a $2 millones`` — Colombian salary shorthand. Comma is the
+# decimal separator (``1,5`` = 1.5), and ``millones`` is the implicit
+# ×1,000,000 COP multiplier. Listings only ever display ranges (or
+# the literal ``Salario confidencial``); pre-defined buckets cap at
+# ``$15 millones`` and floor at ``$1 millón``.
+_SALARY_RANGE_RE = re.compile(
+    r"\$\s*(?P<min>[\d.,]+)\s*a\s*\$\s*(?P<max>[\d.,]+)\s*"
+    r"(?P<unit>mill[oó]n(?:es)?|mil)",
+    re.IGNORECASE,
+)
+_SALARY_SINGLE_RE = re.compile(
+    r"\$\s*(?P<v>[\d.,]+)\s*(?P<unit>mill[oó]n(?:es)?|mil)",
+    re.IGNORECASE,
+)
+
+
+def _parse_salary(
+    raw: str | None,
+) -> tuple[float | None, float | None, str | None, str | None]:
+    """elempleo salary strings → ``(min, max, currency, period)``.
+
+    - ``$1,5 a $2 millones`` → ``(1_500_000, 2_000_000, "COP", "MONTH")``
+    - ``$10 millones``        → ``(10_000_000, 10_000_000, "COP", "MONTH")``
+      (single-value, rare on listings)
+    - ``Salario confidencial`` → ``(None, None, None, None)``
+    - ``""`` / ``None``        → ``(None, None, None, None)``
+    """
+    if not raw:
+        return None, None, None, None
+    text = raw.strip()
+    range_match = _SALARY_RANGE_RE.search(text)
+    if range_match:
+        unit = range_match.group("unit").lower()
+        multiplier = 1_000_000 if _strip_accents(unit).startswith("millon") else 1_000
+        lo = _parse_co_number(range_match.group("min"))
+        hi = _parse_co_number(range_match.group("max"))
+        if lo is None or hi is None:
+            return None, None, None, None
+        return lo * multiplier, hi * multiplier, "COP", "MONTH"
+    single_match = _SALARY_SINGLE_RE.search(text)
+    if single_match:
+        unit = single_match.group("unit").lower()
+        multiplier = 1_000_000 if _strip_accents(unit).startswith("millon") else 1_000
+        value = _parse_co_number(single_match.group("v"))
+        if value is None:
+            return None, None, None, None
+        amount = value * multiplier
+        return amount, amount, "COP", "MONTH"
+    return None, None, None, None
+
+
+def _parse_co_number(raw: str) -> float | None:
+    """``1,5`` → 1.5; ``12,5`` → 12.5; ``2`` → 2.0.
+
+    elempleo uses the European convention (comma decimal, dot
+    thousand) — but the listing buckets never have thousands so this
+    is mostly a comma-swap.
+    """
+    if not raw:
+        return None
+    cleaned = raw.strip()
+    # Defensive: if both . and , are present, dots are thousands.
+    if "." in cleaned and "," in cleaned:
+        cleaned = cleaned.replace(".", "").replace(",", ".")
+    else:
+        cleaned = cleaned.replace(",", ".")
+    try:
+        value = float(cleaned)
+    except ValueError:
+        return None
+    return value if value > 0 else None

--- a/src/ats_scrapers/scrapers/infojobs_br.py
+++ b/src/ats_scrapers/scrapers/infojobs_br.py
@@ -1,0 +1,587 @@
+"""InfoJobs Brasil (https://www.infojobs.com.br) — Brazilian job board scraper.
+
+InfoJobs Brasil is one of the largest general-purpose job boards in
+Brazil (60k+ active postings at any given time). Companies post
+directly to InfoJobs; the site is not aggregated from LinkedIn or
+Indeed. The listing pages are ASP.NET server-rendered HTML with
+stable ``data-id`` attributes on each card. Detail URLs are slugged
+with the numeric id in a trailing ``__{id}.aspx`` suffix:
+
+    /vaga-de-promotor-vendas-em-sao-paulo__11608342.aspx
+
+Pagination uses an AJAX JSON endpoint behind an infinite-scroll
+mechanic — the browser hits
+
+    /mf-publicarea/VacancyList/GetVacancyListFragment?url={encoded}
+
+with ``{encoded}`` being a URL-encoded listing URL that carries a
+``page=N`` query parameter. The response is JSON with an ``eof``
+boolean and a ``listFragmentHTML`` string containing the same card
+markup as the SSR page. We use this endpoint exclusively (rather
+than the SSR variant) because:
+
+  - The SSR page is heavy (~245kB, full chrome each page) and the
+    fragment is ~95kB (just the cards).
+  - The SSR page geo-defaults to São Paulo when called from a
+    non-Brazilian IP, while the fragment URL we pass is honored
+    verbatim.
+
+Each card carries enough fields that we don't need per-job detail
+fetches:
+
+  - data-id="11608342"            → ats_id
+  - data-href="/vaga-de-X__N.aspx" → url
+  - <h2 class="...js_vacancyTitle"> → title
+  - <a href="https://.../company"> → company
+  - "São Paulo - SP" (free text)    → location
+  - js_date data-value="YYYY/MM/DD HH:MM:SS" → posted_at
+  - icon-money + "R$ X,XX a R$ Y,YY" → salary
+  - icon-buildings / icon-house-and-building → modality
+  - text-medium block at bottom → description teaser
+
+Single-source scraper: ``company_slug`` is informational and ignored.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import re
+import urllib.parse
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo
+
+import httpx
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+API_ROOT = "https://www.infojobs.com.br"
+FRAGMENT_PATH = "/mf-publicarea/VacancyList/GetVacancyListFragment"
+# Default listing URL — country-wide, no filters. The fragment endpoint
+# honors the ``page=N`` query string verbatim, unlike the SSR page which
+# geolocates the request.
+DEFAULT_LISTING_URL = f"{API_ROOT}/vagas-de-emprego.aspx"
+DEFAULT_MAX_PAGES = 5_000  # ~20 cards/page → safety ceiling near 100k jobs
+# InfoJobs is friendly but we keep concurrency low to be a polite citizen.
+MAX_CONCURRENCY = 2
+MAX_RETRIES = 4
+RETRY_BASE_DELAY = 2.0
+
+# Card delimiter — every result card opens with this exact attribute set.
+_CARD_START_RE = re.compile(
+    r'<div data-typesimilar="" class="card[^"]*">\s*'
+    r'<div id="vacancy(?P<id>\d+)"[^>]*data-id="(?P=id)"[^>]*'
+    r'data-href="(?P<href>/vaga[^"]+)"',
+)
+# Card body extractors (run scoped per card).
+_TITLE_RE = re.compile(
+    r'<h2[^>]*js_vacancyTitle[^>]*>\s*(?P<t>.*?)\s*</h2>', re.DOTALL,
+)
+_DATE_RE = re.compile(r'class="js_date" data-value="(?P<v>[^"]+)"')
+_COMPANY_LINK_RE = re.compile(
+    r'<a class="text-body[^"]*"\s+href="(?P<href>https://www\.infojobs\.com\.br/[^"]+)"[^>]*>'
+    r'(?P<name>.*?)</a>',
+    re.DOTALL,
+)
+_LOCATION_RE = re.compile(
+    r'<div class="mb-8">\s*(?P<loc>[^<]+?)\s*(?:<|$)',
+    re.DOTALL,
+)
+# Per-icon metadata blocks: <svg class="icon icon-NAME ..."><use .../></svg> TEXT
+_ICON_BLOCK_RE = re.compile(
+    r'icon icon-(?P<icon>[a-z-]+)\s[^"]*"\s*>\s*<use[^/]+/>\s*</svg>'
+    r'\s*(?P<v>[^<]*)',
+)
+# Description teaser — the last <div class="text-medium"> in the card.
+_DESCRIPTION_RE = re.compile(
+    r'<div class="text-medium">\s*(?P<v>.*?)\s*</div>', re.DOTALL,
+)
+
+# Modality (working method) → ``is_remote`` + raw label.
+_MODALITY_LABELS = {
+    "buildings": "Presencial",
+    "house-and-building": "Híbrido",
+    "house": "Home Office",
+}
+
+# Brazilian employment-type label → canonical EmploymentType enum. These
+# labels appear on detail pages and occasionally in the card teaser; we
+# keep the map module-level so future detail-page scraping can reuse it.
+_EMPLOYMENT_MAP: dict[str, str] = {
+    "efetivo": "FULL_TIME",
+    "clt": "FULL_TIME",
+    "temporário": "TEMPORARY",
+    "temporario": "TEMPORARY",
+    "estagiário": "INTERN",
+    "estagiario": "INTERN",
+    "estágio": "INTERN",
+    "estagio": "INTERN",
+    "trainee": "FULL_TIME",
+    "aprendiz": "INTERN",
+    "freelancer": "CONTRACT",
+    "freelance": "CONTRACT",
+    "autônomo": "CONTRACT",
+    "autonomo": "CONTRACT",
+    "pj": "CONTRACT",
+    "cooperado": "CONTRACT",
+}
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"\s+")
+_BRL_AMOUNT_RE = re.compile(r"R\$\s*([\d.,]+)")
+
+
+@ScraperRegistry.register(ATSType.INFOJOBSBR)
+class InfoJobsBrasilScraper(BaseScraper):
+    """InfoJobs Brasil (infojobs.com.br) — Brazilian general-purpose jobs.
+
+    Single-source: ``company_slug`` is ignored. Pass anything (``"any"``,
+    ``""``, ``"brasil"``) — the scraper paginates the entire jobs board.
+
+    Knobs:
+
+    - ``max_pages`` — optional pagination cap for bounded probes;
+      production walks to ``eof`` and fails loudly at the 5,000-page
+      safety limit.
+    - ``listing_url`` — override the base listing URL when you want to
+      restrict to a city / category. The page=N parameter is appended
+      by the scraper; don't include it in the override.
+    """
+
+    ats = ATSType.INFOJOBSBR
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        include_descriptions: bool = True,
+        proxy: str | None = None,
+        max_pages: int | None = None,
+        listing_url: str = DEFAULT_LISTING_URL,
+    ) -> None:
+        super().__init__(
+            company_slug,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        if max_pages is not None and max_pages < 1:
+            raise ScraperError(
+                f"InfoJobs Brasil max_pages must be positive, got {max_pages}"
+            )
+        self._full_catalogue = max_pages is None
+        self.max_pages = min(max_pages or DEFAULT_MAX_PAGES, DEFAULT_MAX_PAGES)
+        self.listing_url = listing_url
+
+    async def afetch(self) -> list[Job]:
+        return await self._fetch_async()
+
+    def fetch(self) -> list[Job]:
+        return self._run_sync(self.afetch())
+
+    async def _fetch_async(self) -> list[Job]:
+        seen_ids: set[str] = set()
+        jobs: list[Job] = []
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True, proxy=self.proxy,
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+            consecutive_empty = 0
+            exhausted = False
+
+            def absorb(payload: dict[str, Any]) -> tuple[bool, int]:
+                fragment = payload.get("listFragmentHTML") or ""
+                new_count = 0
+                for job in self._parse_listing(fragment):
+                    if job.ats_id in seen_ids:
+                        continue
+                    seen_ids.add(job.ats_id)
+                    jobs.append(job)
+                    new_count += 1
+                return bool(payload.get("eof")), new_count
+
+            first = await self._fetch_page(client, sem, 1)
+            exhausted, first_count = absorb(first)
+            if first_count == 0 and not exhausted:
+                consecutive_empty = 1
+
+            reached_tail = exhausted
+            for start in range(2, self.max_pages + 1, MAX_CONCURRENCY):
+                if reached_tail:
+                    break
+                pages = range(start, min(start + MAX_CONCURRENCY, self.max_pages + 1))
+                results = await asyncio.gather(
+                    *(self._fetch_page(client, sem, page) for page in pages),
+                    return_exceptions=True,
+                )
+                for result in results:
+                    if isinstance(result, BaseException):
+                        raise result
+                    payload = result
+                    eof, new_count = absorb(payload)
+                    if eof:
+                        exhausted = True
+                        reached_tail = True
+                        break
+                    if new_count == 0:
+                        consecutive_empty += 1
+                    else:
+                        consecutive_empty = 0
+                    if consecutive_empty >= 3:
+                        if self._full_catalogue:
+                            raise ScraperError(
+                                "InfoJobs Brasil returned repeated empty pages "
+                                "before eof"
+                            )
+                        reached_tail = True
+                        break
+                if reached_tail:
+                    break
+        if self._full_catalogue and not exhausted:
+            raise ScraperError(
+                f"InfoJobs Brasil reached its {DEFAULT_MAX_PAGES}-page safety "
+                "limit before detecting the end of results"
+            )
+        return jobs
+
+    async def _fetch_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        page: int,
+    ) -> dict[str, Any]:
+        # Append/overwrite ``page=N`` on the base listing URL. The
+        # backend reads the param from the URL we pass in, not from the
+        # request URL itself.
+        listing = _set_query_param(self.listing_url, "page", str(page))
+        encoded = urllib.parse.quote(listing, safe="")
+        url = f"{API_ROOT}{FRAGMENT_PATH}?url={encoded}"
+        return await self._request_json(client, sem, url)
+
+    async def _request_json(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        url: str,
+    ) -> dict[str, Any]:
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    response = await client.get(
+                        url, headers={
+                            "User-Agent": (
+                                "Mozilla/5.0 (X11; Linux x86_64) "
+                                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                                "Chrome/124.0.0.0 Safari/537.36"
+                            ),
+                            "Accept": "application/json, text/html;q=0.9",
+                            "Accept-Language": "pt-BR,pt;q=0.9,en;q=0.8",
+                        },
+                    )
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    if attempt == MAX_RETRIES:
+                        raise ScraperError(
+                            f"InfoJobs Brasil fetch failed for {url}: {exc}"
+                        ) from exc
+                    response = None
+            if response is None:
+                # Transport error — back off outside the semaphore so we
+                # don't hold a concurrency slot while sleeping.
+                await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                continue
+            if response.status_code == 200:
+                try:
+                    return response.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"InfoJobs Brasil returned non-JSON for {url}: {exc}"
+                    ) from exc
+            if response.status_code in (429,) or 500 <= response.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"InfoJobs Brasil returned {response.status_code} for "
+                        f"{url} after {MAX_RETRIES} retries"
+                    )
+                retry_after = response.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"InfoJobs Brasil returned {response.status_code} for {url}"
+            )
+        raise ScraperError(
+            f"InfoJobs Brasil exhausted retries for {url}: {last_exc}"
+        )
+
+    def _parse_listing(self, fragment: str):
+        # Split per card on the start marker — every card is bounded by
+        # the next ``<div data-typesimilar=""`` or end of fragment.
+        starts = list(_CARD_START_RE.finditer(fragment))
+        for i, m in enumerate(starts):
+            start = m.start()
+            end = starts[i + 1].start() if i + 1 < len(starts) else len(fragment)
+            body = fragment[start:end]
+            job = self._parse_card(
+                ats_id=m.group("id"), href=m.group("href"), body=body,
+            )
+            if job is not None:
+                yield job
+
+    def _parse_card(self, *, ats_id: str, href: str, body: str) -> Job | None:
+        title_match = _TITLE_RE.search(body)
+        if not title_match:
+            return None
+        title = _strip_html(title_match.group("t"))
+        if not title:
+            return None
+
+        # Company: linked employer name, else "Empresa confidencial".
+        company = "Empresa confidencial"
+        link_match = _COMPANY_LINK_RE.search(body)
+        if link_match:
+            cand = _strip_html(link_match.group("name"))
+            # Strip trailing "verified" tooltip text the link sometimes
+            # wraps inline (e.g. "SODEXO Este selo indica…"). The badge
+            # tooltip leaks through entity decoding; keep only the first
+            # line / cap to a sane length.
+            cand = cand.split("Este selo indica")[0].strip()
+            if cand:
+                company = cand
+
+        # Location lives in <div class="mb-8">Cidade - UF<…> when present.
+        # "Home office" sometimes leaks in here too — keep it; downstream
+        # ``_infer_remote`` reads the value to decide ``is_remote``.
+        location = None
+        loc_match = _LOCATION_RE.search(body)
+        if loc_match:
+            raw_loc = _strip_html(loc_match.group("loc"))
+            if raw_loc:
+                location = raw_loc
+
+        # Metadata icons: money / suitcase / graduate-hat / buildings /
+        # house-and-building. We only key on the ones that map to schema
+        # fields; the rest go into ``raw``.
+        icon_values: dict[str, str] = {}
+        for m in _ICON_BLOCK_RE.finditer(body):
+            v = _strip_html(m.group("v"))
+            if v and m.group("icon") not in icon_values:
+                icon_values[m.group("icon")] = v
+
+        salary_raw = icon_values.get("money")
+        salary_min, salary_max, salary_currency, salary_summary = _parse_salary(
+            salary_raw
+        )
+
+        # Modality / remote inference. icon-house-and-building =
+        # Híbrido, icon-buildings = Presencial. "Remoto" / "Home
+        # office" can appear on either the buildings text or the
+        # location string.
+        modality_raw = None
+        for icon, label in _MODALITY_LABELS.items():
+            if icon in icon_values:
+                modality_raw = icon_values[icon] or label
+                break
+        is_remote = _infer_remote(modality_raw, location)
+
+        # Employment type: rarely surfaced on the card (lives on
+        # the detail page) but mapped defensively when it is.
+        commitment_raw = None
+        for k in ("file", "file-alt", "document", "suitcase"):
+            if k in icon_values and any(
+                t in icon_values[k].lower() for t in _EMPLOYMENT_MAP
+            ):
+                commitment_raw = icon_values[k]
+                break
+        employment_type = (
+            _match_employment_type(commitment_raw) if commitment_raw else None
+        )
+
+        # Description teaser — the last text-medium block in the card.
+        # Multiple may match; take the longest, which is always the
+        # description rather than the date/rating snippets.
+        description = None
+        desc_candidates = [
+            _strip_html(m.group("v"))
+            for m in _DESCRIPTION_RE.finditer(body)
+        ]
+        desc_candidates = [d for d in desc_candidates if d]
+        if desc_candidates:
+            description = max(desc_candidates, key=len)
+
+        # posted_at: structured datetime in the hidden js_date block.
+        posted_at = None
+        date_match = _DATE_RE.search(body)
+        if date_match:
+            posted_at = _parse_brazilian_date(date_match.group("v"))
+
+        raw: dict[str, Any] = {}
+        if "graduate-hat" in icon_values:
+            raw["education"] = icon_values["graduate-hat"]
+        if "suitcase" in icon_values:
+            raw["experience_label"] = icon_values["suitcase"]
+        if modality_raw:
+            raw["modality"] = modality_raw
+        if salary_raw and salary_raw != salary_summary:
+            raw["salary_raw"] = salary_raw
+
+        url = href if href.startswith("http") else f"{API_ROOT}{href}"
+
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.INFOJOBSBR,
+            ats_id=ats_id,
+            location=location,
+            country_iso="BR",
+            region="South America",
+            is_remote=is_remote,
+            salary_currency=salary_currency,
+            salary_period="MONTH" if salary_currency else None,
+            salary_summary=salary_summary,
+            salary_min=salary_min,
+            salary_max=salary_max,
+            employment_type=employment_type,  # type: ignore[arg-type]
+            commitment=commitment_raw,
+            description=description if self.include_descriptions else None,
+            posted_at=posted_at,
+            fetched_at=datetime.now(tz=UTC),
+            language="pt",
+            raw=raw or None,
+        )
+
+
+# --- module-level helpers ---------------------------------------------------
+
+
+def _strip_html(text: str) -> str:
+    if not text:
+        return ""
+    cleaned = _TAG_RE.sub(" ", text)
+    cleaned = html.unescape(cleaned)
+    return _WS_RE.sub(" ", cleaned).strip()
+
+
+def _match_employment_type(raw: str) -> str | None:
+    """Map a (possibly composite) Brazilian employment label to a
+    canonical ``EmploymentType``. Labels are frequently composite
+    (e.g. ``"Efetivo CLT"``, ``"Estágio / Trainee"``) so we match the
+    map keys as tokens/substrings rather than requiring an exact hit.
+    The first matching key (in map insertion order) wins."""
+    lowered = raw.lower()
+    for key, value in _EMPLOYMENT_MAP.items():
+        if key in lowered:
+            return value
+    return None
+
+
+def _set_query_param(url: str, key: str, value: str) -> str:
+    """Return ``url`` with ``key=value`` set in the query string,
+    overwriting any existing value. Preserves order of other params."""
+    parsed = urllib.parse.urlparse(url)
+    params = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+    params = [(k, v) for k, v in params if k != key]
+    params.append((key, value))
+    return urllib.parse.urlunparse(parsed._replace(query=urllib.parse.urlencode(params)))
+
+
+def _parse_brl_amount(raw: str) -> float | None:
+    """``R$ 3.000`` → 3000.0; ``R$ 3.500,50`` → 3500.50.
+
+    Brazilian currency uses ``.`` as the thousand separator and ``,``
+    as the decimal point, opposite to en-US conventions.
+    """
+    if not raw:
+        return None
+    cleaned = raw.replace(".", "").replace(",", ".")
+    try:
+        value = float(cleaned)
+    except ValueError:
+        return None
+    return value if value > 0 else None
+
+
+def _parse_salary(
+    raw: str | None,
+) -> tuple[float | None, float | None, str | None, str | None]:
+    """InfoJobs salary strings:
+
+    - ``"A combinar"``                       → no signal
+    - ``"R$ 1.700,00 a R$ 2.000,00"``        → min=1700, max=2000, BRL
+    - ``"Até R$ 5.000,00"``                  → max only
+    - ``"A partir de R$ 8.000,00"``          → min only
+    - empty / None                            → no signal
+
+    Returns ``(min, max, currency, summary)``. ``summary`` is the
+    original string with whitespace normalized so the public schema
+    has a verbatim form of what users see; it's ``None`` when no
+    numeric amount was extractable (e.g. "A combinar").
+    """
+    if not raw:
+        return None, None, None, None
+    normalized = _WS_RE.sub(" ", raw).strip()
+    nums = _BRL_AMOUNT_RE.findall(normalized)
+    if not nums:
+        return None, None, None, None
+    parsed = [_parse_brl_amount(n) for n in nums]
+    parsed = [p for p in parsed if p is not None]
+    if not parsed:
+        return None, None, None, None
+    lower = normalized.lower()
+    if len(parsed) == 1:
+        if "até" in lower or "ate" in lower:
+            return None, parsed[0], "BRL", normalized
+        if "partir" in lower or "a partir" in lower:
+            return parsed[0], None, "BRL", normalized
+        return parsed[0], parsed[0], "BRL", normalized
+    return parsed[0], parsed[-1], "BRL", normalized
+
+
+def _infer_remote(modality_raw: str | None, location: str | None) -> bool | None:
+    """Combine the modality label and location text to infer remote.
+
+    Returns ``True`` when either signal explicitly states remote; the
+    canonical ``is_remote`` field accepts both ``True`` and ``False``
+    here because the modality icon is structured (i.e. absence really
+    is evidence of on-site, unlike the title-only heuristic).
+    """
+    sources = [s.lower() for s in (modality_raw, location) if s]
+    if not sources:
+        return None
+    blob = " ".join(sources)
+    if "home office" in blob or "remoto" in blob or "remote" in blob:
+        return True
+    if "híbrido" in blob or "hibrido" in blob or "hybrid" in blob:
+        return False
+    if "presencial" in blob or "on-site" in blob:
+        return False
+    return None
+
+
+def _parse_brazilian_date(raw: str) -> datetime | None:
+    """``js_date`` carries an exact ``YYYY/MM/DD HH:MM:SS`` value —
+    the human-readable "Hoje" / "Ontem" / "Há 3 dias" labels are
+    derived from this so we just parse the structured form."""
+    if not raw:
+        return None
+    raw = raw.strip()
+    for fmt in ("%Y/%m/%d %H:%M:%S", "%Y/%m/%d %H:%M", "%Y/%m/%d", "%d/%m/%Y"):
+        try:
+            return datetime.strptime(raw, fmt).replace(
+                tzinfo=ZoneInfo("America/Sao_Paulo"),
+            ).astimezone(UTC)
+        except ValueError:
+            continue
+    return None

--- a/tests/e2e/test_live_jobboards_latam.py
+++ b/tests/e2e/test_live_jobboards_latam.py
@@ -1,0 +1,56 @@
+"""Live smoke tests for credential-free Latin American job boards."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Callable
+from urllib.parse import urlparse
+
+import pytest
+
+from ats_scrapers.models import Job
+from ats_scrapers.scrapers import (
+    BumeranScraper,
+    ElempleoScraper,
+    InfoJobsBrasilScraper,
+)
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.skipif(
+        not os.getenv("ATS_SCRAPERS_LIVE_E2E"),
+        reason="set ATS_SCRAPERS_LIVE_E2E=1 to hit real job-board endpoints",
+    ),
+]
+
+CASES: list[tuple[str, Callable[[], object], str]] = [
+    ("bumeran-ar", lambda: BumeranScraper("ar", max_pages=1), "bumeran.com.ar"),
+    ("elempleo", lambda: ElempleoScraper("elempleo", max_pages=1), "elempleo.com"),
+    (
+        "infojobs-br",
+        lambda: InfoJobsBrasilScraper("infojobs_br", max_pages=1),
+        "infojobs.com.br",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("factory", "expected_domain"),
+    [pytest.param(factory, domain, id=name) for name, factory, domain in CASES],
+)
+async def test_live_jobboard_smoke(
+    factory: Callable[[], object], expected_domain: str
+) -> None:
+    async with asyncio.timeout(180):
+        jobs = await factory().afetch()
+    assert jobs
+    sample: list[Job] = jobs[:50]
+    assert len({job.global_id for job in sample}) == len(sample)
+    for job in sample:
+        assert job.title.strip()
+        assert job.company.strip()
+        assert job.ats_id
+        host = (urlparse(str(job.url)).hostname or "").lower()
+        assert expected_domain in host
+        assert not host.endswith((".local", ".internal"))

--- a/tests/test_bumeran.py
+++ b/tests/test_bumeran.py
@@ -650,7 +650,7 @@ def test_search_page_rejects_404_in_reported_page_range() -> None:
         BumeranScraper("ar")._search_page(FakeSession(), 1)
 
 
-def test_httpcloak_timeout_is_converted_to_milliseconds(monkeypatch) -> None:
+def test_httpcloak_timeout_remains_in_seconds(monkeypatch) -> None:
     import sys
     from types import SimpleNamespace
 
@@ -679,7 +679,7 @@ def test_httpcloak_timeout_is_converted_to_milliseconds(monkeypatch) -> None:
     opened = scraper._open_session()
     scraper._search_page(opened, 0)
 
-    assert timeouts == [12_500, 12_500]
+    assert timeouts == [12.5, 12.5]
 
 
 def test_search_page_rejects_non_object_json() -> None:

--- a/tests/test_bumeran.py
+++ b/tests/test_bumeran.py
@@ -1,0 +1,696 @@
+"""Tests for the Bumeran / Navent (LATAM) scraper.
+
+Bumeran sits behind Cloudflare and so uses ``httpcloak`` for transport
+instead of ``httpx``. ``httpx_mock`` doesn't intercept httpcloak, so the
+test suite stubs the two seams the scraper exposes:
+
+- ``BumeranScraper._open_session`` — returns a sentinel "session"
+- ``BumeranScraper._search_page`` — returns a canned API payload
+
+Both are thin wrappers around the blocking httpcloak path, so faking
+them lets us exercise pagination, multi-region wiring, and field
+mapping without ever hitting the network.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from ats_scrapers.exceptions import CompanyNotFoundError, ScraperError
+from ats_scrapers.models import ATSType
+from ats_scrapers.scrapers import BumeranScraper, ScraperRegistry
+from ats_scrapers.scrapers.bumeran import (
+    DEFAULT_MAX_PAGES,
+    PAGE_SIZE,
+    REGIONS,
+    _clean_description,
+    _parse_datetime,
+)
+
+# --- fixtures ---------------------------------------------------------------
+
+
+def _aviso(
+    *,
+    job_id: int = 1,
+    titulo: str = "Analista de Datos",
+    empresa: str = "Acme S.A.",
+    localizacion: str = "Buenos Aires, Argentina",
+    tipo_trabajo: str = "Full-time",
+    modalidad: str = "Presencial",
+    fecha: str = "11-05-2026 23:43:58",
+    detalle: str = "Buscamos analista de datos con experiencia en SQL.",
+    confidencial: bool = False,
+    id_area: int = 23,
+    id_subarea: int = 2569,
+    id_empresa: int = 13480073,
+    portal: str = "bumeran",
+    cantidad_vacantes: int = 1,
+) -> dict[str, Any]:
+    """Build a single ``content[i]`` entry matching the live searchV2 shape."""
+    return {
+        "id": job_id,
+        "titulo": titulo,
+        "detalle": detalle,
+        "aptoDiscapacitado": False,
+        "idEmpresa": id_empresa,
+        "empresa": empresa,
+        "confidencial": confidencial,
+        "logoURL": None,
+        "validada": None,
+        "empresaPro": False,
+        "fechaHoraPublicacion": fecha,
+        "fechaPublicacion": fecha.split(" ")[0] if " " in fecha else fecha,
+        "fechaModificado": fecha,
+        "planPublicacion": {"id": 1020, "nombre": "Aviso Talento"},
+        "portal": portal,
+        "tipoTrabajo": tipo_trabajo,
+        "idPais": 1,
+        "idArea": id_area,
+        "idSubarea": id_subarea,
+        "leido": None,
+        "visitadoPorPostulante": None,
+        "localizacion": localizacion,
+        "cantidadVacantes": cantidad_vacantes,
+        "guardado": None,
+        "gptwUrl": None,
+        "promedioEmpresa": None,
+        "modalidadTrabajo": modalidad,
+        "tienePreguntas": False,
+        "salarioObligatorio": False,
+        "altaRevisionPerfiles": False,
+        "postulacionRapida": True,
+        "tipoAviso": "talento",
+    }
+
+
+def _page_response(
+    items: list[dict[str, Any]],
+    *,
+    page: int = 0,
+    total: int | None = None,
+    size: int | None = None,
+) -> dict[str, Any]:
+    """Build a full searchV2 envelope around the provided ``content`` items."""
+    return {
+        "number": page,
+        "size": size if size is not None else len(items),
+        "total": total if total is not None else len(items),
+        "content": items,
+        "filters": [],
+        "filtersApplied": [],
+        "totalSearched": total if total is not None else len(items),
+        "homeList": None,
+    }
+
+
+@pytest.fixture
+def patched_scraper(monkeypatch: pytest.MonkeyPatch):
+    """Return a factory that builds a ``BumeranScraper`` with the
+    network seams (``_open_session`` / ``_search_page``) stubbed to a
+    page-indexed payload map. Any page index not in the map yields an
+    empty page (mirrors how the live API responds past the last page).
+    """
+
+    def _factory(
+        company_slug: str = "ar",
+        *,
+        pages: dict[int, dict[str, Any]] | None = None,
+        max_pages: int | None = None,
+    ) -> BumeranScraper:
+        pages = pages or {}
+        # Always make httpcloak look installed so .fetch() doesn't
+        # short-circuit to []. The Session itself is never used because
+        # ``_search_page`` is also stubbed.
+        monkeypatch.setattr(
+            "ats_scrapers.scrapers.bumeran.find_spec", lambda _name: object(),
+        )
+        scraper = BumeranScraper(company_slug, max_pages=max_pages)
+        monkeypatch.setattr(
+            scraper, "_open_session", lambda: object(),
+        )
+
+        def fake_search(_session: Any, page: int) -> dict[str, Any]:
+            return pages.get(page, _page_response([], page=page, total=0, size=0))
+
+        monkeypatch.setattr(scraper, "_search_page", fake_search)
+        return scraper
+
+    return _factory
+
+
+# --- registry / wiring ------------------------------------------------------
+
+
+def test_registry_resolves_bumeran() -> None:
+    assert ScraperRegistry.get(ATSType.BUMERAN) is BumeranScraper
+
+
+def test_fetch_closes_transport_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Session:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    session = Session()
+    monkeypatch.setattr(
+        "ats_scrapers.scrapers.bumeran.find_spec", lambda _name: object(),
+    )
+    scraper = BumeranScraper("ar")
+    monkeypatch.setattr(scraper, "_open_session", lambda: session)
+    monkeypatch.setattr(
+        scraper,
+        "_search_page",
+        lambda _session, page: _page_response([], page=page),
+    )
+
+    assert scraper.fetch() == []
+    assert session.closed is True
+
+
+def test_unknown_region_raises_company_not_found() -> None:
+    with pytest.raises(CompanyNotFoundError):
+        BumeranScraper("mx")  # MX isn't in the LATAM Navent footprint
+
+
+def test_common_options_and_client_kind_are_accepted() -> None:
+    scraper = BumeranScraper(
+        "ar",
+        include_descriptions=False,
+        proxy="http://proxy.example:8080",
+        client_kind="httpx",
+    )
+    assert scraper.include_descriptions is False
+    assert scraper.proxy == "http://proxy.example:8080"
+    assert scraper.client_kind == "httpx"
+
+
+def test_invalid_client_kind_is_rejected() -> None:
+    with pytest.raises(ValueError, match="client_kind"):
+        BumeranScraper("ar", client_kind="browser")
+
+
+@pytest.mark.parametrize(
+    "slug,base_url,country_iso,site_id",
+    [
+        ("ar", "https://www.bumeran.com.ar", "AR", "BMAR"),
+        ("pe", "https://www.bumeran.com.pe", "PE", "BMPE"),
+        ("ec", "https://www.bumeran.com.ec", "EC", "BMEC"),
+        ("ve", "https://www.bumeran.com.ve", "VE", "BMVE"),
+        ("ar-zonajobs", "https://www.zonajobs.com.ar", "AR", "ZJAR"),
+        ("ec-multitrabajos", "https://www.multitrabajos.com", "EC", "BMEC"),
+    ],
+)
+def test_region_table_resolves(
+    slug: str, base_url: str, country_iso: str, site_id: str,
+) -> None:
+    """Every documented slug maps to its known base / country / site-id.
+
+    Catches accidental table edits — the slugs are part of the public
+    interface (companies CSV references them by name)."""
+    assert slug in REGIONS
+    rec = REGIONS[slug]
+    assert rec[0] == base_url
+    assert rec[1] == site_id
+    assert rec[2] == country_iso
+
+
+# --- httpcloak gating -------------------------------------------------------
+
+
+def test_fetch_raises_when_httpcloak_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "ats_scrapers.scrapers.bumeran.find_spec", lambda _name: None,
+    )
+    with pytest.raises(ScraperError, match="httpcloak is required"):
+        BumeranScraper("ar").fetch()
+
+
+@pytest.mark.parametrize("slug", ["cl", "pe-konzerta"])
+def test_unsupported_region_returns_empty_with_warning(
+    slug: str, monkeypatch: pytest.MonkeyPatch, caplog,
+) -> None:
+    """``cl`` and ``pe-konzerta`` slugs are recognised so callers can keep
+    a uniform company list, but the underlying stacks aren't on the
+    shared searchV2 API. Scraper short-circuits with a warning."""
+    import logging
+
+    # Pretend httpcloak is installed so the early-return is purely about
+    # the slug being unsupported.
+    monkeypatch.setattr(
+        "ats_scrapers.scrapers.bumeran.find_spec", lambda _name: object(),
+    )
+    with caplog.at_level(logging.WARNING, logger="ats_scrapers.scrapers.bumeran"):
+        jobs = BumeranScraper(slug).fetch()
+    assert jobs == []
+    assert any("backend is not" in r.getMessage() for r in caplog.records)
+
+
+# --- happy path: field mapping ----------------------------------------------
+
+
+def test_parses_full_aviso_payload(patched_scraper) -> None:
+    """Every populated Bumeran field maps to the right canonical Job slot.
+
+    Anchors the contract on listings — adding/removing a mapping here is
+    a breaking change for the published dataset."""
+    item = _aviso(
+        job_id=1118287655,
+        titulo="Analista de Control de Calidad",
+        empresa="Follow the Sun",
+        localizacion="Grand Bourg, Buenos Aires",
+        tipo_trabajo="Full-time",
+        modalidad="Presencial",
+        fecha="11-05-2026 23:43:58",
+        detalle="&#x1f50e; Analista con experiencia en HPLC, UV e IR.",
+    )
+    scraper = patched_scraper("ar", pages={0: _page_response([item])})
+    jobs = scraper.fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.BUMERAN
+    assert j.ats_id == "1118287655"
+    assert j.title == "Analista de Control de Calidad"
+    assert j.company == "Follow the Sun"
+    assert str(j.url) == (
+        "https://www.bumeran.com.ar/empleos/aviso-1118287655.html"
+    )
+    assert j.location == "Grand Bourg, Buenos Aires"
+    assert j.country_iso == "AR"
+    assert j.region == "South America"
+    assert j.language == "es"
+    assert j.employment_type == "FULL_TIME"
+    assert j.commitment == "Full-time"
+    assert j.is_remote is False  # Presencial
+    # Description: HTML entities decoded, whitespace collapsed.
+    assert j.description == "🔎 Analista con experiencia en HPLC, UV e IR."
+    # raw carries Navent-specific fields the canonical schema can't hold.
+    assert j.raw is not None
+    assert j.raw["idArea"] == 23
+    assert j.raw["portal"] == "bumeran"
+    assert j.raw["country_alias"] == "ar"
+    assert j.raw["site_id"] == "BMAR"
+    # posted_at parsed from DD-MM-YYYY HH:MM:SS
+    assert j.posted_at is not None
+    assert j.posted_at.year == 2026
+    assert j.posted_at.month == 5
+    assert j.posted_at.day == 12
+    assert j.posted_at.tzinfo is not None
+
+
+def test_remoto_modalidad_marks_is_remote_true(patched_scraper) -> None:
+    item = _aviso(modalidad="Remoto")
+    scraper = patched_scraper("pe", pages={0: _page_response([item])})
+    jobs = scraper.fetch()
+    assert jobs[0].is_remote is True
+
+
+def test_hybrid_modalidad_leaves_is_remote_unset(patched_scraper) -> None:
+    """``Híbrido`` postings could be either — defer to the downstream
+    enrichment instead of guessing."""
+    item = _aviso(modalidad="Híbrido")
+    scraper = patched_scraper("ar", pages={0: _page_response([item])})
+    jobs = scraper.fetch()
+    assert jobs[0].is_remote is None
+
+
+def test_confidential_empty_company_maps_to_confidencial(
+    patched_scraper,
+) -> None:
+    """Confidential listings have ``empresa=""``; emit "Confidencial"
+    rather than letting the row default to a numeric employer id."""
+    item = _aviso(empresa="", confidencial=True)
+    scraper = patched_scraper("ar", pages={0: _page_response([item])})
+    jobs = scraper.fetch()
+    assert jobs[0].company == "Confidencial"
+
+
+def test_pasantia_tipo_trabajo_maps_to_intern(patched_scraper) -> None:
+    item = _aviso(tipo_trabajo="Pasantía")
+    scraper = patched_scraper("ar", pages={0: _page_response([item])})
+    jobs = scraper.fetch()
+    assert jobs[0].employment_type == "INTERN"
+
+
+# --- multi-country wiring ---------------------------------------------------
+
+
+def test_zonajobs_country_iso_and_portal(patched_scraper) -> None:
+    """zonajobs.com.ar lives on the AR backend tenant — same currency /
+    country, but the ``portal`` field on the response is ``zonajobs``
+    and the URL we synthesize points at zonajobs.com.ar."""
+    item = _aviso(portal="zonajobs")
+    scraper = patched_scraper("ar-zonajobs", pages={0: _page_response([item])})
+    jobs = scraper.fetch()
+    assert jobs[0].country_iso == "AR"
+    assert str(jobs[0].url).startswith("https://www.zonajobs.com.ar/")
+    assert jobs[0].raw is not None
+    assert jobs[0].raw["country_alias"] == "ar-zonajobs"
+    assert jobs[0].raw["site_id"] == "ZJAR"
+
+
+def test_multitrabajos_uses_ec_country(patched_scraper) -> None:
+    """multitrabajos.com is the EC alt brand — country_iso must follow."""
+    item = _aviso()
+    scraper = patched_scraper(
+        "ec-multitrabajos", pages={0: _page_response([item])},
+    )
+    jobs = scraper.fetch()
+    assert jobs[0].country_iso == "EC"
+    assert str(jobs[0].url).startswith("https://www.multitrabajos.com/")
+    assert jobs[0].raw is not None
+    assert jobs[0].raw["site_id"] == "BMEC"
+
+
+# --- pagination -------------------------------------------------------------
+
+
+def test_paginates_until_total_reached(patched_scraper) -> None:
+    """The first page reports ``total`` and ``size``; subsequent pages
+    are walked until the math says we've covered every row."""
+    page0 = _page_response(
+        [_aviso(job_id=i) for i in range(PAGE_SIZE)],
+        page=0, total=250, size=PAGE_SIZE,
+    )
+    page1 = _page_response(
+        [_aviso(job_id=PAGE_SIZE + i) for i in range(PAGE_SIZE)],
+        page=1, total=250, size=PAGE_SIZE,
+    )
+    page2 = _page_response(
+        [_aviso(job_id=2 * PAGE_SIZE + i) for i in range(50)],
+        page=2, total=250, size=50,
+    )
+    scraper = patched_scraper(
+        "ar", pages={0: page0, 1: page1, 2: page2},
+    )
+    jobs = scraper.fetch()
+    assert len(jobs) == 250
+    assert {int(j.ats_id) for j in jobs} == set(range(250))
+
+
+def test_dedupes_overlapping_pages(patched_scraper) -> None:
+    """A row that appears on consecutive pages must collapse on ats_id —
+    Navent's listing isn't strictly stable across rapid pagination."""
+    page0 = _page_response(
+        [_aviso(job_id=i) for i in range(5)],
+        page=0, total=8, size=5,
+    )
+    page1 = _page_response(
+        [_aviso(job_id=i) for i in (3, 4, 5, 6, 7)],
+        page=1, total=8, size=5,
+    )
+    scraper = patched_scraper("ar", pages={0: page0, 1: page1})
+    jobs = scraper.fetch()
+    assert len(jobs) == 8
+    assert len({j.ats_id for j in jobs}) == 8
+
+
+def test_single_page_when_total_fits(patched_scraper) -> None:
+    """``total <= size`` should not trigger a second fetch."""
+    fetches: list[int] = []
+
+    def _build(monkey, scraper: BumeranScraper) -> None:
+        original = scraper._search_page
+
+        def _spy(session: Any, page: int) -> dict[str, Any]:
+            fetches.append(page)
+            return original(session, page)
+
+        monkey.setattr(scraper, "_search_page", _spy)
+
+    page0 = _page_response(
+        [_aviso(job_id=i) for i in range(3)], page=0, total=3, size=3,
+    )
+    scraper = patched_scraper("ar", pages={0: page0})
+
+    # The factory already monkey-patched _search_page; wrap it once more
+    # to spy on call counts.
+    with pytest.MonkeyPatch.context() as mp:
+        _build(mp, scraper)
+        jobs = scraper.fetch()
+    assert len(jobs) == 3
+    assert fetches == [0]
+
+
+def test_max_pages_caps_pagination(patched_scraper) -> None:
+    """The ``max_pages`` knob protects against runaway scrapes when the
+    API reports a wildly inflated ``total``."""
+    page0 = _page_response(
+        [_aviso(job_id=i) for i in range(2)],
+        page=0, total=10_000, size=2,
+    )
+    page1 = _page_response(
+        [_aviso(job_id=2 + i) for i in range(2)],
+        page=1, total=10_000, size=2,
+    )
+    scraper = BumeranScraper("ar", max_pages=2)
+    # Re-apply the same stubs the factory uses.
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "ats_scrapers.scrapers.bumeran.find_spec", lambda _name: object(),
+        )
+        mp.setattr(scraper, "_open_session", lambda: object())
+
+        pages = {0: page0, 1: page1}
+
+        requested: list[int] = []
+
+        def fake(_s: Any, p: int) -> dict[str, Any]:
+            requested.append(p)
+            return pages.get(p, _page_response([], page=p, total=0, size=0))
+
+        mp.setattr(scraper, "_search_page", fake)
+        jobs = scraper.fetch()
+    assert len(jobs) == 4
+    assert requested == [0, 1]
+
+
+@pytest.mark.parametrize("max_pages", [0, -1])
+def test_invalid_max_pages_is_rejected(max_pages: int) -> None:
+    with pytest.raises(ScraperError, match="max_pages must be positive"):
+        BumeranScraper("ar", max_pages=max_pages)
+
+
+def test_full_catalogue_rejects_reported_total_above_safety_limit(
+    patched_scraper,
+) -> None:
+    page0 = _page_response(
+        [_aviso()], total=(DEFAULT_MAX_PAGES + 1) * PAGE_SIZE, size=PAGE_SIZE,
+    )
+    scraper = patched_scraper("ar", pages={0: page0})
+
+    with pytest.raises(ScraperError, match=r"above the .* safety limit"):
+        scraper.fetch()
+
+
+# --- defensive parsing ------------------------------------------------------
+
+
+def test_skips_items_missing_id_or_title(patched_scraper) -> None:
+    page0 = _page_response([
+        _aviso(job_id=1, titulo="Good"),
+        {"id": 2, "empresa": "no-title", "detalle": ""},  # no title
+        {"titulo": "no-id"},  # no id
+    ])
+    scraper = patched_scraper("ar", pages={0: page0}, max_pages=1)
+    jobs = scraper.fetch()
+    assert [j.ats_id for j in jobs] == ["1"]
+
+
+def test_full_catalogue_rejects_unparseable_rows(patched_scraper) -> None:
+    page0 = _page_response([
+        _aviso(job_id=1, titulo="Good"),
+        {"id": 2, "empresa": "no-title", "detalle": ""},
+    ])
+    scraper = patched_scraper("ar", pages={0: page0})
+
+    with pytest.raises(ScraperError, match=r"parsed 1 of 2 rows"):
+        scraper.fetch()
+
+
+def test_rejects_missing_content_list(patched_scraper) -> None:
+    scraper = patched_scraper(
+        "ar",
+        pages={0: {"number": 0, "size": 1, "total": 1}},
+    )
+
+    with pytest.raises(ScraperError, match="expected content"):
+        scraper.fetch()
+
+
+def test_full_catalogue_rejects_empty_page_for_nonzero_total(
+    patched_scraper,
+) -> None:
+    scraper = patched_scraper(
+        "ar",
+        pages={0: _page_response([], page=0, total=1, size=0)},
+    )
+
+    with pytest.raises(ScraperError, match="was empty"):
+        scraper.fetch()
+
+
+def test_full_catalogue_rejects_fewer_rows_than_reported(
+    patched_scraper,
+) -> None:
+    scraper = patched_scraper(
+        "ar",
+        pages={0: _page_response([_aviso()], page=0, total=3, size=3)},
+    )
+
+    with pytest.raises(ScraperError, match=r"reported=3, fetched=1"):
+        scraper.fetch()
+
+
+def test_falls_back_for_unparsable_date(patched_scraper) -> None:
+    """If the API ships a weird date, the row still gets emitted with
+    ``posted_at=None`` rather than crashing the whole page."""
+    item = _aviso(fecha="not-a-date")
+    scraper = patched_scraper("ar", pages={0: _page_response([item])})
+    jobs = scraper.fetch()
+    assert jobs[0].posted_at is None
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+def test_clean_description_decodes_entities_and_trims() -> None:
+    assert _clean_description("Hola &amp; <b>mundo</b>  ") == "Hola & mundo"
+
+
+def test_clean_description_strips_entity_encoded_tags() -> None:
+    assert _clean_description("&lt;b&gt;Hola&lt;/b&gt; mundo") == "Hola mundo"
+
+
+def test_clean_description_returns_none_for_empty() -> None:
+    assert _clean_description("") is None
+    assert _clean_description("   ") is None
+    assert _clean_description(None) is None
+
+
+def test_clean_description_truncates_at_10k() -> None:
+    out = _clean_description("x" * 20_000)
+    assert out is not None
+    assert len(out) == 10_000
+
+
+def test_parse_datetime_accepts_full_and_date_only() -> None:
+    from zoneinfo import ZoneInfo
+
+    timezone = ZoneInfo("America/Argentina/Buenos_Aires")
+    full = _parse_datetime("11-05-2026 23:43:58", timezone=timezone)
+    assert full is not None
+    assert (full.year, full.month, full.day) == (2026, 5, 12)
+    assert (full.hour, full.minute, full.second) == (2, 43, 58)
+
+    date_only = _parse_datetime("11-05-2026", timezone=timezone)
+    assert date_only is not None
+    assert (date_only.year, date_only.month, date_only.day) == (2026, 5, 11)
+    assert (date_only.hour, date_only.minute, date_only.second) == (3, 0, 0)
+
+
+def test_parse_datetime_returns_none_for_garbage() -> None:
+    from zoneinfo import ZoneInfo
+
+    timezone = ZoneInfo("America/Lima")
+    assert _parse_datetime("", timezone=timezone) is None
+    assert _parse_datetime(None, timezone=timezone) is None
+    assert _parse_datetime("2026-05-11", timezone=timezone) is None
+    assert _parse_datetime(12345, timezone=timezone) is None
+
+
+# --- error handling ---------------------------------------------------------
+
+
+def test_search_page_raises_on_persistent_5xx(monkeypatch) -> None:
+    """Real server failures should surface, not silently emit []."""
+    import ats_scrapers.scrapers.bumeran as bm
+
+    monkeypatch.setattr(bm, "find_spec", lambda _name: object())
+    monkeypatch.setattr(bm, "MAX_RETRIES", 2)
+    monkeypatch.setattr(bm, "RETRY_BASE_DELAY", 0.0)
+
+    class FakeResp:
+        def __init__(self, status: int):
+            self.status_code = status
+            self.text = "boom"
+            self.content = b"boom"
+
+    class FakeSession:
+        def get(self, url: str, timeout: float) -> Any:
+            return FakeResp(200)
+
+        def post(self, url: str, *, headers: Any, json: Any, timeout: float) -> Any:
+            return FakeResp(500)
+
+    scraper = BumeranScraper("ar")
+    monkeypatch.setattr(scraper, "_open_session", lambda: FakeSession())
+    # Use the real _search_page so the retry/raise path is exercised end
+    # to end via the FakeSession above.
+    with pytest.raises(ScraperError):
+        scraper.fetch()
+
+
+def test_search_page_rejects_404_in_reported_page_range() -> None:
+    class FakeResponse:
+        status_code = 404
+        text = "not found"
+        content = b"not found"
+
+    class FakeSession:
+        def post(self, *args: Any, **kwargs: Any) -> FakeResponse:
+            return FakeResponse()
+
+    with pytest.raises(ScraperError, match="unexpected status 404"):
+        BumeranScraper("ar")._search_page(FakeSession(), 1)
+
+
+def test_httpcloak_timeout_is_converted_to_milliseconds(monkeypatch) -> None:
+    import sys
+    from types import SimpleNamespace
+
+    timeouts: list[float] = []
+
+    class FakeResponse:
+        status_code = 200
+        text = '{"content": [], "total": 0, "size": 0, "number": 0}'
+        content = text.encode()
+
+    class FakeSession:
+        def get(self, _url: str, *, timeout: float) -> FakeResponse:
+            timeouts.append(timeout)
+            return FakeResponse()
+
+        def post(self, *args: Any, timeout: float, **kwargs: Any) -> FakeResponse:
+            timeouts.append(timeout)
+            return FakeResponse()
+
+    session = FakeSession()
+    monkeypatch.setitem(
+        sys.modules, "httpcloak", SimpleNamespace(Session=lambda **_kwargs: session),
+    )
+    scraper = BumeranScraper("ar", timeout=12.5)
+
+    opened = scraper._open_session()
+    scraper._search_page(opened, 0)
+
+    assert timeouts == [12_500, 12_500]
+
+
+def test_search_page_rejects_non_object_json() -> None:
+    class FakeResponse:
+        status_code = 200
+        text = "[]"
+        content = b"[]"
+
+    class FakeSession:
+        def post(self, *args: Any, **kwargs: Any) -> FakeResponse:
+            return FakeResponse()
+
+    with pytest.raises(ScraperError, match="expected object"):
+        BumeranScraper("ar")._search_page(FakeSession(), 0)

--- a/tests/test_elempleo.py
+++ b/tests/test_elempleo.py
@@ -1,0 +1,522 @@
+"""Tests for the elempleo (Colombia) scraper.
+
+The site is server-rendered HTML — these tests stub the listing
+page responses with realistic card markup and assert that every
+field maps to the right ``Job`` slot. The fixtures mirror the
+selectors documented in ``elempleo.py``:
+
+  - ``js-offer-title`` + ``title="…"``
+  - ``js-offer-company`` / ``js-offer-city``
+  - ``data-offer-id`` (canonical id; trailing slug id is the fallback)
+  - labelled-pair triplet for Salario / Tipo de contrato / Modalidad
+
+Pagination terminates after two consecutive empty pages, and the Colombian
+salary format (``$1,5 a $2 millones`` → 1.5M–2M COP) needs the
+comma-as-decimal handling exercised explicitly.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType
+from ats_scrapers.scrapers import ElempleoScraper, ScraperRegistry
+from ats_scrapers.scrapers.elempleo import (
+    _EMPLOYMENT_MAP,
+    _parse_co_number,
+    _parse_relative_date,
+    _parse_salary,
+    _strip_accents,
+)
+
+_LISTING_RE = re.compile(r"^https://www\.elempleo\.com/co/ofertas-empleo\?Page=\d+$")
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drop retry backoff so failure-path tests don't take 30s each."""
+    import ats_scrapers.scrapers.elempleo as m
+    monkeypatch.setattr(m, "MAX_RETRIES", 1)
+    monkeypatch.setattr(m, "RETRY_BASE_DELAY", 0.0)
+
+
+def _card(
+    *,
+    offer_id: str,
+    title: str,
+    company: str = "Acme SAS",
+    city: str = "Bogotá",
+    salary: str = "$2 a $2,5 millones",
+    contract: str = "Indefinido",
+    modality: str = "Presencial",
+    date_label: str = "Hoy",
+    description: str = "",
+    omit_data_offer_id: bool = False,
+) -> str:
+    """Realistic single-card fragment.
+
+    Mirrors the structure live elempleo ships — wrapper div carrying
+    ``col-md-12 result-item mb-3 bg-white``, the title anchor with
+    ``title="…"`` and ``js-offer-title`` class, the company span with
+    ``js-offer-company``, the labelled triplet for salary/contract/
+    modality, and the share button carrying ``data-offer-id`` (the
+    canonical id source) plus an optional ``data-offer-description``.
+    """
+    slug = re.sub(r"[^a-z0-9-]", "-", title.lower().replace(" ", "-"))
+    href = f"/co/ofertas-trabajo/{slug}-{offer_id}"
+    data_offer_id = "" if omit_data_offer_id else f'data-offer-id="{offer_id}"'
+    desc_attr = (
+        f'data-offer-description="{description}"' if description else ""
+    )
+    return (
+        f'<div class="col-md-12 result-item mb-3 bg-white" '
+        f'style="text-align: left;">'
+        # title
+        f'<a class="text-ellipsis js-offer-title fw-bold" '
+        f'href="{href}" title="{title}">{title}</a>'
+        # company
+        f'<span class="info-company-name js-offer-company fs-6">'
+        f'{company}</span>'
+        # salary
+        f'<div class="text-blue-petrol-dark">{salary}</div>'
+        f'<div class="small-text pb-2 text-medium-gray">Salario</div>'
+        # contract
+        f'<div class="text-blue-petrol-dark">{contract}</div>'
+        f'<div class="small-text pb-2 text-medium-gray">Tipo de contrato</div>'
+        # city
+        f'<span class="info-city js-offer-city text-blue-petrol-dark">'
+        f'{city}</span>'
+        f'<div class="small-text pb-2 text-medium-gray">Ubicación</div>'
+        # modality
+        f'<div class="text-blue-petrol-dark">{modality}</div>'
+        f'<div class="small-text pb-2 text-medium-gray">Modalidad laboral</div>'
+        # date
+        f'<span class="rounded-pill js-offer-date mi-etiqueta">'
+        f'<i class="fa fa-clock-o"></i>{date_label}</span>'
+        # share button (carries the canonical id + description)
+        f'<a {data_offer_id} {desc_attr} href="#">Compartir</a>'
+        f'</div>'
+    )
+
+
+def _empty_listing() -> str:
+    return "<html><body><div class='no-results'>0</div></body></html>"
+
+
+def _listing(cards: list[str]) -> str:
+    # Trailing pagination sentinel so the card regex knows where to stop.
+    pagination = '<div class="text-center pt-3">pagination</div>'
+    return f"<html><body>{''.join(cards)}{pagination}</body></html>"
+
+
+# --- registry ---------------------------------------------------------------
+
+
+def test_registry_resolves_elempleo() -> None:
+    assert ScraperRegistry.get(ATSType.ELEMPLEO) is ElempleoScraper
+
+
+def test_ats_type_value() -> None:
+    assert ATSType.ELEMPLEO.value == "elempleo"
+
+
+# --- happy path -------------------------------------------------------------
+
+
+def test_parses_full_listing_card(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=1",
+        text=_listing([_card(
+            offer_id="1886709556",
+            title="Terapeuta ocupacional domiciliario",
+            company="Health &amp; Life IPS SAS",
+            city="Bucaramanga",
+            salary="$1,5 a $2 millones",
+            contract="Prestacion de Servicios",
+            modality="Presencial",
+            date_label="Hoy",
+            description="Vacante de terapia ocupacional...",
+        )]),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://www\.elempleo\.com/co/ofertas-empleo\?Page=[2-9]$"),
+        text=_listing([]),
+        is_reusable=True,
+    )
+
+    jobs = ElempleoScraper("any").fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.ELEMPLEO
+    assert j.ats_id == "1886709556"
+    assert j.global_id == "elempleo:1886709556"
+    assert j.title == "Terapeuta ocupacional domiciliario"
+    # HTML entity must be decoded — "&amp;" → "&".
+    assert j.company == "Health & Life IPS SAS"
+    assert j.location == "Bucaramanga, Colombia"
+    assert j.country_iso == "CO"
+    assert j.region == "South America"
+    assert j.language == "es"
+    assert j.is_remote is False  # Presencial
+    assert j.salary_currency == "COP"
+    assert j.salary_period == "MONTH"
+    assert j.salary_min == 1_500_000
+    assert j.salary_max == 2_000_000
+    assert j.salary_summary == "$1,5 a $2 millones"
+    # Prestacion de Servicios → CONTRACT (independent contractor).
+    assert j.employment_type == "CONTRACT"
+    assert j.commitment == "Prestacion de Servicios"
+    assert j.description == "Vacante de terapia ocupacional..."
+    assert j.posted_at is not None  # "Hoy" parses to today
+    assert str(j.url) == (
+        "https://www.elempleo.com/co/ofertas-trabajo/"
+        "terapeuta-ocupacional-domiciliario-1886709556"
+    )
+    assert j.raw is not None
+    assert j.raw["salary_text"] == "$1,5 a $2 millones"
+    assert j.raw["modality"] == "Presencial"
+    assert j.raw["contract_type"] == "Prestacion de Servicios"
+
+
+def test_card_class_with_live_trailing_space_parses(httpx_mock) -> None:
+    card = _card(offer_id="123", title="Trailing Space").replace(
+        'bg-white"', 'bg-white "', 1,
+    )
+    httpx_mock.add_response(url=_LISTING_RE, text=_listing([card]))
+    jobs = ElempleoScraper("any", max_pages=1).fetch()
+    assert [job.ats_id for job in jobs] == ["123"]
+
+
+def test_remote_modality_sets_is_remote(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=1",
+        text=_listing([_card(
+            offer_id="1", title="Ejecutivo Remoto", modality="Remoto",
+        )]),
+    )
+    httpx_mock.add_response(
+        url=_LISTING_RE, text=_listing([]), is_reusable=True,
+    )
+    jobs = ElempleoScraper("any").fetch()
+    assert jobs[0].is_remote is True
+
+
+def test_hybrid_modality_is_not_remote(httpx_mock) -> None:
+    """Híbrido is on-site sometimes — we conservatively flag it as
+    not-fully-remote so the public dataset's is_remote filter stays
+    honest."""
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=1",
+        text=_listing([_card(
+            offer_id="1", title="Híbrido role", modality="Híbrido",
+        )]),
+    )
+    httpx_mock.add_response(
+        url=_LISTING_RE, text=_listing([]), is_reusable=True,
+    )
+    jobs = ElempleoScraper("any").fetch()
+    assert jobs[0].is_remote is False
+
+
+def test_falls_back_to_slug_id_when_data_offer_id_missing(httpx_mock) -> None:
+    """The share-button anchor is occasionally rendered without
+    ``data-offer-id`` (some legacy / preview variants). The trailing
+    numeric slug chunk is the documented fallback."""
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=1",
+        text=_listing([_card(
+            offer_id="9876543", title="Test", omit_data_offer_id=True,
+        )]),
+    )
+    httpx_mock.add_response(
+        url=_LISTING_RE, text=_listing([]), is_reusable=True,
+    )
+    jobs = ElempleoScraper("any").fetch()
+    assert jobs[0].ats_id == "9876543"
+
+
+def test_confidential_salary_yields_no_numeric_signal(httpx_mock) -> None:
+    """``Salario confidencial`` is the most common salary value
+    (~7,300 of the ~10k live postings). Treat it as no-signal — keep
+    summary None so the parquet schema isn't polluted with the
+    placeholder string, currency stays None."""
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=1",
+        text=_listing([_card(
+            offer_id="1", title="X", salary="Salario confidencial",
+        )]),
+    )
+    httpx_mock.add_response(
+        url=_LISTING_RE, text=_listing([]), is_reusable=True,
+    )
+    jobs = ElempleoScraper("any").fetch()
+    j = jobs[0]
+    assert j.salary_currency is None
+    assert j.salary_min is None
+    assert j.salary_max is None
+    assert j.salary_summary is None
+    # We still record the raw text for debugging / downstream parsing.
+    assert j.raw is not None and j.raw["salary_text"] == "Salario confidencial"
+
+
+# --- salary parsing --------------------------------------------------------
+
+
+@pytest.mark.parametrize("raw, expected", [
+    ("$1,5 a $2 millones",   (1_500_000, 2_000_000, "COP", "MONTH")),
+    ("$2 a $2,5 millones",   (2_000_000, 2_500_000, "COP", "MONTH")),
+    ("$12,5 a $15 millones", (12_500_000, 15_000_000, "COP", "MONTH")),
+    ("$10 millones",         (10_000_000, 10_000_000, "COP", "MONTH")),
+    ("$1 millón",            (1_000_000, 1_000_000, "COP", "MONTH")),
+    ("Salario confidencial", (None, None, None, None)),
+    ("",                     (None, None, None, None)),
+    (None,                   (None, None, None, None)),
+])
+def test_parse_salary_shapes(raw, expected) -> None:
+    assert _parse_salary(raw) == expected
+
+
+@pytest.mark.parametrize("raw, expected", [
+    ("1,5", 1.5),
+    ("12,5", 12.5),
+    ("2", 2.0),
+    ("1.000,5", 1000.5),
+    ("0", None),
+    ("", None),
+])
+def test_parse_co_number_decimal_comma(raw, expected) -> None:
+    assert _parse_co_number(raw) == expected
+
+
+# --- contract type mapping --------------------------------------------------
+
+
+@pytest.mark.parametrize("contract, expected", [
+    ("Indefinido",              "FULL_TIME"),
+    ("Definido",                "TEMPORARY"),
+    ("Por obra o labor",        "CONTRACT"),
+    ("Prestacion de Servicios", "CONTRACT"),
+    ("Contrato de aprendizaje", "INTERN"),
+])
+def test_contract_type_maps_to_employment_type(
+    contract: str, expected: str, httpx_mock
+) -> None:
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=1",
+        text=_listing([_card(offer_id="1", title="X", contract=contract)]),
+    )
+    httpx_mock.add_response(
+        url=_LISTING_RE, text=_listing([]), is_reusable=True,
+    )
+    jobs = ElempleoScraper("any").fetch()
+    assert jobs[0].employment_type == expected
+    assert jobs[0].commitment == contract
+
+
+def test_employment_map_keys_are_accent_free() -> None:
+    """The contract-label lookup ASCII-folds before matching so the
+    same map handles ``Híbrido`` and ``Hibrido``. Guard against an
+    accidental accented key sneaking in — it would silently miss."""
+    for key in _EMPLOYMENT_MAP:
+        assert _strip_accents(key) == key, key
+
+
+# --- placeholder handling ---------------------------------------------------
+
+
+def test_mustache_placeholders_are_ignored(httpx_mock) -> None:
+    """elempleo renders dates / contract for older postings as
+    Mustache placeholders like ``{{contracttypetxt}}`` that hydrate
+    client-side. We treat any value starting with ``{{`` as missing
+    so the dataset isn't polluted with literal placeholder strings."""
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=1",
+        text=_listing([_card(
+            offer_id="1", title="X",
+            contract="{{contracttypetxt}}", salary="{{salaryInfo}}",
+            date_label="{{publishDateInfo}}",
+        )]),
+    )
+    httpx_mock.add_response(
+        url=_LISTING_RE, text=_listing([]), is_reusable=True,
+    )
+    jobs = ElempleoScraper("any").fetch()
+    j = jobs[0]
+    assert j.employment_type is None
+    assert j.commitment is None
+    assert j.salary_summary is None
+    assert j.salary_currency is None
+    assert j.posted_at is None  # not "Hoy" → don't synthesize a date
+
+
+@pytest.mark.parametrize(
+    "label, expected_day",
+    [
+        ("Hoy", 10),
+        ("Ayer", 9),
+        ("Hace 2 días", 8),
+        ("Hace 1 día", 9),
+    ],
+)
+def test_parse_relative_date_labels(label: str, expected_day: int) -> None:
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+
+    now = datetime(2026, 5, 10, 17, 30, tzinfo=ZoneInfo("America/Bogota"))
+    parsed = _parse_relative_date(label, now=now)
+
+    assert parsed is not None
+    assert parsed.astimezone(ZoneInfo("America/Bogota")).day == expected_day
+
+
+def test_parse_relative_date_ignores_placeholders() -> None:
+    assert _parse_relative_date("{{publishDateInfo}}") is None
+
+
+# --- pagination -------------------------------------------------------------
+
+
+def test_paginates_multiple_pages(httpx_mock) -> None:
+    """Each page surfaces 20 unique cards; the scraper should
+    accumulate across pages until it hits two consecutive empties."""
+    page1 = _listing([
+        _card(offer_id=f"{100+i}", title=f"Job {i}") for i in range(3)
+    ])
+    page2 = _listing([
+        _card(offer_id=f"{200+i}", title=f"Job p2 {i}") for i in range(2)
+    ])
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=1", text=page1,
+    )
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=2", text=page2,
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://www\.elempleo\.com/co/ofertas-empleo\?Page=[3-9]$"),
+        text=_listing([]),
+        is_reusable=True,
+    )
+    jobs = ElempleoScraper("any").fetch()
+    assert {j.ats_id for j in jobs} == {
+        "100", "101", "102", "200", "201",
+    }
+
+
+def test_stops_after_two_consecutive_empty_pages(httpx_mock) -> None:
+    """Pages beyond the live tail return HTTP 200 with zero cards.
+    The scraper tolerates one empty page (mid-stream render glitch)
+    but stops at two consecutive empties — page 4 must never be
+    requested."""
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=1",
+        text=_listing([_card(offer_id="1", title="A")]),
+    )
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=2",
+        text=_listing([]),
+    )
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=3",
+        text=_listing([]),
+    )
+    # Page 4 has no stub — httpx_mock would error if it were requested.
+    jobs = ElempleoScraper("any", max_pages=20).fetch()
+    assert len(jobs) == 1
+
+
+def test_full_catalogue_rejects_empty_result(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=1",
+        text=_listing([]),
+    )
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=2",
+        text=_listing([]),
+    )
+
+    with pytest.raises(ScraperError, match="no parseable jobs"):
+        ElempleoScraper("any").fetch()
+
+
+def test_rejects_page_without_jobs_or_end_marker(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=1",
+        text="<html><body>Access denied</body></html>",
+    )
+
+    with pytest.raises(ScraperError, match="end-of-results markup"):
+        ElempleoScraper("any", max_pages=1).fetch()
+
+
+def test_rejects_page_when_any_matched_card_is_unparseable(httpx_mock) -> None:
+    malformed_card = (
+        '<div class="col-md-12 result-item mb-3 bg-white">'
+        '<span class="js-offer-company">Broken markup</span>'
+        "</div>"
+    )
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=1",
+        text=_listing([
+            _card(offer_id="1", title="Valid card"),
+            malformed_card,
+        ]),
+    )
+
+    with pytest.raises(ScraperError, match="2 job cards but parsed 1"):
+        ElempleoScraper("any", max_pages=1).fetch()
+
+
+def test_max_pages_caps_pagination(httpx_mock) -> None:
+    """Hard ceiling so a buggy site returning fresh-looking cards
+    forever can't run unbounded."""
+    for p in range(1, 4):
+        httpx_mock.add_response(
+            url=f"https://www.elempleo.com/co/ofertas-empleo?Page={p}",
+            text=_listing([_card(offer_id=str(p * 10), title=f"Job {p}")]),
+        )
+    jobs = ElempleoScraper("any", max_pages=3).fetch()
+    assert len(jobs) == 3
+
+
+def test_deduplicates_repeated_ids_across_pages(httpx_mock) -> None:
+    """When the same posting appears on two pages (rare — happens
+    when a fresh job pushes a stale one across a page boundary mid-
+    scrape), de-dup by ats_id."""
+    card = _card(offer_id="555", title="Dup")
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=1",
+        text=_listing([card]),
+    )
+    httpx_mock.add_response(
+        url="https://www.elempleo.com/co/ofertas-empleo?Page=2",
+        text=_listing([card]),
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://www\.elempleo\.com/co/ofertas-empleo\?Page=[3-9]$"),
+        text=_listing([]),
+        is_reusable=True,
+    )
+    jobs = ElempleoScraper("any").fetch()
+    assert len(jobs) == 1
+
+
+# --- error handling ---------------------------------------------------------
+
+
+def test_persistent_500_raises(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_LISTING_RE, status_code=500, is_reusable=True,
+    )
+    with pytest.raises(ScraperError):
+        ElempleoScraper("any").fetch()
+
+
+def test_unexpected_status_raises(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_LISTING_RE, status_code=403, is_reusable=True,
+    )
+    with pytest.raises(ScraperError, match="403"):
+        ElempleoScraper("any").fetch()

--- a/tests/test_infojobs_br.py
+++ b/tests/test_infojobs_br.py
@@ -1,0 +1,535 @@
+"""Tests for the InfoJobs Brasil scraper.
+
+InfoJobs Brasil is a server-rendered ASP.NET site whose infinite-scroll
+behavior is backed by a JSON fragment endpoint
+(``/mf-publicarea/VacancyList/GetVacancyListFragment``). The fragment
+payload carries the same card markup the SSR page does. These tests
+exercise:
+
+- Card parsing for every Job slot the scraper populates
+- Brazilian salary parsing (``R$ 1.700,00 a R$ 2.000,00``, "Até",
+  "A partir de", "A combinar")
+- Modality → remote inference (Presencial / Híbrido / Home office)
+- Date parsing (``YYYY/MM/DD HH:MM:SS`` exact form)
+- Pagination termination (``eof: true`` or three consecutive
+  duplicate-only pages)
+- The ``url`` query param is set on the listing URL, not the
+  fragment-endpoint URL (the backend reads ``page`` from the
+  encoded value, not from its own request URL)
+- ``page`` cap honors ``max_pages``
+"""
+
+from __future__ import annotations
+
+import re
+import urllib.parse
+
+import pytest
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType
+from ats_scrapers.scrapers import InfoJobsBrasilScraper, ScraperRegistry
+from ats_scrapers.scrapers.infojobs_br import (
+    DEFAULT_MAX_PAGES,
+    _infer_remote,
+    _parse_brazilian_date,
+    _parse_brl_amount,
+    _parse_salary,
+    _set_query_param,
+)
+
+_FRAGMENT_RE = re.compile(
+    r"^https://www\.infojobs\.com\.br/mf-publicarea/VacancyList/GetVacancyListFragment\?url="
+)
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import ats_scrapers.scrapers.infojobs_br as ij
+    monkeypatch.setattr(ij, "MAX_RETRIES", 1)
+    monkeypatch.setattr(ij, "RETRY_BASE_DELAY", 0.0)
+
+
+def _card(
+    *,
+    job_id: str,
+    title: str = "Engenheiro de Software",
+    company: str | None = "Acme Tech",
+    company_href: str | None = "https://www.infojobs.com.br/acme-tech",
+    location: str = "São Paulo - SP",
+    posted_at: str = "2026/05/12 12:03:00",
+    salary: str = "A combinar",
+    modality_icon: str = "buildings",
+    modality_label: str = "Presencial",
+    education: str = "Ensino Médio (2º Grau)",
+    experience: str = "Sem experiência",
+    description: str = "Vaga incrível em uma empresa em crescimento.",
+) -> str:
+    """Build a realistic card matching the live HTML structure."""
+    if company is None:
+        company_block = (
+            '<div class="text-body">\n'
+            '    Empresa\n'
+            '    <span class="text-nowrap">confidencial</span>\n'
+            '</div>'
+        )
+    else:
+        company_block = (
+            '<div class="text-body">\n'
+            f'    <a class="text-body text-decoration-none" href="{company_href}">\n'
+            f'        {company}\n'
+            '    </a>\n'
+            '</div>'
+        )
+    slug = re.sub(r"[^a-z0-9-]", "-", title.lower().replace(" ", "-"))
+    href = f"/vaga-de-{slug}__{job_id}.aspx"
+    return (
+        f'<div data-typesimilar="" class="card card-shadow js_rowCard active">'
+        f'<div id="vacancy{job_id}" data-modelversion="" data-id="{job_id}" '
+        f'class="js_vacancyLoad js_cardLink" data-href="{href}" '
+        f'data-testabbutton="false">'
+        f'<div class="d-flex flex-wrap gap-8">'
+        f'<div hidden class="js_date" data-value="{posted_at}">'
+        f'<div class="tag mb-2 tag-outline-premium tag-sm"><span>NOVA</span></div>'
+        f'</div></div>'
+        f'<div class="d-flex gap-8 justify-content-between">'
+        f'<a class="text-decoration-none" href="{href}">'
+        f'<h2 class="h3 font-weight-bold text-body mb-2 js_vacancyTitle">{title}</h2>'
+        f'</a>'
+        f'<div class="text-medium small text-nowrap">Hoje</div>'
+        f'</div>'
+        f'<div class="d-flex align-items-baseline">{company_block}</div>'
+        f'<div class="mb-8">{location}</div>'
+        f'<div class="d-inline-flex flex-wrap mb-8 text-medium">'
+        f'<div><svg class="icon icon-money   icon-size-16"><use xlink:href="#money" /></svg> {salary}</div>'
+        f'<div><svg class="icon icon-suitcase   icon-size-16"><use xlink:href="#suitcase" /></svg> {experience}</div>'
+        f'<div><svg class="icon icon-graduate-hat   icon-size-16"><use xlink:href="#graduate-hat" /></svg> {education}</div>'
+        f'<div><svg class="icon icon-{modality_icon}   icon-size-16"><use xlink:href="#{modality_icon}" /></svg> {modality_label}</div>'
+        f'</div>'
+        f'<div class="text-medium">{description}</div>'
+        f'</div></div>'
+    )
+
+
+def _fragment(cards: list[str], *, eof: bool = False) -> dict:
+    """Wrap card HTML the way the live API does."""
+    body = (
+        '<div class="js_vacanciesGridFragment mb-16">'
+        + "".join(cards)
+        + '</div>'
+    )
+    return {"eof": eof, "listFragmentHTML": body}
+
+
+def _empty_fragment(*, eof: bool = False) -> dict:
+    return {"eof": eof, "listFragmentHTML": '<div class="js_vacanciesGridFragment mb-16"></div>'}
+
+
+def _requested_pages(httpx_mock) -> list[int]:
+    pages: list[int] = []
+    for request in httpx_mock.get_requests():
+        outer_query = urllib.parse.parse_qs(
+            urllib.parse.urlparse(str(request.url)).query
+        )
+        inner_url = outer_query["url"][0]
+        inner_query = urllib.parse.parse_qs(
+            urllib.parse.urlparse(inner_url).query
+        )
+        pages.append(int(inner_query["page"][0]))
+    return pages
+
+
+# --- registry ---------------------------------------------------------------
+
+
+def test_registry_resolves_infojobs_br() -> None:
+    assert ScraperRegistry.get(ATSType.INFOJOBSBR) is InfoJobsBrasilScraper
+
+
+def test_ats_type_value_is_infojobs_br() -> None:
+    """The enum value drives every downstream CSV column name and
+    storage path — pin it explicitly."""
+    assert ATSType.INFOJOBSBR.value == "infojobs_br"
+
+
+def test_default_cap_covers_documented_catalogue_size() -> None:
+    assert DEFAULT_MAX_PAGES >= 3_000
+
+
+# --- happy path -------------------------------------------------------------
+
+
+def test_parses_full_card(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE.pattern + r".*page%3D1"),
+        json=_fragment([_card(
+            job_id="11608342",
+            title="Promotor de Vendas",
+            company="Gi Group",
+            location="São Paulo - SP",
+            posted_at="2026/05/12 12:03:00",
+            salary="R$ 1.700,00 a R$ 2.000,00",
+            modality_icon="buildings",
+            modality_label="Presencial",
+            description="Vaga de promotor para grande rede.",
+        )], eof=True),
+    )
+    jobs = InfoJobsBrasilScraper("any", max_pages=1).fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.INFOJOBSBR
+    assert j.ats_id == "11608342"
+    assert j.title == "Promotor de Vendas"
+    assert j.company == "Gi Group"
+    assert j.location == "São Paulo - SP"
+    assert j.country_iso == "BR"
+    assert j.region == "South America"
+    assert j.language == "pt"
+    assert j.is_remote is False
+    assert j.salary_currency == "BRL"
+    assert j.salary_period == "MONTH"
+    assert j.salary_min == 1700.0
+    assert j.salary_max == 2000.0
+    assert j.salary_summary == "R$ 1.700,00 a R$ 2.000,00"
+    assert j.description == "Vaga de promotor para grande rede."
+    assert j.posted_at is not None
+    assert j.posted_at.year == 2026 and j.posted_at.month == 5 and j.posted_at.day == 12
+    assert str(j.url).endswith(
+        "/vaga-de-promotor-de-vendas__11608342.aspx"
+    )
+    assert j.raw is not None
+    assert j.raw["education"] == "Ensino Médio (2º Grau)"
+    assert j.raw["modality"] == "Presencial"
+
+
+def test_company_falls_back_to_empresa_confidencial(httpx_mock) -> None:
+    """When there's no anchor to a company page the card displays
+    'Empresa confidencial' and the scraper should propagate that
+    verbatim instead of inventing a name."""
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE.pattern + r".*page%3D1"),
+        json=_fragment([_card(job_id="1", company=None)], eof=True),
+    )
+    jobs = InfoJobsBrasilScraper("any", max_pages=1).fetch()
+    assert jobs[0].company == "Empresa confidencial"
+
+
+def test_hibrido_modality_sets_is_remote_false(httpx_mock) -> None:
+    """Híbrido (icon-house-and-building) → not fully remote."""
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE.pattern + r".*page%3D1"),
+        json=_fragment([_card(
+            job_id="1",
+            modality_icon="house-and-building",
+            modality_label="Híbrido",
+        )], eof=True),
+    )
+    jobs = InfoJobsBrasilScraper("any", max_pages=1).fetch()
+    assert jobs[0].is_remote is False
+    assert jobs[0].raw is not None
+    assert jobs[0].raw["modality"] == "Híbrido"
+
+
+def test_home_office_modality_sets_is_remote_true(httpx_mock) -> None:
+    """Remote roles appear with Home Office / Remoto labels."""
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE.pattern + r".*page%3D1"),
+        json=_fragment([_card(
+            job_id="1",
+            modality_icon="buildings",
+            modality_label="Home Office",
+            location="Remoto",
+        )], eof=True),
+    )
+    jobs = InfoJobsBrasilScraper("any", max_pages=1).fetch()
+    assert jobs[0].is_remote is True
+
+
+def test_salary_a_combinar_yields_no_signal(httpx_mock) -> None:
+    """``A combinar`` (negotiable) is the most common label on
+    InfoJobs cards — no numeric extraction should fire."""
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE.pattern + r".*page%3D1"),
+        json=_fragment([_card(job_id="1", salary="A combinar")], eof=True),
+    )
+    jobs = InfoJobsBrasilScraper("any", max_pages=1).fetch()
+    j = jobs[0]
+    assert j.salary_currency is None
+    assert j.salary_min is None and j.salary_max is None
+    assert j.salary_summary is None
+
+
+# --- salary parsing ---------------------------------------------------------
+
+
+def test_parse_brl_amount_handles_brazilian_thousand_separator() -> None:
+    """Brazilian formatting uses ``.`` as thousands, ``,`` as decimal —
+    opposite to en-US. Mishandling collapses ``R$ 1.700,00`` into
+    1.7 instead of 1700.0."""
+    assert _parse_brl_amount("1.700,00") == 1700.0
+    assert _parse_brl_amount("8.000,00") == 8000.0
+    assert _parse_brl_amount("99.000,00") == 99000.0
+    assert _parse_brl_amount("3.500,50") == 3500.50
+    assert _parse_brl_amount("0") is None
+    assert _parse_brl_amount("") is None
+
+
+@pytest.mark.parametrize("raw, expected", [
+    ("A combinar", (None, None, None, None)),
+    ("", (None, None, None, None)),
+    (None, (None, None, None, None)),
+    (
+        "R$ 1.700,00 a R$ 2.000,00",
+        (1700.0, 2000.0, "BRL", "R$ 1.700,00 a R$ 2.000,00"),
+    ),
+    (
+        "Até R$ 5.000,00",
+        (None, 5000.0, "BRL", "Até R$ 5.000,00"),
+    ),
+    (
+        "A partir de R$ 8.000,00",
+        (8000.0, None, "BRL", "A partir de R$ 8.000,00"),
+    ),
+    ("R$ 3.500,00", (3500.0, 3500.0, "BRL", "R$ 3.500,00")),
+])
+def test_parse_salary_shapes(raw, expected) -> None:
+    assert _parse_salary(raw) == expected
+
+
+def test_parse_salary_normalizes_whitespace_in_summary() -> None:
+    """The real DOM ships values like ``R$ 1.700,00\\n  a\\n  R$ 2.000,00``
+    with embedded line breaks. The summary should collapse those so
+    consumers see a clean single-line string."""
+    raw = "R$ 1.700,00\r\n                a\r\n                R$ 2.000,00"
+    min_, max_, cur, summary = _parse_salary(raw)
+    assert min_ == 1700.0 and max_ == 2000.0 and cur == "BRL"
+    assert summary == "R$ 1.700,00 a R$ 2.000,00"
+
+
+# --- date parsing ------------------------------------------------------------
+
+
+def test_parse_brazilian_date_full_timestamp() -> None:
+    """The hidden ``js_date`` block carries a structured timestamp —
+    parse it directly, don't try to derive from 'Hoje' / 'Ontem'."""
+    dt = _parse_brazilian_date("2026/05/12 12:03:00")
+    assert dt is not None
+    assert (dt.year, dt.month, dt.day, dt.hour) == (2026, 5, 12, 15)
+    assert dt.tzinfo is not None
+
+
+def test_parse_brazilian_date_dd_mm_yyyy() -> None:
+    """Some legacy detail pages use DD/MM/YYYY only — also accept that
+    form so we don't crash if the listing emits it."""
+    dt = _parse_brazilian_date("12/05/2026")
+    assert dt is not None
+    assert (dt.year, dt.month, dt.day) == (2026, 5, 12)
+
+
+def test_parse_brazilian_date_invalid_returns_none() -> None:
+    assert _parse_brazilian_date("") is None
+    assert _parse_brazilian_date("never") is None
+
+
+# --- remote inference --------------------------------------------------------
+
+
+@pytest.mark.parametrize("modality, location, expected", [
+    ("Home Office", "Brasil", True),
+    ("Remoto", "São Paulo - SP", True),
+    ("Presencial", "Belo Horizonte - MG", False),
+    ("Híbrido", "Curitiba - PR", False),
+    (None, "Home Office", True),
+    (None, None, None),
+])
+def test_infer_remote(modality, location, expected) -> None:
+    assert _infer_remote(modality, location) is expected
+
+
+# --- URL helper --------------------------------------------------------------
+
+
+def test_set_query_param_appends_when_missing() -> None:
+    out = _set_query_param("https://example.com/x.aspx", "page", "2")
+    assert out == "https://example.com/x.aspx?page=2"
+
+
+def test_set_query_param_overwrites_existing() -> None:
+    """``?page=1&foo=bar`` updated with page=3 should become
+    ``?foo=bar&page=3`` — the foo param stays, the old page= is
+    dropped, the new one appended. parse_qsl preserves order minus
+    the removed key."""
+    out = _set_query_param(
+        "https://example.com/x.aspx?page=1&foo=bar", "page", "3",
+    )
+    parsed = urllib.parse.urlparse(out)
+    params = dict(urllib.parse.parse_qsl(parsed.query))
+    assert params == {"page": "3", "foo": "bar"}
+
+
+# --- pagination termination --------------------------------------------------
+
+
+def test_stops_when_eof_true(httpx_mock) -> None:
+    """The fragment payload carries an ``eof`` boolean; honor it as
+    the cheapest stop signal rather than walking to max_pages."""
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE),
+        json=_fragment([_card(job_id="100"), _card(job_id="101")], eof=True),
+    )
+    jobs = InfoJobsBrasilScraper("any", max_pages=50).fetch()
+    assert {j.ats_id for j in jobs} == {"100", "101"}
+
+
+def test_stops_after_three_consecutive_duplicate_pages(httpx_mock) -> None:
+    """If ``eof`` stays False but the page returns 0 new ids three
+    times in a row we stop. Real InfoJobs pagination occasionally
+    re-emits the last page when you walk past the live tail."""
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE.pattern + r".*page%3D1"),
+        json=_fragment([_card(job_id="100"), _card(job_id="101")]),
+    )
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE),
+        json=_fragment([_card(job_id="100"), _card(job_id="101")]),
+        is_reusable=True,
+    )
+    jobs = InfoJobsBrasilScraper("any", max_pages=20).fetch()
+    assert {j.ats_id for j in jobs} == {"100", "101"}
+    assert _requested_pages(httpx_mock) == [1, 2, 3, 4, 5]
+
+
+def test_paginates_until_eof(httpx_mock) -> None:
+    """Distinct ids per page → walk through until ``eof: True``."""
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE.pattern + r".*page%3D1"),
+        json=_fragment([_card(job_id="1"), _card(job_id="2")]),
+    )
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE.pattern + r".*page%3D2"),
+        json=_fragment([_card(job_id="3"), _card(job_id="4")]),
+    )
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE.pattern + r".*page%3D3"),
+        json=_fragment([_card(job_id="5")], eof=True),
+    )
+    jobs = InfoJobsBrasilScraper("any", max_pages=10).fetch()
+    assert {j.ats_id for j in jobs} == {"1", "2", "3", "4", "5"}
+
+
+def test_ignores_speculative_failure_after_ordered_eof(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE.pattern + r".*page%3D1"),
+        json=_fragment([_card(job_id="1")]),
+    )
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE.pattern + r".*page%3D2"),
+        json=_fragment([_card(job_id="2")], eof=True),
+    )
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE.pattern + r".*page%3D3"),
+        status_code=500,
+    )
+
+    jobs = InfoJobsBrasilScraper("any", max_pages=3).fetch()
+
+    assert {job.ats_id for job in jobs} == {"1", "2"}
+
+
+def test_max_pages_caps_pagination(httpx_mock) -> None:
+    """Even if every page is fresh and ``eof`` never fires, the cap
+    is hard. Prevents a buggy site from looping forever."""
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE),
+        json=_fragment([_card(job_id="42")]),  # same id every page
+        is_reusable=True,
+    )
+    # Three consecutive dupes would stop us at page 4; the cap should
+    # bite before that. Set max_pages=2 and check we got exactly 1 job
+    # (deduped across pages 1+2).
+    jobs = InfoJobsBrasilScraper("any", max_pages=2).fetch()
+    assert {j.ats_id for j in jobs} == {"42"}
+    assert _requested_pages(httpx_mock) == [1, 2]
+
+
+def test_default_full_run_fails_at_safety_limit(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import ats_scrapers.scrapers.infojobs_br as infojobs_br
+
+    monkeypatch.setattr(infojobs_br, "DEFAULT_MAX_PAGES", 2)
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE),
+        json=_fragment([_card(job_id="42")]),
+        is_reusable=True,
+    )
+
+    with pytest.raises(ScraperError, match="safety limit"):
+        InfoJobsBrasilScraper("any").fetch()
+
+
+def test_default_full_run_rejects_repeated_empty_pages_without_eof(
+    httpx_mock,
+) -> None:
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE),
+        json=_empty_fragment(),
+        is_reusable=True,
+    )
+
+    with pytest.raises(ScraperError, match="repeated empty pages before eof"):
+        InfoJobsBrasilScraper("any").fetch()
+
+
+# --- error paths ------------------------------------------------------------
+
+
+def test_non_json_response_raises_scraper_error(httpx_mock) -> None:
+    """The API endpoint sometimes returns 200 with an HTML interstitial
+    when CDN caching misbehaves — surface that as a typed ScraperError."""
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE),
+        text="<html>error page</html>",
+        is_reusable=True,
+    )
+    with pytest.raises(ScraperError, match="non-JSON"):
+        InfoJobsBrasilScraper("any", max_pages=1).fetch()
+
+
+def test_persistent_500_raises(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE),
+        status_code=500, is_reusable=True,
+    )
+    with pytest.raises(ScraperError):
+        InfoJobsBrasilScraper("any", max_pages=1).fetch()
+
+
+# --- listing-URL passthrough -------------------------------------------------
+
+
+def test_fragment_url_carries_listing_with_page_param(httpx_mock) -> None:
+    """The backend reads ``page`` from the encoded listing URL, not
+    from the request URL. We verify the captured request URL contains
+    the listing URL with ``page=1`` percent-encoded inside.
+
+    Also pins the listing-URL override knob — a per-city listing URL
+    passes through verbatim with only ``page=N`` appended.
+    """
+    httpx_mock.add_response(
+        url=re.compile(_FRAGMENT_RE),
+        json={"eof": True, "listFragmentHTML": ""},
+        is_reusable=True,
+    )
+    InfoJobsBrasilScraper(
+        "any", max_pages=1,
+        listing_url="https://www.infojobs.com.br/empregos-em-rio-de-janeiro.aspx",
+    ).fetch()
+    requests = httpx_mock.get_requests()
+    assert requests, "expected at least one fragment request"
+    qs = urllib.parse.urlparse(str(requests[0].url)).query
+    inner = urllib.parse.parse_qs(qs)["url"][0]
+    inner_parsed = urllib.parse.urlparse(inner)
+    inner_params = urllib.parse.parse_qs(inner_parsed.query)
+    assert inner_parsed.path == "/empregos-em-rio-de-janeiro.aspx"
+    assert inner_params["page"] == ["1"]

--- a/tests/test_latam_jobboard_contracts.py
+++ b/tests/test_latam_jobboard_contracts.py
@@ -1,0 +1,36 @@
+"""Shared contracts for the credential-free Latin American job boards."""
+
+from __future__ import annotations
+
+import pytest
+
+from ats_scrapers.scrapers.base import BaseScraper
+from ats_scrapers.scrapers.elempleo import ElempleoScraper
+from ats_scrapers.scrapers.infojobs_br import InfoJobsBrasilScraper
+from pipeline.publisher import ATS_DEDUP_PRIORITY
+
+
+@pytest.mark.parametrize(
+    ("scraper_type", "slug"),
+    [
+        (ElempleoScraper, "co"),
+        (InfoJobsBrasilScraper, "all"),
+    ],
+)
+def test_custom_scrapers_preserve_standard_options(
+    scraper_type: type[BaseScraper], slug: str
+) -> None:
+    scraper = scraper_type(
+        slug,
+        include_descriptions=False,
+        proxy="http://proxy.example:8080",
+    )
+
+    assert scraper.include_descriptions is False
+    assert scraper.proxy == "http://proxy.example:8080"
+
+
+def test_jobboard_dedup_priorities_prefer_employer_sources() -> None:
+    assert ATS_DEDUP_PRIORITY["bumeran"] > ATS_DEDUP_PRIORITY["workday"]
+    assert ATS_DEDUP_PRIORITY["elempleo"] > ATS_DEDUP_PRIORITY["workday"]
+    assert ATS_DEDUP_PRIORITY["infojobs_br"] > ATS_DEDUP_PRIORITY["workday"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -30,7 +30,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
         "jobs_cz", "manfred", "thehub", "ycombinator", "wellfound",
-        "infojobs_es",
+        "infojobs_es", "bumeran", "elempleo", "infojobs_br",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr",
         "recruitee", "taleo", "teamtailor",

--- a/tests/test_run_pipeline_guards.py
+++ b/tests/test_run_pipeline_guards.py
@@ -804,6 +804,112 @@ def test_streaming_failure_preserves_previous_jobs_csv(
     assert not (out_dir / ".jobs.csv.tmp").exists()
 
 
+@pytest.mark.parametrize("has_previous", [True, False])
+def test_required_empty_output_removes_partial_file(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, has_previous: bool,
+) -> None:
+    out_dir = tmp_path / "empty"
+    out_dir.mkdir()
+    out_path = out_dir / "jobs.csv"
+    previous = (
+        "url,title,company,ats_type,ats_id\n"
+        "https://example.com/old,Old,Acme,custom,old\n"
+    )
+    if has_previous:
+        out_path.write_text(previous, encoding="utf-8")
+
+    class EmptyScraper:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def fetch(self):
+            return []
+
+    monkeypatch.setattr(runner, "DATA_ROOT", tmp_path)
+    monkeypatch.setitem(
+        runner.CONFIGS,
+        "empty",
+        {
+            "scraper": EmptyScraper,
+            "singleton": True,
+            "output": "empty/jobs.csv",
+            "fail_closed_on_empty": True,
+        },
+    )
+
+    rc = asyncio.run(
+        runner.run("empty", concurrency=1, max_tenants=None, timeout=1)
+    )
+
+    assert rc == 1
+    if has_previous:
+        assert out_path.read_text(encoding="utf-8") == previous
+    else:
+        assert not out_path.exists()
+    assert not (out_dir / ".jobs.csv.tmp").exists()
+
+
+@pytest.mark.parametrize("has_previous", [True, False])
+def test_required_shard_failure_removes_partial_output(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, has_previous: bool,
+) -> None:
+    (tmp_path / "ats-companies").mkdir()
+    (tmp_path / "ats-companies" / "shards.csv").write_text(
+        "name,slug,url\nGood,good,https://good\nBad,bad,https://bad\n",
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / "sharded"
+    out_dir.mkdir()
+    out_path = out_dir / "jobs.csv"
+    previous = (
+        "url,title,company,ats_type,ats_id\n"
+        "https://example.com/old,Old,Acme,custom,old\n"
+    )
+    if has_previous:
+        out_path.write_text(previous, encoding="utf-8")
+
+    class ShardedScraper:
+        def __init__(self, slug, **_kwargs) -> None:
+            self.slug = slug
+
+        def fetch(self):
+            if self.slug == "bad":
+                raise RuntimeError("shard failed")
+            return [
+                Job(
+                    url="https://example.com/new",
+                    title="New",
+                    company="Acme",
+                    ats_type=ATSType.CUSTOM,
+                    ats_id="new",
+                )
+            ]
+
+    monkeypatch.setattr(runner, "DATA_ROOT", tmp_path)
+    monkeypatch.setitem(
+        runner.CONFIGS,
+        "sharded",
+        {
+            "scraper": ShardedScraper,
+            "slug": lambda row: row["slug"],
+            "csv": "ats-companies/shards.csv",
+            "output": "sharded/jobs.csv",
+            "fail_closed_on_any_error": True,
+        },
+    )
+
+    rc = asyncio.run(
+        runner.run("sharded", concurrency=2, max_tenants=None, timeout=1)
+    )
+
+    assert rc == 1
+    if has_previous:
+        assert out_path.read_text(encoding="utf-8") == previous
+    else:
+        assert not out_path.exists()
+    assert not (out_dir / ".jobs.csv.tmp").exists()
+
+
 def test_streaming_pipeline_skips_capped_description_cache(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -167,6 +167,7 @@ dependencies = [
     { name = "httpx" },
     { name = "pandas" },
     { name = "pydantic" },
+    { name = "tzdata" },
 ]
 
 [package.optional-dependencies]
@@ -241,6 +242,7 @@ requires-dist = [
     { name = "pytest-httpx", marker = "extra == 'test'", specifier = ">=0.30" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
     { name = "types-boto3", marker = "extra == 'dev'" },
+    { name = "tzdata", specifier = ">=2022.1" },
 ]
 provides-extras = ["scrapers", "parquet", "all", "test", "dev"]
 


### PR DESCRIPTION
## Sources

- Bumeran Argentina, Peru, Venezuela, and Multitrabajos Ecuador
- Elempleo Colombia
- InfoJobs Brasil

## Data-quality safeguards

- public credential-free endpoints only; no API keys, paid proxies, or browser automation
- fail closed if any required regional shard fails, preserving the previous complete dataset
- source-provided identifiers, companies, locations, salaries, timestamps, and canonical URLs are preserved
- marketplace rows receive lower dedup priority than canonical employer ATS rows

## Validation

- `uv run ruff check .`
- `uv run pytest -q` — 1,425 passed, 2 skipped, 23 deselected
- live production probes — 3 passed, each returning non-empty real jobs with unique IDs and valid source domains

This is the first source-focused replacement for the oversized #214.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds credential-free Latin American job-board scraping and publishing support.
- Adds Bumeran, Elempleo, and InfoJobs Brasil adapters, source configurations, and normalized job metadata.
- Adds fail-closed handling that preserves prior datasets after empty or partially failed required scrapes.
- Adds parser, pipeline-guard, contract, and live-probe coverage for the new sources.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain in the fixes associated with the previous review threads.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the live E2E tests for job boards with ATS\_SCRAPERS\_LIVE\_E2E=1 and confirmed the pytest run completed successfully with 3 tests passing in 1.21 seconds.
- From the collection proof, recorded the parameterized cases that passed: bumeran-ar, elempleo, and infojobs-br.
- Opened and reviewed the two test run log artifacts to verify the outputs and the identified parameterized cases.

<a href="https://app.greptile.com/trex/runs/15772243/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/run_pipeline.py | Registers the three sources and correctly prevents empty or failed required scrapes from replacing prior output. |
| src/ats_scrapers/scrapers/elempleo.py | Adds the Colombian board scraper with strict per-page parsing and full-catalogue completion validation. |
| src/ats_scrapers/scrapers/bumeran.py | Adds regional Navent scraping with shard-aware catalogue validation and normalized job mapping. |
| src/ats_scrapers/scrapers/infojobs_br.py | Adds credential-free InfoJobs Brasil catalogue retrieval and normalization. |
| tests/test_run_pipeline_guards.py | Covers preservation and temporary-file cleanup for empty and partially failed required scrapes. |
| tests/test_elempleo.py | Covers strict malformed-card rejection, empty-catalogue failure, pagination, and field parsing. |

<sub>Reviews (7): Last reviewed commit: ["fix: use second-based Bumeran timeouts"](https://github.com/kalil0321/ats-scrapers/commit/2d1f6ecf554b135891cc5ac3fa0ad97a48f58b97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47018484)</sub>

<!-- /greptile_comment -->