### PR TITLE
Add Foundit and TimesJobs credential-free job sources

### DIFF
--- a/ats-companies/foundit.csv
+++ b/ats-companies/foundit.csv
@@ -1,0 +1,6 @@
+name,slug,url
+Foundit India,in,https://www.foundit.in
+Foundit Indonesia,id,https://www.foundit.id
+Foundit Malaysia,my,https://www.foundit.my
+Foundit Philippines,ph,https://www.foundit.com.ph
+Foundit Singapore,sg,https://www.foundit.sg

--- a/ats-companies/timesjobs.csv
+++ b/ats-companies/timesjobs.csv
@@ -1,0 +1,2 @@
+name,slug,url
+TimesJobs,timesjobs,https://www.timesjobs.com

--- a/pipeline/publisher.py
+++ b/pipeline/publisher.py
@@ -547,6 +547,7 @@ ATS_DEDUP_PRIORITY: dict[str, int] = {
     "tiktok": 1, "uber": 1,
     # Hybrid jobboards
     "welcometothejungle": 3, "mercor": 3, "gem": 3,
+    "foundit": 4, "timesjobs": 4,
     # Sourcing/matching layer that mirrors others
     "eightfold": 5,
     # National public-sector aggregators — government-curated but the

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -52,6 +52,7 @@ from ats_scrapers.scrapers import (
     DarwinboxScraper,
     EightfoldScraper,
     EuresScraper,
+    FounditScraper,
     GemScraper,
     GetOnBrdScraper,
     GoogleScraper,
@@ -83,6 +84,7 @@ from ats_scrapers.scrapers import (
     TeslaScraper,
     TheHubScraper,
     TikTokScraper,
+    TimesJobsScraper,
     UberScraper,
     WantedScraper,
     WellfoundScraper,
@@ -664,6 +666,20 @@ CONFIGS: dict[str, dict[str, Any]] = {
         # InfoJobs Spain - Spanish direct-posting job board. ~70k live.
         "scraper": InfoJobsSpainScraper, "singleton": True,
         "output": "infojobs_es/jobs.csv",
+    },
+    "foundit": {
+        "scraper": FounditScraper,
+        "slug": lambda r: _slug_col(r) or None,
+        "kwargs": lambda r: {"bucket_strategy": "keyword"},
+        "csv": "ats-companies/foundit.csv",
+        "output": "foundit/jobs.csv",
+        "fail_closed_on_any_error": True,
+        "skip_description_enrichment": True,
+    },
+    "timesjobs": {
+        "scraper": TimesJobsScraper, "singleton": True,
+        "output": "timesjobs/jobs.csv",
+        "fail_closed_on_empty": True,
     },
     "jobs_cz": {
         # jobs.cz - Czech Republic's largest direct-posting board. ~10k live via seeded search.
@@ -1441,6 +1457,47 @@ async def run(ats: str, concurrency: int, max_tenants: int | None, timeout: floa
                 print(
                     f"[{ats}] ACTION retry: streaming scrape failed after "
                     f"{counts['jobs']:,} jobs and no previous jobs.csv exists."
+                )
+            return 1
+
+        empty_output_failure = (
+            bool(cfg.get("fail_closed_on_empty"))
+            and bool(targets)
+            and counts["jobs"] == 0
+        )
+        if empty_output_failure:
+            tmp_output_path.unlink(missing_ok=True)
+            if output_path.exists():
+                print(
+                    f"[{ats}] ACTION keep_previous: required scrape returned "
+                    f"0 jobs; preserved {output_path} instead of publishing "
+                    "an empty dataset."
+                )
+            else:
+                print(
+                    f"[{ats}] ACTION retry: required scrape returned 0 jobs "
+                    "and no previous jobs.csv exists."
+                )
+            return 1
+
+        sharded_failure = (
+            bool(cfg.get("fail_closed_on_any_error"))
+            and counts["error"] > 0
+        )
+        if sharded_failure:
+            tmp_output_path.unlink(missing_ok=True)
+            if output_path.exists():
+                print(
+                    f"[{ats}] ACTION keep_previous: {counts['error']}/"
+                    f"{len(targets)} required shards failed after "
+                    f"{counts['jobs']:,} jobs; preserved {output_path} "
+                    "instead of publishing a partial dataset."
+                )
+            else:
+                print(
+                    f"[{ats}] ACTION retry: {counts['error']}/"
+                    f"{len(targets)} required shards failed and no previous "
+                    "jobs.csv exists."
                 )
             return 1
 

--- a/src/ats_scrapers/models.py
+++ b/src/ats_scrapers/models.py
@@ -87,6 +87,8 @@ class ATSType(StrEnum):
     YCOMBINATOR = "ycombinator"
     WELLFOUND = "wellfound"
     INFOJOBSES = "infojobs_es"
+    FOUNDIT = "foundit"
+    TIMESJOBS = "timesjobs"
     # Additional multi-tenant ATSes (post-0.1)
     BAMBOOHR = "bamboohr"
     BREEZY = "breezy"

--- a/src/ats_scrapers/scrapers/__init__.py
+++ b/src/ats_scrapers/scrapers/__init__.py
@@ -24,6 +24,7 @@ from ats_scrapers.scrapers.cornerstone import CornerstoneScraper
 from ats_scrapers.scrapers.darwinbox import DarwinboxScraper
 from ats_scrapers.scrapers.eightfold import EightfoldScraper
 from ats_scrapers.scrapers.eures import EuresScraper
+from ats_scrapers.scrapers.foundit import FounditScraper
 from ats_scrapers.scrapers.gem import GemScraper
 from ats_scrapers.scrapers.getonbrd import GetOnBrdScraper
 from ats_scrapers.scrapers.google import GoogleScraper
@@ -56,6 +57,7 @@ from ats_scrapers.scrapers.teamtailor import TeamtailorScraper
 from ats_scrapers.scrapers.tesla import TeslaScraper
 from ats_scrapers.scrapers.thehub import TheHubScraper
 from ats_scrapers.scrapers.tiktok import TikTokScraper
+from ats_scrapers.scrapers.timesjobs import TimesJobsScraper
 from ats_scrapers.scrapers.uber import UberScraper
 from ats_scrapers.scrapers.usajobs import USAJobsScraper
 from ats_scrapers.scrapers.wanted import WantedScraper
@@ -83,6 +85,7 @@ __all__ = [
     "DarwinboxScraper",
     "EightfoldScraper",
     "EuresScraper",
+    "FounditScraper",
     "GemScraper",
     "GetOnBrdScraper",
     "GoogleScraper",
@@ -115,6 +118,7 @@ __all__ = [
     "TeslaScraper",
     "TheHubScraper",
     "TikTokScraper",
+    "TimesJobsScraper",
     "USAJobsScraper",
     "UberScraper",
     "WTTJScraper",

--- a/src/ats_scrapers/scrapers/foundit.py
+++ b/src/ats_scrapers/scrapers/foundit.py
@@ -1,0 +1,759 @@
+"""Foundit (formerly Monster India) — India + SEA jobs aggregator.
+
+Foundit is the rebrand of Monster.com's India / APAC operations.
+It runs separate country domains, each fronted by the same backend:
+
+  - ``https://www.foundit.in/``      — India (~300k live postings)
+  - ``https://www.foundit.sg/``      — Singapore (~125k)
+  - ``https://www.foundit.my/``      — Malaysia (~35k)
+  - ``https://www.foundit.id/``      — Indonesia (~17k)
+  - ``https://www.foundit.com.ph/``  — Philippines (~37k)
+
+The whole site is fronted by **Akamai Bot Manager** (the ``_abck`` /
+``bm_sz`` cookies on the HTML pages give it away) — the SPA HTML
+returns 200 for the homepage but blocks deep search URLs with
+``Access Denied`` from ``errors.edgesuite.net``. However the JSON
+**search API** at ``/middleware/jobsearch`` is anonymous, accepts
+plain ``httpx`` (no TLS-fingerprint check), and returns the same
+structured rows the SPA renders client-side. We hit the API
+directly with a Chrome-ish ``User-Agent`` + ``Referer`` and skip the
+SPA entirely.
+
+API reverse-engineered live on 2026-05-12. Query params:
+
+    sort=1            most-recent first (0 = relevance)
+    limit=100         page size; >100 silently truncates extras
+    query=            free-text search; empty == all jobs
+    searchId=         session-id cookie; empty works for anon
+    queryDerived=true required for the no-query "all jobs" view
+    country=india     country token (matches the domain channel)
+    start=N           offset; capped around 9500 (see below)
+
+Each entry in ``jobSearchResponse.data`` carries the job id, title,
+company, location, salary range (already structured + ISO 4217
+currency), skills, experience window, qualifications, posted-at
+epoch, and the ``jdUrl`` slug. Description prose lives on the
+detail page (Next.js ``__NEXT_DATA__``) — we don't fetch per-job by
+default because the catalogue is large; downstream LLM enrichment
+fills it in.
+
+**Deep-pagination cap**: the API silently clamps ``start`` to ~9500.
+Past that, the same rows repeat with wrap-around cursors (verified
+live: ``start=10000`` returns the same payload as ``start=9500``).
+So the unrestricted ``"all jobs"`` walk tops out at ~10 000 / 300 000
+on India. The same cap applies *per query bucket* — even with
+``query=engineer`` (62k hits) we can only read the first 9500 rows.
+
+**Keyword bucketing** (``bucket_strategy="keyword"``) opt-in mode
+works around the cap by iterating ~80 broad seed terms (engineer,
+manager, sales, …). Each seed yields its own top-9500 window;
+the union — deduped by ``ats_id`` — recovers a large fraction of
+the ~522k catalogue. Coverage isn't 100 % (a job nobody's seeds
+hit gets missed), but live runs on India typically lift the take
+from ~10k to 200k+. The default ``"none"`` mode preserves the
+original single-call no-query behaviour for backwards-compat.
+
+Single-source scraper, multi-region: ``company_slug`` picks the
+country. Pass one of ``"in"`` (default), ``"sg"``, ``"my"``,
+``"id"``, ``"ph"``. Aliases (``"india"``, ``"singapore"``, …) are
+also accepted and canonicalised to the two-letter slug.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, Literal
+
+import httpx
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType, EmploymentType, Job
+from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+BucketStrategy = Literal["none", "keyword"]
+
+log = logging.getLogger(__name__)
+
+
+# --- Country / domain map ---------------------------------------------
+
+# slug → (domain, country query token, ISO 3166-1 alpha-2, region label).
+# The ``country`` query token is what the API expects (not the slug,
+# not the alpha-2). India uses ``india``, Singapore ``singapore``, etc.
+_COUNTRY_TABLE: dict[str, tuple[str, str, str, str]] = {
+    "in": ("www.foundit.in",     "india",       "IN", "Asia"),
+    "sg": ("www.foundit.sg",     "singapore",   "SG", "Asia"),
+    "my": ("www.foundit.my",     "malaysia",    "MY", "Asia"),
+    "id": ("www.foundit.id",     "indonesia",   "ID", "Asia"),
+    "ph": ("www.foundit.com.ph", "philippines", "PH", "Asia"),
+}
+
+# Accepted alternate forms — canonicalised to the two-letter slug
+# above. Lower-cased before lookup.
+_COUNTRY_ALIASES: dict[str, str] = {
+    "india": "in",
+    "singapore": "sg",
+    "malaysia": "my",
+    "indonesia": "id",
+    "philippines": "ph",
+    "ph_ph": "ph",
+}
+
+
+# --- API knobs --------------------------------------------------------
+
+# 100 is the largest size the API honours (>100 returns the same 100
+# row payload). 100 × pages == real per-page count.
+PER_PAGE = 100
+
+# Past ``start ~= 9500`` the API silently wraps to recently-seen
+# rows. Capping at 9500 covers the freshest ~10k jobs per channel.
+# India alone has 300k+ so the long tail is left for query-seed
+# bucketing in a follow-up.
+MAX_USABLE_OFFSET = 9500
+DEFAULT_MAX_PAGES = (MAX_USABLE_OFFSET // PER_PAGE) + 1  # 96
+
+# Stop a bucket only after this many *consecutive* pages yield no new
+# rows. A single empty page is not enough: a keyword bucket's early
+# pages can be fully covered by an earlier seed while later pages still
+# hold unique jobs, so we must keep paging past the first overlap.
+
+# Retry knobs. The API returns 200 reliably from residential IPs;
+# datacenter IPs can see intermittent 403 / 502 — we back off and
+# retry a small number of times then bail with whatever we have.
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1.5
+
+# Chrome-on-Linux user agent. The middleware endpoint accepts any
+# UA — even ``curl/7.x`` works — but we mirror the real SPA's
+# Chrome UA to blend in if the WAF rules tighten later.
+_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36"
+)
+
+
+# --- Keyword bucketing -----------------------------------------------
+
+# Broad seed terms for ``bucket_strategy="keyword"``. The set is
+# tuned to span the catalogue: white-collar roles (engineer, manager,
+# analyst, ...), blue-collar (driver, technician, electrician, ...),
+# seniority modifiers (junior / senior / lead / head), broad
+# functions (sales, marketing, finance, ...), and language /
+# technology pivots (python, java, sql) — the latter add coverage
+# in IT-heavy markets like India where the same job appears under
+# multiple non-IT seeds too. The list is intentionally English-
+# only: live probing showed the API tokenises Latin-script queries
+# against multilingual postings reasonably well (Hindi / Tagalog
+# job titles still rank against English seeds because foundit
+# canonicalises titles internally). Adding non-Latin seeds would
+# yield marginal coverage at the cost of brittler parameter
+# encoding through Akamai.
+#
+# Ordering matters slightly: high-volume seeds run first so we
+# capture the most jobs before any rate-limit retry budget is
+# consumed. Roughly ~80 seeds × ~9500 max each → ~760k possible
+# row reads pre-dedup against the 522k true catalogue.
+_DEFAULT_KEYWORD_SEEDS: tuple[str, ...] = (
+    # high-volume generic
+    "engineer", "manager", "developer", "analyst", "executive",
+    "consultant", "senior", "specialist", "associate", "officer",
+    "lead", "supervisor", "coordinator", "assistant", "intern",
+    "head", "director", "vp", "president", "chief",
+    # functions
+    "sales", "marketing", "finance", "accounting", "accountant",
+    "hr", "operations", "logistics", "supply chain", "procurement",
+    "design", "designer", "product", "project", "program",
+    "research", "quality", "support", "service", "admin",
+    # IT-specific
+    "software", "java", "python", "javascript", "data",
+    "cloud", "devops", "fullstack", "backend", "frontend",
+    "android", "ios", "qa", "sre", "security",
+    # blue-collar / trades
+    "driver", "technician", "electrician", "mechanic",
+    "machinist", "welder", "operator", "foreman",
+    # services / healthcare / education
+    "teacher", "trainer", "doctor", "nurse", "pharmacist",
+    "lawyer", "chef", "retail", "hospitality", "warehouse",
+    # role descriptors
+    "junior", "graduate", "fresher", "entry level", "trainee",
+    "customer", "business", "tech", "media", "communications",
+)
+
+
+def _default_keyword_seeds() -> tuple[str, ...]:
+    """Return the default seed list (frozen tuple, safe to share).
+
+    Exposed as a helper so callers / tests can introspect or
+    override without poking the private constant directly.
+    """
+    return _DEFAULT_KEYWORD_SEEDS
+
+
+# --- Mapping helpers --------------------------------------------------
+
+# Foundit's free-text employment label → our canonical enum. Lower-
+# cased and stripped before lookup. Unknown values fall through to
+# ``None``; ``raw["employment_types"]`` retains the original list.
+_EMPLOYMENT_TYPE_MAP: dict[str, EmploymentType] = {
+    "full time": "FULL_TIME",
+    "full-time": "FULL_TIME",
+    "permanent": "FULL_TIME",
+    "part time": "PART_TIME",
+    "part-time": "PART_TIME",
+    "contract": "CONTRACT",
+    "contractual": "CONTRACT",
+    "freelance": "CONTRACT",
+    "internship": "INTERN",
+    "intern": "INTERN",
+    "trainee": "INTERN",
+    "temporary": "TEMPORARY",
+    "casual": "TEMPORARY",
+    "walk in": "FULL_TIME",  # Foundit's walk-in interview convention.
+}
+
+
+@ScraperRegistry.register(ATSType.FOUNDIT)
+class FounditScraper(BaseScraper):
+    """Foundit (Monster India / APAC) — country-paginated job listings.
+
+    Constructor knobs:
+        company_slug: country selector. One of ``"in"`` (default,
+            India), ``"sg"``, ``"my"``, ``"id"``, ``"ph"`` — or the
+            full English name (``"india"``, ``"singapore"``, …).
+        max_pages: stop after this many pages **per query bucket**
+            even if more remain. ``None`` walks until the API's
+            deep-pagination cap (``MAX_USABLE_OFFSET / PER_PAGE``).
+        bucket_strategy: ``"none"`` (default) issues a single
+            no-query walk capped at ~9500 rows — fastest, fully
+            backwards-compatible. ``"keyword"`` iterates ~80
+            broad seed terms (``keyword_seeds``), each up to its
+            own 9500-row cap, and dedups by job id. Roughly 20-25x
+            the row count on India at ~80x the wall-clock cost.
+        keyword_seeds: override the default seed list for
+            ``bucket_strategy="keyword"``. Useful for smoke tests
+            or for tuning to a local market.
+    """
+
+    ats = ATSType.FOUNDIT
+
+    def __init__(
+        self,
+        company_slug: str = "in",
+        *,
+        timeout: float = 30.0,
+        include_descriptions: bool = False,
+        proxy: str | None = None,
+        max_pages: int | None = None,
+        bucket_strategy: BucketStrategy = "none",
+        keyword_seeds: Sequence[str] | None = None,
+    ) -> None:
+        normalized = (company_slug or "in").lower().strip()
+        normalized = _COUNTRY_ALIASES.get(normalized, normalized)
+        if normalized not in _COUNTRY_TABLE:
+            raise ScraperError(
+                f"Foundit unknown country slug {company_slug!r}. "
+                f"Known: {sorted(_COUNTRY_TABLE)} (or aliases "
+                f"{sorted(_COUNTRY_ALIASES)})"
+            )
+        if bucket_strategy not in ("none", "keyword"):
+            raise ScraperError(
+                f"Foundit unknown bucket_strategy {bucket_strategy!r}. "
+                f"Known: 'none', 'keyword'."
+            )
+        if max_pages is not None and max_pages < 1:
+            raise ScraperError(
+                f"Foundit max_pages must be positive, got {max_pages}"
+            )
+        super().__init__(
+            normalized,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        if include_descriptions:
+            raise ScraperError(
+                "Foundit listing API does not expose descriptions; "
+                "set include_descriptions=False"
+            )
+        self.country_slug = normalized
+        domain, token, iso, region = _COUNTRY_TABLE[normalized]
+        self._domain = domain
+        self._country_token = token
+        self._country_iso = iso
+        self._region = region
+        self._full_catalogue = max_pages is None
+        self.max_pages = min(max_pages or DEFAULT_MAX_PAGES, DEFAULT_MAX_PAGES)
+        self.bucket_strategy: BucketStrategy = bucket_strategy
+        if keyword_seeds is None:
+            self.keyword_seeds: tuple[str, ...] = _DEFAULT_KEYWORD_SEEDS
+        else:
+            # Dedup-preserving-order; strip empties so callers can
+            # pass a casual list without surprises.
+            seen_kw: set[str] = set()
+            cleaned: list[str] = []
+            for kw in keyword_seeds:
+                if not isinstance(kw, str):
+                    continue
+                k = kw.strip()
+                if not k or k.lower() in seen_kw:
+                    continue
+                seen_kw.add(k.lower())
+                cleaned.append(k)
+            self.keyword_seeds = tuple(cleaned)
+        if bucket_strategy == "keyword" and not self.keyword_seeds:
+            raise ScraperError(
+                "bucket_strategy='keyword' requires at least one non-empty seed"
+            )
+
+    # ----- public entry point -----------------------------------------
+
+    async def afetch(self) -> list[Job]:
+        return await asyncio.to_thread(self._fetch_sync)
+
+    def fetch(self) -> list[Job]:
+        return self._run_sync(self.afetch())
+
+    def _fetch_sync(self) -> list[Job]:
+        fetched_at = datetime.now(tz=UTC)
+        jobs: list[Job] = []
+        seen: set[str] = set()
+        with httpx.Client(
+            timeout=self.timeout,
+            proxy=self.proxy,
+            headers={
+                "Accept": "application/json",
+                "Accept-Language": "en-US,en;q=0.9",
+                "Referer": f"https://{self._domain}/",
+                "User-Agent": _USER_AGENT,
+            },
+            follow_redirects=True,
+        ) as client:
+            if self.bucket_strategy == "keyword":
+                self._fetch_keyword_buckets(
+                    client, jobs, seen, fetched_at=fetched_at,
+                )
+            else:
+                # Original single-call no-query walk.
+                self._walk_query(
+                    client, query="", jobs=jobs, seen=seen,
+                    fetched_at=fetched_at,
+                )
+
+        log.info(
+            "Foundit %s [%s]: fetched %d unique jobs",
+            self.country_slug, self.bucket_strategy, len(jobs),
+        )
+        if self._full_catalogue and not jobs:
+            raise ScraperError(
+                f"Foundit {self.country_slug} full-catalogue scrape "
+                "returned no jobs"
+            )
+        return jobs
+
+    # ----- bucketing --------------------------------------------------
+
+    def _fetch_keyword_buckets(
+        self,
+        client: httpx.Client,
+        jobs: list[Job],
+        seen: set[str],
+        *,
+        fetched_at: datetime,
+    ) -> None:
+        """Iterate keyword seeds, walking each as its own paginated
+        bucket. Mutates ``jobs`` / ``seen`` in place; dedup is by
+        ``ats_id`` so a job hit by N seeds counts once.
+        """
+        total_seeds = len(self.keyword_seeds)
+        for idx, keyword in enumerate(self.keyword_seeds, start=1):
+            before = len(jobs)
+            self._walk_query(
+                client, query=keyword, jobs=jobs, seen=seen,
+                fetched_at=fetched_at,
+            )
+            added = len(jobs) - before
+            log.debug(
+                "Foundit %s keyword %d/%d %r: +%d new jobs (total %d)",
+                self.country_slug, idx, total_seeds, keyword,
+                added, len(jobs),
+            )
+
+    def _walk_query(
+        self,
+        client: httpx.Client,
+        *,
+        query: str,
+        jobs: list[Job],
+        seen: set[str],
+        fetched_at: datetime,
+    ) -> None:
+        """Paginate one query bucket up to ``max_pages`` / the API's
+        ~9500 cap. New rows are appended to ``jobs`` and their ids
+        added to ``seen``; existing ids are skipped.
+        """
+        query_seen: set[str] = set()
+        for page_no in range(self.max_pages):
+            start = page_no * PER_PAGE
+            if start > MAX_USABLE_OFFSET:
+                break
+            payload = self._fetch_page(client, start, query=query)
+            rows = list(
+                _iter_job_rows(payload, strict=self._full_catalogue)
+            )
+            if not rows:
+                break
+            new_for_query = 0
+            for row in rows:
+                job = self._parse_row(row, fetched_at=fetched_at)
+                if job is None:
+                    if self._full_catalogue:
+                        raise ScraperError(
+                            f"Foundit {self.country_slug} start={start} "
+                            "could not parse every returned job row"
+                        )
+                    continue
+                if job.ats_id in query_seen:
+                    continue
+                query_seen.add(job.ats_id)  # type: ignore[arg-type]
+                new_for_query += 1
+                if job.ats_id in seen:
+                    continue
+                seen.add(job.ats_id)  # type: ignore[arg-type]
+                jobs.append(job)
+            if new_for_query == 0:
+                # The API wrapped to a window already seen in this same
+                # query. Cross-seed duplicates do not trigger this stop.
+                if self._full_catalogue:
+                    raise ScraperError(
+                        f"Foundit {self.country_slug} start={start} repeated "
+                        "a previously seen result window"
+                    )
+                break
+
+    # ----- one page ---------------------------------------------------
+
+    def _fetch_page(
+        self, client: httpx.Client, start: int, *, query: str = "",
+    ) -> dict[str, Any]:
+        """GET one search page with retry on transient failures.
+
+        ``query`` is the ``query=`` filter — empty for the unrestricted
+        walk, non-empty for keyword bucketing.
+        """
+        url = f"https://{self._domain}/middleware/jobsearch"
+        params = {
+            "sort": "1",
+            "limit": str(PER_PAGE),
+            "query": query,
+            "searchId": "",
+            "queryDerived": "true",
+            "country": self._country_token,
+            "start": str(start),
+        }
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                response = client.get(url, params=params)
+            except httpx.HTTPError as exc:
+                last_exc = exc
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Foundit {self.country_slug} start={start} "
+                        f"transport failed after {MAX_RETRIES} retries: {exc}"
+                    ) from exc
+                _sleep_backoff(attempt)
+                continue
+
+            status = response.status_code
+            if status == 200:
+                try:
+                    body = response.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"Foundit {self.country_slug} start={start} returned "
+                        "non-JSON"
+                    ) from exc
+                if not isinstance(body, dict):
+                    raise ScraperError(
+                        f"Foundit {self.country_slug} start={start} returned "
+                        f"{type(body).__name__}, expected object"
+                    )
+                if body.get("jobSearchStatus") != 200:
+                    raise ScraperError(
+                        f"Foundit {self.country_slug} start={start} API status="
+                        f"{body.get('jobSearchStatus')} "
+                        f"({body.get('jobSearchStatusText')})"
+                    )
+                response_body = body.get("jobSearchResponse")
+                if not isinstance(response_body, dict):
+                    raise ScraperError(
+                        f"Foundit {self.country_slug} start={start} omitted "
+                        "jobSearchResponse"
+                    )
+                return response_body
+            if status in (403, 429) or 500 <= status < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Foundit {self.country_slug} start={start} returned "
+                        f"{status} after {MAX_RETRIES} retries"
+                    )
+                _sleep_backoff(attempt)
+                continue
+            # Some other 4xx — surface so an operator notices.
+            raise ScraperError(
+                f"Foundit {self.country_slug} start={start} returned {status}"
+            )
+        raise ScraperError(
+            f"Foundit {self.country_slug} start={start} exhausted retries: "
+            f"{last_exc}"
+        )
+
+    # ----- single-row parser ------------------------------------------
+
+    def _parse_row(
+        self,
+        row: dict[str, Any],
+        *,
+        fetched_at: datetime,
+    ) -> Job | None:
+        """Map one API row → ``Job``. Returns ``None`` when the row
+        lacks the bare minimum (id + title + jdUrl).
+        """
+        ats_id = _str_or_none(row.get("id")) or _str_or_none(row.get("jobId"))
+        if not ats_id:
+            return None
+        title = _clean_text(row.get("title"))
+        jd_url = _str_or_none(row.get("jdUrl")) or _str_or_none(
+            row.get("seoJdUrl")
+        )
+        if not title or not jd_url:
+            return None
+
+        url = _absolute_url(self._domain, jd_url)
+
+        company = _clean_text(row.get("companyName")) or "Unknown"
+        location = _clean_text(row.get("locations")) or None
+
+        # Posted-at: the row carries multiple timestamps; ``createdAt``
+        # is the canonical first-publish moment in epoch milliseconds.
+        posted_at = _epoch_ms_to_dt(row.get("createdAt"))
+
+        # Salary — Foundit exposes structured min/max + currency.
+        # Currency is a 3-letter ISO code (``INR``, ``SGD``, ``MYR``,
+        # ``IDR``, ``PHP``) — pass through to Job verbatim.
+        currency = _str_or_none(row.get("currencyCode"))
+        min_sal = _nested_amount(row.get("minimumSalary"))
+        max_sal = _nested_amount(row.get("maximumSalary"))
+        salary_summary = _clean_text(row.get("salary")) or None
+        # The ``hideSalary`` flag is set on confidential listings; the
+        # numeric values are still in the payload but the SPA hides
+        # them. Honour the hint so we don't surface salaries the
+        # employer chose not to publish.
+        if row.get("hideSalary"):
+            min_sal = None
+            max_sal = None
+            salary_summary = None
+            currency = None
+        elif min_sal is None and max_sal is None:
+            salary_summary = None
+            currency = None
+
+        # Employment type: a list — pick the first one we can map.
+        employment_label = None
+        emp_list = row.get("employmentTypes")
+        if isinstance(emp_list, list) and emp_list:
+            employment_label = _clean_text(emp_list[0]) or None
+        employment_type: EmploymentType | None = None
+        if employment_label:
+            employment_type = _EMPLOYMENT_TYPE_MAP.get(
+                employment_label.lower().strip(),
+            )
+
+        # Years of experience — ``minimumExperience`` is the typical
+        # "minimum years required". ``None`` when missing or zero
+        # (entry-level postings often omit it entirely).
+        experience: int | None = None
+        min_exp = row.get("minimumExperience")
+        if isinstance(min_exp, dict):
+            yrs = min_exp.get("years")
+            if isinstance(yrs, (int, float)) and yrs > 0:
+                experience = int(yrs)
+
+        # Raw overflow — keep the ATS-specific extras the canonical
+        # schema can't represent. Keep small (<5KB serialized): drop
+        # the verbose ``companyProfile`` blob (~5KB on its own).
+        raw_overflow: dict[str, object] = {
+            "industry": _clean_text(row.get("industry")) or None,
+            "experience_label": _clean_text(row.get("exp")) or None,
+            "education": list(_iter_strings(row.get("qualifications"))),
+            "skills": _split_skills(row.get("skills")),
+            "functions": list(_iter_strings(row.get("functions"))),
+            "roles": list(_iter_strings(row.get("roles"))),
+            "designations": list(_iter_strings(row.get("designations"))),
+            "employment_types": list(_iter_strings(row.get("employmentTypes"))),
+            "job_types": list(_iter_strings(row.get("jobTypes"))),
+            "country_slug": self.country_slug,
+            "channel_name": _clean_text(row.get("channelName")) or None,
+            "is_urgently_hiring": bool(row.get("isUrgentlyHiring")),
+            "kiwi_job_id": _str_or_none(row.get("kiwiJobId")),
+        }
+
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.FOUNDIT,
+            ats_id=ats_id,
+            location=location,
+            country_iso=self._country_iso,
+            region=self._region,
+            language="en",
+            salary_currency=currency,
+            salary_period="YEAR" if currency else None,
+            salary_summary=salary_summary,
+            salary_min=min_sal,
+            salary_max=max_sal,
+            experience=experience,
+            employment_type=employment_type,
+            commitment=employment_label,
+            posted_at=posted_at,
+            fetched_at=fetched_at,
+            raw=raw_overflow,
+        )
+
+
+# --- module-level helpers ---------------------------------------------
+
+
+def _iter_job_rows(
+    payload: dict[str, Any],
+    *,
+    strict: bool = False,
+) -> Iterable[dict[str, Any]]:
+    """Yield the real job rows from a ``jobSearchResponse`` payload.
+
+    The API interleaves ad/banner placements (``{"index": N, "type":
+    "adsense"}``) with the actual job entries; those lack the canonical
+    fields. We filter on the presence of ``id`` / ``jobId`` since
+    every real posting carries one.
+    """
+    data = payload.get("data")
+    if not isinstance(data, list):
+        raise ScraperError("Foundit response omitted list-valued data")
+    for row in data:
+        if not isinstance(row, dict):
+            if strict:
+                raise ScraperError(
+                    "Foundit data contained a non-object row"
+                )
+            continue
+        if "id" not in row and "jobId" not in row:
+            if strict and row.get("type") not in {"adsense", "banner"}:
+                raise ScraperError(
+                    "Foundit data contained an unrecognized row without "
+                    "a job identifier"
+                )
+            continue
+        yield row
+
+
+def _absolute_url(domain: str, path_or_url: str) -> str:
+    """Foundit's ``jdUrl`` is a site-relative path. Build the absolute
+    URL using the *country* domain (so the public dataset's URL
+    matches the channel the job lives on, not the .in default).
+    """
+    if path_or_url.startswith(("http://", "https://")):
+        return path_or_url
+    if not path_or_url.startswith("/"):
+        path_or_url = "/" + path_or_url
+    return f"https://{domain}{path_or_url}"
+
+
+def _str_or_none(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        v = value.strip()
+        return v or None
+    if isinstance(value, (int, float)):
+        return str(int(value))
+    return None
+
+
+def _clean_text(value: object) -> str | None:
+    """Strip + collapse whitespace, return None for empties. We don't
+    decode HTML entities here — Foundit's ``title`` / ``companyName``
+    are plain text in practice (the HTML-entity ones live in
+    ``companyProfile``, which we don't surface to ``Job.description``).
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _nested_amount(value: object) -> float | None:
+    """Salary fields are ``{"currency": "INR", "absoluteValue": N,
+    "absoluteMonthlyValue": M}``. We use the annualised
+    ``absoluteValue``. Zero is treated as "not set" — Foundit
+    encodes "no salary disclosed" as a 0 there.
+    """
+    if not isinstance(value, dict):
+        return None
+    amount = value.get("absoluteValue")
+    if not isinstance(amount, (int, float)):
+        return None
+    if amount <= 0:
+        return None
+    return float(amount)
+
+
+def _epoch_ms_to_dt(value: object) -> datetime | None:
+    """Foundit timestamps are epoch milliseconds — convert to UTC.
+    Returns ``None`` on missing / malformed input rather than crashing
+    the row."""
+    if not isinstance(value, (int, float)):
+        return None
+    if value <= 0:
+        return None
+    try:
+        return datetime.fromtimestamp(value / 1000.0, tz=UTC)
+    except (ValueError, OSError, OverflowError):
+        return None
+
+
+def _iter_strings(value: object) -> Iterable[str]:
+    """Yield clean non-empty strings from a list field. Drops dicts /
+    nulls silently."""
+    if not isinstance(value, list):
+        return
+    for item in value:
+        if isinstance(item, str):
+            s = item.strip()
+            if s:
+                yield s
+
+
+def _split_skills(value: object) -> list[str]:
+    """``skills`` arrives as a comma-separated string (``"Java, Python,
+    SQL"``). Split into a tidy list — keeps ``raw["skills"]`` as a
+    proper array rather than a free-text blob."""
+    if not isinstance(value, str):
+        return []
+    return [s.strip() for s in value.split(",") if s.strip()]
+
+
+def _sleep_backoff(attempt: int) -> None:
+    """Exponential backoff for transient 5xx / 429 — factored out so
+    tests can monkey-patch it to a no-op and not pay wall-clock cost.
+    """
+    time.sleep(RETRY_BASE_DELAY * (2 ** (attempt - 1)))

--- a/src/ats_scrapers/scrapers/timesjobs.py
+++ b/src/ats_scrapers/scrapers/timesjobs.py
@@ -1,0 +1,556 @@
+"""TimesJobs (https://www.timesjobs.com) — Indian hybrid jobboard scraper.
+
+TimesJobs (a Times Internet property) is one of India's largest job
+boards, alongside Naukri and Foundit/Monster. The site recently
+migrated to a Next.js SPA backed by a public JSON API at
+``tjapi.timesjobs.com`` which the frontend calls via:
+
+    POST https://tjapi.timesjobs.com/search/api/v1/search/jobs/list
+
+The endpoint is unauthenticated and accepts page-based pagination via
+``{"keyword": " ", "location": "", "page": "1", "size": "100"}``. An
+empty ``keyword`` returns HTTP 400 ("Invalid JSON format"); a single
+space matches every active listing (~200 k jobs at any given time).
+
+Page size limit appears generous (we successfully request ``size=1000``
+in probes), but we stay at 100/page to keep individual responses small
+and the server polite.
+
+The list response carries enough fields per row that we don't need to
+fetch the per-job detail endpoint
+(``/job-api/api/jobs/public/{jobId}``) — title, company, location,
+truncated description, skills, experience range, posted date, and a
+public ``jobDetailUrl`` are all present on the list payload.
+
+Single-source scraper: ``company_slug`` is informational and ignored.
+Output rows carry the publishing employer's name as ``company`` so
+cross-ATS dedup against the same role on Workday/Greenhouse still works.
+
+Although TimesJobs is an Indian board, the inventory mixes India-based
+roles with global postings (Google in Taiwan, Hilton in the US, …) —
+so ``country_iso`` is left ``None`` and the downstream LLM enrichment
+derives it from the ``location`` string instead of hard-coding ``IN``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import logging
+import re
+from contextlib import suppress
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Awaitable, Callable
+    from typing import Any
+
+log = logging.getLogger(__name__)
+
+API_URL = "https://tjapi.timesjobs.com/search/api/v1/search/jobs/list"
+# A single space matches every active listing. An empty keyword returns
+# HTTP 400 from the API.
+WILDCARD_KEYWORD = " "
+PAGE_SIZE = 100
+MAX_PAGES = 5000  # Safety belt — live board is ~2 k pages at 100/page.
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1.5
+
+_HEADERS = {
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+    "Origin": "https://www.timesjobs.com",
+    "Referer": "https://www.timesjobs.com/",
+    "User-Agent": "Mozilla/5.0",
+}
+
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+@ScraperRegistry.register(ATSType.TIMESJOBS)
+class TimesJobsScraper(BaseScraper):
+    """TimesJobs (timesjobs.com) — Indian hybrid job board.
+
+    Single-source scraper: ``company_slug`` is ignored. Pass anything
+    (``"any"``, ``""``, ``"india"``) — the scraper enumerates the entire
+    active board.
+    """
+
+    ats = ATSType.TIMESJOBS
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        include_descriptions: bool = True,
+        proxy: str | None = None,
+        max_pages: int | None = None,
+    ) -> None:
+        super().__init__(
+            company_slug,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        if max_pages is not None and max_pages < 1:
+            raise ScraperError(
+                f"TimesJobs max_pages must be positive, got {max_pages}"
+            )
+        self._full_catalogue = max_pages is None
+        self.max_pages = max_pages
+
+    async def afetch(self) -> list[Job]:
+        return await self._fetch_async()
+
+    def fetch(self) -> list[Job]:
+        """Legacy in-memory fetch — accumulates the full corpus into a
+        list. At ~200 k jobs that's a few hundred MB; for cron contexts
+        that write straight to disk prefer :meth:`fetch_stream`."""
+        return self._run_sync(self.afetch())
+
+    async def fetch_stream(self) -> AsyncGenerator[Job, None]:
+        """Stream jobs as they're parsed.
+
+        Same producer-queue-consumer pattern as
+        :meth:`ats_scrapers.scrapers.eures.EuresScraper.fetch_stream` — keeps
+        memory bounded regardless of corpus size."""
+        queue: asyncio.Queue[Job] = asyncio.Queue(maxsize=2000)
+        producer_done = asyncio.Event()
+
+        async def on_job(job: Job) -> None:
+            await queue.put(job)
+
+        async def producer() -> None:
+            try:
+                await self._fetch_async(on_job=on_job)
+            finally:
+                producer_done.set()
+
+        task = asyncio.create_task(producer())
+        try:
+            while True:
+                if producer_done.is_set() and queue.empty():
+                    await task  # propagate any producer exception
+                    break
+                try:
+                    item = await asyncio.wait_for(queue.get(), timeout=0.5)
+                except TimeoutError:
+                    continue
+                yield item
+        finally:
+            if not task.done():
+                task.cancel()
+            with suppress(BaseException):
+                await task
+
+    async def _fetch_async(
+        self,
+        *,
+        on_job: Callable[[Job], Awaitable[None]] | None = None,
+    ) -> list[Job]:
+        seen: set[str] = set()
+        all_jobs: list[Job] = []
+        raw_rows = 0
+        lock = asyncio.Lock()
+
+        async def absorb(
+            items: list[dict[str, Any]],
+            *,
+            page: int,
+        ) -> None:
+            nonlocal raw_rows
+            parsed = [self._parse(item) for item in items]
+            if self._full_catalogue and any(job is None for job in parsed):
+                raise ScraperError(
+                    f"TimesJobs page={page} could not parse every returned row"
+                )
+            new_jobs: list[Job] = []
+            async with lock:
+                raw_rows += len(items)
+                for job in parsed:
+                    if job is None:
+                        continue
+                    if job.ats_id in seen:
+                        continue
+                    seen.add(job.ats_id)
+                    new_jobs.append(job)
+            if on_job is not None:
+                for job in new_jobs:
+                    await on_job(job)
+            else:
+                all_jobs.extend(new_jobs)
+
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True, proxy=self.proxy
+        ) as client:
+            # Fetch page 1 synchronously so we know the total count and
+            # can fan-out the remaining pages concurrently. The API
+            # returns ``totalPages`` as a float, so coerce to int.
+            first = await self._search(client, page=1)
+            await absorb(self._page_jobs(first, page=1), page=1)
+
+            total_pages_raw = first.get("totalPages")
+            if total_pages_raw is None:
+                raise ScraperError(
+                    "TimesJobs response omitted required totalPages"
+                )
+            try:
+                total_pages = int(total_pages_raw)
+            except (TypeError, ValueError) as exc:
+                raise ScraperError(
+                    f"TimesJobs returned invalid totalPages={total_pages_raw!r}"
+                ) from exc
+            if total_pages < 1:
+                raise ScraperError(
+                    f"TimesJobs returned invalid totalPages={total_pages}"
+                )
+            reported_total = first.get("total")
+            if not isinstance(reported_total, int) or reported_total < 0:
+                raise ScraperError(
+                    f"TimesJobs returned invalid total={reported_total!r}"
+                )
+            if self.max_pages is not None:
+                total_pages = min(total_pages, self.max_pages)
+            elif total_pages > MAX_PAGES:
+                raise ScraperError(
+                    f"TimesJobs reports {total_pages} pages, above the "
+                    f"validated safety limit of {MAX_PAGES}; refusing a "
+                    "silent partial scrape"
+                )
+            if total_pages > 1:
+                sem = asyncio.Semaphore(MAX_CONCURRENCY)
+
+                async def one(page: int) -> None:
+                    async with sem:
+                        payload = await self._search(client, page=page)
+                    await absorb(self._page_jobs(payload, page=page), page=page)
+
+                tasks = [
+                    asyncio.create_task(one(page))
+                    for page in range(2, total_pages + 1)
+                ]
+                try:
+                    await asyncio.gather(*tasks)
+                except BaseException:
+                    for task in tasks:
+                        task.cancel()
+                    await asyncio.gather(*tasks, return_exceptions=True)
+                    raise
+
+        if self._full_catalogue and not seen:
+            raise ScraperError(
+                "TimesJobs full-catalogue scrape returned no jobs"
+            )
+        if self._full_catalogue and raw_rows < reported_total:
+            raise ScraperError(
+                "TimesJobs catalogue ended before the reported total "
+                f"({raw_rows}/{reported_total})"
+            )
+        return all_jobs
+
+    @staticmethod
+    def _page_jobs(
+        payload: dict[str, Any],
+        *,
+        page: int,
+    ) -> list[dict[str, Any]]:
+        jobs = payload.get("jobs")
+        if not isinstance(jobs, list) or not all(
+            isinstance(item, dict) for item in jobs
+        ):
+            raise ScraperError(
+                f"TimesJobs page={page} omitted list-valued jobs"
+            )
+        return jobs
+
+    async def _search(
+        self, client: httpx.AsyncClient, *, page: int
+    ) -> dict[str, Any]:
+        body = {
+            "keyword": WILDCARD_KEYWORD,
+            "location": "",
+            "page": str(page),
+            "size": str(PAGE_SIZE),
+        }
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                r = await client.post(API_URL, json=body, headers=_HEADERS)
+            except httpx.HTTPError as exc:
+                last_exc = exc
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"TimesJobs fetch failed (page={page}): {exc}"
+                    ) from exc
+                await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                continue
+
+            if r.status_code == 200:
+                try:
+                    data = r.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"TimesJobs returned non-JSON for page={page}: {exc}"
+                    ) from exc
+                if not isinstance(data, dict):
+                    raise ScraperError(
+                        f"TimesJobs API shape changed — expected a dict, "
+                        f"got {type(data).__name__}"
+                    )
+                return data
+
+            if r.status_code in (429,) or 500 <= r.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"TimesJobs returned {r.status_code} after "
+                        f"{MAX_RETRIES} retries (page={page})"
+                    )
+                retry_after = r.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+
+            raise ScraperError(
+                f"TimesJobs returned {r.status_code} (page={page}): "
+                f"{r.text[:120]}"
+            )
+
+        raise ScraperError(
+            f"TimesJobs exhausted retries (page={page}): {last_exc}"
+        )
+
+    def _parse(self, item: dict[str, Any]) -> Job | None:
+        ats_id = str(item.get("jobId") or "").strip()
+        title = (item.get("title") or "").strip()
+        url = (item.get("jobDetailUrl") or "").strip()
+        if not (ats_id and title and url):
+            return None
+
+        company = (item.get("company") or item.get("hfCompany") or "").strip() or "Unknown"
+        location = _clean_location(item.get("location"))
+
+        # Salary: TimesJobs uses -1 to indicate "not disclosed", and the
+        # currency is always present (mostly INR). Only emit salary
+        # fields when a real range is provided.
+        salary_min, salary_max = _clean_salary_range(
+            item.get("lowSalary"), item.get("highSalary"),
+        )
+        salary_currency = item.get("currency") if (salary_min or salary_max) else None
+        if isinstance(salary_currency, str):
+            salary_currency = salary_currency.strip().upper() or None
+            # The API uses "RS" / "RR" in a few rows; normalize the most
+            # common alternates to the canonical ISO code.
+            if salary_currency in {"RS", "RR", "RUPEES", "INR."}:
+                salary_currency = "INR"
+            if not (isinstance(salary_currency, str) and len(salary_currency) == 3):
+                salary_currency = None
+
+        description = _clean_description(item.get("description"))
+        posted_at = _date_to_dt(item.get("postDate"))
+
+        # Job type "On-site" / "Remote" / "Hybrid" is surfaced by the
+        # API — promote "Remote" to ``is_remote=True``. We don't set
+        # ``is_remote=False`` for on-site since the canonical model
+        # only ever asserts True (the absence of a remote marker is
+        # not evidence of on-site).
+        job_type = item.get("jobType")
+        is_remote = (
+            True if isinstance(job_type, str) and "remote" in job_type.lower()
+            else None
+        )
+
+        # Skills is a comma-joined string on the list endpoint. Split,
+        # trim, drop empties.
+        skills_raw = item.get("skills")
+        skills: list[str] = []
+        if isinstance(skills_raw, str):
+            skills = [s.strip() for s in skills_raw.split(",") if s.strip()]
+
+        # Experience is a (from, to) range — surface the lower bound
+        # as ``experience`` for canonical filtering, keep the raw range
+        # in ``raw`` so consumers can render "5-8 years".
+        exp_from = _safe_int(item.get("experienceFrom"))
+        exp_to = _safe_int(item.get("experienceTo"))
+        experience = exp_from if exp_from is not None and exp_from >= 0 else None
+
+        raw: dict[str, Any] = {}
+        if exp_from is not None and exp_from >= 0:
+            raw["experience_from"] = exp_from
+        if exp_to is not None and exp_to >= 0:
+            raw["experience_to"] = exp_to
+        if exp_from is not None and exp_to is not None and exp_from >= 0 and exp_to >= 0:
+            raw["experience_label"] = (
+                f"{exp_from}-{exp_to} years" if exp_from != exp_to
+                else f"{exp_from} years"
+            )
+        if skills:
+            raw["skills"] = skills[:30]
+        if isinstance(job_type, str) and job_type.strip():
+            raw["job_type"] = job_type.strip()
+        job_function = item.get("jobFunction")
+        if isinstance(job_function, str) and job_function.strip():
+            raw["job_function"] = job_function.strip()
+        expiry = item.get("expiryDate")
+        if isinstance(expiry, str) and expiry.strip():
+            raw["expiry_date"] = expiry.strip()
+
+        return Job(
+            url=url,
+            title=title,
+            company=company,
+            ats_type=ATSType.TIMESJOBS,
+            ats_id=ats_id,
+            location=location,
+            country_iso=_infer_in_country_iso(location),
+            language="en",
+            is_remote=is_remote,
+            salary_currency=salary_currency,
+            salary_min=salary_min,
+            salary_max=salary_max,
+            experience=experience,
+            department=raw.get("job_function"),
+            commitment=raw.get("job_type"),
+            description=description if self.include_descriptions else None,
+            posted_at=posted_at,
+            fetched_at=datetime.now(tz=UTC),
+            raw=raw or None,
+        )
+
+
+# A non-exhaustive set of major Indian metros + state names that
+# unambiguously imply ``country_iso='IN'`` when they appear as the
+# whole or majority of a TimesJobs ``location`` string. The list is
+# deliberately conservative — for ambiguous / mixed locations
+# ("Other City(s) in New York, Bengaluru") we leave ``country_iso``
+# unset and the downstream LLM enrichment decides.
+_INDIAN_CITIES = frozenset(
+    {
+        "ahmedabad", "bengaluru", "bangalore", "bhubaneswar", "chandigarh",
+        "chennai", "coimbatore", "delhi", "new delhi", "faridabad",
+        "ghaziabad", "gurgaon", "gurugram", "guwahati", "hubli",
+        "hyderabad", "hyderabad/secunderabad", "indore", "jaipur",
+        "jamshedpur", "kanpur", "kochi", "kolkata", "kozhikode",
+        "lucknow", "ludhiana", "madurai", "mangalore", "mumbai",
+        "mysore", "nagpur", "nashik", "navi mumbai", "noida",
+        "patna", "pune", "raipur", "ranchi", "secunderabad",
+        "surat", "thane", "thiruvananthapuram", "tiruchirapalli",
+        "trichy", "trivandrum", "vadodara", "varanasi", "vijayawada",
+        "visakhapatnam", "vizag",
+    }
+)
+
+_INDIAN_REGIONS = frozenset({
+    "andhra pradesh", "arunachal pradesh", "assam", "bihar",
+    "chhattisgarh", "goa", "gujarat", "haryana", "himachal pradesh",
+    "jharkhand", "karnataka", "kerala", "madhya pradesh",
+    "maharashtra", "manipur", "meghalaya", "mizoram", "nagaland",
+    "odisha", "punjab", "rajasthan", "sikkim", "tamil nadu",
+    "telangana", "tripura", "uttar pradesh", "uttarakhand",
+    "west bengal", "delhi", "india",
+})
+
+
+def _infer_in_country_iso(location: str | None) -> str | None:
+    """Return ``"IN"`` when the location string is unambiguously
+    Indian, otherwise ``None`` so LLM enrichment can derive it.
+
+    TimesJobs is an Indian board but indexes global postings too —
+    blindly stamping every row with ``IN`` would corrupt the country
+    field for the ~30% non-IN inventory.
+    """
+    if not isinstance(location, str) or not location.strip():
+        return None
+    parts = [p.strip().lower() for p in location.split(",") if p.strip()]
+    if not parts:
+        return None
+    if parts[-1] == "india":
+        return "IN"
+    if (
+        parts[-1] == "in"
+        and len(parts) > 1
+        and all(
+            part in _INDIAN_CITIES or part in _INDIAN_REGIONS
+            for part in parts[:-1]
+        )
+    ):
+        return "IN"
+    if all(p in _INDIAN_CITIES or p in _INDIAN_REGIONS for p in parts):
+        return "IN"
+    return None
+
+
+def _clean_location(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = re.sub(r"\s+", " ", value).strip()
+    return cleaned or None
+
+
+def _clean_salary_range(
+    low: object, high: object
+) -> tuple[float | None, float | None]:
+    lo = _to_positive_float(low)
+    hi = _to_positive_float(high)
+    return lo, hi
+
+
+def _to_positive_float(value: object) -> float | None:
+    if isinstance(value, bool):  # bool subclass of int — exclude explicitly
+        return None
+    if isinstance(value, (int, float)) and value > 0:
+        return float(value)
+    return None
+
+
+def _safe_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            return int(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def _date_to_dt(value: object) -> datetime | None:
+    """``postDate`` is an ISO date string (``YYYY-MM-DD``)."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    s = value.strip()
+    # Support both ``YYYY-MM-DD`` and the occasional full ISO timestamp.
+    try:
+        if "T" in s:
+            parsed = datetime.fromisoformat(s.replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                return parsed.replace(tzinfo=UTC)
+            return parsed.astimezone(UTC)
+        return datetime.strptime(s, "%Y-%m-%d").replace(tzinfo=UTC)
+    except ValueError:
+        return None
+
+
+def _clean_description(value: object) -> str | None:
+    """Strip HTML, collapse whitespace, truncate to ~10kB."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = html.unescape(value)
+    text = _TAG_RE.sub(" ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text[:10_000] or None

--- a/src/ats_scrapers/scrapers/timesjobs.py
+++ b/src/ats_scrapers/scrapers/timesjobs.py
@@ -175,7 +175,6 @@ class TimesJobsScraper(BaseScraper):
                 )
             new_jobs: list[Job] = []
             async with lock:
-                raw_rows += len(items)
                 for job in parsed:
                     if job is None:
                         continue
@@ -183,6 +182,16 @@ class TimesJobsScraper(BaseScraper):
                         continue
                     seen.add(job.ats_id)
                     new_jobs.append(job)
+                if (
+                    self._full_catalogue
+                    and page > 1
+                    and items
+                    and not new_jobs
+                ):
+                    raise ScraperError(
+                        f"TimesJobs page={page} repeated an earlier result page"
+                    )
+                raw_rows += len(items)
             if on_job is not None:
                 for job in new_jobs:
                     await on_job(job)

--- a/src/ats_scrapers/scrapers/timesjobs.py
+++ b/src/ats_scrapers/scrapers/timesjobs.py
@@ -159,7 +159,6 @@ class TimesJobsScraper(BaseScraper):
     ) -> list[Job]:
         seen: set[str] = set()
         all_jobs: list[Job] = []
-        raw_rows = 0
         lock = asyncio.Lock()
 
         async def absorb(
@@ -167,7 +166,6 @@ class TimesJobsScraper(BaseScraper):
             *,
             page: int,
         ) -> None:
-            nonlocal raw_rows
             parsed = [self._parse(item) for item in items]
             if self._full_catalogue and any(job is None for job in parsed):
                 raise ScraperError(
@@ -191,7 +189,6 @@ class TimesJobsScraper(BaseScraper):
                     raise ScraperError(
                         f"TimesJobs page={page} repeated an earlier result page"
                     )
-                raw_rows += len(items)
             if on_job is not None:
                 for job in new_jobs:
                     await on_job(job)
@@ -259,10 +256,10 @@ class TimesJobsScraper(BaseScraper):
             raise ScraperError(
                 "TimesJobs full-catalogue scrape returned no jobs"
             )
-        if self._full_catalogue and raw_rows < reported_total:
+        if self._full_catalogue and len(seen) < reported_total:
             raise ScraperError(
                 "TimesJobs catalogue ended before the reported total "
-                f"({raw_rows}/{reported_total})"
+                f"({len(seen)}/{reported_total} unique jobs)"
             )
         return all_jobs
 
@@ -426,6 +423,11 @@ class TimesJobsScraper(BaseScraper):
             language="en",
             is_remote=is_remote,
             salary_currency=salary_currency,
+            salary_period=(
+                "YEAR"
+                if salary_min is not None or salary_max is not None
+                else None
+            ),
             salary_min=salary_min,
             salary_max=salary_max,
             experience=experience,

--- a/tests/e2e/test_live_foundit_timesjobs.py
+++ b/tests/e2e/test_live_foundit_timesjobs.py
@@ -1,0 +1,51 @@
+"""Live smoke tests for Foundit and TimesJobs."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Callable
+from urllib.parse import urlparse
+
+import pytest
+
+from ats_scrapers.models import Job
+from ats_scrapers.scrapers import FounditScraper, TimesJobsScraper
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.skipif(
+        not os.getenv("ATS_SCRAPERS_LIVE_E2E"),
+        reason="set ATS_SCRAPERS_LIVE_E2E=1 to hit real job-board endpoints",
+    ),
+]
+
+CASES: list[tuple[str, Callable[[], object], str]] = [
+    ("foundit-in", lambda: FounditScraper("in", max_pages=1), "foundit.in"),
+    (
+        "timesjobs",
+        lambda: TimesJobsScraper("timesjobs", max_pages=1),
+        "timesjobs.com",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("factory", "expected_domain"),
+    [pytest.param(factory, domain, id=name) for name, factory, domain in CASES],
+)
+async def test_live_jobboard_smoke(
+    factory: Callable[[], object], expected_domain: str
+) -> None:
+    async with asyncio.timeout(180):
+        jobs = await factory().afetch()
+    assert jobs
+    sample: list[Job] = jobs[:50]
+    assert len({job.global_id for job in sample}) == len(sample)
+    for job in sample:
+        assert job.title.strip()
+        assert job.company.strip()
+        assert job.ats_id
+        host = (urlparse(str(job.url)).hostname or "").lower()
+        assert host == expected_domain or host.endswith(f".{expected_domain}")
+        assert not host.endswith((".local", ".internal"))

--- a/tests/test_foundit.py
+++ b/tests/test_foundit.py
@@ -1,0 +1,792 @@
+"""Tests for the Foundit (Monster India / APAC) scraper.
+
+Scope: country slug resolution, API row parsing (incl. structured
+salary, employment-type mapping, posted-at epoch handling, ad-row
+filtering), pagination + dedup, retry/backoff on 429/5xx, and
+registry wiring. The httpx network path is exercised via
+``pytest-httpx`` — we never hit the live site.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType
+from ats_scrapers.scrapers import FounditScraper, ScraperRegistry
+from ats_scrapers.scrapers import foundit as f_mod
+
+# Per-country regex the httpx-mock matcher uses. We compile from the
+# scraper's canonical domain map so adding a new country here doesn't
+# silently miss the test.
+_API_RE_BY_DOMAIN: dict[str, re.Pattern[str]] = {
+    domain: re.compile(rf"^https://{re.escape(domain)}/middleware/jobsearch")
+    for (domain, _t, _i, _r) in f_mod._COUNTRY_TABLE.values()
+}
+_INDIA_RE = _API_RE_BY_DOMAIN["www.foundit.in"]
+
+
+@pytest.fixture(autouse=True)
+def _fast_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Backoff sleeps add seconds per retry — patch to a no-op so the
+    retry path doesn't cost wall-clock time."""
+    monkeypatch.setattr(f_mod, "_sleep_backoff", lambda attempt: None)
+    monkeypatch.setattr(f_mod, "MAX_RETRIES", 2)
+
+
+def _make_row(
+    *,
+    job_id: str = "49286015",
+    title: str = "Customer Service Executive",
+    company: str = "Tech Mahindra Limited",
+    locations: str = "Mumbai City, Mumbai",
+    jd_url: str = "/job/customer-service-tech-mahindra-mumbai-49286015",
+    currency: str = "INR",
+    min_salary: int = 250_000,
+    max_salary: int = 550_000,
+    salary_summary: str = "2,50,000-5,50,000 INR",
+    employment_types: list[str] | None = None,
+    min_exp_years: int = 1,
+    qualifications: list[str] | None = None,
+    skills: str = "Customer Service, Sales, Communication",
+    functions: list[str] | None = None,
+    roles: list[str] | None = None,
+    industry: str = "BPO/ITES",
+    created_at_ms: int = 1_775_488_663_000,
+    hide_salary: bool = False,
+) -> dict[str, Any]:
+    """One realistic Foundit API row. Mirrors the May 2026 payload."""
+    return {
+        "id": job_id,
+        "jobId": int(job_id) if job_id.isdigit() else 0,
+        "title": title,
+        "companyName": company,
+        "locations": locations,
+        "jdUrl": jd_url,
+        "currencyCode": currency,
+        "minimumSalary": {
+            "currency": currency,
+            "absoluteValue": min_salary,
+            "absoluteMonthlyValue": min_salary // 12,
+        },
+        "maximumSalary": {
+            "currency": currency,
+            "absoluteValue": max_salary,
+            "absoluteMonthlyValue": max_salary // 12,
+        },
+        "salary": salary_summary,
+        "hideSalary": 1 if hide_salary else 0,
+        "employmentTypes": (
+            employment_types if employment_types is not None else ["Full time"]
+        ),
+        "minimumExperience": {"years": min_exp_years},
+        "maximumExperience": {"years": min_exp_years + 4},
+        "qualifications": (
+            qualifications if qualifications is not None else ["12th Class (XII)"]
+        ),
+        "skills": skills,
+        "functions": (
+            functions if functions is not None else ["Customer Service/Call Centre/BPO"]
+        ),
+        "roles": roles if roles is not None else ["Customer Service Executive"],
+        "designations": ["Customer Service Executive"],
+        "industry": industry,
+        "exp": f"{min_exp_years}-{min_exp_years + 4} Years",
+        "createdAt": created_at_ms,
+        "channelName": "India",
+        "isUrgentlyHiring": False,
+        "kiwiJobId": "145448017",
+        "jobTypes": [],
+    }
+
+
+def _make_page(
+    rows: list[dict[str, Any]],
+    *,
+    total: int | None = None,
+    next_cursor: str | None = None,
+    previous_cursor: str | None = None,
+) -> dict[str, Any]:
+    """Wrap a list of rows in the canonical ``jobSearchStatus / response``
+    envelope the scraper expects."""
+    return {
+        "jobSearchStatus": 200,
+        "jobSearchStatusText": "OK",
+        "jobSearchResponse": {
+            "data": list(rows),
+            "meta": {
+                "paging": {
+                    "cursors": {
+                        "next": next_cursor or str(len(rows)),
+                        "previous": previous_cursor or "0",
+                    },
+                    "total": total if total is not None else len(rows),
+                    "limit": len(rows),
+                },
+                "resultId": "test-result-id",
+                "searchId": "test-search-id",
+                "version": "DEFAULT",
+                "buildVersion": "0.0.1",
+            },
+            "spellCheckApplied": False,
+            "filters": [],
+            "selectedFilters": [],
+            "filterLabels": [],
+            "spellCheck": None,
+            "apiId": "DEFAULT",
+            "IS_NEW_SEARCH_PAGE": True,
+        },
+    }
+
+
+# --- registry / construction ------------------------------------------
+
+
+def test_registry_resolves_foundit() -> None:
+    assert ScraperRegistry.get(ATSType.FOUNDIT) is FounditScraper
+
+
+def test_default_country_slug_is_india() -> None:
+    s = FounditScraper()
+    assert s.country_slug == "in"
+    assert s._country_iso == "IN"
+    assert s._domain == "www.foundit.in"
+    assert s.include_descriptions is False
+
+
+def test_description_option_is_explicitly_unsupported() -> None:
+    with pytest.raises(ScraperError, match="does not expose descriptions"):
+        FounditScraper("in", include_descriptions=True)
+
+
+@pytest.mark.parametrize(
+    ("slug", "iso", "domain"),
+    [
+        ("in", "IN", "www.foundit.in"),
+        ("sg", "SG", "www.foundit.sg"),
+        ("my", "MY", "www.foundit.my"),
+        ("id", "ID", "www.foundit.id"),
+        ("ph", "PH", "www.foundit.com.ph"),
+    ],
+)
+def test_known_country_slugs(slug: str, iso: str, domain: str) -> None:
+    s = FounditScraper(slug)
+    assert s._country_iso == iso
+    assert s._domain == domain
+
+
+@pytest.mark.parametrize(
+    ("alias", "expected_slug"),
+    [
+        ("india", "in"),
+        ("INDIA", "in"),
+        ("singapore", "sg"),
+        ("malaysia", "my"),
+        ("indonesia", "id"),
+        ("philippines", "ph"),
+    ],
+)
+def test_country_aliases(alias: str, expected_slug: str) -> None:
+    s = FounditScraper(alias)
+    assert s.country_slug == expected_slug
+
+
+def test_unknown_country_slug_raises() -> None:
+    with pytest.raises(ScraperError, match="unknown country slug"):
+        FounditScraper("atlantis")
+
+
+# --- parsing ----------------------------------------------------------
+
+
+def test_parses_minimal_realistic_row(httpx_mock: Any) -> None:
+    """End-to-end parse of a single canonical row. Pins the field
+    mapping the public dataset relies on."""
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([_make_row()]))
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    jobs = FounditScraper("in", max_pages=5).fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.FOUNDIT
+    assert j.ats_id == "49286015"
+    assert j.global_id == "foundit:49286015"
+    assert j.title == "Customer Service Executive"
+    assert j.company == "Tech Mahindra Limited"
+    assert str(j.url) == (
+        "https://www.foundit.in/job/customer-service-tech-mahindra-mumbai-49286015"
+    )
+    assert j.location == "Mumbai City, Mumbai"
+    assert j.country_iso == "IN"
+    assert j.region == "Asia"
+    assert j.language == "en"
+    assert j.salary_currency == "INR"
+    assert j.salary_period == "YEAR"
+    assert j.salary_min == 250_000
+    assert j.salary_max == 550_000
+    assert j.salary_summary == "2,50,000-5,50,000 INR"
+    assert j.experience == 1
+    assert j.employment_type == "FULL_TIME"
+    assert j.commitment == "Full time"
+    assert j.posted_at == datetime.fromtimestamp(1_775_488_663, tz=UTC)
+    assert j.fetched_at is not None
+    assert j.raw is not None
+    assert j.raw["industry"] == "BPO/ITES"
+    assert j.raw["experience_label"] == "1-5 Years"
+    assert j.raw["education"] == ["12th Class (XII)"]
+    assert j.raw["skills"] == ["Customer Service", "Sales", "Communication"]
+    assert j.raw["functions"] == ["Customer Service/Call Centre/BPO"]
+    assert j.raw["country_slug"] == "in"
+    assert j.raw["channel_name"] == "India"
+    assert j.raw["is_urgently_hiring"] is False
+    assert j.raw["kiwi_job_id"] == "145448017"
+
+
+def test_uses_country_domain_for_url(httpx_mock: Any) -> None:
+    """When scraping Singapore, the absolute URL must reference
+    ``www.foundit.sg`` — not the .in default. The public dataset
+    stores the channel-specific URL so consumers can link back."""
+    sg_re = _API_RE_BY_DOMAIN["www.foundit.sg"]
+    httpx_mock.add_response(
+        url=sg_re,
+        json=_make_page([_make_row(jd_url="/job/sg-engineer-101", job_id="101")]),
+    )
+    httpx_mock.add_response(url=sg_re, json=_make_page([]))
+
+    [job] = FounditScraper("sg", max_pages=5).fetch()
+    assert str(job.url).startswith("https://www.foundit.sg/")
+    assert job.country_iso == "SG"
+
+
+def test_absolute_jd_url_is_preserved(httpx_mock: Any) -> None:
+    """If the API ever switches to absolute URLs, we mustn't
+    double-prefix the host."""
+    abs_url = "https://www.foundit.in/job/external-42"
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(jd_url=abs_url, job_id="42")]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    [job] = FounditScraper("in", max_pages=5).fetch()
+    assert str(job.url) == abs_url
+
+
+@pytest.mark.parametrize(
+    ("label", "expected"),
+    [
+        ("Full time", "FULL_TIME"),
+        ("Permanent", "FULL_TIME"),
+        ("Part time", "PART_TIME"),
+        ("Contract", "CONTRACT"),
+        ("Freelance", "CONTRACT"),
+        ("Internship", "INTERN"),
+        ("Trainee", "INTERN"),
+        ("Temporary", "TEMPORARY"),
+    ],
+)
+def test_employment_type_mapping(
+    httpx_mock: Any, label: str, expected: str,
+) -> None:
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(employment_types=[label])]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    [job] = FounditScraper("in", max_pages=5).fetch()
+    assert job.employment_type == expected
+    assert job.commitment == label
+
+
+def test_employment_type_unknown_label_falls_back_to_none(
+    httpx_mock: Any,
+) -> None:
+    """An unrecognised label leaves ``employment_type`` ``None`` —
+    we don't fabricate a guess — but ``commitment`` keeps the raw
+    string so downstream consumers can see the original."""
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(employment_types=["Apprenticeship-X"])]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    [job] = FounditScraper("in", max_pages=5).fetch()
+    assert job.employment_type is None
+    assert job.commitment == "Apprenticeship-X"
+
+
+def test_employment_types_empty_list(httpx_mock: Any) -> None:
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(employment_types=[])]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    [job] = FounditScraper("in", max_pages=5).fetch()
+    assert job.employment_type is None
+    assert job.commitment is None
+
+
+def test_hide_salary_suppresses_compensation(httpx_mock: Any) -> None:
+    """Confidential listings have ``hideSalary=1``. We honour the
+    flag and skip the salary fields rather than leak values the
+    employer chose not to publish."""
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(hide_salary=True)]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    [job] = FounditScraper("in", max_pages=5).fetch()
+    assert job.salary_min is None
+    assert job.salary_max is None
+    assert job.salary_currency is None
+    assert job.salary_summary is None
+    assert job.salary_currency is None
+    assert job.salary_summary is None
+
+
+def test_zero_salary_is_treated_as_missing(httpx_mock: Any) -> None:
+    """Foundit encodes "not disclosed" as 0 in ``absoluteValue``.
+    Treat as ``None`` so downstream filters / averages aren't
+    poisoned by zero rows."""
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(min_salary=0, max_salary=0)]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    [job] = FounditScraper("in", max_pages=5).fetch()
+    assert job.salary_min is None
+    assert job.salary_max is None
+
+
+def test_zero_experience_is_treated_as_missing(httpx_mock: Any) -> None:
+    """Entry-level postings come with ``minimumExperience.years=0`` —
+    that's not a valid lower bound, treat as missing."""
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(min_exp_years=0)]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    [job] = FounditScraper("in", max_pages=5).fetch()
+    assert job.experience is None
+
+
+def test_invalid_created_at_falls_back_to_none(httpx_mock: Any) -> None:
+    """A garbage epoch must not crash the parse — ``posted_at``
+    stays ``None`` and the row still ships."""
+    row = _make_row(created_at_ms=0)
+    row["createdAt"] = None  # null in the JSON payload
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([row]))
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    [job] = FounditScraper("in", max_pages=5).fetch()
+    assert job.posted_at is None
+
+
+def test_ad_placement_rows_are_skipped(httpx_mock: Any) -> None:
+    """The API interleaves ``{"index": N, "type": "adsense"}`` /
+    ``{"type": "banner"}`` entries — those have no ``id`` field and
+    must be filtered out before parsing."""
+    rows: list[dict[str, Any]] = [
+        _make_row(job_id="1"),
+        {"index": 0, "type": "adsense"},
+        {"index": 0, "type": "banner"},
+        _make_row(job_id="2"),
+    ]
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page(rows))
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    jobs = FounditScraper("in", max_pages=5).fetch()
+    assert [j.ats_id for j in jobs] == ["1", "2"]
+
+
+def test_skips_rows_missing_required_fields(httpx_mock: Any) -> None:
+    """A row without title or jdUrl is a stub — skip cleanly rather
+    than fabricate values."""
+    valid = _make_row(job_id="1")
+    no_title = _make_row(job_id="2", title="")
+    no_jdurl = _make_row(job_id="3", jd_url="")
+    httpx_mock.add_response(
+        url=_INDIA_RE, json=_make_page([valid, no_title, no_jdurl]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    jobs = FounditScraper("in", max_pages=5).fetch()
+    assert [j.ats_id for j in jobs] == ["1"]
+
+
+def test_full_catalogue_rejects_rows_missing_required_fields(
+    httpx_mock: Any,
+) -> None:
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([
+            _make_row(job_id="1"),
+            _make_row(job_id="2", title=""),
+        ]),
+    )
+
+    with pytest.raises(ScraperError, match="parse every returned job row"):
+        FounditScraper("in").fetch()
+
+
+def test_skips_row_with_no_id(httpx_mock: Any) -> None:
+    """Defensive: a row with neither ``id`` nor ``jobId`` is dropped
+    before reaching the parser. The page yields zero real rows so
+    pagination stops (no second request needed)."""
+    bogus = {"title": "no id", "jdUrl": "/job/x"}
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([bogus]))
+
+    jobs = FounditScraper("in", max_pages=5).fetch()
+    assert jobs == []
+
+
+def test_full_catalogue_rejects_unrecognized_rows_without_ids(
+    httpx_mock: Any,
+) -> None:
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([{"title": "no id", "jdUrl": "/job/x"}]),
+    )
+
+    with pytest.raises(ScraperError, match="without a job identifier"):
+        FounditScraper("in").fetch()
+
+
+def test_full_catalogue_allows_known_ad_rows(httpx_mock: Any) -> None:
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([
+            _make_row(job_id="1"),
+            {"index": 0, "type": "adsense"},
+            {"index": 1, "type": "banner"},
+        ]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    jobs = FounditScraper("in").fetch()
+    assert [job.ats_id for job in jobs] == ["1"]
+
+
+def test_falls_back_to_job_id_when_id_missing(httpx_mock: Any) -> None:
+    """The API typically populates both ``id`` and ``jobId`` — if only
+    the numeric ``jobId`` is present, use it as ``ats_id``."""
+    row = _make_row(job_id="123")
+    row.pop("id")
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([row]))
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    [job] = FounditScraper("in", max_pages=5).fetch()
+    assert job.ats_id == "123"
+
+
+# --- pagination & dedup -----------------------------------------------
+
+
+def test_paginates_until_empty_page(httpx_mock: Any) -> None:
+    """Walks pages until the response yields zero rows."""
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(job_id="1")]),
+    )
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(job_id="2")]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    jobs = FounditScraper("in", max_pages=10).fetch()
+    assert [j.ats_id for j in jobs] == ["1", "2"]
+
+
+def test_pagination_offsets_are_per_page_multiples(httpx_mock: Any) -> None:
+    """Each request advances ``start`` by ``PER_PAGE`` — verify the
+    URL pattern explicitly so a regression in the offset math is
+    caught at the wire level."""
+    for i in range(3):
+        httpx_mock.add_response(
+            url=_INDIA_RE,
+            json=_make_page([_make_row(job_id=f"p{i}")]),
+        )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    FounditScraper("in", max_pages=10).fetch()
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 4
+    starts = [r.url.params["start"] for r in requests]
+    assert starts == ["0", "100", "200", "300"]
+
+
+def test_dedupes_repeated_rows_across_pages(httpx_mock: Any) -> None:
+    """Past the deep-pagination cap the API repeats the same window.
+    The dedup-by-ats_id + zero-new-rows stop condition handles this
+    without needing to know the exact cap."""
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(job_id="1"), _make_row(job_id="2")]),
+    )
+    # Page 2 returns the same query-local ids, proving the API wrapped.
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(job_id="1"), _make_row(job_id="2")]),
+    )
+    jobs = FounditScraper("in", max_pages=10).fetch()
+    assert [j.ats_id for j in jobs] == ["1", "2"]
+
+
+def test_max_pages_caps_walk(httpx_mock: Any) -> None:
+    """Honour the constructor cap — useful for smoke runs."""
+    for i in range(3):
+        httpx_mock.add_response(
+            url=_INDIA_RE,
+            json=_make_page([_make_row(job_id=f"p{i}")]),
+        )
+
+    jobs = FounditScraper("in", max_pages=3).fetch()
+    assert len(jobs) == 3
+    assert len(httpx_mock.get_requests()) == 3
+
+
+def test_offset_cap_stops_walk_even_below_max_pages(
+    httpx_mock: Any, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The hard ``MAX_USABLE_OFFSET`` ceiling stops the loop before
+    a very large ``max_pages`` would otherwise burn through requests
+    against a wrap-around region."""
+    monkeypatch.setattr(f_mod, "MAX_USABLE_OFFSET", 150)
+    # MAX_USABLE_OFFSET=150 with PER_PAGE=100 → only starts 0 and 100
+    # are issued; start=200 > 150 → break before request.
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(job_id="a")]),
+    )
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(job_id="b")]),
+    )
+
+    FounditScraper("in", max_pages=99).fetch()
+    starts = [r.url.params["start"] for r in httpx_mock.get_requests()]
+    assert starts == ["0", "100"]
+
+
+# --- retry / error handling -------------------------------------------
+
+
+def test_retries_on_5xx_then_succeeds(httpx_mock: Any) -> None:
+    httpx_mock.add_response(url=_INDIA_RE, status_code=502, text="bad gateway")
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(job_id="1")]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    jobs = FounditScraper("in", max_pages=5).fetch()
+    assert [j.ats_id for j in jobs] == ["1"]
+
+
+def test_retries_on_429_then_succeeds(httpx_mock: Any) -> None:
+    httpx_mock.add_response(url=_INDIA_RE, status_code=429, text="rate limited")
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(job_id="1")]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    jobs = FounditScraper("in", max_pages=5).fetch()
+    assert [j.ats_id for j in jobs] == ["1"]
+
+
+def test_retries_on_transient_403_then_succeeds(httpx_mock: Any) -> None:
+    httpx_mock.add_response(url=_INDIA_RE, status_code=403)
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(job_id="1")]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+    assert [job.ats_id for job in FounditScraper("in").fetch()] == ["1"]
+
+
+def test_non_object_json_fails_closed(httpx_mock: Any) -> None:
+    httpx_mock.add_response(url=_INDIA_RE, json=[])
+    with pytest.raises(ScraperError, match="expected object"):
+        FounditScraper("in").fetch()
+
+
+def test_fails_pagination_after_exhausted_retries(
+    httpx_mock: Any,
+) -> None:
+    """A failed page cannot return a silently partial catalogue."""
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json=_make_page([_make_row(job_id="1")]),
+    )
+    # Page 2 always 502 — both retries fail.
+    httpx_mock.add_response(url=_INDIA_RE, status_code=502)
+    httpx_mock.add_response(url=_INDIA_RE, status_code=502)
+
+    with pytest.raises(ScraperError, match="returned 502"):
+        FounditScraper("in", max_pages=5).fetch()
+
+
+def test_4xx_other_than_429_fails_immediately(httpx_mock: Any) -> None:
+    httpx_mock.add_response(url=_INDIA_RE, status_code=400, text="bad request")
+
+    with pytest.raises(ScraperError, match="returned 400"):
+        FounditScraper("in", max_pages=5).fetch()
+
+
+def test_non_json_200_fails_pagination(httpx_mock: Any) -> None:
+    httpx_mock.add_response(url=_INDIA_RE, status_code=200, text="<html>oops</html>")
+
+    with pytest.raises(ScraperError, match="non-JSON"):
+        FounditScraper("in", max_pages=5).fetch()
+
+
+def test_api_level_error_status_fails_pagination(httpx_mock: Any) -> None:
+    """The envelope's own ``jobSearchStatus != 200`` signals an
+    application-level error (e.g. a bad ``country`` token). Fail
+    closed by raising rather than returning partial results."""
+    httpx_mock.add_response(
+        url=_INDIA_RE,
+        json={
+            "jobSearchStatus": 400,
+            "jobSearchStatusText": "Bad Request",
+            "jobSearchResponse": {},
+        },
+    )
+
+    with pytest.raises(ScraperError, match="API status=400"):
+        FounditScraper("in", max_pages=5).fetch()
+
+
+def test_full_catalogue_rejects_empty_result(httpx_mock: Any) -> None:
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    with pytest.raises(ScraperError, match="returned no jobs"):
+        FounditScraper("in").fetch()
+
+
+@pytest.mark.parametrize("invalid_data", [None, {}, "jobs"])
+def test_response_rejects_non_list_data(
+    httpx_mock: Any,
+    invalid_data: object,
+) -> None:
+    payload = _make_page([])
+    payload["jobSearchResponse"]["data"] = invalid_data
+    httpx_mock.add_response(url=_INDIA_RE, json=payload)
+
+    with pytest.raises(ScraperError, match="list-valued data"):
+        FounditScraper("in", max_pages=1).fetch()
+
+
+def test_sync_fetch_uses_event_loop_safe_bridge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import threading
+
+    scraper = FounditScraper("in", max_pages=1)
+    outer_thread = threading.get_ident()
+    worker_threads: list[int] = []
+
+    def fake_fetch_sync() -> list:
+        worker_threads.append(threading.get_ident())
+        return []
+
+    monkeypatch.setattr(scraper, "_fetch_sync", fake_fetch_sync)
+
+    async def invoke_sync_api() -> list:
+        return scraper.fetch()
+
+    assert asyncio.run(invoke_sync_api()) == []
+    assert worker_threads and worker_threads[0] != outer_thread
+
+
+# --- request shape ---------------------------------------------------
+
+
+def test_request_carries_required_params(httpx_mock: Any) -> None:
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    FounditScraper("in", max_pages=1).fetch()
+    [req] = httpx_mock.get_requests()
+    qs = req.url.params
+    assert qs["sort"] == "1"
+    assert qs["limit"] == "100"
+    assert qs["query"] == ""
+    assert qs["searchId"] == ""
+    assert qs["queryDerived"] == "true"
+    assert qs["country"] == "india"
+    assert qs["start"] == "0"
+
+
+def test_request_carries_browserlike_headers(httpx_mock: Any) -> None:
+    """The middleware endpoint accepts any UA in May 2026 but we
+    mirror Chrome to blend in if the WAF tightens."""
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    FounditScraper("in", max_pages=1).fetch()
+    [req] = httpx_mock.get_requests()
+    assert req.headers["Accept"] == "application/json"
+    assert req.headers["Referer"] == "https://www.foundit.in/"
+    assert "Chrome" in req.headers["User-Agent"]
+
+
+def test_singapore_uses_singapore_referer_and_country(
+    httpx_mock: Any,
+) -> None:
+    sg_re = _API_RE_BY_DOMAIN["www.foundit.sg"]
+    httpx_mock.add_response(url=sg_re, json=_make_page([]))
+
+    FounditScraper("sg", max_pages=1).fetch()
+    [req] = httpx_mock.get_requests()
+    assert req.url.params["country"] == "singapore"
+    assert req.headers["Referer"] == "https://www.foundit.sg/"
+
+
+# --- module-level helper coverage ------------------------------------
+
+
+def test_split_skills_strips_and_filters_empties() -> None:
+    out = f_mod._split_skills(" Java , , Python ,SQL")
+    assert out == ["Java", "Python", "SQL"]
+
+
+def test_split_skills_non_string_returns_empty() -> None:
+    assert f_mod._split_skills(None) == []
+    assert f_mod._split_skills(["Java"]) == []
+
+
+def test_nested_amount_handles_missing_field() -> None:
+    assert f_mod._nested_amount(None) is None
+    assert f_mod._nested_amount({"currency": "INR"}) is None
+    assert f_mod._nested_amount({"absoluteValue": "100"}) is None
+
+
+def test_epoch_ms_to_dt_roundtrips() -> None:
+    out = f_mod._epoch_ms_to_dt(1_775_488_663_000)
+    assert out == datetime.fromtimestamp(1_775_488_663, tz=UTC)
+
+
+def test_epoch_ms_to_dt_rejects_garbage() -> None:
+    assert f_mod._epoch_ms_to_dt(None) is None
+    assert f_mod._epoch_ms_to_dt("nope") is None
+    assert f_mod._epoch_ms_to_dt(-1) is None
+
+
+def test_str_or_none_int_to_str() -> None:
+    """``id`` arrives as a string in current payloads, but ``jobId`` is
+    numeric — the helper must round-trip ints to canonical strings."""
+    assert f_mod._str_or_none(49286015) == "49286015"
+    assert f_mod._str_or_none("  abc  ") == "abc"
+    assert f_mod._str_or_none("") is None
+    assert f_mod._str_or_none(None) is None

--- a/tests/test_foundit_bucketing.py
+++ b/tests/test_foundit_bucketing.py
@@ -1,0 +1,304 @@
+"""Tests for Foundit's ``bucket_strategy="keyword"`` mode.
+
+The opt-in keyword bucketing walks ~80 seed terms to bypass the
+~9500-row deep-pagination cap on the ``/middleware/jobsearch``
+endpoint. These tests pin:
+
+  * The default ``bucket_strategy="none"`` keeps the old single-call
+    no-query behaviour (full backwards-compat).
+  * ``bucket_strategy="keyword"`` issues one walk per seed, passes
+    the seed as ``query=``, dedupes across seeds, and respects the
+    per-bucket 9500 cap.
+  * Constructor validation rejects unknown strategies and dedupes
+    user-supplied seed lists.
+
+httpx is exercised via ``pytest-httpx``; we never hit the live site.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pytest
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.scrapers import FounditScraper
+from ats_scrapers.scrapers import foundit as f_mod
+
+_INDIA_RE = re.compile(
+    r"^https://www\.foundit\.in/middleware/jobsearch"
+)
+
+
+@pytest.fixture(autouse=True)
+def _fast_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No-op backoff so retry paths don't burn wall-clock time."""
+    monkeypatch.setattr(f_mod, "_sleep_backoff", lambda attempt: None)
+    monkeypatch.setattr(f_mod, "MAX_RETRIES", 2)
+
+
+def _make_row(job_id: str, title: str = "Engineer") -> dict[str, Any]:
+    """Minimal valid Foundit row — only the fields ``_parse_row``
+    strictly requires plus a couple of nicities."""
+    return {
+        "id": job_id,
+        "jobId": int(job_id) if job_id.isdigit() else 0,
+        "title": title,
+        "companyName": "Acme",
+        "locations": "Mumbai",
+        "jdUrl": f"/job/{title.lower()}-{job_id}",
+        "currencyCode": "INR",
+        "minimumSalary": {"absoluteValue": 100000},
+        "maximumSalary": {"absoluteValue": 200000},
+        "employmentTypes": ["Full time"],
+        "minimumExperience": {"years": 1},
+        "createdAt": 1_775_488_663_000,
+    }
+
+
+def _make_page(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "jobSearchStatus": 200,
+        "jobSearchStatusText": "OK",
+        "jobSearchResponse": {
+            "data": list(rows),
+            "meta": {
+                "paging": {
+                    "cursors": {"next": str(len(rows)), "previous": "0"},
+                    "total": len(rows),
+                    "limit": len(rows),
+                },
+            },
+        },
+    }
+
+
+# --- constructor validation -------------------------------------------
+
+
+def test_default_strategy_is_none() -> None:
+    s = FounditScraper()
+    assert s.bucket_strategy == "none"
+    # Default seeds are populated but unused unless strategy is keyword.
+    assert s.keyword_seeds == f_mod._default_keyword_seeds()
+
+
+def test_unknown_bucket_strategy_raises() -> None:
+    with pytest.raises(ScraperError, match="bucket_strategy"):
+        FounditScraper(bucket_strategy="random")  # type: ignore[arg-type]
+
+
+def test_keyword_seeds_override_strips_and_dedupes() -> None:
+    s = FounditScraper(
+        bucket_strategy="keyword",
+        keyword_seeds=["engineer", "Engineer", "  ", "manager", "manager"],
+    )
+    # Order preserved, case-insensitive dedup, empties dropped.
+    assert s.keyword_seeds == ("engineer", "manager")
+
+
+def test_keyword_strategy_rejects_empty_seed_list() -> None:
+    with pytest.raises(ScraperError, match="at least one non-empty seed"):
+        FounditScraper(bucket_strategy="keyword", keyword_seeds=["", "  "])
+
+
+def test_default_keyword_seeds_are_nonempty_and_unique() -> None:
+    """Sanity-check the shipped seed list: at least 50 unique non-empty
+    English seeds. A regression that empties / dupes the list would
+    silently collapse coverage."""
+    seeds = f_mod._default_keyword_seeds()
+    assert len(seeds) >= 50
+    assert all(s.strip() for s in seeds)
+    # case-insensitive dedup
+    lowered = [s.lower() for s in seeds]
+    assert len(set(lowered)) == len(lowered)
+
+
+# --- backwards-compat -------------------------------------------------
+
+
+def test_none_strategy_uses_empty_query(httpx_mock: Any) -> None:
+    """``bucket_strategy="none"`` keeps the original behaviour: one
+    call sequence, ``query=`` empty. No regression for existing
+    callers."""
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([_make_row("1")]))
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    jobs = FounditScraper("in", max_pages=5).fetch()
+    assert [j.ats_id for j in jobs] == ["1"]
+    requests = httpx_mock.get_requests()
+    # Every request must carry an empty query in the original mode.
+    assert all(r.url.params["query"] == "" for r in requests)
+
+
+# --- keyword bucketing ------------------------------------------------
+
+
+def test_keyword_strategy_passes_seed_as_query(httpx_mock: Any) -> None:
+    """Each seed becomes a ``query=`` value. Distinct seeds yield
+    distinct first-page requests with the right param."""
+    # Two seeds, each returning one row then an empty page (stop).
+    seeds = ("engineer", "manager")
+    for kw in seeds:
+        httpx_mock.add_response(
+            url=_INDIA_RE,
+            json=_make_page([_make_row(kw + "-1", title=kw)]),
+        )
+        httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    jobs = FounditScraper(
+        "in", max_pages=5,
+        bucket_strategy="keyword",
+        keyword_seeds=list(seeds),
+    ).fetch()
+
+    assert {j.ats_id for j in jobs} == {"engineer-1", "manager-1"}
+    queries = [r.url.params["query"] for r in httpx_mock.get_requests()]
+    # First two pages of bucket A, then first two pages of bucket B.
+    assert queries == ["engineer", "engineer", "manager", "manager"]
+
+
+def test_keyword_strategy_dedupes_across_seeds(httpx_mock: Any) -> None:
+    """A job hit by two seeds must appear once. Dedup is by ``ats_id``,
+    not by row identity — the parser builds a fresh ``Job`` per row."""
+    shared = _make_row("shared-1", title="Senior Engineer")
+    unique_a = _make_row("only-a", title="Engineer")
+    unique_b = _make_row("only-b", title="Manager")
+
+    # engineer bucket returns shared + unique_a.
+    httpx_mock.add_response(
+        url=_INDIA_RE, json=_make_page([shared, unique_a]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+    # manager bucket returns shared (already seen) + unique_b.
+    httpx_mock.add_response(
+        url=_INDIA_RE, json=_make_page([shared, unique_b]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    jobs = FounditScraper(
+        "in", max_pages=5,
+        bucket_strategy="keyword",
+        keyword_seeds=["engineer", "manager"],
+    ).fetch()
+    assert [j.ats_id for j in jobs] == ["shared-1", "only-a", "only-b"]
+
+
+def test_keyword_strategy_respects_per_bucket_offset_cap(
+    httpx_mock: Any, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The 9500 offset cap applies *per bucket*. Verify it stops each
+    walk independently instead of leaking into the next seed."""
+    monkeypatch.setattr(f_mod, "MAX_USABLE_OFFSET", 150)
+
+    # Bucket "engineer": pages at start=0 and start=100, then break.
+    httpx_mock.add_response(
+        url=_INDIA_RE, json=_make_page([_make_row("e1")]),
+    )
+    httpx_mock.add_response(
+        url=_INDIA_RE, json=_make_page([_make_row("e2")]),
+    )
+    # Bucket "manager": same two pages.
+    httpx_mock.add_response(
+        url=_INDIA_RE, json=_make_page([_make_row("m1")]),
+    )
+    httpx_mock.add_response(
+        url=_INDIA_RE, json=_make_page([_make_row("m2")]),
+    )
+
+    FounditScraper(
+        "in", max_pages=99,
+        bucket_strategy="keyword",
+        keyword_seeds=["engineer", "manager"],
+    ).fetch()
+
+    reqs = httpx_mock.get_requests()
+    starts_by_query: dict[str, list[str]] = {}
+    for r in reqs:
+        starts_by_query.setdefault(
+            r.url.params["query"], [],
+        ).append(r.url.params["start"])
+    assert starts_by_query == {
+        "engineer": ["0", "100"],
+        "manager": ["0", "100"],
+    }
+
+
+def test_keyword_strategy_stops_bucket_on_repeat_window(
+    httpx_mock: Any,
+) -> None:
+    """When a bucket returns the same rows on consecutive pages (the
+    9500-cap wrap-around), the walker bails — and moves on to the
+    next seed.
+
+    Repeat detection is query-local, so overlap with another seed does
+    not look like this API wrap-around.
+    """
+    repeat_row = _make_row("r1")
+
+    # Bucket 1 repeats its own first-page window and stops immediately.
+    for _ in range(2):
+        httpx_mock.add_response(
+            url=_INDIA_RE, json=_make_page([repeat_row]),
+        )
+    # Bucket 2: one new row, then a truly empty page → immediate stop.
+    httpx_mock.add_response(
+        url=_INDIA_RE, json=_make_page([_make_row("b2")]),
+    )
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    jobs = FounditScraper(
+        "in", max_pages=10,
+        bucket_strategy="keyword",
+        keyword_seeds=["foo", "bar"],
+    ).fetch()
+    assert [j.ats_id for j in jobs] == ["r1", "b2"]
+    queries = [r.url.params["query"] for r in httpx_mock.get_requests()]
+    assert queries == ["foo", "foo", "bar", "bar"]
+
+
+def test_keyword_strategy_continues_past_cross_seed_duplicate_page(
+    httpx_mock: Any,
+) -> None:
+    shared = _make_row("shared")
+    unique = _make_row("manager-only")
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([shared]))
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([shared]))
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([unique]))
+    httpx_mock.add_response(url=_INDIA_RE, json=_make_page([]))
+
+    jobs = FounditScraper(
+        "in",
+        max_pages=5,
+        bucket_strategy="keyword",
+        keyword_seeds=["engineer", "manager"],
+    ).fetch()
+
+    assert [job.ats_id for job in jobs] == ["shared", "manager-only"]
+    assert [request.url.params["query"] for request in httpx_mock.get_requests()] == [
+        "engineer",
+        "engineer",
+        "manager",
+        "manager",
+        "manager",
+    ]
+
+
+def test_keyword_strategy_fails_on_bucket_error(
+    httpx_mock: Any,
+) -> None:
+    """A failed bucket cannot publish a silently partial catalogue."""
+    # Bucket "engineer": all 502 (2 attempts after retry override).
+    httpx_mock.add_response(url=_INDIA_RE, status_code=502)
+    httpx_mock.add_response(url=_INDIA_RE, status_code=502)
+    with pytest.raises(ScraperError, match="returned 502"):
+        FounditScraper(
+            "in", max_pages=5,
+            bucket_strategy="keyword",
+            keyword_seeds=["engineer", "manager"],
+        ).fetch()
+    assert [request.url.params["query"] for request in httpx_mock.get_requests()] == [
+        "engineer", "engineer",
+    ]

--- a/tests/test_foundit_timesjobs_contracts.py
+++ b/tests/test_foundit_timesjobs_contracts.py
@@ -1,0 +1,38 @@
+"""Shared contracts for Foundit and TimesJobs."""
+
+from __future__ import annotations
+
+import pytest
+
+from ats_scrapers.scrapers.base import BaseScraper
+from ats_scrapers.scrapers.foundit import FounditScraper
+from ats_scrapers.scrapers.timesjobs import TimesJobsScraper
+from pipeline.publisher import ATS_DEDUP_PRIORITY
+from scripts.run_pipeline import CONFIGS
+
+
+@pytest.mark.parametrize(
+    ("scraper_type", "slug"),
+    [(FounditScraper, "in"), (TimesJobsScraper, "all")],
+)
+def test_scrapers_preserve_standard_options(
+    scraper_type: type[BaseScraper], slug: str
+) -> None:
+    scraper = scraper_type(
+        slug,
+        include_descriptions=False,
+        proxy="http://proxy.example:8080",
+    )
+    assert scraper.include_descriptions is False
+    assert scraper.proxy == "http://proxy.example:8080"
+
+
+def test_dedup_priorities_prefer_employer_sources() -> None:
+    assert ATS_DEDUP_PRIORITY["foundit"] > ATS_DEDUP_PRIORITY["workday"]
+    assert ATS_DEDUP_PRIORITY["timesjobs"] > ATS_DEDUP_PRIORITY["workday"]
+
+
+def test_fail_closed_configs_are_active() -> None:
+    assert CONFIGS["foundit"]["fail_closed_on_any_error"] is True
+    assert CONFIGS["foundit"]["skip_description_enrichment"] is True
+    assert CONFIGS["timesjobs"]["fail_closed_on_empty"] is True

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -30,7 +30,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
         "jobs_cz", "manfred", "thehub", "ycombinator", "wellfound",
-        "infojobs_es",
+        "infojobs_es", "foundit", "timesjobs",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr",
         "recruitee", "taleo", "teamtailor",

--- a/tests/test_run_pipeline_guards.py
+++ b/tests/test_run_pipeline_guards.py
@@ -804,6 +804,112 @@ def test_streaming_failure_preserves_previous_jobs_csv(
     assert not (out_dir / ".jobs.csv.tmp").exists()
 
 
+@pytest.mark.parametrize("has_previous", [True, False])
+def test_required_empty_output_removes_partial_file(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, has_previous: bool,
+) -> None:
+    out_dir = tmp_path / "empty"
+    out_dir.mkdir()
+    out_path = out_dir / "jobs.csv"
+    previous = (
+        "url,title,company,ats_type,ats_id\n"
+        "https://example.com/old,Old,Acme,custom,old\n"
+    )
+    if has_previous:
+        out_path.write_text(previous, encoding="utf-8")
+
+    class EmptyScraper:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def fetch(self):
+            return []
+
+    monkeypatch.setattr(runner, "DATA_ROOT", tmp_path)
+    monkeypatch.setitem(
+        runner.CONFIGS,
+        "empty",
+        {
+            "scraper": EmptyScraper,
+            "singleton": True,
+            "output": "empty/jobs.csv",
+            "fail_closed_on_empty": True,
+        },
+    )
+
+    rc = asyncio.run(
+        runner.run("empty", concurrency=1, max_tenants=None, timeout=1)
+    )
+
+    assert rc == 1
+    if has_previous:
+        assert out_path.read_text(encoding="utf-8") == previous
+    else:
+        assert not out_path.exists()
+    assert not (out_dir / ".jobs.csv.tmp").exists()
+
+
+@pytest.mark.parametrize("has_previous", [True, False])
+def test_required_shard_failure_removes_partial_output(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, has_previous: bool,
+) -> None:
+    (tmp_path / "ats-companies").mkdir()
+    (tmp_path / "ats-companies" / "shards.csv").write_text(
+        "name,slug,url\nGood,good,https://good\nBad,bad,https://bad\n",
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / "sharded"
+    out_dir.mkdir()
+    out_path = out_dir / "jobs.csv"
+    previous = (
+        "url,title,company,ats_type,ats_id\n"
+        "https://example.com/old,Old,Acme,custom,old\n"
+    )
+    if has_previous:
+        out_path.write_text(previous, encoding="utf-8")
+
+    class ShardedScraper:
+        def __init__(self, slug, **_kwargs) -> None:
+            self.slug = slug
+
+        def fetch(self):
+            if self.slug == "bad":
+                raise RuntimeError("shard failed")
+            return [
+                Job(
+                    url="https://example.com/new",
+                    title="New",
+                    company="Acme",
+                    ats_type=ATSType.CUSTOM,
+                    ats_id="new",
+                )
+            ]
+
+    monkeypatch.setattr(runner, "DATA_ROOT", tmp_path)
+    monkeypatch.setitem(
+        runner.CONFIGS,
+        "sharded",
+        {
+            "scraper": ShardedScraper,
+            "slug": lambda row: row["slug"],
+            "csv": "ats-companies/shards.csv",
+            "output": "sharded/jobs.csv",
+            "fail_closed_on_any_error": True,
+        },
+    )
+
+    rc = asyncio.run(
+        runner.run("sharded", concurrency=2, max_tenants=None, timeout=1)
+    )
+
+    assert rc == 1
+    if has_previous:
+        assert out_path.read_text(encoding="utf-8") == previous
+    else:
+        assert not out_path.exists()
+    assert not (out_dir / ".jobs.csv.tmp").exists()
+
+
 def test_streaming_pipeline_skips_capped_description_cache(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_timesjobs.py
+++ b/tests/test_timesjobs.py
@@ -1,0 +1,559 @@
+"""Tests for the TimesJobs scraper.
+
+The API is a page-based JSON POST endpoint at
+``tjapi.timesjobs.com/search/api/v1/search/jobs/list`` keyed by a
+single-space wildcard keyword. We pin: registry wiring, pagination via
+``totalPages``, the salary ``-1`` sentinel, India-specific country
+inference, skill/experience extraction into ``raw``, and the standard
+retry / shape-changed defensive paths.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType
+from ats_scrapers.scrapers import ScraperRegistry, TimesJobsScraper
+
+API_URL = "https://tjapi.timesjobs.com/search/api/v1/search/jobs/list"
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tighten retry timings so test runs stay snappy."""
+    import ats_scrapers.scrapers.timesjobs as tj
+
+    monkeypatch.setattr(tj, "MAX_RETRIES", 1)
+    monkeypatch.setattr(tj, "RETRY_BASE_DELAY", 0.0)
+
+
+def _job(
+    job_id: str = "80497778",
+    *,
+    title: str = "QA Automation Engineer",
+    company: str = "Acme",
+    location: str = "Bengaluru",
+    description: str = "Build automated tests.",
+    low_salary: int = -1,
+    high_salary: int = -1,
+    currency: str = "INR",
+    skills: str = "Selenium, Java, Pytest",
+    experience_from: int = 3,
+    experience_to: int = 6,
+    job_type: str = "On-site",
+    job_function: str = "IT Software : QA & Testing",
+    post_date: str = "2026-05-11",
+    job_detail_url: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "jobId": job_id,
+        "title": title,
+        "company": company,
+        "hfCompany": company,
+        "location": location,
+        "description": description,
+        "lowSalary": low_salary,
+        "highSalary": high_salary,
+        "currency": currency,
+        "skills": skills,
+        "experienceFrom": experience_from,
+        "experienceTo": experience_to,
+        "jobType": job_type,
+        "jobFunction": job_function,
+        "postDate": post_date,
+        "expiryDate": "2026-07-09",
+        "jobDetailUrl": (
+            job_detail_url
+            or f"https://www.timesjobs.com/job-detail/job-{job_id}"
+        ),
+    }
+
+
+def _response(
+    jobs: list[dict[str, Any]],
+    *,
+    page: int = 1,
+    total_pages: float | int = 1,
+    total: int | None = None,
+) -> dict[str, Any]:
+    return {
+        "total": total if total is not None else len(jobs),
+        "page": page,
+        "size": len(jobs),
+        # The real API returns totalPages as a float (e.g. 1978.0).
+        "totalPages": total_pages,
+        "jobs": jobs,
+    }
+
+
+# --- registry / wiring ------------------------------------------------------
+
+
+def test_registry_resolves_timesjobs() -> None:
+    assert ScraperRegistry.get(ATSType.TIMESJOBS) is TimesJobsScraper
+
+
+def test_ats_type_value() -> None:
+    assert ATSType.TIMESJOBS.value == "timesjobs"
+
+
+# --- happy path -------------------------------------------------------------
+
+
+def test_parses_minimal_job(httpx_mock) -> None:
+    httpx_mock.add_response(url=API_URL, json=_response([_job()]))
+    jobs = TimesJobsScraper("any").fetch()
+    assert len(jobs) == 1
+    j = jobs[0]
+    assert j.ats_type is ATSType.TIMESJOBS
+    assert j.ats_id == "80497778"
+    assert j.global_id == "timesjobs:80497778"
+    assert j.title == "QA Automation Engineer"
+    assert j.company == "Acme"
+    assert j.location == "Bengaluru"
+    assert j.country_iso == "IN"
+    assert j.language == "en"
+    assert j.description == "Build automated tests."
+    assert str(j.url).startswith("https://www.timesjobs.com/job-detail/")
+
+
+def test_paginates_via_total_pages(httpx_mock) -> None:
+    """Page 1 is fetched synchronously to learn the page count, then
+    remaining pages fan out concurrently."""
+    httpx_mock.add_response(
+        url=API_URL,
+        match_json={
+            "keyword": " ", "location": "", "page": "1", "size": "100",
+        },
+        json=_response(
+            [_job(job_id="1"), _job(job_id="2")],
+            page=1,
+            total_pages=3.0,
+            total=4,
+        ),
+    )
+    httpx_mock.add_response(
+        url=API_URL,
+        match_json={
+            "keyword": " ", "location": "", "page": "2", "size": "100",
+        },
+        json=_response([_job(job_id="3")], page=2, total_pages=3.0, total=4),
+    )
+    httpx_mock.add_response(
+        url=API_URL,
+        match_json={
+            "keyword": " ", "location": "", "page": "3", "size": "100",
+        },
+        json=_response([_job(job_id="4")], page=3, total_pages=3.0, total=4),
+    )
+    jobs = TimesJobsScraper("any").fetch()
+    assert sorted(j.ats_id for j in jobs) == ["1", "2", "3", "4"]
+
+
+def test_dedupes_repeated_job_ids(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response(
+            [_job(job_id="1"), _job(job_id="1"), _job(job_id="2")],
+        ),
+    )
+    jobs = TimesJobsScraper("any").fetch()
+    assert sorted(j.ats_id for j in jobs) == ["1", "2"]
+
+
+# --- field extraction -------------------------------------------------------
+
+
+def test_salary_minus_one_is_treated_as_missing(httpx_mock) -> None:
+    """TimesJobs encodes 'salary not disclosed' as low/high = -1. Make
+    sure we don't emit a -1 salary range."""
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([_job(low_salary=-1, high_salary=-1)]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.salary_min is None
+    assert j.salary_max is None
+    assert j.salary_currency is None
+
+
+def test_real_salary_range_is_preserved(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([
+            _job(low_salary=800_000, high_salary=1_500_000, currency="INR"),
+        ]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.salary_min == 800_000
+    assert j.salary_max == 1_500_000
+    assert j.salary_currency == "INR"
+
+
+def test_currency_alias_rs_is_normalized_to_inr(httpx_mock) -> None:
+    """A handful of rows use 'RS' instead of the ISO 'INR' code."""
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([
+            _job(low_salary=500_000, high_salary=900_000, currency="RS"),
+        ]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.salary_currency == "INR"
+
+
+def test_skills_split_into_raw_list(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([
+            _job(skills="Selenium Automation, Java Programming, Test Frameworks"),
+        ]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.raw is not None
+    assert j.raw["skills"] == [
+        "Selenium Automation", "Java Programming", "Test Frameworks",
+    ]
+
+
+def test_experience_label_in_raw(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([
+            _job(experience_from=5, experience_to=8),
+        ]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.experience == 5
+    assert j.raw is not None
+    assert j.raw["experience_from"] == 5
+    assert j.raw["experience_to"] == 8
+    assert j.raw["experience_label"] == "5-8 years"
+
+
+def test_experience_label_collapses_when_from_equals_to(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([_job(experience_from=4, experience_to=4)]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.raw is not None
+    assert j.raw["experience_label"] == "4 years"
+
+
+def test_remote_job_type_sets_is_remote(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([_job(job_type="Remote")]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.is_remote is True
+    assert j.commitment == "Remote"
+
+
+def test_onsite_job_type_leaves_is_remote_none(httpx_mock) -> None:
+    """Per the model contract is_remote only ever asserts True — absence
+    of a remote marker should not be encoded as False."""
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([_job(job_type="On-site")]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.is_remote is None
+    assert j.commitment == "On-site"
+
+
+def test_post_date_parsed_to_datetime(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([_job(post_date="2026-05-11")]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.posted_at is not None
+    assert j.posted_at.year == 2026
+    assert j.posted_at.month == 5
+    assert j.posted_at.day == 11
+    assert j.posted_at.tzinfo is not None
+    assert j.posted_at.utcoffset() is not None
+    assert j.posted_at.utcoffset().total_seconds() == 0
+
+
+def test_html_is_stripped_from_description(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([
+            _job(description="<p>Lead the <b>QA</b> team.</p>"),
+        ]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.description is not None
+    assert "<" not in j.description
+    assert "QA" in j.description
+
+
+# --- country_iso inference --------------------------------------------------
+
+
+def test_country_iso_in_for_clearly_indian_location(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([_job(location="Bengaluru")]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.country_iso == "IN"
+
+
+def test_country_iso_none_for_global_location(httpx_mock) -> None:
+    """TimesJobs indexes global postings too — stamping every row with
+    IN would corrupt the country field. Leave it unset for non-Indian
+    locations and let downstream LLM enrichment derive it."""
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([_job(location="Taiwan")]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.country_iso is None
+
+
+def test_country_iso_none_for_mixed_location(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([_job(location="Bengaluru, New York")]),
+    )
+    j = TimesJobsScraper("any").fetch()[0]
+    assert j.country_iso is None
+
+
+# --- defensive --------------------------------------------------------------
+
+
+def test_skips_rows_missing_required_fields(httpx_mock) -> None:
+    """Rows without jobId/title/jobDetailUrl are skipped rather than
+    failing the whole page."""
+    bad_no_id = _job()
+    bad_no_id.pop("jobId")
+    bad_no_title = _job(job_id="2")
+    bad_no_title.pop("title")
+    bad_no_url = _job(job_id="3")
+    bad_no_url.pop("jobDetailUrl")
+    good = _job(job_id="4")
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([bad_no_id, bad_no_title, bad_no_url, good]),
+    )
+    jobs = TimesJobsScraper("any", max_pages=1).fetch()
+    assert [j.ats_id for j in jobs] == ["4"]
+
+
+def test_full_catalogue_rejects_rows_missing_required_fields(
+    httpx_mock,
+) -> None:
+    bad = _job()
+    bad.pop("jobDetailUrl")
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([_job(job_id="1"), bad]),
+    )
+
+    with pytest.raises(ScraperError, match="parse every returned row"):
+        TimesJobsScraper("any").fetch()
+
+
+def test_non_dict_response_raises(httpx_mock) -> None:
+    httpx_mock.add_response(url=API_URL, json=["not", "a", "dict"])
+    with pytest.raises(ScraperError, match="API shape changed"):
+        TimesJobsScraper("any").fetch()
+
+
+def test_persistent_500_raises(httpx_mock) -> None:
+    httpx_mock.add_response(url=API_URL, status_code=500, is_reusable=True)
+    with pytest.raises(ScraperError):
+        TimesJobsScraper("any").fetch()
+
+
+def test_400_on_subsequent_page_raises(httpx_mock) -> None:
+    """A requested page came from totalPages, so a 400 is a failure."""
+    httpx_mock.add_response(
+        url=API_URL,
+        match_json={
+            "keyword": " ", "location": "", "page": "1", "size": "100",
+        },
+        json=_response(
+            [_job(job_id="1")], page=1, total_pages=2.0, total=2,
+        ),
+    )
+    httpx_mock.add_response(
+        url=API_URL,
+        match_json={
+            "keyword": " ", "location": "", "page": "2", "size": "100",
+        },
+        status_code=400,
+        json={"error": "Invalid JSON format"},
+    )
+    with pytest.raises(ScraperError, match=r"returned 400.*page=2"):
+        TimesJobsScraper("any").fetch()
+
+
+def test_400_on_first_page_raises(httpx_mock) -> None:
+    httpx_mock.add_response(url=API_URL, status_code=400)
+    with pytest.raises(ScraperError, match="returned 400"):
+        TimesJobsScraper("any").fetch()
+
+
+def test_missing_total_pages_raises(httpx_mock) -> None:
+    payload = _response([_job()])
+    payload.pop("totalPages")
+    httpx_mock.add_response(url=API_URL, json=payload)
+    with pytest.raises(ScraperError, match="totalPages"):
+        TimesJobsScraper("any").fetch()
+
+
+def test_missing_total_raises(httpx_mock) -> None:
+    payload = _response([_job()])
+    payload.pop("total")
+    httpx_mock.add_response(url=API_URL, json=payload)
+
+    with pytest.raises(ScraperError, match="invalid total"):
+        TimesJobsScraper("any").fetch()
+
+
+def test_full_catalogue_rejects_fewer_rows_than_reported(
+    httpx_mock,
+) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([_job()], total=2),
+    )
+
+    with pytest.raises(ScraperError, match=r"reported total \(1/2\)"):
+        TimesJobsScraper("any").fetch()
+
+
+def test_missing_jobs_field_raises(httpx_mock) -> None:
+    payload = _response([_job()])
+    payload.pop("jobs")
+    httpx_mock.add_response(url=API_URL, json=payload)
+
+    with pytest.raises(ScraperError, match="list-valued jobs"):
+        TimesJobsScraper("any").fetch()
+
+
+def test_missing_jobs_on_later_page_raises(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([_job(job_id="1")], total_pages=2, total=2),
+    )
+    payload = _response([], page=2, total_pages=2, total=2)
+    payload["jobs"] = None
+    httpx_mock.add_response(url=API_URL, json=payload)
+
+    with pytest.raises(ScraperError, match=r"page=2.*list-valued jobs"):
+        TimesJobsScraper("any").fetch()
+
+
+def test_full_catalogue_rejects_empty_result(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([], total_pages=1, total=0),
+    )
+
+    with pytest.raises(ScraperError, match="returned no jobs"):
+        TimesJobsScraper("any").fetch()
+
+
+def test_transient_failure_retries_then_succeeds(
+    httpx_mock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import ats_scrapers.scrapers.timesjobs as tj
+
+    monkeypatch.setattr(tj, "MAX_RETRIES", 2)
+    httpx_mock.add_response(url=API_URL, status_code=503)
+    httpx_mock.add_response(url=API_URL, json=_response([_job()]))
+
+    assert len(TimesJobsScraper("any").fetch()) == 1
+
+
+def test_fetch_stream_waits_for_cancelled_producer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scraper = TimesJobsScraper("any")
+    cleanup_finished = asyncio.Event()
+    sample = scraper._parse(_job())
+    assert sample is not None
+
+    async def fake_fetch_async(*, on_job=None):
+        try:
+            assert on_job is not None
+            await on_job(sample)
+            await asyncio.Future()
+        finally:
+            cleanup_finished.set()
+
+    monkeypatch.setattr(scraper, "_fetch_async", fake_fetch_async)
+
+    async def consume_one() -> None:
+        stream = scraper.fetch_stream()
+        assert await anext(stream) is sample
+        await stream.aclose()
+        assert cleanup_finished.is_set()
+
+    asyncio.run(consume_one())
+
+
+def test_failed_later_page_raises_instead_of_returning_partial(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([_job(job_id="1")], total_pages=2, total=2),
+    )
+    httpx_mock.add_response(url=API_URL, status_code=500)
+    with pytest.raises(ScraperError, match="page=2"):
+        TimesJobsScraper("any").fetch()
+
+
+def test_failed_page_cancels_sibling_tasks(monkeypatch) -> None:
+    scraper = TimesJobsScraper("any")
+    sibling_cancelled = False
+
+    async def fake_search(_client, *, page: int):
+        nonlocal sibling_cancelled
+        if page == 1:
+            return _response([_job(job_id="1")], total_pages=3, total=3)
+        if page == 2:
+            await asyncio.sleep(0)
+            raise ScraperError("page 2 failed")
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            sibling_cancelled = True
+            raise
+
+    monkeypatch.setattr(scraper, "_search", fake_search)
+
+    with pytest.raises(ScraperError, match="page 2 failed"):
+        scraper.fetch()
+    assert sibling_cancelled is True
+
+
+def test_country_iso_accepts_india_suffix(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([_job(location="Bengaluru, Karnataka, India")]),
+    )
+    assert TimesJobsScraper("any").fetch()[0].country_iso == "IN"
+
+
+@pytest.mark.parametrize(
+    "location,expected",
+    [("Bengaluru, IN", "IN"), ("Indianapolis, IN", None)],
+)
+def test_country_iso_disambiguates_in_suffix(httpx_mock, location, expected) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response([_job(location=location)]),
+    )
+    assert TimesJobsScraper("any").fetch()[0].country_iso == expected

--- a/tests/test_timesjobs.py
+++ b/tests/test_timesjobs.py
@@ -165,6 +165,30 @@ def test_dedupes_repeated_job_ids(httpx_mock) -> None:
     assert sorted(j.ats_id for j in jobs) == ["1", "2"]
 
 
+def test_full_catalogue_rejects_repeated_result_page(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response(
+            [_job(job_id="1")],
+            page=1,
+            total_pages=2,
+            total=2,
+        ),
+    )
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response(
+            [_job(job_id="1")],
+            page=2,
+            total_pages=2,
+            total=2,
+        ),
+    )
+
+    with pytest.raises(ScraperError, match="repeated an earlier result page"):
+        TimesJobsScraper("any").fetch()
+
+
 # --- field extraction -------------------------------------------------------
 
 

--- a/tests/test_timesjobs.py
+++ b/tests/test_timesjobs.py
@@ -159,6 +159,7 @@ def test_dedupes_repeated_job_ids(httpx_mock) -> None:
         url=API_URL,
         json=_response(
             [_job(job_id="1"), _job(job_id="1"), _job(job_id="2")],
+            total=2,
         ),
     )
     jobs = TimesJobsScraper("any").fetch()
@@ -189,6 +190,30 @@ def test_full_catalogue_rejects_repeated_result_page(httpx_mock) -> None:
         TimesJobsScraper("any").fetch()
 
 
+def test_full_catalogue_rejects_partial_page_overlap(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response(
+            [_job(job_id="1"), _job(job_id="2")],
+            page=1,
+            total_pages=2,
+            total=4,
+        ),
+    )
+    httpx_mock.add_response(
+        url=API_URL,
+        json=_response(
+            [_job(job_id="2"), _job(job_id="3")],
+            page=2,
+            total_pages=2,
+            total=4,
+        ),
+    )
+
+    with pytest.raises(ScraperError, match=r"3/4 unique jobs"):
+        TimesJobsScraper("any").fetch()
+
+
 # --- field extraction -------------------------------------------------------
 
 
@@ -216,6 +241,7 @@ def test_real_salary_range_is_preserved(httpx_mock) -> None:
     assert j.salary_min == 800_000
     assert j.salary_max == 1_500_000
     assert j.salary_currency == "INR"
+    assert j.salary_period == "YEAR"
 
 
 def test_currency_alias_rs_is_normalized_to_inr(httpx_mock) -> None:
@@ -453,7 +479,9 @@ def test_full_catalogue_rejects_fewer_rows_than_reported(
         json=_response([_job()], total=2),
     )
 
-    with pytest.raises(ScraperError, match=r"reported total \(1/2\)"):
+    with pytest.raises(
+        ScraperError, match=r"reported total \(1/2 unique jobs\)"
+    ):
         TimesJobsScraper("any").fetch()
 
 


### PR DESCRIPTION
## Sources

- Foundit India
- TimesJobs India

## Data-quality safeguards

- public credential-free endpoints only; no API keys, paid proxies, or browser automation
- full-catalogue runs fail closed on shard, transport, parser, pagination, or empty-output drift
- source identifiers, companies, locations, timestamps, and canonical URLs are preserved
- marketplace rows receive lower dedup priority than canonical employer ATS rows

## Validation

- `uv run ruff check .`
- `uv run pytest -q` — 1,414 passed, 2 skipped, 22 deselected
- live production probes — 2 passed, both returning non-empty real jobs with unique IDs and valid source domains

This is a two-source replacement for the oversized #214.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds credential-free Foundit and TimesJobs job sources with fail-closed catalogue safeguards.
- Registers both scraper adapters and pipeline configurations.
- Adds Foundit keyword-bucket pagination across five country shards.
- Adds concurrent, streaming TimesJobs pagination with schema and unique-count validation.
- Assigns marketplace sources lower cross-ATS deduplication priority.
- Adds focused unit, contract, pipeline-guard, and live-probe coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain in the implemented changes.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the general contract validation for the Foundit and TimesJobs endpoints and observed baseline results showing HTTP 200 OK and successful test passes.
- Re-ran the same validation after the change and confirmed both endpoints still return HTTP 200 OK and the named source tests passed, completing in about 2.51 seconds with exit code 0.
- Executed the exact quiet invocation to validate an independent pass, which completed in about 2.45 seconds with exit code 0.

<a href="https://app.greptile.com/trex/runs/15772274/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/ats_scrapers/scrapers/foundit.py | Adds the Foundit adapter with country sharding, keyword bucketing, strict full-catalogue row validation, retries, and pagination-wrap detection. |
| src/ats_scrapers/scrapers/timesjobs.py | Adds the TimesJobs adapter with bounded concurrent pagination, streaming output, strict response validation, deduplication, and unique-count completeness checks. |
| scripts/run_pipeline.py | Registers both sources and prevents empty, failed-stream, or failed-shard runs from replacing prior catalogue output. |
| pipeline/publisher.py | Assigns Foundit and TimesJobs marketplace records lower deduplication precedence than canonical employer ATS records. |
| tests/test_timesjobs.py | Covers TimesJobs parsing, pagination, schema drift, malformed rows, repeated pages, partial overlap, and reported-total validation. |
| tests/test_foundit.py | Covers Foundit request construction, parsing, retries, pagination, and strict full-catalogue failure behavior. |
| tests/test_run_pipeline_guards.py | Verifies failed shards, streaming errors, and empty required outputs preserve existing data and remove temporary output. |

<sub>Reviews (5): Last reviewed commit: ["fix: validate TimesJobs unique totals"](https://github.com/kalil0321/ats-scrapers/commit/5a30200e0117bacf4366599281a7cc3f63fdbe6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47031442)</sub>

<!-- /greptile_comment -->