### PR TITLE
Add ByteDance and Torre credential-free job sources

### DIFF
--- a/ats-companies/bytedance.csv
+++ b/ats-companies/bytedance.csv
@@ -1,0 +1,2 @@
+name,slug,url
+ByteDance,bytedance,https://joinbytedance.com

--- a/ats-companies/torre.csv
+++ b/ats-companies/torre.csv
@@ -1,0 +1,2 @@
+name,slug,url
+Torre,torre,https://torre.ai

--- a/pipeline/publisher.py
+++ b/pipeline/publisher.py
@@ -544,9 +544,10 @@ ATS_DEDUP_PRIORITY: dict[str, int] = {
     "workday": 1,
     # Big-tech bespoke careers — also priority 1 (single-tenant, canonical)
     "amazon": 1, "apple": 1, "google": 1, "meta": 1, "tesla": 1,
-    "tiktok": 1, "uber": 1,
+    "bytedance": 1, "tiktok": 1, "uber": 1,
     # Hybrid jobboards
     "welcometothejungle": 3, "mercor": 3, "gem": 3,
+    "torre": 4,
     # Sourcing/matching layer that mirrors others
     "eightfold": 5,
     # National public-sector aggregators — government-curated but the

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -676,7 +676,10 @@ CONFIGS: dict[str, dict[str, Any]] = {
         "scraper": TorreScraper, "singleton": True,
         "output": "torre/jobs.csv",
         "fail_closed_on_empty": True,
-        "defer_descriptions_to_cache": True,
+        # The public catalogue currently exceeds 250k rows. Publishing
+        # search summaries avoids a cold-start crawl of one detail page
+        # per row; get_description remains available for targeted backfills.
+        "skip_description_enrichment": True,
     },
     "jobs_cz": {
         # jobs.cz - Czech Republic's largest direct-posting board. ~10k live via seeded search.

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -48,6 +48,7 @@ from ats_scrapers.scrapers import (
     BreezyScraper,
     BuiltInScraper,
     BundesagenturScraper,
+    BytedanceScraper,
     CornerstoneScraper,
     DarwinboxScraper,
     EightfoldScraper,
@@ -83,6 +84,7 @@ from ats_scrapers.scrapers import (
     TeslaScraper,
     TheHubScraper,
     TikTokScraper,
+    TorreScraper,
     UberScraper,
     WantedScraper,
     WellfoundScraper,
@@ -664,6 +666,16 @@ CONFIGS: dict[str, dict[str, Any]] = {
         # InfoJobs Spain - Spanish direct-posting job board. ~70k live.
         "scraper": InfoJobsSpainScraper, "singleton": True,
         "output": "infojobs_es/jobs.csv",
+    },
+    "bytedance": {
+        "scraper": BytedanceScraper, "singleton": True,
+        "output": "bytedance/jobs.csv",
+        "fail_closed_on_empty": True,
+    },
+    "torre": {
+        "scraper": TorreScraper, "singleton": True,
+        "output": "torre/jobs.csv",
+        "fail_closed_on_empty": True,
     },
     "jobs_cz": {
         # jobs.cz - Czech Republic's largest direct-posting board. ~10k live via seeded search.
@@ -1441,6 +1453,47 @@ async def run(ats: str, concurrency: int, max_tenants: int | None, timeout: floa
                 print(
                     f"[{ats}] ACTION retry: streaming scrape failed after "
                     f"{counts['jobs']:,} jobs and no previous jobs.csv exists."
+                )
+            return 1
+
+        empty_output_failure = (
+            bool(cfg.get("fail_closed_on_empty"))
+            and bool(targets)
+            and counts["jobs"] == 0
+        )
+        if empty_output_failure:
+            tmp_output_path.unlink(missing_ok=True)
+            if output_path.exists():
+                print(
+                    f"[{ats}] ACTION keep_previous: required scrape returned "
+                    f"0 jobs; preserved {output_path} instead of publishing "
+                    "an empty dataset."
+                )
+            else:
+                print(
+                    f"[{ats}] ACTION retry: required scrape returned 0 jobs "
+                    "and no previous jobs.csv exists."
+                )
+            return 1
+
+        sharded_failure = (
+            bool(cfg.get("fail_closed_on_any_error"))
+            and counts["error"] > 0
+        )
+        if sharded_failure:
+            tmp_output_path.unlink(missing_ok=True)
+            if output_path.exists():
+                print(
+                    f"[{ats}] ACTION keep_previous: {counts['error']}/"
+                    f"{len(targets)} required shards failed after "
+                    f"{counts['jobs']:,} jobs; preserved {output_path} "
+                    "instead of publishing a partial dataset."
+                )
+            else:
+                print(
+                    f"[{ats}] ACTION retry: {counts['error']}/"
+                    f"{len(targets)} required shards failed and no previous "
+                    "jobs.csv exists."
                 )
             return 1
 

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -676,6 +676,7 @@ CONFIGS: dict[str, dict[str, Any]] = {
         "scraper": TorreScraper, "singleton": True,
         "output": "torre/jobs.csv",
         "fail_closed_on_empty": True,
+        "defer_descriptions_to_cache": True,
     },
     "jobs_cz": {
         # jobs.cz - Czech Republic's largest direct-posting board. ~10k live via seeded search.

--- a/src/ats_scrapers/models.py
+++ b/src/ats_scrapers/models.py
@@ -87,6 +87,8 @@ class ATSType(StrEnum):
     YCOMBINATOR = "ycombinator"
     WELLFOUND = "wellfound"
     INFOJOBSES = "infojobs_es"
+    BYTEDANCE = "bytedance"
+    TORRE = "torre"
     # Additional multi-tenant ATSes (post-0.1)
     BAMBOOHR = "bamboohr"
     BREEZY = "breezy"

--- a/src/ats_scrapers/scrapers/__init__.py
+++ b/src/ats_scrapers/scrapers/__init__.py
@@ -20,6 +20,7 @@ from ats_scrapers.scrapers.beisen_legacy import BeisenLegacyScraper
 from ats_scrapers.scrapers.breezy import BreezyScraper
 from ats_scrapers.scrapers.builtin import BuiltInScraper
 from ats_scrapers.scrapers.bundesagentur import BundesagenturScraper
+from ats_scrapers.scrapers.bytedance import BytedanceScraper
 from ats_scrapers.scrapers.cornerstone import CornerstoneScraper
 from ats_scrapers.scrapers.darwinbox import DarwinboxScraper
 from ats_scrapers.scrapers.eightfold import EightfoldScraper
@@ -56,6 +57,7 @@ from ats_scrapers.scrapers.teamtailor import TeamtailorScraper
 from ats_scrapers.scrapers.tesla import TeslaScraper
 from ats_scrapers.scrapers.thehub import TheHubScraper
 from ats_scrapers.scrapers.tiktok import TikTokScraper
+from ats_scrapers.scrapers.torre import TorreScraper
 from ats_scrapers.scrapers.uber import UberScraper
 from ats_scrapers.scrapers.usajobs import USAJobsScraper
 from ats_scrapers.scrapers.wanted import WantedScraper
@@ -79,6 +81,7 @@ __all__ = [
     "BreezyScraper",
     "BuiltInScraper",
     "BundesagenturScraper",
+    "BytedanceScraper",
     "CornerstoneScraper",
     "DarwinboxScraper",
     "EightfoldScraper",
@@ -115,6 +118,7 @@ __all__ = [
     "TeslaScraper",
     "TheHubScraper",
     "TikTokScraper",
+    "TorreScraper",
     "USAJobsScraper",
     "UberScraper",
     "WTTJScraper",

--- a/src/ats_scrapers/scrapers/bytedance.py
+++ b/src/ats_scrapers/scrapers/bytedance.py
@@ -1,0 +1,294 @@
+"""ByteDance / joinbytedance.com careers scraper.
+
+    POST https://jobs.bytedance.com/api/v1/public/supplier/search/job/posts
+
+Requires ``website-path: en`` plus the standard origin/referer headers
+from ``https://joinbytedance.com``; otherwise the endpoint refuses with
+400.
+
+This is the same ATSx/Throne SaaS backend that powers TikTok's
+``api.lifeattiktok.com``, just a different tenant — schema is identical.
+We concatenate ``description`` + ``requirement`` for the canonical
+description, map ``recruit_type.en_name`` to the employment-type enum,
+and walk ``city_info.parent`` for the location string.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, ClassVar
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from ats_scrapers.fetch import Fetcher
+
+API_URL = "https://jobs.bytedance.com/api/v1/public/supplier/search/job/posts"
+PAGE_SIZE = 100
+MAX_RETRIES = 4
+
+_EMPLOYMENT_TYPE_PATTERNS = {
+    "intern": "INTERN",
+    "internship": "INTERN",
+    "contract": "CONTRACT",
+    "contractor": "CONTRACT",
+    "temporary": "TEMPORARY",
+    "part-time": "PART_TIME",
+    "part time": "PART_TIME",
+    "parttime": "PART_TIME",
+    "full-time": "FULL_TIME",
+    "full time": "FULL_TIME",
+    "fulltime": "FULL_TIME",
+    "regular": "FULL_TIME",
+    "permanent": "FULL_TIME",
+}
+
+HEADERS = {
+    "accept": "*/*",
+    "accept-language": "en-US",
+    "content-type": "application/json",
+    "website-path": "en",
+    "origin": "https://joinbytedance.com",
+    "referer": "https://joinbytedance.com/",
+    "user-agent": "Mozilla/5.0",
+}
+
+
+@ScraperRegistry.register(ATSType.BYTEDANCE)
+class BytedanceScraper(BaseScraper):
+    """ByteDance scraper — `company_slug` is informational; jobs are global."""
+
+    ats = ATSType.BYTEDANCE
+    default_headers: ClassVar[dict[str, str]] = HEADERS
+
+    async def afetch(self) -> list[Job]:
+        all_jobs: list[Job] = []
+        offset = 0
+        async with self.make_fetcher(retries=MAX_RETRIES) as fetch:
+            while True:
+                payload = {
+                    "limit": PAGE_SIZE,
+                    "offset": offset,
+                    "keyword": "",
+                    "category_id_list": [],
+                    "subject_id_list": [],
+                    "location_code_list": [],
+                    "job_function_id_list": [],
+                }
+                body = await self._post_page(fetch, payload)
+                code = body.get("code")
+                if code:
+                    raise ScraperError(
+                        f"ByteDance API error code {code}: {body.get('message')}"
+                    )
+                payload_data = body.get("data")
+                if not isinstance(payload_data, dict):
+                    raise ScraperError("ByteDance response omitted data object")
+                if not isinstance(payload_data.get("job_post_list"), list):
+                    raise ScraperError(
+                        "ByteDance response omitted job_post_list"
+                    )
+                total = payload_data.get("count")
+                if not isinstance(total, int) or total < 0:
+                    raise ScraperError("ByteDance response had invalid count")
+                jobs = payload_data["job_post_list"]
+                if not all(isinstance(job, dict) for job in jobs):
+                    raise ScraperError(
+                        "ByteDance job_post_list contained a non-object row"
+                    )
+                if not jobs:
+                    if not all_jobs:
+                        raise ScraperError(
+                            "ByteDance full-catalogue scrape returned no jobs"
+                        )
+                    if offset < total:
+                        raise ScraperError(
+                            "ByteDance returned an empty page before count "
+                            f"was reached ({offset}/{total})"
+                        )
+                    break
+                parsed = [self._parse_job(job) for job in jobs]
+                if any(job is None for job in parsed):
+                    raise ScraperError(
+                        "ByteDance could not parse every returned job row"
+                    )
+                all_jobs.extend(job for job in parsed if job is not None)
+                offset += len(jobs)
+                if offset >= total:
+                    break
+                if len(jobs) < PAGE_SIZE:
+                    raise ScraperError(
+                        "ByteDance returned a short page before count "
+                        f"was reached ({offset}/{total})"
+                    )
+        return all_jobs
+
+    def fetch(self) -> list[Job]:
+        return self._run_sync(self.afetch())
+
+    async def _post_page(
+        self,
+        fetch: Fetcher,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        body = await fetch.post_json(API_URL, json=payload)
+        if not isinstance(body, dict):
+            raise ScraperError(
+                "ByteDance returned a non-object JSON response"
+            )
+        return body
+
+    def _parse_job(self, item: dict[str, Any]) -> Job | None:
+        ats_id = str(item.get("id") or "")
+        title = (item.get("title") or item.get("name") or "").strip()
+        if not ats_id or not title:
+            return None
+        post_info = item.get("job_post_info") or {}
+
+        # Description: concatenate ``description`` + ``requirement``
+        # (the API splits the body into two fields). Strip and cap.
+        description = _compose_description(
+            item.get("description"),
+            item.get("requirement"),
+        )
+
+        # ``recruit_type.en_name`` is the canonical employment-type label
+        # ("Intern" / "Regular" / "Contract") — map to our enum.
+        employment_type, commitment = _map_recruit_type(item.get("recruit_type"))
+
+        # ``job_category.en_name`` is the high-level area
+        # ("Algorithm" / "Engineering"); ``job_subject.en_name`` is the
+        # team/role family ("PhD Graduates- 2026 Start", etc.).
+        department = _extract_label(item.get("job_category"))
+        team = _extract_label(item.get("job_subject"))
+
+        # Use the employer-set ``code`` (e.g. "A72890A") as the
+        # requisition id when present; fall back to the numeric ats_id.
+        requisition_id = (
+            item["code"].strip()
+            if isinstance(item.get("code"), str) and item["code"].strip()
+            else (ats_id or None)
+        )
+
+        raw: dict[str, Any] = {}
+        for k in ("job_category", "job_subject", "recruit_type",
+                  "experience", "department_info", "skill_list",
+                  "tag_list", "process_type"):
+            v = item.get(k)
+            if v:
+                raw[k] = v
+
+        return Job(
+            url=f"https://joinbytedance.com/search/{ats_id}",
+            title=title,
+            company="ByteDance",
+            ats_type=ATSType.BYTEDANCE,
+            ats_id=ats_id,
+            location=_extract_location(item),
+            department=department,
+            team=team if team and team != department else None,
+            employment_type=employment_type,
+            commitment=commitment,
+            description=description if self.include_descriptions else None,
+            requisition_id=requisition_id,
+            salary_min=_to_float(post_info.get("min_salary")),
+            salary_max=_to_float(post_info.get("max_salary")),
+            salary_currency=post_info.get("currency"),
+            posted_at=_parse_ts(item.get("publish_time") or item.get("post_time")),
+            fetched_at=datetime.now(tz=UTC),
+            raw=raw or None,
+        )
+
+
+def _compose_description(*sources: object) -> str | None:
+    """Concatenate description-like fields and cap at 10kB.
+
+    The body sometimes contains repeated whitespace from the API; we
+    collapse runs of blank lines to keep storage tight.
+    """
+    parts: list[str] = []
+    for source in sources:
+        if isinstance(source, str) and source.strip():
+            parts.append(source.strip())
+    if not parts:
+        return None
+    text = "\n\n".join(parts)
+    text = re.sub(r"\n{3,}", "\n\n", text).strip()
+    return text[:10_000] or None
+
+
+def _extract_label(value: object) -> str | None:
+    """ByteDance wraps category-style fields as
+    ``{"en_name": "Algorithm", "i18n_name": "Algorithm", ...}``.
+    Prefer ``en_name``; fall through to ``i18n_name`` / ``name``."""
+    if not isinstance(value, dict):
+        return None
+    for key in ("en_name", "i18n_name", "name"):
+        v = value.get(key)
+        if isinstance(v, str) and v.strip():
+            return v.strip()
+    return None
+
+
+def _map_recruit_type(value: object) -> tuple[str | None, str | None]:
+    """Map ``recruit_type`` to ``(employment_type, commitment)``.
+
+    The API ships ``{"en_name": "Regular", "i18n_name": "Regular", ...}``.
+    We surface the human label in ``commitment`` and translate to the
+    canonical FT/PT/CONTRACT/INTERN/TEMPORARY enum.
+    """
+    label = _extract_label(value)
+    if not label:
+        return None, None
+    norm = label.lower()
+    for needle, mapped in _EMPLOYMENT_TYPE_PATTERNS.items():
+        if needle in norm:
+            return mapped, label
+    return None, label
+
+
+def _extract_location(item: dict) -> str | None:
+    """ByteDance's `city_info` is a nested location object with parent chain.
+
+    The current API exposes a single `city_info` dict whose `parent` chain
+    walks up to country. Legacy `city_list` is handled as a fallback.
+    """
+    city_info = item.get("city_info")
+    if isinstance(city_info, dict):
+        parts = []
+        node = city_info
+        while isinstance(node, dict):
+            name = node.get("en_name") or node.get("name")
+            if name:
+                parts.append(name)
+            node = node.get("parent")
+        if parts:
+            return ", ".join(parts)
+    # Legacy: city_list[0].name
+    city_list = item.get("city_list") or []
+    if city_list and isinstance(city_list[0], dict):
+        return city_list[0].get("name")
+    return None
+
+
+def _to_float(value: object) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_ts(value: int | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromtimestamp(value, tz=UTC)
+    except (ValueError, OSError):
+        return None

--- a/src/ats_scrapers/scrapers/torre.py
+++ b/src/ats_scrapers/scrapers/torre.py
@@ -153,7 +153,6 @@ class TorreScraper(BaseScraper):
         seen: set[str] = set()
         seen_cursors: set[str] = set()
         jobs: list[Job] = []
-        raw_rows = 0
         reported_total: int | None = None
         async with self.make_fetcher(retries=MAX_RETRIES) as fetch:
             cursor: str | None = None
@@ -198,7 +197,6 @@ class TorreScraper(BaseScraper):
                     raise ScraperError(
                         f"Torre could not parse every row on page {page}"
                     )
-                raw_rows += len(results)
                 for job in parsed:
                     if job is None:
                         continue
@@ -228,11 +226,11 @@ class TorreScraper(BaseScraper):
         if (
             self.max_pages is None
             and reported_total is not None
-            and raw_rows < reported_total
+            and len(seen) < reported_total
         ):
             raise ScraperError(
                 "Torre catalogue ended before the reported total "
-                f"({raw_rows}/{reported_total})"
+                f"({len(seen)}/{reported_total} unique jobs)"
             )
         return jobs
 

--- a/src/ats_scrapers/scrapers/torre.py
+++ b/src/ats_scrapers/scrapers/torre.py
@@ -32,9 +32,9 @@ publisher's cross-ATS dedup still works.
 
 Note: the search endpoint returns only a **summary** (``tagline``,
 skills list, structured compensation) — the full posting body is not
-included. ``Job.description`` is populated from the tagline plus a
-bulletised skills list; the LLM enrichment pass downstream is expected
-to fetch the full body from ``url`` if a richer description is needed.
+included. The pipeline defers descriptions to :meth:`get_description`,
+which extracts the full responsibilities body from the public posting
+page and falls back to the search summary if that detail request fails.
 """
 
 from __future__ import annotations
@@ -131,6 +131,23 @@ class TorreScraper(BaseScraper):
 
     def fetch(self) -> list[Job]:
         return self._run_sync(self.afetch())
+
+    def get_description(self, job: Job) -> str | None:
+        fallback = job.description
+        if job.raw:
+            search_summary = job.raw.get("search_summary")
+            if isinstance(search_summary, str) and search_summary.strip():
+                fallback = search_summary.strip()
+
+        async def run() -> str | None:
+            try:
+                async with self.make_fetcher(retries=MAX_RETRIES) as fetch:
+                    detail_html = await fetch.get_text(str(job.url))
+            except ScraperError:
+                return fallback
+            return _parse_detail_description(detail_html) or fallback
+
+        return self._run_sync(run())
 
     async def _fetch_async(self) -> list[Job]:
         seen: set[str] = set()
@@ -346,15 +363,14 @@ class TorreScraper(BaseScraper):
             if isinstance(s, dict) and isinstance(s.get("name"), str) and s.get("name").strip()
         ]
 
-        description = (
-            _build_description(opp.get("tagline"), skill_names)
-            if self.include_descriptions
-            else None
-        )
+        search_summary = _build_description(opp.get("tagline"), skill_names)
+        description = search_summary if self.include_descriptions else None
 
         # ``raw`` overflow — keep verbatim the Torre-specific fields the
         # canonical schema can't represent.
         raw: dict[str, Any] = {}
+        if search_summary:
+            raw["search_summary"] = search_summary
         org_size = first_org.get("size")
         if isinstance(org_size, (int, float)):
             raw["organization_size"] = org_size
@@ -452,3 +468,22 @@ def _build_description(tagline: object, skills: list[str]) -> str | None:
     if not parts:
         return None
     return "\n\n".join(parts)
+
+
+def _parse_detail_description(detail_html: str) -> str | None:
+    if not detail_html:
+        return None
+    try:
+        from bs4 import BeautifulSoup
+    except ImportError as exc:  # pragma: no cover
+        raise ScraperError(
+            "Torre detail parsing requires beautifulsoup4. Install with "
+            "`pip install ats-scrapers[scrapers]`."
+        ) from exc
+
+    soup = BeautifulSoup(detail_html, "html.parser")
+    responsibilities = soup.select_one(".opportunity-responsibilities__preview")
+    if responsibilities is None:
+        return None
+    description = responsibilities.get_text("\n", strip=True)
+    return description or None

--- a/src/ats_scrapers/scrapers/torre.py
+++ b/src/ats_scrapers/scrapers/torre.py
@@ -1,0 +1,454 @@
+"""Torre.co (https://torre.ai) — LATAM-leaning direct-employer job platform.
+
+Torre is a Colombian-founded job/talent platform with global reach,
+especially strong across LATAM and remote roles. Companies post directly
+(not aggregated from other sources), so coverage is high-signal:
+~200k active opportunities worldwide at the time of writing — with
+the bulk concentrated in Spanish-speaking Latin America, plus a long
+remote/global tail in EN/PT.
+
+Public POST search API at ``https://search.torre.co/opportunities/_search/``
+— no auth, no key. The endpoint returns a fixed-shape envelope::
+
+    {
+        "total": 200534,
+        "size": 25,
+        "offset": 0,
+        "results": [ ...opportunity objects... ],
+        "pagination": {"previous": null, "next": "<base64-cursor>"}
+    }
+
+Pagination is **cursor-based** via ``?after=<token>`` even though the URL
+also accepts ``offset=N`` — the latter is silently ignored at the server
+side as of 2026-05, so the cursor is the only reliable forward-iterator.
+Page size is capped server-side at around 30 per call (the response is
+a 400 with ``meta.message: "Request size by <UA> too large: N"`` for
+anything larger). We hard-code ``PAGE_SIZE = 25`` to stay well under
+that bound across UA variants.
+
+Single-source scraper: ``company_slug`` is informational and ignored.
+Output rows carry the publishing employer's name as ``company`` so the
+publisher's cross-ATS dedup still works.
+
+Note: the search endpoint returns only a **summary** (``tagline``,
+skills list, structured compensation) — the full posting body is not
+included. ``Job.description`` is populated from the tagline plus a
+bulletised skills list; the LLM enrichment pass downstream is expected
+to fetch the full body from ``url`` if a richer description is needed.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, ClassVar
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from ats_scrapers.fetch import Fetcher
+
+SEARCH_URL = "https://search.torre.co/opportunities/_search/"
+# Server caps page size around 30 for unauthenticated UAs (returns 400 with
+# ``meta.message: "Request size by <UA> too large: N"``). 25 leaves a small
+# safety margin for future tightening.
+PAGE_SIZE = 25
+MAX_RETRIES = 5
+USER_AGENT = "Mozilla/5.0 (compatible; ats_scrapers/1.0; +https://stapply.ai)"
+HEADERS = {
+    "User-Agent": USER_AGENT,
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+}
+
+# Canonical web URL for a posting (verified live 2026-07-24).
+POSTING_URL = "https://torre.ai/post/{id}-{slug}"
+
+# Torre exposes ``commitment`` as the human-readable label (``full-time``,
+# ``part-time``, ``contract``, ``internship``, ``temporary``, ``freelance``).
+# Map to the canonical employment_type enum.
+_COMMITMENT_MAP: dict[str, str] = {
+    "full-time": "FULL_TIME",
+    "part-time": "PART_TIME",
+    "contract": "CONTRACT",
+    "contractor": "CONTRACT",
+    "freelance": "CONTRACT",
+    "internship": "INTERN",
+    "intern": "INTERN",
+    "temporary": "TEMPORARY",
+}
+
+# ``compensation.data.periodicity`` → canonical ``salary_period``. Torre uses
+# lowercase singular nouns; the schema uses uppercase nouns.
+_PERIOD_MAP: dict[str, str] = {
+    "hourly": "HOUR",
+    "daily": "DAY",
+    "weekly": "WEEK",
+    "monthly": "MONTH",
+    "yearly": "YEAR",
+    "annually": "YEAR",
+}
+
+
+@ScraperRegistry.register(ATSType.TORRE)
+class TorreScraper(BaseScraper):
+    """Torre.co (torre.ai) — direct-employer job platform.
+
+    Single-source scraper: ``company_slug`` is ignored. Pass anything
+    (``"any"``, ``""``, ``"latam"``) — the scraper enumerates the entire
+    public opportunity feed via cursor-based pagination.
+    """
+
+    ats = ATSType.TORRE
+    default_headers: ClassVar[dict[str, str]] = HEADERS
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        include_descriptions: bool = True,
+        proxy: str | None = None,
+        max_pages: int | None = None,
+    ) -> None:
+        super().__init__(
+            company_slug,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        if max_pages is not None and max_pages < 1:
+            raise ScraperError(
+                f"Torre max_pages must be positive, got {max_pages}"
+            )
+        self.max_pages = max_pages
+
+    async def afetch(self) -> list[Job]:
+        return await self._fetch_async()
+
+    def fetch(self) -> list[Job]:
+        return self._run_sync(self.afetch())
+
+    async def _fetch_async(self) -> list[Job]:
+        seen: set[str] = set()
+        seen_cursors: set[str] = set()
+        jobs: list[Job] = []
+        raw_rows = 0
+        reported_total: int | None = None
+        async with self.make_fetcher(retries=MAX_RETRIES) as fetch:
+            cursor: str | None = None
+            page = 0
+            while True:
+                if self.max_pages is not None and page >= self.max_pages:
+                    break
+                payload = await self._fetch_page(fetch, cursor=cursor)
+                page += 1
+                if not isinstance(payload.get("results"), list):
+                    raise ScraperError("Torre response omitted results list")
+                total = payload.get("total")
+                if not isinstance(total, int) or total < 0:
+                    raise ScraperError("Torre response had invalid total")
+                if reported_total is None:
+                    reported_total = total
+                    if reported_total == 0:
+                        raise ScraperError(
+                            "Torre full-catalogue response reported zero jobs"
+                        )
+                results = payload["results"]
+                if not results:
+                    if not jobs:
+                        raise ScraperError(
+                            "Torre full-catalogue scrape returned no jobs"
+                        )
+                    pagination = payload.get("pagination")
+                    if (
+                        isinstance(pagination, dict)
+                        and pagination.get("next")
+                    ):
+                        raise ScraperError(
+                            "Torre returned an empty page with a next cursor"
+                        )
+                    break
+                if not all(isinstance(opp, dict) for opp in results):
+                    raise ScraperError(
+                        "Torre results contained a non-object row"
+                    )
+                parsed = [self._parse_job(opp) for opp in results]
+                if any(job is None for job in parsed):
+                    raise ScraperError(
+                        f"Torre could not parse every row on page {page}"
+                    )
+                raw_rows += len(results)
+                for job in parsed:
+                    if job is None:
+                        continue
+                    ats_id = job.ats_id
+                    if ats_id in seen:
+                        continue
+                    seen.add(ats_id)
+                    jobs.append(job)
+                # Cursor-based pagination. ``pagination.next`` is None when
+                # we've reached the end. Some responses omit pagination
+                # entirely when the result count is below page size; treat
+                # that as "done" too.
+                next_cursor = (
+                    (payload.get("pagination") or {}).get("next")
+                    if isinstance(payload.get("pagination"), dict) else None
+                )
+                if not next_cursor:
+                    break
+                if not isinstance(next_cursor, str):
+                    raise ScraperError("Torre returned a non-string next cursor")
+                if next_cursor == cursor or next_cursor in seen_cursors:
+                    raise ScraperError(
+                        f"Torre repeated pagination cursor {next_cursor!r}"
+                    )
+                seen_cursors.add(next_cursor)
+                cursor = next_cursor
+        if (
+            self.max_pages is None
+            and reported_total is not None
+            and raw_rows < reported_total
+        ):
+            raise ScraperError(
+                "Torre catalogue ended before the reported total "
+                f"({raw_rows}/{reported_total})"
+            )
+        return jobs
+
+    # --- HTTP layer ---------------------------------------------------------
+
+    async def _fetch_page(
+        self,
+        fetch: Fetcher,
+        *,
+        cursor: str | None,
+    ) -> dict[str, Any]:
+        params: dict[str, str | int] = {
+            "size": PAGE_SIZE,
+            "aggregate": "false",
+        }
+        if cursor:
+            params["after"] = cursor
+        payload = await fetch.post_json(SEARCH_URL, params=params, json={})
+        if not isinstance(payload, dict):
+            raise ScraperError(
+                f"Torre returned {type(payload).__name__}, expected object"
+            )
+        return payload
+
+    # --- parsing ------------------------------------------------------------
+
+    def _parse_job(self, opp: dict[str, Any]) -> Job | None:
+        ats_id = str(opp.get("id") or "").strip()
+        title = (opp.get("objective") or "").strip()
+        slug = (opp.get("slug") or "").strip()
+        if not ats_id or not title:
+            return None
+
+        url = POSTING_URL.format(id=ats_id, slug=slug or ats_id)
+
+        orgs = opp.get("organizations") or []
+        first_org: dict[str, Any] = (
+            orgs[0] if isinstance(orgs, list) and orgs and isinstance(orgs[0], dict)
+            else {}
+        )
+        company = (first_org.get("name") or "").strip() or "Unknown"
+
+        # Location: prefer ``place.location[].id`` (always populated when the
+        # opportunity has any geographic grounding); fall back to the
+        # top-level ``locations`` array. Multi-location postings are
+        # comma-joined.
+        place = opp.get("place") if isinstance(opp.get("place"), dict) else {}
+        place_locs = (place or {}).get("location") or []
+        location_names: list[str] = []
+        country_iso: str | None = None
+        lat: float | None = None
+        lon: float | None = None
+        if isinstance(place_locs, list) and place_locs:
+            for entry in place_locs:
+                if not isinstance(entry, dict):
+                    continue
+                name = (entry.get("id") or "").strip()
+                if name:
+                    location_names.append(name)
+                cc = entry.get("countryCode")
+                if isinstance(cc, str) and len(cc) == 2 and country_iso is None:
+                    country_iso = cc.upper()
+                if lat is None and lon is None:
+                    e_lat, e_lon = entry.get("latitude"), entry.get("longitude")
+                    if isinstance(e_lat, (int, float)) and isinstance(e_lon, (int, float)):
+                        lat, lon = float(e_lat), float(e_lon)
+        if not location_names:
+            top_locs = opp.get("locations") or []
+            if isinstance(top_locs, list):
+                location_names = [
+                    s.strip() for s in top_locs
+                    if isinstance(s, str) and s.strip()
+                ]
+        location = ", ".join(location_names[:5]) if location_names else None
+
+        # Compensation. Three observed shapes:
+        #   - compensation: None  → no salary data
+        #   - compensation: {data: None, ...}  → employer hid salary
+        #   - compensation: {data: {code: "to-be-agreed", minAmount: 0, ...}}
+        #     → employer marked it negotiable; min/max are 0, treat as unknown
+        #   - compensation: {data: {code: "range", minAmount: 500, maxAmount: 1000, ...}}
+        #     → real range, populate fields.
+        comp_root = opp.get("compensation") if isinstance(opp.get("compensation"), dict) else {}
+        comp_data = (comp_root or {}).get("data") if isinstance((comp_root or {}).get("data"), dict) else None
+        salary_min: float | None = None
+        salary_max: float | None = None
+        salary_currency: str | None = None
+        salary_period: str | None = None
+        salary_summary: str | None = None
+        if isinstance(comp_data, dict):
+            min_amt = comp_data.get("minAmount")
+            max_amt = comp_data.get("maxAmount")
+            min_f = _to_positive_float(min_amt)
+            max_f = _to_positive_float(max_amt)
+            if min_f is not None or max_f is not None:
+                salary_min = min_f
+                salary_max = max_f
+                cur = comp_data.get("currency")
+                if isinstance(cur, str) and len(cur) == 3:
+                    salary_currency = cur.upper()
+                per = (comp_data.get("periodicity") or "").lower()
+                salary_period = _PERIOD_MAP.get(per)  # type: ignore[assignment]
+                # Build a human summary like "500 – 1000 USD / monthly"
+                if salary_currency:
+                    if min_f is not None and max_f is not None and min_f != max_f:
+                        amounts = f"{_fmt(min_f)} – {_fmt(max_f)}"
+                    elif max_f is not None:
+                        amounts = _fmt(max_f)
+                    elif min_f is not None:
+                        amounts = f"from {_fmt(min_f)}"
+                    else:
+                        amounts = ""
+                    if amounts:
+                        salary_summary = (
+                            f"{amounts} {salary_currency}"
+                            + (f" / {per}" if per else "")
+                        )
+
+        # Employment type: map ``commitment`` (or fall back to ``type``).
+        raw_commitment = (opp.get("commitment") or "").strip().lower()
+        employment_type = _COMMITMENT_MAP.get(raw_commitment)
+        commitment_label = opp.get("commitment") if isinstance(opp.get("commitment"), str) else None
+
+        # Skills: keep only the names, capped at 15 to bound size.
+        skill_names: list[str] = [
+            s.get("name")
+            for s in (opp.get("skills") or [])
+            if isinstance(s, dict) and isinstance(s.get("name"), str) and s.get("name").strip()
+        ]
+
+        description = (
+            _build_description(opp.get("tagline"), skill_names)
+            if self.include_descriptions
+            else None
+        )
+
+        # ``raw`` overflow — keep verbatim the Torre-specific fields the
+        # canonical schema can't represent.
+        raw: dict[str, Any] = {}
+        org_size = first_org.get("size")
+        if isinstance(org_size, (int, float)):
+            raw["organization_size"] = org_size
+        org_pub = first_org.get("publicId")
+        if isinstance(org_pub, str) and org_pub:
+            raw["organization_public_id"] = org_pub
+        if skill_names:
+            raw["skills"] = skill_names[:15]
+        for key in ("type", "opportunity"):
+            v = opp.get(key)
+            if isinstance(v, str) and v:
+                raw[key] = v
+        if isinstance(opp.get("external"), bool):
+            raw["external"] = opp["external"]
+        deadline = opp.get("deadline")
+        if isinstance(deadline, str) and deadline:
+            raw["deadline"] = deadline
+        ac_details = (comp_root or {}).get("additionalCompensationDetails")
+        if isinstance(ac_details, dict) and ac_details:
+            raw["additional_compensation"] = ac_details
+
+        # ``is_remote``: only ever set True (matches project pattern; never
+        # claim on-site without a positive signal).
+        remote_flag = bool(opp.get("remote")) or bool((place or {}).get("remote"))
+        is_remote: bool | None = True if remote_flag else None
+
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.TORRE,
+            ats_id=ats_id,
+            location=location,
+            country_iso=country_iso,
+            lat=lat,
+            lon=lon,
+            is_remote=is_remote,
+            salary_currency=salary_currency,
+            salary_period=salary_period,  # type: ignore[arg-type]
+            salary_summary=salary_summary,
+            salary_min=salary_min,
+            salary_max=salary_max,
+            employment_type=employment_type,  # type: ignore[arg-type]
+            commitment=commitment_label,
+            description=description,
+            posted_at=_parse_iso(opp.get("created")),
+            fetched_at=datetime.now(tz=UTC),
+            raw=raw or None,
+        )
+
+
+def _to_positive_float(value: object) -> float | None:
+    """Coerce to ``float`` only when strictly positive.
+
+    Torre uses ``0.0`` as a sentinel for "no value" (paired with the
+    ``code: "to-be-agreed"`` marker on negotiable comp). Treating 0 as
+    a real bound would let nonsense ranges leak into the salary fields.
+    """
+    if isinstance(value, bool):  # bool is an int subclass — exclude.
+        return None
+    if isinstance(value, (int, float)) and value > 0:
+        return float(value)
+    return None
+
+
+def _fmt(value: float) -> str:
+    """Strip trailing ``.0`` from whole-number floats for the summary."""
+    if value == int(value):
+        return f"{int(value):,}"
+    return f"{value:,.2f}"
+
+
+def _parse_iso(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _build_description(tagline: object, skills: list[str]) -> str | None:
+    """The search endpoint exposes only a one-line ``tagline`` summary —
+    not the full posting body. Concatenate the tagline with a bulleted
+    skills list so the description field has *something* searchable;
+    LLM enrichment downstream is expected to fetch the full body from
+    ``url`` when richer text is needed.
+    """
+    parts: list[str] = []
+    if isinstance(tagline, str) and tagline.strip():
+        parts.append(tagline.strip())
+    if skills:
+        bullet = "\n".join(f"- {s}" for s in skills[:15])
+        parts.append(f"Skills:\n{bullet}")
+    if not parts:
+        return None
+    return "\n\n".join(parts)

--- a/tests/e2e/test_live_bytedance_torre.py
+++ b/tests/e2e/test_live_bytedance_torre.py
@@ -1,0 +1,47 @@
+"""Live smoke tests for ByteDance and Torre."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Callable
+from urllib.parse import urlparse
+
+import pytest
+
+from ats_scrapers.models import Job
+from ats_scrapers.scrapers import BytedanceScraper, TorreScraper
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.skipif(
+        not os.getenv("ATS_SCRAPERS_LIVE_E2E"),
+        reason="set ATS_SCRAPERS_LIVE_E2E=1 to hit real job-board endpoints",
+    ),
+]
+
+CASES: list[tuple[str, Callable[[], object], str]] = [
+    ("bytedance", lambda: BytedanceScraper("bytedance"), "joinbytedance.com"),
+    ("torre", lambda: TorreScraper("torre", max_pages=1), "torre"),
+]
+
+
+@pytest.mark.parametrize(
+    ("factory", "expected_domain"),
+    [pytest.param(factory, domain, id=name) for name, factory, domain in CASES],
+)
+async def test_live_jobboard_smoke(
+    factory: Callable[[], object], expected_domain: str
+) -> None:
+    async with asyncio.timeout(180):
+        jobs = await factory().afetch()
+    assert jobs
+    sample: list[Job] = jobs[:50]
+    assert len({job.global_id for job in sample}) == len(sample)
+    for job in sample:
+        assert job.title.strip()
+        assert job.company.strip()
+        assert job.ats_id
+        host = (urlparse(str(job.url)).hostname or "").lower()
+        assert expected_domain in host
+        assert not host.endswith((".local", ".internal"))

--- a/tests/test_bytedance.py
+++ b/tests/test_bytedance.py
@@ -1,0 +1,362 @@
+"""Tests for the ByteDance scraper.
+
+Scope: parser behaviour against a fixed fixture mirroring the live
+``/api/v1/public/supplier/search/job/posts`` response. The HTTP layer
+is shared verbatim with the TikTok scraper (same ATSx/Throne backend)
+and is not exercised here — those tests would re-cover identical code.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType
+from ats_scrapers.scrapers.bytedance import (
+    API_URL,
+    BytedanceScraper,
+    _compose_description,
+    _extract_label,
+    _extract_location,
+    _map_recruit_type,
+)
+
+# A realistic single job_post_list entry — fields and nesting shape
+# verified against the live endpoint on 2026-05-12.
+_FIXTURE = {
+    "id": "7607020417963968773",
+    "code": "A72890A",
+    "title": "Machine Learning Engineer Graduate (Recommendation) - 2026 Start",
+    "description": "Team Introduction\nWe build recommendation systems.",
+    "requirement": "Minimum Qualifications\n- PhD or Masters in CS",
+    "recruit_type": {
+        "id": "201",
+        "name": "正式",
+        "en_name": "Regular",
+        "i18n_name": "正式",
+    },
+    "job_category": {
+        "id": "6704215862603155720",
+        "name": "算法",
+        "en_name": "Algorithm",
+        "i18n_name": "Algorithm",
+    },
+    "city_info": {
+        "code": "CT_163",
+        "location_type": 3,
+        "name": "新加坡",
+        "en_name": "Singapore",
+        "i18n_name": "Singapore",
+        "parent": {
+            "code": "CT_SG",
+            "name": "新加坡",
+            "en_name": "Singapore",
+            "i18n_name": "Singapore",
+        },
+    },
+    "tag_list": None,
+    "job_subject": {
+        "id": "7100000000000000001",
+        "name": "PhD Graduates- 2026 Start",
+        "en_name": "PhD Graduates- 2026 Start",
+        "i18n_name": "PhD Graduates- 2026 Start",
+    },
+    "vacancies": None,
+    "department_info": None,
+    "job_post_info": {
+        "min_salary": None,
+        "max_salary": None,
+        "currency": None,
+    },
+    "process_type": None,
+    "publish_time": 1715500000,
+}
+
+
+def test_parses_fixture_into_job() -> None:
+    job = BytedanceScraper("bytedance")._parse_job(_FIXTURE)
+    assert job.ats_id == "7607020417963968773"
+    assert job.ats_type is ATSType.BYTEDANCE
+    assert job.company == "ByteDance"
+    assert job.title.startswith("Machine Learning Engineer Graduate")
+    assert str(job.url) == "https://joinbytedance.com/search/7607020417963968773"
+    assert job.global_id == "bytedance:7607020417963968773"
+    # ``code`` becomes ``requisition_id``; ``ats_id`` keeps the numeric id.
+    assert job.requisition_id == "A72890A"
+
+
+def test_description_concatenates_description_and_requirement() -> None:
+    job = BytedanceScraper("bytedance")._parse_job(_FIXTURE)
+    assert job.description is not None
+    assert "Team Introduction" in job.description
+    assert "Minimum Qualifications" in job.description
+    # Two-newline separator between the two source fields.
+    assert "We build recommendation systems.\n\nMinimum Qualifications" in job.description
+
+
+def test_employment_type_mapped_from_recruit_type() -> None:
+    """``recruit_type.en_name == 'Regular'`` → FULL_TIME, label preserved."""
+    job = BytedanceScraper("bytedance")._parse_job(_FIXTURE)
+    assert job.employment_type == "FULL_TIME"
+    assert job.commitment == "Regular"
+
+
+def test_intern_recruit_type_maps_to_intern() -> None:
+    item = {**_FIXTURE, "recruit_type": {"en_name": "Intern", "name": "实习"}}
+    job = BytedanceScraper("bytedance")._parse_job(item)
+    assert job.employment_type == "INTERN"
+    assert job.commitment == "Intern"
+
+
+def test_department_and_team_from_category_and_subject() -> None:
+    job = BytedanceScraper("bytedance")._parse_job(_FIXTURE)
+    assert job.department == "Algorithm"
+    assert job.team == "PhD Graduates- 2026 Start"
+
+
+def test_team_suppressed_when_equal_to_department() -> None:
+    item = {
+        **_FIXTURE,
+        "job_subject": {"en_name": "Algorithm", "name": "算法"},
+    }
+    job = BytedanceScraper("bytedance")._parse_job(item)
+    assert job.team is None
+
+
+def test_location_walks_city_info_parent_chain() -> None:
+    job = BytedanceScraper("bytedance")._parse_job(_FIXTURE)
+    # Singapore (city) + Singapore (country parent) — comma-joined.
+    assert job.location == "Singapore, Singapore"
+
+
+def test_location_handles_legacy_city_list_shape() -> None:
+    item = {
+        **_FIXTURE,
+        "city_info": None,
+        "city_list": [{"name": "Tokyo"}],
+    }
+    job = BytedanceScraper("bytedance")._parse_job(item)
+    assert job.location == "Tokyo"
+
+
+def test_salary_fields_absent_when_missing() -> None:
+    job = BytedanceScraper("bytedance")._parse_job(_FIXTURE)
+    assert job.salary_min is None
+    assert job.salary_max is None
+    assert job.salary_currency is None
+    assert job.salary is None
+
+
+def test_salary_fields_parsed_when_present() -> None:
+    item = {
+        **_FIXTURE,
+        "job_post_info": {
+            "min_salary": 120000,
+            "max_salary": 180000,
+            "currency": "USD",
+        },
+    }
+    job = BytedanceScraper("bytedance")._parse_job(item)
+    assert job.salary_min == 120000.0
+    assert job.salary_max == 180000.0
+    assert job.salary_currency == "USD"
+
+
+def test_raw_keeps_only_truthy_fields() -> None:
+    job = BytedanceScraper("bytedance")._parse_job(_FIXTURE)
+    assert job.raw is not None
+    # ``tag_list``, ``department_info``, ``process_type`` are null → omitted.
+    assert "tag_list" not in job.raw
+    assert "department_info" not in job.raw
+    assert "process_type" not in job.raw
+    # ``job_category`` / ``job_subject`` / ``recruit_type`` survive.
+    assert "job_category" in job.raw
+    assert "job_subject" in job.raw
+    assert "recruit_type" in job.raw
+
+
+def test_ats_type_registered_for_bytedance() -> None:
+    """The decorator wires the scraper into the registry."""
+    from ats_scrapers.scrapers.base import ScraperRegistry
+
+    assert ScraperRegistry.get(ATSType.BYTEDANCE) is BytedanceScraper
+
+
+def test_fetch_retries_transient_response(httpx_mock, monkeypatch) -> None:
+    import ats_scrapers.scrapers.bytedance as module
+
+    monkeypatch.setattr(module, "MAX_RETRIES", 2)
+    httpx_mock.add_response(url=API_URL, status_code=503)
+    httpx_mock.add_response(
+        url=API_URL,
+        json={
+            "code": 0,
+            "data": {"job_post_list": [_FIXTURE], "count": 1},
+        },
+    )
+    assert [job.ats_id for job in BytedanceScraper("any").fetch()] == [
+        "7607020417963968773"
+    ]
+
+
+@pytest.mark.parametrize("status", [408, 429, 503])
+def test_fetch_retries_transient_statuses(httpx_mock, monkeypatch, status) -> None:
+    import ats_scrapers.fetch as fetch_module
+
+    delays = []
+
+    async def fake_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    monkeypatch.setattr(
+        "ats_scrapers.scrapers.bytedance.MAX_RETRIES", 2,
+    )
+    monkeypatch.setattr(fetch_module.asyncio, "sleep", fake_sleep)
+    httpx_mock.add_response(
+        url=API_URL,
+        status_code=status,
+        headers={"Retry-After": "1"},
+    )
+    httpx_mock.add_response(
+        url=API_URL,
+        json={
+            "code": 0,
+            "data": {"job_post_list": [_FIXTURE], "count": 1},
+        },
+    )
+
+    assert len(BytedanceScraper("any").fetch()) == 1
+    assert delays == [1.0]
+
+
+def test_fetch_rejects_non_object_json(httpx_mock) -> None:
+    httpx_mock.add_response(url=API_URL, json=[])
+    with pytest.raises(ScraperError, match="non-object"):
+        BytedanceScraper("any").fetch()
+
+
+def test_fetcher_uses_explicit_proxy() -> None:
+    fetcher = BytedanceScraper(
+        "any", proxy="http://proxy.example:8080",
+    ).make_fetcher()
+    assert fetcher.proxy == "http://proxy.example:8080"
+
+
+def test_fetcher_uses_proxy_from_environment(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "ATS_SCRAPERS_PROXY", "http://env-proxy.example:8080",
+    )
+    fetcher = BytedanceScraper("any").make_fetcher()
+    assert fetcher.proxy == "http://env-proxy.example:8080"
+
+
+def test_fetch_rejects_empty_full_catalogue(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json={"code": 0, "data": {"job_post_list": [], "count": 0}},
+    )
+
+    with pytest.raises(ScraperError, match="returned no jobs"):
+        BytedanceScraper("any").fetch()
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        None,
+        {},
+        {"job_post_list": []},
+        {"job_post_list": [], "count": None},
+    ],
+)
+def test_fetch_rejects_incomplete_result_envelope(httpx_mock, data) -> None:
+    httpx_mock.add_response(url=API_URL, json={"code": 0, "data": data})
+
+    with pytest.raises(ScraperError):
+        BytedanceScraper("any").fetch()
+
+
+def test_fetch_rejects_unparseable_job_row(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json={
+            "code": 0,
+            "data": {"job_post_list": [{"id": "missing-title"}], "count": 1},
+        },
+    )
+
+    with pytest.raises(ScraperError, match="parse every returned job"):
+        BytedanceScraper("any").fetch()
+
+
+def test_fetch_rejects_short_page_before_reported_count(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json={
+            "code": 0,
+            "data": {"job_post_list": [_FIXTURE], "count": 2},
+        },
+    )
+
+    with pytest.raises(ScraperError, match="short page before count"):
+        BytedanceScraper("any").fetch()
+
+
+# --- Helper-function units --------------------------------------------------
+
+
+def test_compose_description_collapses_blank_runs() -> None:
+    out = _compose_description("Para one\n\n\n\nPara two", "Para three")
+    assert out == "Para one\n\nPara two\n\nPara three"
+
+
+def test_compose_description_returns_none_for_empty() -> None:
+    assert _compose_description(None, "", "   ") is None
+
+
+def test_compose_description_caps_at_10kb() -> None:
+    big = "x" * 20_000
+    out = _compose_description(big)
+    assert out is not None
+    assert len(out) == 10_000
+
+
+def test_extract_label_prefers_en_name() -> None:
+    assert _extract_label({"name": "算法", "en_name": "Algorithm"}) == "Algorithm"
+
+
+def test_extract_label_falls_through_to_name() -> None:
+    assert _extract_label({"name": "算法"}) == "算法"
+
+
+def test_extract_label_returns_none_for_non_dict() -> None:
+    assert _extract_label(None) is None
+    assert _extract_label("Algorithm") is None
+
+
+def test_map_recruit_type_unknown_label_kept_as_commitment() -> None:
+    """Unknown labels fall through to ``commitment`` with no enum."""
+    emp, com = _map_recruit_type({"en_name": "Apprentice"})
+    assert emp is None
+    assert com == "Apprentice"
+
+
+def test_map_recruit_type_missing_returns_none_pair() -> None:
+    assert _map_recruit_type(None) == (None, None)
+
+
+def test_extract_location_country_only_walks_parent() -> None:
+    item = {
+        "city_info": {
+            "en_name": "Mountain View",
+            "parent": {
+                "en_name": "California",
+                "parent": {"en_name": "United States"},
+            },
+        }
+    }
+    assert _extract_location(item) == "Mountain View, California, United States"
+
+
+def test_extract_location_returns_none_when_absent() -> None:
+    assert _extract_location({}) is None

--- a/tests/test_bytedance_torre_contracts.py
+++ b/tests/test_bytedance_torre_contracts.py
@@ -1,0 +1,27 @@
+"""Shared contracts for ByteDance and Torre."""
+
+from __future__ import annotations
+
+from ats_scrapers.scrapers.torre import TorreScraper
+from pipeline.publisher import ATS_DEDUP_PRIORITY
+from scripts.run_pipeline import CONFIGS
+
+
+def test_torre_preserves_standard_options() -> None:
+    scraper = TorreScraper(
+        "all",
+        include_descriptions=False,
+        proxy="http://proxy.example:8080",
+    )
+    assert scraper.include_descriptions is False
+    assert scraper.proxy == "http://proxy.example:8080"
+
+
+def test_dedup_priorities_match_source_authority() -> None:
+    assert ATS_DEDUP_PRIORITY["bytedance"] == ATS_DEDUP_PRIORITY["workday"]
+    assert ATS_DEDUP_PRIORITY["torre"] > ATS_DEDUP_PRIORITY["workday"]
+
+
+def test_singleton_configs_fail_closed_on_empty() -> None:
+    assert CONFIGS["bytedance"]["fail_closed_on_empty"] is True
+    assert CONFIGS["torre"]["fail_closed_on_empty"] is True

--- a/tests/test_bytedance_torre_contracts.py
+++ b/tests/test_bytedance_torre_contracts.py
@@ -25,4 +25,8 @@ def test_dedup_priorities_match_source_authority() -> None:
 def test_singleton_configs_fail_closed_on_empty() -> None:
     assert CONFIGS["bytedance"]["fail_closed_on_empty"] is True
     assert CONFIGS["torre"]["fail_closed_on_empty"] is True
-    assert CONFIGS["torre"]["defer_descriptions_to_cache"] is True
+
+
+def test_torre_pipeline_avoids_cold_start_detail_crawl() -> None:
+    assert CONFIGS["torre"]["skip_description_enrichment"] is True
+    assert "defer_descriptions_to_cache" not in CONFIGS["torre"]

--- a/tests/test_bytedance_torre_contracts.py
+++ b/tests/test_bytedance_torre_contracts.py
@@ -25,3 +25,4 @@ def test_dedup_priorities_match_source_authority() -> None:
 def test_singleton_configs_fail_closed_on_empty() -> None:
     assert CONFIGS["bytedance"]["fail_closed_on_empty"] is True
     assert CONFIGS["torre"]["fail_closed_on_empty"] is True
+    assert CONFIGS["torre"]["defer_descriptions_to_cache"] is True

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -30,7 +30,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
         "jobs_cz", "manfred", "thehub", "ycombinator", "wellfound",
-        "infojobs_es",
+        "infojobs_es", "bytedance", "torre",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr",
         "recruitee", "taleo", "teamtailor",

--- a/tests/test_run_pipeline_guards.py
+++ b/tests/test_run_pipeline_guards.py
@@ -804,6 +804,112 @@ def test_streaming_failure_preserves_previous_jobs_csv(
     assert not (out_dir / ".jobs.csv.tmp").exists()
 
 
+@pytest.mark.parametrize("has_previous", [True, False])
+def test_required_empty_output_removes_partial_file(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, has_previous: bool,
+) -> None:
+    out_dir = tmp_path / "empty"
+    out_dir.mkdir()
+    out_path = out_dir / "jobs.csv"
+    previous = (
+        "url,title,company,ats_type,ats_id\n"
+        "https://example.com/old,Old,Acme,custom,old\n"
+    )
+    if has_previous:
+        out_path.write_text(previous, encoding="utf-8")
+
+    class EmptyScraper:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def fetch(self):
+            return []
+
+    monkeypatch.setattr(runner, "DATA_ROOT", tmp_path)
+    monkeypatch.setitem(
+        runner.CONFIGS,
+        "empty",
+        {
+            "scraper": EmptyScraper,
+            "singleton": True,
+            "output": "empty/jobs.csv",
+            "fail_closed_on_empty": True,
+        },
+    )
+
+    rc = asyncio.run(
+        runner.run("empty", concurrency=1, max_tenants=None, timeout=1)
+    )
+
+    assert rc == 1
+    if has_previous:
+        assert out_path.read_text(encoding="utf-8") == previous
+    else:
+        assert not out_path.exists()
+    assert not (out_dir / ".jobs.csv.tmp").exists()
+
+
+@pytest.mark.parametrize("has_previous", [True, False])
+def test_required_shard_failure_removes_partial_output(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, has_previous: bool,
+) -> None:
+    (tmp_path / "ats-companies").mkdir()
+    (tmp_path / "ats-companies" / "shards.csv").write_text(
+        "name,slug,url\nGood,good,https://good\nBad,bad,https://bad\n",
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / "sharded"
+    out_dir.mkdir()
+    out_path = out_dir / "jobs.csv"
+    previous = (
+        "url,title,company,ats_type,ats_id\n"
+        "https://example.com/old,Old,Acme,custom,old\n"
+    )
+    if has_previous:
+        out_path.write_text(previous, encoding="utf-8")
+
+    class ShardedScraper:
+        def __init__(self, slug, **_kwargs) -> None:
+            self.slug = slug
+
+        def fetch(self):
+            if self.slug == "bad":
+                raise RuntimeError("shard failed")
+            return [
+                Job(
+                    url="https://example.com/new",
+                    title="New",
+                    company="Acme",
+                    ats_type=ATSType.CUSTOM,
+                    ats_id="new",
+                )
+            ]
+
+    monkeypatch.setattr(runner, "DATA_ROOT", tmp_path)
+    monkeypatch.setitem(
+        runner.CONFIGS,
+        "sharded",
+        {
+            "scraper": ShardedScraper,
+            "slug": lambda row: row["slug"],
+            "csv": "ats-companies/shards.csv",
+            "output": "sharded/jobs.csv",
+            "fail_closed_on_any_error": True,
+        },
+    )
+
+    rc = asyncio.run(
+        runner.run("sharded", concurrency=2, max_tenants=None, timeout=1)
+    )
+
+    assert rc == 1
+    if has_previous:
+        assert out_path.read_text(encoding="utf-8") == previous
+    else:
+        assert not out_path.exists()
+    assert not (out_dir / ".jobs.csv.tmp").exists()
+
+
 def test_streaming_pipeline_skips_capped_description_cache(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_torre.py
+++ b/tests/test_torre.py
@@ -1,0 +1,488 @@
+"""Tests for the Torre.co (LATAM + global remote) scraper.
+
+Torre exposes a public POST search API with cursor-based pagination.
+These tests pin the parsing contract for the canonical ``Job`` row and
+exercise the cursor-following pagination loop. No live HTTP — fixtures
+below are trimmed from real probe responses (2026-05-12).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pytest
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType
+from ats_scrapers.scrapers import ScraperRegistry, TorreScraper
+
+# pytest-httpx matches on URL path; matching with a regex keeps the test
+# tolerant of query-string ordering (httpx serializes ``params={}`` dicts
+# in insertion order, but the order isn't part of the contract).
+_SEARCH_RE = re.compile(r"^https://search\.torre\.co/opportunities/_search/")
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import ats_scrapers.scrapers.torre as torre
+
+    monkeypatch.setattr(torre, "MAX_RETRIES", 1)
+
+
+# --- fixture builders -------------------------------------------------------
+
+
+def _opp_to_be_agreed() -> dict[str, Any]:
+    """Real-world shape: ``compensation.data.code == "to-be-agreed"``,
+    min/max amounts both 0. Must NOT populate salary fields (treating 0
+    as a real bound would corrupt the dataset)."""
+    return {
+        "id": "Yd6mya1w",
+        "objective": "Asesor Profesional de Seguros e Inversiones",
+        "slug": "grupo-cuatro-vidas-asesor-profesional-de-seguros-e-inversiones",
+        "tagline": "Gestionarás capital y diseñarás estrategias.",
+        "type": "full-time-employment",
+        "opportunity": "employee",
+        "organizations": [
+            {
+                "id": 2923370,
+                "hashedId": "RZ3Lj7ro",
+                "name": "Grupo Cuatro Vidas",
+                "publicId": "GrupoCuatroVidas",
+                "size": 15,
+            }
+        ],
+        "locations": ["Querétaro, Qro., México"],
+        "remote": True,
+        "external": False,
+        "deadline": None,
+        "created": "2025-04-30T16:42:17.000Z",
+        "status": "open",
+        "commitment": "full-time",
+        "compensation": {
+            "data": {
+                "code": "to-be-agreed",
+                "currency": "MXN",
+                "minAmount": 0.0,
+                "minHourlyUSD": 0.0,
+                "maxAmount": 0.0,
+                "maxHourlyUSD": 0.0,
+                "periodicity": "monthly",
+                "negotiable": False,
+            },
+            "visible": True,
+            "additionalCompensationDetails": {"comissions": "65000"},
+        },
+        "skills": [
+            {"name": "Customer care", "proficiency": "novice"},
+            {"name": "Sales", "proficiency": "novice"},
+            {"name": "Insurance sales", "proficiency": "no-experience-interested"},
+        ],
+        "place": {
+            "remote": True,
+            "anywhere": False,
+            "locationType": "hybrid",
+            "location": [
+                {
+                    "id": "Querétaro, Qro., México",
+                    "countryCode": "MX",
+                    "latitude": 20.5887932,
+                    "longitude": -100.3898881,
+                }
+            ],
+        },
+    }
+
+
+def _opp_with_salary_range() -> dict[str, Any]:
+    """Real range: ``code == "range"``, min/max populated, currency USD."""
+    return {
+        "id": "arQneQnW",
+        "objective": "Mac User Research Participant",
+        "slug": "lusauto-mac-user-research-participant",
+        "tagline": "Contribuirás al éxito global en autopartes.",
+        "type": "full-time-employment",
+        "opportunity": "employee",
+        "organizations": [
+            {"id": 870801, "name": "Lusauto", "publicId": "Lusauto", "size": 100}
+        ],
+        "locations": ["Perú"],
+        "remote": True,
+        "external": False,
+        "deadline": "2026-06-08T14:01:21.000Z",
+        "created": "2026-05-09T14:01:21.000Z",
+        "status": "open",
+        "commitment": "part-time",
+        "compensation": {
+            "data": {
+                "code": "range",
+                "currency": "USD",
+                "minAmount": 500.0,
+                "maxAmount": 1000.0,
+                "periodicity": "monthly",
+                "negotiable": False,
+            },
+            "visible": True,
+            "additionalCompensationDetails": {},
+        },
+        "skills": [
+            {"name": "Office automation"},
+            {"name": "Software development"},
+        ],
+        "place": {
+            "remote": True,
+            "locationType": "remote_countries",
+            "location": [
+                {
+                    "id": "Perú",
+                    "countryCode": "PE",
+                    "latitude": -9.189967,
+                    "longitude": -75.015152,
+                }
+            ],
+        },
+    }
+
+
+def _opp_no_compensation() -> dict[str, Any]:
+    """``compensation.data`` is None when the employer hid the salary."""
+    return {
+        "id": "8wDqNZOd",
+        "objective": "Arquitecto de Soluciones Plataforma",
+        "slug": "acme-arquitecto",
+        "tagline": "Design platform architectures.",
+        "type": "full-time-employment",
+        "opportunity": "employee",
+        "organizations": [{"id": 1, "name": "Acme", "publicId": "Acme"}],
+        "locations": ["Colombia"],
+        "remote": True,
+        "created": "2025-12-01T00:00:00.000Z",
+        "status": "open",
+        "commitment": "full-time",
+        "compensation": {
+            "data": None,
+            "visible": False,
+            "additionalCompensationDetails": {},
+        },
+        "skills": [],
+        "place": {
+            "remote": True,
+            "location": [
+                {"id": "Bogotá, Colombia", "countryCode": "CO"}
+            ],
+        },
+    }
+
+
+def _envelope(
+    results: list[dict[str, Any]],
+    *,
+    next_cursor: str | None,
+    total: int | None = None,
+) -> dict:
+    return {
+        "total": len(results) if total is None else total,
+        "size": len(results),
+        "offset": 0,
+        "results": results,
+        "pagination": {
+            "previous": None,
+            "next": next_cursor,
+        },
+    }
+
+
+# --- registry / wiring ------------------------------------------------------
+
+
+def test_registry_resolves_torre() -> None:
+    assert ScraperRegistry.get(ATSType.TORRE) is TorreScraper
+
+
+def test_scraper_ats_attribute() -> None:
+    assert TorreScraper("any").ats is ATSType.TORRE
+
+
+# --- happy path: structured-range salary ------------------------------------
+
+
+def test_parses_full_opportunity_with_salary_range(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        json=_envelope([_opp_with_salary_range()], next_cursor=None),
+    )
+
+    jobs = TorreScraper("any").fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+
+    assert j.ats_type is ATSType.TORRE
+    assert j.ats_id == "arQneQnW"
+    assert j.title == "Mac User Research Participant"
+    assert j.company == "Lusauto"
+    assert str(j.url) == (
+        "https://torre.ai/post/arQneQnW-lusauto-mac-user-research-participant"
+    )
+    # place.location → location + country + lat/lon
+    assert j.location == "Perú"
+    assert j.country_iso == "PE"
+    assert j.lat == pytest.approx(-9.189967)
+    assert j.lon == pytest.approx(-75.015152)
+    # remote flag: only ever set True per project convention
+    assert j.is_remote is True
+    # Structured salary
+    assert j.salary_currency == "USD"
+    assert j.salary_period == "MONTH"
+    assert j.salary_min == 500.0
+    assert j.salary_max == 1000.0
+    assert j.salary_summary is not None
+    assert "500" in j.salary_summary and "1,000" in j.salary_summary
+    assert "USD" in j.salary_summary
+    # Employment type: part-time → PART_TIME, raw commitment preserved
+    assert j.employment_type == "PART_TIME"
+    assert j.commitment == "part-time"
+    # Description: tagline + bulleted skills list
+    assert j.description is not None
+    assert "Contribuirás al éxito global" in j.description
+    assert "- Office automation" in j.description
+    assert "- Software development" in j.description
+    # Posted_at parsed from ISO 8601
+    assert j.posted_at is not None
+    assert j.posted_at.year == 2026
+    # raw overflow
+    assert j.raw is not None
+    assert j.raw.get("organization_public_id") == "Lusauto"
+    assert j.raw.get("organization_size") == 100
+    assert j.raw.get("type") == "full-time-employment"
+    assert j.raw.get("opportunity") == "employee"
+    assert j.raw.get("external") is False
+    assert "deadline" in j.raw
+    assert j.raw.get("skills") == ["Office automation", "Software development"]
+
+
+def test_include_descriptions_false_omits_description(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        json=_envelope([_opp_with_salary_range()], next_cursor=None),
+    )
+
+    jobs = TorreScraper("any", include_descriptions=False).fetch()
+
+    assert len(jobs) == 1
+    assert jobs[0].description is None
+
+
+# --- to-be-agreed: salary must stay None ------------------------------------
+
+
+def test_to_be_agreed_yields_no_salary_fields(httpx_mock) -> None:
+    """``code == "to-be-agreed"`` ships with ``minAmount=0``, ``maxAmount=0``.
+    Treating these as real bounds would let nonsense ``0 MXN`` rows leak
+    into the dataset. The currency must NOT be set either when both
+    bounds are empty (per JOB_SCHEMA.md: ``salary_currency`` is set
+    iff the ATS exposes a real range)."""
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        json=_envelope([_opp_to_be_agreed()], next_cursor=None),
+    )
+
+    jobs = TorreScraper("any").fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.salary_min is None
+    assert j.salary_max is None
+    assert j.salary_currency is None
+    assert j.salary_period is None
+    assert j.salary_summary is None
+    # but the rest of the row still parses:
+    assert j.title == "Asesor Profesional de Seguros e Inversiones"
+    assert j.country_iso == "MX"
+    assert j.employment_type == "FULL_TIME"
+    assert j.commitment == "full-time"
+
+
+def test_null_compensation_data_yields_no_salary_fields(httpx_mock) -> None:
+    """``compensation.data: None`` is the "employer hid it" case. Treat
+    identically to "no salary at all"."""
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        json=_envelope([_opp_no_compensation()], next_cursor=None),
+    )
+
+    j = TorreScraper("any").fetch()[0]
+    assert j.salary_currency is None
+    assert j.salary_min is None
+    assert j.salary_max is None
+    # other fields still parse:
+    assert j.country_iso == "CO"
+    assert j.location == "Bogotá, Colombia"
+
+
+# --- pagination -------------------------------------------------------------
+
+
+def test_follows_cursor_pagination(httpx_mock) -> None:
+    """Two pages: first response has ``pagination.next`` set, second is
+    null → loop exits. Both opportunities should appear in the result."""
+    httpx_mock.add_response(
+        url=re.compile(rf"{_SEARCH_RE.pattern}(?!.*after=)"),
+        json=_envelope(
+            [_opp_with_salary_range()],
+            next_cursor="CURSOR_PAGE_2",
+            total=2,
+        ),
+    )
+    httpx_mock.add_response(
+        url=re.compile(rf"{_SEARCH_RE.pattern}.*after=CURSOR_PAGE_2"),
+        json=_envelope([_opp_to_be_agreed()], next_cursor=None, total=2),
+    )
+
+    jobs = TorreScraper("any").fetch()
+    assert len(jobs) == 2
+    assert {j.ats_id for j in jobs} == {"arQneQnW", "Yd6mya1w"}
+
+
+def test_dedups_repeated_ids_across_pages(httpx_mock) -> None:
+    """Defensive: if the server somehow yields the same opportunity on
+    two consecutive pages (cursor edge cases), we de-duplicate by
+    ``ats_id`` before adding to the output list."""
+    httpx_mock.add_response(
+        url=re.compile(rf"{_SEARCH_RE.pattern}(?!.*after=)"),
+        json=_envelope(
+            [_opp_with_salary_range()], next_cursor="C2", total=2,
+        ),
+    )
+    httpx_mock.add_response(
+        url=re.compile(rf"{_SEARCH_RE.pattern}.*after=C2"),
+        # Same id appears again.
+        json=_envelope(
+            [_opp_with_salary_range()], next_cursor=None, total=2,
+        ),
+    )
+    jobs = TorreScraper("any").fetch()
+    assert len(jobs) == 1
+
+
+def test_rejects_empty_first_page(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_SEARCH_RE, json=_envelope([], next_cursor=None)
+    )
+
+    with pytest.raises(ScraperError, match="reported zero jobs"):
+        TorreScraper("any").fetch()
+
+
+def test_rejects_missing_results_key(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        json={"pagination": {"next": None}},
+    )
+
+    with pytest.raises(ScraperError, match="omitted results"):
+        TorreScraper("any").fetch()
+
+
+def test_rejects_empty_page_with_next_cursor(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=re.compile(rf"{_SEARCH_RE.pattern}(?!.*after=)"),
+        json=_envelope([_opp_with_salary_range()], next_cursor="C2"),
+    )
+    httpx_mock.add_response(
+        url=re.compile(rf"{_SEARCH_RE.pattern}.*after=C2"),
+        json=_envelope([], next_cursor="C3"),
+    )
+
+    with pytest.raises(ScraperError, match="empty page with a next cursor"):
+        TorreScraper("any").fetch()
+
+
+def test_rejects_repeated_pagination_cursor(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=re.compile(rf"{_SEARCH_RE.pattern}(?!.*after=)"),
+        json=_envelope(
+            [_opp_with_salary_range()], next_cursor="C2", total=2,
+        ),
+    )
+    httpx_mock.add_response(
+        url=re.compile(rf"{_SEARCH_RE.pattern}.*after=C2"),
+        json=_envelope(
+            [_opp_to_be_agreed()], next_cursor="C2", total=2,
+        ),
+    )
+
+    with pytest.raises(ScraperError, match="repeated pagination cursor"):
+        TorreScraper("any").fetch()
+
+
+def test_rejects_unparseable_result_row(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        json=_envelope(
+            [{"id": "missing-objective"}], next_cursor=None, total=1,
+        ),
+    )
+
+    with pytest.raises(ScraperError, match="could not parse every row"):
+        TorreScraper("any").fetch()
+
+
+def test_rejects_catalogue_ending_before_reported_total(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        json=_envelope(
+            [_opp_with_salary_range()], next_cursor=None, total=2,
+        ),
+    )
+
+    with pytest.raises(ScraperError, match=r"reported total \(1/2\)"):
+        TorreScraper("any").fetch()
+
+
+@pytest.mark.parametrize("total", [None, -1, "2"])
+def test_rejects_invalid_total(httpx_mock, total) -> None:
+    payload = _envelope(
+        [_opp_with_salary_range()], next_cursor=None, total=1,
+    )
+    payload["total"] = total
+    httpx_mock.add_response(url=_SEARCH_RE, json=payload)
+
+    with pytest.raises(ScraperError, match="invalid total"):
+        TorreScraper("any").fetch()
+
+
+def test_fetcher_uses_proxy_from_environment(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "ATS_SCRAPERS_PROXY", "http://env-proxy.example:8080",
+    )
+    fetcher = TorreScraper("any").make_fetcher()
+    assert fetcher.proxy == "http://env-proxy.example:8080"
+
+
+# --- error handling ---------------------------------------------------------
+
+
+def test_500_response_raises_scraper_error(httpx_mock) -> None:
+    httpx_mock.add_response(url=_SEARCH_RE, status_code=500, is_reusable=True)
+    with pytest.raises(ScraperError):
+        TorreScraper("any").fetch()
+
+
+def test_400_response_raises_scraper_error(httpx_mock) -> None:
+    """When the server rejects the page-size (``too large``) it returns
+    400 with a JSON body. The scraper currently fixes ``PAGE_SIZE`` to
+    something well under the cap, but a future bump should surface as
+    a hard error rather than silent zero-results."""
+    httpx_mock.add_response(
+        url=_SEARCH_RE,
+        status_code=400,
+        json={"meta": {"message": "Request size too large"}},
+    )
+    with pytest.raises(ScraperError):
+        TorreScraper("any").fetch()
+
+
+def test_non_object_json_raises_scraper_error(httpx_mock) -> None:
+    httpx_mock.add_response(url=_SEARCH_RE, json=[])
+    with pytest.raises(ScraperError, match="expected object"):
+        TorreScraper("any").fetch()

--- a/tests/test_torre.py
+++ b/tests/test_torre.py
@@ -389,10 +389,7 @@ def test_follows_cursor_pagination(httpx_mock) -> None:
     assert {j.ats_id for j in jobs} == {"arQneQnW", "Yd6mya1w"}
 
 
-def test_dedups_repeated_ids_across_pages(httpx_mock) -> None:
-    """Defensive: if the server somehow yields the same opportunity on
-    two consecutive pages (cursor edge cases), we de-duplicate by
-    ``ats_id`` before adding to the output list."""
+def test_rejects_duplicate_ids_that_mask_reported_total(httpx_mock) -> None:
     httpx_mock.add_response(
         url=re.compile(rf"{_SEARCH_RE.pattern}(?!.*after=)"),
         json=_envelope(
@@ -406,8 +403,30 @@ def test_dedups_repeated_ids_across_pages(httpx_mock) -> None:
             [_opp_with_salary_range()], next_cursor=None, total=2,
         ),
     )
-    jobs = TorreScraper("any").fetch()
-    assert len(jobs) == 1
+    with pytest.raises(ScraperError, match=r"1/2 unique jobs"):
+        TorreScraper("any").fetch()
+
+
+def test_rejects_partial_overlap_that_masks_reported_total(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=re.compile(rf"{_SEARCH_RE.pattern}(?!.*after=)"),
+        json=_envelope(
+            [_opp_with_salary_range(), _opp_to_be_agreed()],
+            next_cursor="C2",
+            total=4,
+        ),
+    )
+    httpx_mock.add_response(
+        url=re.compile(rf"{_SEARCH_RE.pattern}.*after=C2"),
+        json=_envelope(
+            [_opp_to_be_agreed(), _opp_no_compensation()],
+            next_cursor=None,
+            total=4,
+        ),
+    )
+
+    with pytest.raises(ScraperError, match=r"3/4 unique jobs"):
+        TorreScraper("any").fetch()
 
 
 def test_rejects_empty_first_page(httpx_mock) -> None:
@@ -481,7 +500,9 @@ def test_rejects_catalogue_ending_before_reported_total(httpx_mock) -> None:
         ),
     )
 
-    with pytest.raises(ScraperError, match=r"reported total \(1/2\)"):
+    with pytest.raises(
+        ScraperError, match=r"reported total \(1/2 unique jobs\)"
+    ):
         TorreScraper("any").fetch()
 
 

--- a/tests/test_torre.py
+++ b/tests/test_torre.py
@@ -16,6 +16,7 @@ import pytest
 from ats_scrapers.exceptions import ScraperError
 from ats_scrapers.models import ATSType
 from ats_scrapers.scrapers import ScraperRegistry, TorreScraper
+from ats_scrapers.scrapers.torre import _parse_detail_description
 
 # pytest-httpx matches on URL path; matching with a regex keeps the test
 # tolerant of query-string ordering (httpx serializes ``params={}`` dicts
@@ -271,6 +272,51 @@ def test_include_descriptions_false_omits_description(httpx_mock) -> None:
 
     assert len(jobs) == 1
     assert jobs[0].description is None
+    assert jobs[0].raw is not None
+    assert "Contribuirás al éxito global" in jobs[0].raw["search_summary"]
+
+
+def test_parses_full_detail_description() -> None:
+    detail_html = """
+    <section>
+      <div class="opportunity-responsibilities__preview">
+        <p>Build the core product.</p>
+        <p>Partner directly with customers.</p>
+      </div>
+    </section>
+    """
+
+    assert _parse_detail_description(detail_html) == (
+        "Build the core product.\nPartner directly with customers."
+    )
+
+
+def test_get_description_fetches_public_posting_body(httpx_mock) -> None:
+    scraper = TorreScraper("any", include_descriptions=False)
+    job = scraper._parse_job(_opp_with_salary_range())
+    assert job is not None
+    httpx_mock.add_response(
+        url=str(job.url),
+        html=(
+            '<div class="opportunity-responsibilities__preview">'
+            "<p>Own the production platform.</p>"
+            "</div>"
+        ),
+    )
+
+    assert scraper.get_description(job) == "Own the production platform."
+
+
+def test_get_description_falls_back_to_search_summary(httpx_mock) -> None:
+    scraper = TorreScraper("any", include_descriptions=False)
+    job = scraper._parse_job(_opp_with_salary_range())
+    assert job is not None
+    httpx_mock.add_response(url=str(job.url), status_code=503, is_reusable=True)
+
+    description = scraper.get_description(job)
+
+    assert description is not None
+    assert "Contribuirás al éxito global" in description
 
 
 # --- to-be-agreed: salary must stay None ------------------------------------


### PR DESCRIPTION
## Sources

- ByteDance global careers
- Torre global jobs marketplace

## Data-quality safeguards

- public credential-free endpoints only; no API keys, paid proxies, or browser automation
- full-catalogue runs fail closed on transport, parser, pagination, or empty-output drift
- source identifiers, companies, locations, timestamps, and canonical URLs are preserved
- marketplace rows receive lower dedup priority than canonical employer ATS rows

## Validation

- `uv run ruff check .`
- `uv run pytest -q` — 1,347 passed, 2 skipped, 22 deselected
- live production probes — 2 passed, both returning non-empty real jobs with unique IDs and valid source domains

This is a two-source replacement for the oversized #214.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds credential-free ByteDance and Torre sources.
- Registers both source types and scraper adapters.
- Adds singleton pipeline configurations with empty-output preservation.
- Adds source-specific parsing, pagination, dedup priority, and regression coverage.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because overlapping ByteDance pages can still replace the prior snapshot with an incomplete catalogue.

ByteDance declares completion from the raw number of API rows, while the runner later removes duplicate IDs and accepts any remaining non-empty output, allowing duplicate page overlap to publish fewer unique jobs than the reported catalogue.

**Files Needing Attention:** src/ats_scrapers/scrapers/bytedance.py

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/ats_scrapers/scrapers/bytedance.py | Adds ByteDance catalogue pagination and parsing, but completeness is based on raw rows and can accept a duplicate-masked truncation. |
| src/ats_scrapers/scrapers/torre.py | Adds Torre cursor pagination, unique-ID completeness validation, parsing, and description fallback. |
| scripts/run_pipeline.py | Registers both singleton sources and adds guards that preserve prior output after empty or required-shard failures. |
| pipeline/publisher.py | Assigns canonical priority to ByteDance and lower marketplace priority to Torre. |
| src/ats_scrapers/models.py | Adds ByteDance and Torre to the supported source enum. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/ats_scrapers/scrapers/bytedance.py:111-116
**Duplicate pages mask truncation**

When ByteDance returns overlapping job IDs across pages, this loop advances `offset` using the raw row count and declares the reported catalogue complete. The runner then removes duplicate `(company, ats_id)` rows but accepts the remaining non-empty output, causing an incomplete ByteDance snapshot to replace the previous catalogue.

`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix: fail closed on Torre overlap"](https://github.com/kalil0321/ats-scrapers/commit/737107bb10ca38eb652e835427df758db0e5d70a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47029570)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Scraper Adapters](https://app.greptile.com/kalil0321/-/custom-context/knowledge-base/kalil0321/ats-scrapers/-/docs/scraper-adapters.md)
- Knowledge Base — [Run Pipeline: Tenant List → Flat Jobs CSV](https://app.greptile.com/kalil0321/-/custom-context/knowledge-base/kalil0321/ats-scrapers/-/docs/run-pipeline-script.md)
- Knowledge Base — [Publishing pipeline](https://app.greptile.com/kalil0321/-/custom-context/knowledge-base/kalil0321/ats-scrapers/-/docs/publishing-pipeline.md)
</details>

<!-- /greptile_comment -->