### PR TITLE
Add Job Bank Canada and SEEK credential-free sources

### DIFF
--- a/ats-companies/jobbankca.csv
+++ b/ats-companies/jobbankca.csv
@@ -1,0 +1,2 @@
+name,slug,url
+Job Bank Canada,jobbankca,https://www.jobbank.gc.ca

--- a/ats-companies/seek.csv
+++ b/ats-companies/seek.csv
@@ -1,0 +1,9 @@
+name,slug,url
+JobStreet Indonesia,id,https://id.jobstreet.com
+JobStreet Malaysia,my,https://my.jobstreet.com
+JobStreet Philippines,ph,https://ph.jobstreet.com
+JobStreet Singapore,sg,https://sg.jobstreet.com
+JobsDB Hong Kong,hk,https://hk.jobsdb.com
+JobsDB Thailand,th,https://th.jobsdb.com
+SEEK Australia,au,https://www.seek.com.au
+SEEK New Zealand,nz,https://www.seek.co.nz

--- a/pipeline/publisher.py
+++ b/pipeline/publisher.py
@@ -547,12 +547,14 @@ ATS_DEDUP_PRIORITY: dict[str, int] = {
     "tiktok": 1, "uber": 1,
     # Hybrid jobboards
     "welcometothejungle": 3, "mercor": 3, "gem": 3,
+    "seek": 4,
     # Sourcing/matching layer that mirrors others
     "eightfold": 5,
     # National public-sector aggregators — government-curated but the
     # same role often appears here AND on the employer's direct ATS.
     "bundesagentur": 6,
     "arbetsformedlingen": 6,
+    "jobbankca": 6,
     "usajobs": 6,
 }
 

--- a/pipeline/publisher.py
+++ b/pipeline/publisher.py
@@ -698,7 +698,7 @@ def _dedup_from_per_ats_csvs(
     not the corpus) before we run the eager dedup on it. This is the
     key memory win vs an in-memory ``pl.concat([..]).collect()``: the
     per-ATS scans are pulled in one ATS at a time, and the keys
-    parquet on disk is small (~80 MB / million rows for the eight
+    parquet on disk is small (~80 MB / million rows for the nine
     thin string columns we project).
 
     Returns ``(survivors_by_ats, n_raw, n_kept)``.
@@ -731,6 +731,9 @@ def _dedup_from_per_ats_csvs(
                 _key_col_or_empty(schema_names, "location")
                 .str.to_lowercase()
                 .alias("location"),
+                _key_col_or_empty(schema_names, "country_iso")
+                .str.to_uppercase()
+                .alias("country_iso"),
                 _key_col_or_empty(schema_names, "ats_id").alias("ats_id"),
             ]
         )
@@ -849,16 +852,26 @@ def _decide_dedup_survivors_polars(
     # ---- Pass 4 (Phase 1): cross-ATS (company_norm, title_core, country) -
     # ``title_core`` strips the trailing parenthesised Berufenet tag
     # that eures appends but Bundesagentur doesn't. ``country_iso`` is
-    # extracted from free-form ``location`` text (eures encodes it as
-    # the leading ``DE``/``FR``/… token, Bundesagentur as a full
-    # ``", Deutschland"`` suffix). The combination catches the
-    # formatting-only cross-source dups that Pass 2 misses entirely.
+    # prefers the scraper's structured value and falls back to extracting
+    # free-form ``location`` text (eures encodes it as the leading
+    # ``DE``/``FR``/… token, Bundesagentur as a full ``", Deutschland"``
+    # suffix). The combination catches formatting-only cross-source dups
+    # that Pass 2 misses entirely.
+    structured_country = (
+        pl.col("country_iso")
+        if "country_iso" in work.columns
+        else pl.lit("", dtype=pl.String)
+    ).str.strip_chars()
+    derived_country = pl.col("location").map_elements(
+        _country_iso_from_location, return_dtype=pl.String
+    )
     work = work.with_columns(
         pl.col("title_raw")
         .map_elements(_title_core, return_dtype=pl.String)
         .alias("_title_core"),
-        pl.col("location")
-        .map_elements(_country_iso_from_location, return_dtype=pl.String)
+        pl.when(structured_country.str.len_bytes() > 0)
+        .then(structured_country)
+        .otherwise(derived_country)
         .alias("_country_iso"),
     )
     work = work.with_columns(

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -59,6 +59,7 @@ from ats_scrapers.scrapers import (
     GupyScraper,
     InfoJobsSpainScraper,
     JazzHRScraper,
+    JobBankCAScraper,
     JobsChScraper,
     JobsCzScraper,
     JoinComScraper,
@@ -76,6 +77,7 @@ from ats_scrapers.scrapers import (
     RecruiterboxScraper,
     RemoteOKScraper,
     RipplingScraper,
+    SeekScraper,
     SmartRecruitersScraper,
     SuccessFactorsScraper,
     TaleoScraper,
@@ -664,6 +666,18 @@ CONFIGS: dict[str, dict[str, Any]] = {
         # InfoJobs Spain - Spanish direct-posting job board. ~70k live.
         "scraper": InfoJobsSpainScraper, "singleton": True,
         "output": "infojobs_es/jobs.csv",
+    },
+    "jobbankca": {
+        "scraper": JobBankCAScraper, "singleton": True,
+        "output": "jobbankca/jobs.csv",
+        "fail_closed_on_empty": True,
+    },
+    "seek": {
+        "scraper": SeekScraper,
+        "slug": lambda r: _slug_col(r) or None,
+        "csv": "ats-companies/seek.csv",
+        "output": "seek/jobs.csv",
+        "fail_closed_on_any_error": True,
     },
     "jobs_cz": {
         # jobs.cz - Czech Republic's largest direct-posting board. ~10k live via seeded search.
@@ -1441,6 +1455,47 @@ async def run(ats: str, concurrency: int, max_tenants: int | None, timeout: floa
                 print(
                     f"[{ats}] ACTION retry: streaming scrape failed after "
                     f"{counts['jobs']:,} jobs and no previous jobs.csv exists."
+                )
+            return 1
+
+        empty_output_failure = (
+            bool(cfg.get("fail_closed_on_empty"))
+            and bool(targets)
+            and counts["jobs"] == 0
+        )
+        if empty_output_failure:
+            tmp_output_path.unlink(missing_ok=True)
+            if output_path.exists():
+                print(
+                    f"[{ats}] ACTION keep_previous: required scrape returned "
+                    f"0 jobs; preserved {output_path} instead of publishing "
+                    "an empty dataset."
+                )
+            else:
+                print(
+                    f"[{ats}] ACTION retry: required scrape returned 0 jobs "
+                    "and no previous jobs.csv exists."
+                )
+            return 1
+
+        sharded_failure = (
+            bool(cfg.get("fail_closed_on_any_error"))
+            and counts["error"] > 0
+        )
+        if sharded_failure:
+            tmp_output_path.unlink(missing_ok=True)
+            if output_path.exists():
+                print(
+                    f"[{ats}] ACTION keep_previous: {counts['error']}/"
+                    f"{len(targets)} required shards failed after "
+                    f"{counts['jobs']:,} jobs; preserved {output_path} "
+                    "instead of publishing a partial dataset."
+                )
+            else:
+                print(
+                    f"[{ats}] ACTION retry: {counts['error']}/"
+                    f"{len(targets)} required shards failed and no previous "
+                    "jobs.csv exists."
                 )
             return 1
 

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -1239,8 +1239,12 @@ async def run(ats: str, concurrency: int, max_tenants: int | None, timeout: floa
                 kw = kwargs_factory(r) if kwargs_factory else {}
                 targets.append((slug, kw))
 
+    configured_target_count = len(targets)
+    omitted_required_shards = 0
     if max_tenants:
         targets = targets[:max_tenants]
+        if cfg.get("fail_closed_on_any_error"):
+            omitted_required_shards = configured_target_count - len(targets)
 
     print(f"[{ats}] Scraping {len(targets)} tenants (concurrency={concurrency}, timeout={timeout}s)")
     sem = asyncio.Semaphore(concurrency)
@@ -1480,22 +1484,24 @@ async def run(ats: str, concurrency: int, max_tenants: int | None, timeout: floa
 
         sharded_failure = (
             bool(cfg.get("fail_closed_on_any_error"))
-            and counts["error"] > 0
+            and (counts["error"] > 0 or omitted_required_shards > 0)
         )
         if sharded_failure:
             tmp_output_path.unlink(missing_ok=True)
+            required_failures = counts["error"] + omitted_required_shards
             if output_path.exists():
                 print(
-                    f"[{ats}] ACTION keep_previous: {counts['error']}/"
-                    f"{len(targets)} required shards failed after "
+                    f"[{ats}] ACTION keep_previous: {required_failures}/"
+                    f"{configured_target_count} required shards failed or "
+                    "were omitted after "
                     f"{counts['jobs']:,} jobs; preserved {output_path} "
                     "instead of publishing a partial dataset."
                 )
             else:
                 print(
-                    f"[{ats}] ACTION retry: {counts['error']}/"
-                    f"{len(targets)} required shards failed and no previous "
-                    "jobs.csv exists."
+                    f"[{ats}] ACTION retry: {required_failures}/"
+                    f"{configured_target_count} required shards failed or "
+                    "were omitted and no previous jobs.csv exists."
                 )
             return 1
 

--- a/src/ats_scrapers/models.py
+++ b/src/ats_scrapers/models.py
@@ -87,6 +87,8 @@ class ATSType(StrEnum):
     YCOMBINATOR = "ycombinator"
     WELLFOUND = "wellfound"
     INFOJOBSES = "infojobs_es"
+    JOBBANKCA = "jobbankca"
+    SEEK = "seek"
     # Additional multi-tenant ATSes (post-0.1)
     BAMBOOHR = "bamboohr"
     BREEZY = "breezy"

--- a/src/ats_scrapers/scrapers/__init__.py
+++ b/src/ats_scrapers/scrapers/__init__.py
@@ -32,6 +32,7 @@ from ats_scrapers.scrapers.gupy import GupyScraper
 from ats_scrapers.scrapers.icims import iCIMSScraper
 from ats_scrapers.scrapers.infojobs_es import InfoJobsSpainScraper
 from ats_scrapers.scrapers.jazzhr import JazzHRScraper
+from ats_scrapers.scrapers.jobbankca import JobBankCAScraper
 from ats_scrapers.scrapers.jobs_cz import JobsCzScraper
 from ats_scrapers.scrapers.jobsch import JobsChScraper
 from ats_scrapers.scrapers.join_com import JoinComScraper
@@ -49,6 +50,7 @@ from ats_scrapers.scrapers.recruitee import RecruiteeScraper
 from ats_scrapers.scrapers.recruiterbox import RecruiterboxScraper
 from ats_scrapers.scrapers.remoteok import RemoteOKScraper
 from ats_scrapers.scrapers.rippling import RipplingScraper
+from ats_scrapers.scrapers.seek import SeekScraper
 from ats_scrapers.scrapers.smartrecruiters import SmartRecruitersScraper
 from ats_scrapers.scrapers.successfactors import SuccessFactorsScraper
 from ats_scrapers.scrapers.taleo import TaleoScraper
@@ -90,6 +92,7 @@ __all__ = [
     "GupyScraper",
     "InfoJobsSpainScraper",
     "JazzHRScraper",
+    "JobBankCAScraper",
     "JobsChScraper",
     "JobsCzScraper",
     "JoinComScraper",
@@ -108,6 +111,7 @@ __all__ = [
     "RemoteOKScraper",
     "RipplingScraper",
     "ScraperRegistry",
+    "SeekScraper",
     "SmartRecruitersScraper",
     "SuccessFactorsScraper",
     "TaleoScraper",

--- a/src/ats_scrapers/scrapers/jobbankca.py
+++ b/src/ats_scrapers/scrapers/jobbankca.py
@@ -1,0 +1,494 @@
+"""Job Bank Canada (jobbank.gc.ca) scraper.
+
+Canada's federal-government job board, run by Employment and Social
+Development Canada. ~62k live postings across private and public
+sector employers. Free, unauthenticated, server-rendered HTML — there's
+no public JSON API surfaced by the site.
+
+The search endpoint paginates 25 results per page:
+
+    GET https://www.jobbank.gc.ca/jobsearch/jobsearch?searchstring=&sort=M&page=N
+
+Each result is a ``<article id="article-{id}">`` block containing the
+title (``.noctitle``), employer (``.business``), location
+(``.location``), posting date (``.date``), and salary (``.salary``) —
+plus a handful of optional flag tags (``.telework``, ``.appmethod``,
+``.postedonJB``, ``.new``). Salary is free text (``$25.00 hourly``,
+``$110,000.00 to $150,000.00 annually``) and currency is implicitly CAD.
+
+The full description lives on a per-job detail page; pulling it would
+mean 62k extra requests for marginal gain, so we leave ``description``
+empty and ship the teaser metadata only.
+
+Single-source scraper: ``company_slug`` is informational and ignored —
+every fetch returns the entire active dataset.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import logging
+import re
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType, Job, SalaryPeriod
+from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SEARCH_URL = "https://www.jobbank.gc.ca/jobsearch/jobsearch"
+POSTING_URL_TEMPLATE = "https://www.jobbank.gc.ca/jobsearch/jobposting/{id}"
+PAGE_SIZE = 25  # Server renders 25 results per page; not configurable.
+MAX_PAGES = 5000
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 4
+RETRY_BASE_DELAY = 1.5
+DEFAULT_USER_AGENT = "Mozilla/5.0"
+DEFAULT_TIMEOUT = 60.0
+
+# --- Parsing primitives -----------------------------------------------------
+#
+# Job Bank's listing HTML is server-rendered JSF — verbose but stable.
+# Anchor on the unambiguous ``<article id="article-{N}">`` opener, then
+# pull each ``<li class="...">`` payload with a targeted regex. We use
+# ``html.unescape`` on every captured fragment so entities like ``&amp;``
+# round-trip cleanly into the canonical Job schema.
+
+_ARTICLE_OPEN_RE = re.compile(r'<article\s+id="article-(\d+)"', re.IGNORECASE)
+_TITLE_RE = re.compile(
+    r'<span\s+class="noctitle"[^>]*>(.*?)</span>', re.IGNORECASE | re.DOTALL
+)
+_BUSINESS_RE = re.compile(
+    r'<li\s+class="business"[^>]*>(.*?)</li>', re.IGNORECASE | re.DOTALL
+)
+_LOCATION_RE = re.compile(
+    r'<li\s+class="location"[^>]*>(.*?)</li>', re.IGNORECASE | re.DOTALL
+)
+_DATE_RE = re.compile(
+    r'<li\s+class="date"[^>]*>(.*?)</li>', re.IGNORECASE | re.DOTALL
+)
+_SALARY_RE = re.compile(
+    r'<li\s+class="salary"[^>]*>(.*?)</li>', re.IGNORECASE | re.DOTALL
+)
+_TELEWORK_RE = re.compile(
+    r'<span\s+class="telework"[^>]*>(.*?)</span>', re.IGNORECASE | re.DOTALL
+)
+_APPMETHOD_RE = re.compile(
+    r'<span\s+class="appmethod"[^>]*>(.*?)</span>', re.IGNORECASE | re.DOTALL
+)
+_POSTED_ON_JB_RE = re.compile(r'class="postedonJB"', re.IGNORECASE)
+_NEW_FLAG_RE = re.compile(r'<span\s+class="new"', re.IGNORECASE)
+_JOB_NUMBER_RE = re.compile(
+    r'<li\s+class="source"[^>]*>.*?Job\s*number:.*?(\d{3,})',
+    re.IGNORECASE | re.DOTALL,
+)
+_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"\s+")
+
+# Canadian province / territory abbreviations seen in location strings
+# like ``Calgary, AB`` or ``Burlington (ON)``. Used to set ``country_iso``
+# defensively even when the location string lacks ", Canada".
+_CA_PROVINCES = frozenset({
+    "AB", "BC", "MB", "NB", "NL", "NS", "NT", "NU",
+    "ON", "PE", "QC", "SK", "YT",
+})
+
+# English listings render dates as ``May 08, 2026``; French listings use
+# ``08 mai 2026``. ``_parse_date`` supports both locale-specific forms.
+_MONTHS_EN = {
+    "january": 1, "february": 2, "march": 3, "april": 4, "may": 5,
+    "june": 6, "july": 7, "august": 8, "september": 9, "october": 10,
+    "november": 11, "december": 12,
+    # Abbreviations that occasionally appear.
+    "jan": 1, "feb": 2, "mar": 3, "apr": 4, "jun": 6, "jul": 7,
+    "aug": 8, "sep": 9, "sept": 9, "oct": 10, "nov": 11, "dec": 12,
+}
+_MONTHS_FR = {
+    "janvier": 1, "février": 2, "fevrier": 2, "mars": 3,
+    "avril": 4, "mai": 5, "juin": 6, "juillet": 7, "août": 8,
+    "aout": 8, "septembre": 9, "octobre": 10, "novembre": 11,
+    "décembre": 12, "decembre": 12,
+}
+
+
+@ScraperRegistry.register(ATSType.JOBBANKCA)
+class JobBankCAScraper(BaseScraper):
+    """Job Bank Canada scraper. Single-source: ``company_slug`` is unused."""
+
+    ats = ATSType.JOBBANKCA
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = DEFAULT_TIMEOUT,
+        include_descriptions: bool = True,
+        proxy: str | None = None,
+        max_pages: int | None = None,
+        language: str = "en",
+    ) -> None:
+        super().__init__(
+            company_slug,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        if max_pages is not None and max_pages < 1:
+            raise ScraperError(
+                f"Job Bank max_pages must be positive, got {max_pages}"
+            )
+        self._full_catalogue = max_pages is None
+        self.max_pages = min(max_pages or MAX_PAGES, MAX_PAGES)
+        # ``en`` (default) → english site. ``fr`` → ``?lang=fra`` variant.
+        self.language = language
+
+    async def afetch(self) -> list[Job]:
+        return await self._fetch_async()
+
+    def fetch(self) -> list[Job]:
+        return self._run_sync(self.afetch())
+
+    async def _fetch_async(self) -> list[Job]:
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        repeated_pages = 0
+        exhausted = False
+        sem = asyncio.Semaphore(MAX_CONCURRENCY)
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True,
+            proxy=self.proxy,
+            headers={
+                "User-Agent": DEFAULT_USER_AGENT,
+                "Accept": "text/html,application/xhtml+xml",
+                "Accept-Language": "en-CA,en;q=0.9",
+            },
+        ) as client:
+            # Sequential paging: the cheapest termination signal is "this
+            # page returned 0 articles", which we can only observe in
+            # order. ~2,500 pages at PAGE_SIZE=25 — the per-page cost
+            # dominates, but parallel pre-fetching past the unknown last
+            # page would just waste work.
+            page = 1
+            while page <= self.max_pages:
+                html_text = await self._fetch_page(client, sem, page)
+                fetched = datetime.now(tz=UTC)
+                page_jobs = self._parse_page(html_text, fetched_at=fetched)
+                article_count = sum(
+                    1 for _ in _ARTICLE_OPEN_RE.finditer(html_text)
+                )
+                if len(page_jobs) != article_count:
+                    raise ScraperError(
+                        f"Job Bank page={page} contained {article_count} "
+                        f"articles but parsed {len(page_jobs)}"
+                    )
+                if not page_jobs:
+                    if 'id="results-count"' not in html_text:
+                        raise ScraperError(
+                            f"Job Bank page={page} lacked result markup"
+                        )
+                    if _ARTICLE_OPEN_RE.search(html_text):
+                        raise ScraperError(
+                            f"Job Bank page={page} contained unparseable articles"
+                        )
+                    exhausted = True
+                    break
+                added = 0
+                for job in page_jobs:
+                    if job.ats_id in seen:
+                        continue
+                    seen.add(job.ats_id)
+                    jobs.append(job)
+                    added += 1
+                logger.debug(
+                    "jobbankca page=%d parsed=%d new=%d cumulative=%d",
+                    page, len(page_jobs), added, len(jobs),
+                )
+                repeated_pages = repeated_pages + 1 if added == 0 else 0
+                if repeated_pages >= 2:
+                    raise ScraperError(
+                        "Job Bank repeated only known jobs on consecutive pages"
+                    )
+                page += 1
+        if self._full_catalogue and not jobs:
+            raise ScraperError(
+                "Job Bank full-catalogue scrape returned no jobs"
+            )
+        if self._full_catalogue and not exhausted:
+            raise ScraperError(
+                f"Job Bank reached its {MAX_PAGES}-page safety limit before "
+                "detecting the end of results"
+            )
+        return jobs
+
+    async def _fetch_page(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        page: int,
+    ) -> str:
+        params: dict[str, Any] = {
+            "searchstring": "",
+            "sort": "M",  # ``M`` = most recent.
+            "page": page,
+        }
+        if self.language == "fr":
+            params["lang"] = "fra"
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            async with sem:
+                try:
+                    r = await client.get(SEARCH_URL, params=params)
+                except httpx.HTTPError as exc:
+                    last_exc = exc
+                    await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                    continue
+            if r.status_code == 200:
+                return r.text
+            if r.status_code == 429 or 500 <= r.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"Job Bank Canada returned {r.status_code} on page={page} "
+                        f"after {MAX_RETRIES} retries"
+                    )
+                retry_after = r.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            raise ScraperError(
+                f"Job Bank Canada returned {r.status_code} on page={page}"
+            )
+        raise ScraperError(
+            f"Job Bank Canada exhausted retries on page={page}: {last_exc}"
+        )
+
+    # --- parsing ------------------------------------------------------------
+
+    def _parse_page(
+        self, html_text: str, *, fetched_at: datetime | None = None,
+    ) -> list[Job]:
+        """Split the page into ``<article>`` blocks and parse each.
+
+        Blocks that fail to parse are skipped with a debug log entry —
+        we never want a single malformed listing to bring down the run.
+        """
+        jobs: list[Job] = []
+        positions = [m.start() for m in _ARTICLE_OPEN_RE.finditer(html_text)]
+        if not positions:
+            return jobs
+        positions.append(len(html_text))
+        for i in range(len(positions) - 1):
+            chunk = html_text[positions[i]:positions[i + 1]]
+            job = self._parse_job(chunk, fetched_at=fetched_at)
+            if job is not None:
+                jobs.append(job)
+        return jobs
+
+    def _parse_job(
+        self, chunk: str, *, fetched_at: datetime | None = None,
+    ) -> Job | None:
+        m = _ARTICLE_OPEN_RE.search(chunk)
+        if not m:
+            return None
+        ats_id = m.group(1).strip()
+        title = _capture_text(_TITLE_RE, chunk)
+        if not ats_id or not title:
+            return None
+
+        company = _capture_text(_BUSINESS_RE, chunk) or "Job Bank Canada"
+        location = _capture_text(_LOCATION_RE, chunk)
+        if location:
+            # Strip the leading "Location" wb-inv label that survives
+            # tag-stripping ("LocationCalgary, AB" → "Calgary, AB").
+            location = re.sub(r"^Location\s*", "", location).strip() or None
+
+        # Date renders as ``May 08, 2026`` on the English site. The
+        # ``.date`` <li> sometimes carries an ``"Expires May 22, 2026"``
+        # second line; we strip everything past the first comma+year.
+        date_raw = _capture_text(_DATE_RE, chunk)
+        posted_at = _parse_date(date_raw)
+
+        # Salary: ``Salary $42.00 to $50.00 hourly (to be negotiated)``.
+        # Drop the leading "Salary" wb-inv label before storing.
+        salary_raw = _capture_text(_SALARY_RE, chunk)
+        salary_summary = None
+        salary_currency = None
+        salary_period = None
+        if salary_raw:
+            salary_summary = re.sub(r"^Salary\s*", "", salary_raw).strip() or None
+            salary_period = _salary_period(salary_summary)
+            if salary_summary and "$" in salary_summary and salary_period:
+                salary_currency = "CAD"
+
+        telework = _capture_text(_TELEWORK_RE, chunk)
+        appmethod = _capture_text(_APPMETHOD_RE, chunk)
+        is_remote = _infer_is_remote(telework, title)
+
+        job_number = None
+        jn = _JOB_NUMBER_RE.search(chunk)
+        if jn:
+            job_number = jn.group(1).strip()
+
+        raw: dict[str, Any] = {"posted_text": date_raw} if date_raw else {}
+        if telework:
+            raw["telework"] = telework
+        if appmethod:
+            raw["application_method"] = appmethod
+        if _POSTED_ON_JB_RE.search(chunk):
+            raw["posted_on_job_bank"] = True
+        if _NEW_FLAG_RE.search(chunk):
+            raw["new_flag"] = True
+        if job_number and job_number != ats_id:
+            raw["jobbank_number"] = job_number
+
+        country_iso = _infer_country_iso(location)
+        language = self.language if self.language in {"en", "fr"} else "en"
+
+        return Job(
+            url=POSTING_URL_TEMPLATE.format(id=ats_id),
+            title=title,
+            company=company,
+            ats_type=ATSType.JOBBANKCA,
+            ats_id=ats_id,
+            location=location,
+            country_iso=country_iso,
+            region="North America" if country_iso == "CA" else None,
+            is_remote=is_remote,
+            salary_summary=salary_summary,
+            salary_currency=salary_currency,
+            salary_period=salary_period,
+            commitment=telework or None,
+            requisition_id=job_number,
+            posted_at=posted_at,
+            fetched_at=fetched_at or datetime.now(tz=UTC),
+            language=language,
+            raw=raw or None,
+        )
+
+
+# --- module-level helpers ----------------------------------------------------
+
+
+def _salary_period(summary: str | None) -> SalaryPeriod | None:
+    if not summary:
+        return None
+    normalized = summary.casefold().replace("’", "'")
+    markers: tuple[tuple[SalaryPeriod, tuple[str, ...]], ...] = (
+        ("HOUR", ("hourly", "per hour", "par heure", "de l'heure", "à l'heure")),
+        ("DAY", ("daily", "per day", "par jour")),
+        ("WEEK", ("weekly", "per week", "par semaine")),
+        ("MONTH", ("monthly", "per month", "par mois")),
+        (
+            "YEAR",
+            ("annually", "annual", "yearly", "per year", "par année", "annuel"),
+        ),
+    )
+    for period, candidates in markers:
+        if any(candidate in normalized for candidate in candidates):
+            return period
+    return None
+
+
+def _capture_text(pattern: re.Pattern[str], chunk: str) -> str | None:
+    """Run ``pattern`` against ``chunk`` and return cleaned inner text.
+
+    Strips nested tags, collapses whitespace, unescapes HTML entities.
+    Returns ``None`` when the match is empty.
+    """
+    m = pattern.search(chunk)
+    if not m:
+        return None
+    raw = m.group(1)
+    text = _TAG_RE.sub(" ", raw)
+    text = html.unescape(text)
+    text = _WS_RE.sub(" ", text).strip()
+    return text or None
+
+
+def _parse_date(value: str | None) -> datetime | None:
+    """Parse an English or French Job Bank publication date."""
+    if not value:
+        return None
+    # Some listings include a trailing "Expires..." clause we don't
+    # care about for posted_at.
+    head = value.split("Expires", 1)[0].strip()
+    m = re.search(r"([A-Za-z]+)\s+(\d{1,2}),\s*(\d{4})", head)
+    if m:
+        month = _MONTHS_EN.get(m.group(1).lower())
+        if month is not None:
+            try:
+                return datetime(
+                    int(m.group(3)), month, int(m.group(2)), tzinfo=UTC,
+                )
+            except ValueError:
+                return None
+    french = re.search(r"(\d{1,2})\s+([A-Za-zÀ-ÿ]+)\s+(\d{4})", head)
+    if not french:
+        return None
+    month = _MONTHS_FR.get(french.group(2).lower())
+    if month is None:
+        return None
+    try:
+        return datetime(
+            int(french.group(3)), month, int(french.group(1)), tzinfo=UTC,
+        )
+    except ValueError:
+        return None
+
+
+def _infer_is_remote(telework: str | None, title: str) -> bool | None:
+    """Set ``is_remote=True`` only when the source explicitly says so.
+
+    Job Bank ships ``<span class="telework">`` with one of four
+    labels: ``On site``, ``Hybrid``, ``Remote``, ``Telework``. We
+    return ``True`` for the last two (telework is the older synonym),
+    ``False`` only for the explicit ``On site``, and ``None`` for
+    hybrid or missing flags so the downstream enrichment isn't
+    forced to commit prematurely.
+    """
+    if telework:
+        t = telework.strip().lower()
+        if "remote" in t or "telework" in t or "télétravail" in t:
+            return True
+        if t == "on site" or "sur place" in t:
+            return False
+        if "hybrid" in t or "hybride" in t:
+            return None
+    # Title-only fallback mirrors the schema's documented behavior:
+    # only ever assert True, never False.
+    title_lc = title.lower()
+    if "remote" in title_lc or "télétravail" in title_lc:
+        return True
+    return None
+
+
+def _infer_country_iso(location: str | None) -> str | None:
+    """Return ``"CA"`` when the location string contains a Canadian
+    province / territory code or the word ``Canada``.
+
+    Job Bank only posts Canadian jobs in practice, but we still gate on
+    a visible signal so we don't claim country for, say, a freshly
+    redesigned page where the location field is empty.
+    """
+    if not location:
+        return "CA"  # Job Bank is Canada-only; default when unknown.
+    if "Canada" in location:
+        return "CA"
+    for token in re.findall(r"\b([A-Z]{2})\b", location):
+        if token in _CA_PROVINCES:
+            return "CA"
+    # Province inside parens, e.g. ``Burlington (ON)``.
+    for token in re.findall(r"\(([A-Z]{2})\)", location):
+        if token in _CA_PROVINCES:
+            return "CA"
+    return "CA"

--- a/src/ats_scrapers/scrapers/jobbankca.py
+++ b/src/ats_scrapers/scrapers/jobbankca.py
@@ -32,6 +32,7 @@ import logging
 import re
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
+from urllib.parse import urljoin, urlsplit
 
 import httpx
 
@@ -63,6 +64,11 @@ DEFAULT_TIMEOUT = 60.0
 # round-trip cleanly into the canonical Job schema.
 
 _ARTICLE_OPEN_RE = re.compile(r'<article\s+id="article-(\d+)"', re.IGNORECASE)
+_RESULT_HREF_RE = re.compile(
+    r'<a\b(?=[^>]*\bclass=["\'][^"\']*\bresultJobItem\b[^"\']*["\'])'
+    r'[^>]*\bhref=["\']([^"\']+)["\']',
+    re.IGNORECASE,
+)
 _TITLE_RE = re.compile(
     r'<span\s+class="noctitle"[^>]*>(.*?)</span>', re.IGNORECASE | re.DOTALL
 )
@@ -355,7 +361,7 @@ class JobBankCAScraper(BaseScraper):
         language = self.language if self.language in {"en", "fr"} else "en"
 
         return Job(
-            url=POSTING_URL_TEMPLATE.format(id=ats_id),
+            url=_posting_url(chunk, ats_id),
             title=title,
             company=company,
             ats_type=ATSType.JOBBANKCA,
@@ -374,6 +380,24 @@ class JobBankCAScraper(BaseScraper):
             language=language,
             raw=raw or None,
         )
+
+
+def _posting_url(chunk: str, ats_id: str) -> str:
+    fallback = POSTING_URL_TEMPLATE.format(id=ats_id)
+    match = _RESULT_HREF_RE.search(chunk)
+    if not match:
+        return fallback
+
+    href = html.unescape(match.group(1)).strip()
+    parsed = urlsplit(urljoin("https://www.jobbank.gc.ca", href))
+    path = re.sub(r";jsessionid=[^/?#]+", "", parsed.path, flags=re.IGNORECASE)
+    if (
+        parsed.netloc.lower() != "www.jobbank.gc.ca"
+        or not path.startswith("/jobsearch/jobposting")
+        or not path.endswith(f"/{ats_id}")
+    ):
+        return fallback
+    return f"https://www.jobbank.gc.ca{path}"
 
 
 # --- module-level helpers ----------------------------------------------------

--- a/src/ats_scrapers/scrapers/seek.py
+++ b/src/ats_scrapers/scrapers/seek.py
@@ -1,0 +1,509 @@
+"""SEEK / JobsDB / JobStreet — APAC job board family scraper.
+
+SEEK Ltd. owns a family of regional job boards across the Asia-Pacific
+that all share the same backend search service (``chalice-search v5``).
+A single scraper covers every brand because the API shape is identical
+— only the host and ``siteKey`` parameter change:
+
+    GET https://{host}/api/jobsearch/v5/search
+        ?siteKey={siteKey}&page=N&pageSize=100&sortmode=ListedDate
+
+No authentication, no API key, JSON response. The eight covered sites
+host roughly **474k live postings** in aggregate (as of May 2026):
+
+==========  =================  ===========  =======  ============
+Region      Host               siteKey      ISO      Approx. jobs
+==========  =================  ===========  =======  ============
+au          au.seek.com        AU-Main      AU        159k
+nz          www.seek.co.nz     NZ-Main      NZ         19k
+hk          hk.jobsdb.com      HK-Main      HK         34k
+th          th.jobsdb.com      TH-Main      TH         18k
+my          my.jobstreet.com   MY-Main      MY         50k
+id          id.jobstreet.com   ID-Main      ID         56k
+ph          ph.jobstreet.com   PH-Main      PH         73k
+sg          sg.jobstreet.com   SG-Main      SG         66k
+==========  =================  ===========  =======  ============
+
+Usage. The ``company_slug`` constructor argument picks the region:
+
+    SeekScraper("au")   # SEEK AU only
+    SeekScraper("sg")   # JobStreet Singapore only
+    SeekScraper("all")  # all eight regions, sequentially
+
+Pagination. The API caps ``pageSize`` at 100 (200 returns HTML).
+``page * pageSize`` does **not** appear to have a hard cap the way
+Bundesagentur / EURES do, so we iterate ``page=1..N`` until either
+``len(data) < pageSize``, ``page * pageSize >= totalCount``, or a
+safety limit of 1000 pages — whichever comes first.
+
+Description handling. The search response only carries a ``teaser``
+plus a few ``bulletPoints`` — the full job description requires a
+per-posting fetch. With 159k AU postings alone, opting into a second
+round-trip per row would be 159k extra requests; we deliberately keep
+the search payload as the description source (summary only) and let
+downstream enrichment fetch full bodies on demand if a consumer needs
+them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+# Region code → (host, siteKey, country_iso). The "all" sentinel is
+# handled separately in ``_fetch_async`` — it isn't a real region.
+SEEK_SITES: dict[str, tuple[str, str, str]] = {
+    "au": ("au.seek.com", "AU-Main", "AU"),
+    "nz": ("www.seek.co.nz", "NZ-Main", "NZ"),
+    "hk": ("hk.jobsdb.com", "HK-Main", "HK"),
+    "th": ("th.jobsdb.com", "TH-Main", "TH"),
+    "my": ("my.jobstreet.com", "MY-Main", "MY"),
+    "id": ("id.jobstreet.com", "ID-Main", "ID"),
+    "ph": ("ph.jobstreet.com", "PH-Main", "PH"),
+    "sg": ("sg.jobstreet.com", "SG-Main", "SG"),
+}
+
+# ISO 3166-1 alpha-2 → ISO 4217 currency. Only used when a row already
+# has a populated ``salaryLabel`` — we never invent a currency for
+# salary-less rows.
+_REGION_CURRENCY: dict[str, str] = {
+    "AU": "AUD",
+    "NZ": "NZD",
+    "HK": "HKD",
+    "TH": "THB",
+    "MY": "MYR",
+    "ID": "IDR",
+    "PH": "PHP",
+    "SG": "SGD",
+}
+
+PAGE_SIZE = 100  # API caps pageSize at 100 (>100 returns HTML).
+PAGE_SAFETY_CAP = 5000  # Stop after this many pages regardless of total.
+# AU alone is ~159k postings (~1590 pages); a 1000-page cap would silently
+# drop ~59k rows. 5000 pages (~500k postings) covers the largest region
+# with headroom while still bounding a runaway/looping response.
+MAX_CONCURRENCY = 4
+MAX_RETRIES = 5
+RETRY_BASE_DELAY = 1.5
+
+@ScraperRegistry.register(ATSType.SEEK)
+class SeekScraper(BaseScraper):
+    """SEEK / JobsDB / JobStreet — single scraper for the whole family.
+
+    ``company_slug`` is interpreted as a region code (``au``, ``nz``,
+    ``hk``, ``th``, ``my``, ``id``, ``ph``, ``sg``) or the special
+    ``all`` value that iterates every region.
+    """
+
+    ats = ATSType.SEEK
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        include_descriptions: bool = True,
+        proxy: str | None = None,
+        max_pages: int | None = None,
+    ) -> None:
+        super().__init__(
+            company_slug,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        if max_pages is not None and max_pages < 1:
+            raise ScraperError(
+                f"SEEK max_pages must be positive, got {max_pages}"
+            )
+        self.max_pages = max_pages
+        region = company_slug.strip().lower()
+        if region == "all":
+            self.regions: tuple[str, ...] = tuple(SEEK_SITES)
+        elif region in SEEK_SITES:
+            self.regions = (region,)
+        else:
+            raise ScraperError(
+                f"Unknown SEEK region {company_slug!r}. "
+                f"Valid: {sorted(SEEK_SITES)} or 'all'."
+            )
+
+    async def afetch(self) -> list[Job]:
+        return await self._fetch_async()
+
+    def fetch(self) -> list[Job]:
+        return self._run_sync(self.afetch())
+
+    async def _fetch_async(self) -> list[Job]:
+        jobs: list[Job] = []
+        seen: set[str] = set()
+        async with httpx.AsyncClient(
+            timeout=self.timeout, follow_redirects=True, proxy=self.proxy
+        ) as client:
+            sem = asyncio.Semaphore(MAX_CONCURRENCY)
+            for region in self.regions:
+                region_jobs = await self._fetch_region(client, sem, region)
+                # Cross-region dedup — same posting can theoretically
+                # appear under two siteKeys (rare but observed for
+                # multi-country remote roles).
+                for job in region_jobs:
+                    if job.global_id in seen:
+                        continue
+                    seen.add(job.global_id)
+                    jobs.append(job)
+        return jobs
+
+    async def _fetch_region(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        region: str,
+    ) -> list[Job]:
+        host, site_key, country_iso = SEEK_SITES[region]
+        first = await self._search(client, sem, host=host,
+                                   site_key=site_key, page=1)
+        total, data = self._page_data(first, region=region, page=1)
+        if not data:
+            raise ScraperError(
+                f"SEEK region={region} returned an empty catalogue"
+            )
+        parsed_jobs = [
+            self._parse_job(item, host=host, country_iso=country_iso)
+            for item in data
+        ]
+        if any(job is None for job in parsed_jobs):
+            raise ScraperError(
+                f"SEEK region={region} page=1 contained unparseable jobs"
+            )
+        jobs: list[Job] = [job for job in parsed_jobs if job is not None]
+        if total <= PAGE_SIZE:
+            return jobs
+
+        # Pages beyond the first — fan out with bounded concurrency.
+        last_page = (total + PAGE_SIZE - 1) // PAGE_SIZE
+        if last_page > PAGE_SAFETY_CAP:
+            raise ScraperError(
+                f"SEEK region={region} reports {last_page} pages, above the "
+                f"validated safety limit of {PAGE_SAFETY_CAP}; refusing a "
+                "silent partial scrape"
+            )
+        if self.max_pages is not None:
+            last_page = min(last_page, self.max_pages)
+        if last_page <= 1:
+            return [j for j in jobs if j is not None]
+
+        results: list[list[Job]] = [jobs]
+
+        async def one_page(page: int) -> tuple[list[Job], int]:
+            payload = await self._search(client, sem, host=host,
+                                         site_key=site_key, page=page)
+            _, items = self._page_data(payload, region=region, page=page)
+            parsed = [
+                self._parse_job(it, host=host, country_iso=country_iso)
+                for it in items
+            ]
+            if any(job is None for job in parsed):
+                raise ScraperError(
+                    f"SEEK region={region} page={page} contained "
+                    "unparseable jobs"
+                )
+            return [job for job in parsed if job is not None], len(items)
+
+        for start in range(2, last_page + 1, MAX_CONCURRENCY):
+            pages = range(start, min(start + MAX_CONCURRENCY, last_page + 1))
+            tasks = [asyncio.create_task(one_page(page)) for page in pages]
+            try:
+                batches = await asyncio.gather(*tasks)
+            except BaseException:
+                for task in tasks:
+                    task.cancel()
+                await asyncio.gather(*tasks, return_exceptions=True)
+                raise
+            reached_end = False
+            for batch, count in batches:
+                results.append(batch)
+                if count < PAGE_SIZE:
+                    reached_end = True
+                    break
+            if reached_end:
+                break
+
+        flat: list[Job] = []
+        for batch in results:
+            for j in batch:
+                if j is not None:
+                    flat.append(j)
+        return flat
+
+    @staticmethod
+    def _page_data(
+        payload: dict[str, Any], *, region: str, page: int,
+    ) -> tuple[int, list[dict[str, Any]]]:
+        total = payload.get("totalCount")
+        if isinstance(total, bool) or not isinstance(total, int) or total < 0:
+            raise ScraperError(
+                f"SEEK region={region} page={page} omitted a valid totalCount"
+            )
+        data = payload.get("data")
+        if not isinstance(data, list) or not all(
+            isinstance(item, dict) for item in data
+        ):
+            raise ScraperError(
+                f"SEEK region={region} page={page} returned invalid data"
+            )
+        offset = (page - 1) * PAGE_SIZE
+        if data and total <= offset:
+            raise ScraperError(
+                f"SEEK region={region} page={page} returned jobs beyond "
+                f"its totalCount={total}"
+            )
+        if total > offset + len(data) and len(data) < PAGE_SIZE:
+            raise ScraperError(
+                f"SEEK region={region} page={page} returned {len(data)} jobs "
+                f"before totalCount={total} was exhausted"
+            )
+        return total, data
+
+    async def _search(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        *,
+        host: str,
+        site_key: str,
+        page: int,
+    ) -> dict[str, Any]:
+        url = (
+            f"https://{host}/api/jobsearch/v5/search"
+            f"?siteKey={site_key}&page={page}&pageSize={PAGE_SIZE}"
+            f"&sortmode=ListedDate"
+        )
+        last_exc: Exception | None = None
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                async with sem:
+                    r = await client.get(
+                        url,
+                        headers={
+                            "Accept": "application/json",
+                            "User-Agent": "Mozilla/5.0",
+                        },
+                    )
+            except httpx.HTTPError as exc:
+                last_exc = exc
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"SEEK fetch failed for {url}: {exc}"
+                    ) from exc
+                await asyncio.sleep(RETRY_BASE_DELAY * attempt)
+                continue
+            if r.status_code == 200:
+                try:
+                    return r.json()
+                except ValueError as exc:
+                    raise ScraperError(
+                        f"SEEK returned non-JSON for {url}: {exc}"
+                    ) from exc
+            if r.status_code in (429,) or 500 <= r.status_code < 600:
+                if attempt == MAX_RETRIES:
+                    raise ScraperError(
+                        f"SEEK returned {r.status_code} for {url} after "
+                        f"{MAX_RETRIES} retries"
+                    )
+                retry_after = r.headers.get("Retry-After")
+                delay = (
+                    float(retry_after) if retry_after and retry_after.isdigit()
+                    else RETRY_BASE_DELAY * (2 ** attempt)
+                )
+                await asyncio.sleep(delay)
+                continue
+            # 4xx other than 429 — treat as a terminal slice failure so
+            # we don't burn retries on a permanent error.
+            raise ScraperError(
+                f"SEEK returned {r.status_code} for {url}: {r.text[:120]}"
+            )
+        raise ScraperError(f"SEEK exhausted retries for {url}: {last_exc}")
+
+    def _parse_job(
+        self,
+        item: dict[str, Any],
+        *,
+        host: str,
+        country_iso: str,
+    ) -> Job | None:
+        ats_id = str(item.get("id") or "").strip()
+        title = (item.get("title") or "").strip()
+        if not ats_id or not title:
+            return None
+
+        advertiser = item.get("advertiser") or {}
+        company = (
+            advertiser.get("description")
+            or item.get("companyName")
+            or "Unknown"
+        )
+
+        # Location — the search response gives a list. ``label`` is the
+        # display string (e.g. ``"Tampines North, East Region"``);
+        # ``countryCode`` is the ISO-2. If multiple locations are listed
+        # we keep the first and append the country only when the label
+        # doesn't already include it (most APAC labels are city / region
+        # only, no country suffix).
+        locations = item.get("locations") or []
+        location: str | None = None
+        loc_country: str | None = None
+        if locations and isinstance(locations[0], dict):
+            primary = locations[0]
+            label = (primary.get("label") or "").strip() or None
+            loc_country = (primary.get("countryCode") or "").strip().upper() or None
+            location = label
+
+        country = loc_country or country_iso
+
+        # Description — search response is summary-only. We concatenate
+        # the teaser with the bullet points (when both are present) so
+        # downstream consumers have *something* searchable; the model's
+        # canonical 25k-character cap is preserved.
+        teaser = (item.get("teaser") or "").strip()
+        bullets = [
+            b.strip() for b in (item.get("bulletPoints") or [])
+            if isinstance(b, str) and b.strip()
+        ]
+        if teaser and bullets:
+            description = teaser + "\n\n- " + "\n- ".join(bullets)
+        elif bullets:
+            description = "- " + "\n- ".join(bullets)
+        else:
+            description = teaser or None
+        if description is not None and len(description) > 25_000:
+            description = description[:25_000]
+
+        # Classification — ``classifications[0].classification.description``
+        # is the high-level category (e.g. "Information & Communication
+        # Technology"). ``subclassification`` is finer-grained — we keep
+        # the parent in ``department``.
+        department: str | None = None
+        classifications = item.get("classifications") or []
+        if classifications and isinstance(classifications[0], dict):
+            cls = classifications[0].get("classification") or {}
+            label = (cls.get("description") or cls.get("label") or "").strip()
+            department = label or None
+
+        salary_label = (item.get("salaryLabel") or "").strip() or None
+        salary_currency = _REGION_CURRENCY.get(country) if salary_label else None
+        salary_period = _infer_salary_period(salary_label) if salary_currency else None
+
+        posted_at = _parse_iso8601(item.get("listingDate"))
+
+        raw: dict[str, Any] = {}
+        # Surface a compact subset of identifiers. ``advertiser.id`` is
+        # the most useful cross-posting key.
+        adv_id = advertiser.get("id")
+        if adv_id:
+            raw["advertiserId"] = str(adv_id)
+        employer = item.get("employer") or {}
+        emp_id = employer.get("id")
+        if emp_id:
+            raw["employerId"] = str(emp_id)
+        for k in ("roleId", "displayType", "isFeatured", "workTypes",
+                  "companyProfileStructuredDataId"):
+            v = item.get(k)
+            if v not in (None, "", []):
+                raw[k] = v
+        wa = item.get("workArrangements") or {}
+        if isinstance(wa, dict) and wa.get("data"):
+            # workArrangements.data is a small list of {id, label}; we
+            # keep the labels as a flat list of strings.
+            labels: list[str] = []
+            for entry in wa["data"]:
+                if not isinstance(entry, dict):
+                    continue
+                lbl = entry.get("label")
+                if isinstance(lbl, dict):
+                    text = lbl.get("text")
+                    if isinstance(text, str) and text:
+                        labels.append(text)
+            if labels:
+                raw["workArrangements"] = labels
+
+        return Job(
+            url=f"https://{host}/job/{ats_id}",
+            title=title,
+            company=company,
+            ats_type=ATSType.SEEK,
+            ats_id=ats_id,
+            location=location,
+            country_iso=country,
+            region=(
+                "Oceania" if country in ("AU", "NZ")
+                else "Asia" if country in {"HK", "TH", "MY", "ID", "PH", "SG"}
+                else None
+            ),
+            salary_currency=salary_currency,
+            salary_period=salary_period,
+            salary_summary=salary_label,
+            department=department,
+            description=description if self.include_descriptions else None,
+            posted_at=posted_at,
+            fetched_at=datetime.now(tz=UTC),
+            language=None,
+            raw=raw or None,
+        )
+
+
+def _infer_salary_period(label: str | None) -> str | None:
+    """Map a SEEK ``salaryLabel`` to a ``SalaryPeriod``.
+
+    SEEK labels embed the cadence in free text, e.g.
+    ``"$120,000 – $140,000 per year"``, ``"$45 per hour"``,
+    ``"$8,000 per month"``. We scan for the period keyword and default to
+    ``"YEAR"`` when none is present (the dominant case for annual ranges).
+    """
+    if not label:
+        return None
+    low = label.lower()
+    if "per hour" in low or "/hour" in low or "hourly" in low:
+        return "HOUR"
+    if "per day" in low or "/day" in low or "daily" in low:
+        return "DAY"
+    if "per week" in low or "/week" in low or "weekly" in low:
+        return "WEEK"
+    if "per month" in low or "/month" in low or "monthly" in low:
+        return "MONTH"
+    return "YEAR"
+
+
+def _parse_iso8601(value: object) -> datetime | None:
+    """Parse SEEK's ``listingDate`` (``2026-04-29T00:23:37Z``).
+
+    Returns ``None`` for missing / malformed values rather than raising —
+    a single bad date in a 158k payload shouldn't abort the whole scrape.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return None
+    s = value.strip()
+    # ``datetime.fromisoformat`` accepts a trailing offset but not the
+    # literal ``Z`` shorthand until Python 3.11; we normalize defensively.
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(UTC)

--- a/tests/e2e/test_live_jobboards_public_markets.py
+++ b/tests/e2e/test_live_jobboards_public_markets.py
@@ -1,0 +1,52 @@
+"""Live smoke tests for SEEK and Job Bank Canada."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Callable
+from urllib.parse import urlparse
+
+import pytest
+
+from ats_scrapers.models import Job
+from ats_scrapers.scrapers import JobBankCAScraper, SeekScraper
+from ats_scrapers.scrapers.base import BaseScraper
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.skipif(
+        os.getenv("ATS_SCRAPERS_LIVE_E2E") != "1",
+        reason="set ATS_SCRAPERS_LIVE_E2E=1 to hit real job-board endpoints",
+    ),
+]
+
+CASES: list[tuple[str, Callable[[], BaseScraper], str]] = [
+    (
+        "jobbank-ca",
+        lambda: JobBankCAScraper("jobbankca", max_pages=1),
+        "jobbank.gc.ca",
+    ),
+    ("seek-au", lambda: SeekScraper("au", max_pages=1), "seek.com"),
+]
+
+
+@pytest.mark.parametrize(
+    ("factory", "expected_domain"),
+    [pytest.param(factory, domain, id=name) for name, factory, domain in CASES],
+)
+async def test_live_jobboard_smoke(
+    factory: Callable[[], BaseScraper], expected_domain: str
+) -> None:
+    async with asyncio.timeout(180):
+        jobs = await factory().afetch()
+    assert jobs
+    sample: list[Job] = jobs[:50]
+    assert len({job.global_id for job in sample}) == len(sample)
+    for job in sample:
+        assert job.title.strip()
+        assert job.company.strip()
+        assert job.ats_id
+        host = (urlparse(str(job.url)).hostname or "").lower()
+        assert host == expected_domain or host.endswith(f".{expected_domain}")
+        assert not host.endswith((".local", ".internal"))

--- a/tests/test_jobbankca.py
+++ b/tests/test_jobbankca.py
@@ -1,0 +1,424 @@
+"""Tests for the Job Bank Canada scraper.
+
+The scraper parses server-rendered HTML — no JSON API. Fixtures here
+mirror the live ``jobsearch?searchstring=&sort=M&page=N`` markup so
+parsing regressions surface immediately.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType
+from ats_scrapers.scrapers import JobBankCAScraper, ScraperRegistry
+from ats_scrapers.scrapers.jobbankca import (
+    _infer_country_iso,
+    _infer_is_remote,
+    _parse_date,
+)
+
+_SEARCH_RE = re.compile(r"^https://www\.jobbank\.gc\.ca/jobsearch/jobsearch")
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import ats_scrapers.scrapers.jobbankca as jb
+    monkeypatch.setattr(jb, "MAX_RETRIES", 2)
+    monkeypatch.setattr(jb, "RETRY_BASE_DELAY", 0.0)
+
+
+def _article(
+    *,
+    job_id: str = "49482951",
+    title: str = "electrician, industrial",
+    business: str = "Kristian Electric Ltd",
+    location: str = "Calgary, AB",
+    date: str = "May 08, 2026",
+    salary: str = "$42.00 to $50.00 hourly (to be negotiated)",
+    telework: str | None = None,
+    appmethod: str = "Direct Apply",
+    new_flag: bool = True,
+    posted_on_jb: bool = True,
+    job_number: str | None = "3571211",
+) -> str:
+    flags = []
+    if new_flag:
+        flags.append('<span class="new">New</span>')
+    if telework:
+        flags.append(f'<span class="telework">{telework}</span>')
+    flags.append(f'<span class="appmethod">{appmethod}</span>')
+    if posted_on_jb:
+        flags.append(
+            '<span class="postedonJB">Posted on Job Bank'
+            '<span class="description">info</span></span>'
+        )
+    flag_block = (
+        f'<span class="flag">{"".join(flags)}</span>'
+        if flags else ""
+    )
+    source_li = ""
+    if job_number is not None:
+        source_li = (
+            '<li class="source">'
+            '<span class="job-source job-source-icon-16">'
+            '<span class="wb-inv">Job Bank</span></span>'
+            '<span class="wb-inv">Job number:</span>'
+            f'<span class="fa fa-hashtag"></span>{job_number}</li>'
+        )
+    return (
+        f'<article id="article-{job_id}" class="action-buttons">'
+        f'<a href="/jobsearch/jobposting/{job_id};jsessionid=ABC?source=searchresults"'
+        ' class="resultJobItem">'
+        f'<h3 class="title">{flag_block}'
+        '<span class="job-source job-source-icon-16">'
+        '<span class="wb-inv">Job Bank</span></span>'
+        f'<span class="noctitle">{title}</span></h3>'
+        '<ul class="list-unstyled">'
+        f'<li class="date">{date}</li>'
+        f'<li class="business">{business}</li>'
+        '<li class="location">'
+        '<span class="fas fa-map-marker-alt"></span> '
+        '<span class="wb-inv">Location</span>'
+        f'{location}</li>'
+        f'<li class="salary"><span class="fa fa-dollar"></span>Salary {salary}</li>'
+        f'{source_li}'
+        '</ul></a></article>'
+    )
+
+
+def _page(articles: list[str]) -> str:
+    body = "\n".join(articles)
+    return (
+        '<!DOCTYPE html><html><body>'
+        '<span class="found" id="results-count">62,139</span>'
+        f'{body}'
+        '</body></html>'
+    )
+
+
+# --- registry / wiring -------------------------------------------------------
+
+
+def test_registry_resolves_jobbankca() -> None:
+    assert ScraperRegistry.get(ATSType.JOBBANKCA) is JobBankCAScraper
+
+
+def test_ats_enum_value() -> None:
+    assert ATSType.JOBBANKCA.value == "jobbankca"
+
+
+# --- parse_job: full happy-path ---------------------------------------------
+
+
+def test_parses_full_article() -> None:
+    """Every field on a typical article block round-trips into a Job."""
+    chunk = _article(telework="On site")
+    job = JobBankCAScraper("any")._parse_job(chunk)
+    assert job is not None
+    assert job.ats_type is ATSType.JOBBANKCA
+    assert job.ats_id == "49482951"
+    assert job.title == "electrician, industrial"
+    assert job.company == "Kristian Electric Ltd"
+    assert job.location == "Calgary, AB"
+    assert str(job.url) == "https://www.jobbank.gc.ca/jobsearch/jobposting/49482951"
+    assert job.country_iso == "CA"
+    assert job.region == "North America"
+    assert job.language == "en"
+    assert job.salary_summary == "$42.00 to $50.00 hourly (to be negotiated)"
+    assert job.salary_currency == "CAD"
+    assert job.salary_period == "HOUR"
+    assert job.is_remote is False  # "On site" → explicit no
+    assert job.commitment == "On site"
+    assert job.requisition_id == "3571211"  # Job number, distinct from ats_id
+    assert job.posted_at is not None
+    assert job.posted_at.year == 2026
+    assert job.posted_at.month == 5
+    assert job.posted_at.day == 8
+    assert job.raw is not None
+    assert job.raw.get("application_method") == "Direct Apply"
+    assert job.raw.get("posted_on_job_bank") is True
+    assert job.raw.get("new_flag") is True
+    assert job.raw.get("jobbank_number") == "3571211"
+
+
+def test_global_id_uses_jobbankca_prefix() -> None:
+    job = JobBankCAScraper("any")._parse_job(_article(job_id="123"))
+    assert job is not None
+    assert job.global_id == "jobbankca:123"
+
+
+# --- parse_job: variations --------------------------------------------------
+
+
+def test_strips_location_wb_inv_label() -> None:
+    """The wb-inv 'Location' label collapses next to the city after
+    tag-stripping. Make sure the leading prefix gets cut."""
+    job = JobBankCAScraper("any")._parse_job(
+        _article(location="Burlington (ON)")
+    )
+    assert job is not None
+    assert job.location == "Burlington (ON)"
+    assert job.country_iso == "CA"
+
+
+def test_telework_remote_marks_is_remote_true() -> None:
+    job = JobBankCAScraper("any")._parse_job(_article(telework="Remote"))
+    assert job is not None
+    assert job.is_remote is True
+    assert job.commitment == "Remote"
+
+
+def test_hybrid_telework_leaves_is_remote_none() -> None:
+    job = JobBankCAScraper("any")._parse_job(_article(telework="Hybrid"))
+    assert job is not None
+    assert job.is_remote is None  # Hybrid: noncommittal.
+
+
+def test_missing_telework_falls_back_to_title_keyword() -> None:
+    job = JobBankCAScraper("any")._parse_job(
+        _article(title="Senior Engineer (Remote)", telework=None)
+    )
+    assert job is not None
+    assert job.is_remote is True
+
+
+def test_non_dollar_salary_keeps_summary_drops_currency() -> None:
+    """A salary string without a ``$`` shouldn't claim CAD."""
+    chunk = _article(salary="To be negotiated")
+    job = JobBankCAScraper("any")._parse_job(chunk)
+    assert job is not None
+    assert job.salary_summary == "To be negotiated"
+    assert job.salary_currency is None
+
+
+@pytest.mark.parametrize(
+    ("salary", "period"),
+    [
+        ("$200 daily", "DAY"),
+        ("$1,200 weekly", "WEEK"),
+        ("$5,000 monthly", "MONTH"),
+        ("$80,000 annually", "YEAR"),
+        ("$25 par heure", "HOUR"),
+    ],
+)
+def test_salary_period_preserves_source_cadence(salary, period) -> None:
+    job = JobBankCAScraper("any")._parse_job(_article(salary=salary))
+    assert job is not None
+    assert job.salary_currency == "CAD"
+    assert job.salary_period == period
+
+
+def test_unknown_salary_cadence_does_not_emit_structured_currency() -> None:
+    job = JobBankCAScraper("any")._parse_job(_article(salary="$42 negotiable"))
+    assert job is not None
+    assert job.salary_summary == "$42 negotiable"
+    assert job.salary_currency is None
+    assert job.salary_period is None
+
+
+def test_job_number_omitted_when_same_as_ats_id() -> None:
+    job = JobBankCAScraper("any")._parse_job(
+        _article(job_id="3571211", job_number="3571211")
+    )
+    assert job is not None
+    assert job.requisition_id == "3571211"
+    # Don't duplicate the same id into raw — only when the two differ.
+    assert (job.raw or {}).get("jobbank_number") is None
+
+
+def test_missing_required_fields_returns_none() -> None:
+    """Articles without a title are dropped silently."""
+    chunk = '<article id="article-123" class="x"><div>broken</div></article>'
+    assert JobBankCAScraper("any")._parse_job(chunk) is None
+
+
+def test_french_language_constructor() -> None:
+    """A scraper instantiated with ``language='fr'`` tags rows accordingly."""
+    scraper = JobBankCAScraper("any", language="fr")
+    job = scraper._parse_job(_article())
+    assert job is not None
+    assert job.language == "fr"
+
+
+# --- _parse_page ------------------------------------------------------------
+
+
+def test_parse_page_extracts_all_articles() -> None:
+    html_text = _page([
+        _article(job_id="111", title="Welder"),
+        _article(job_id="222", title="Carpenter", business="Acme Co"),
+        _article(job_id="333", title="Plumber"),
+    ])
+    jobs = JobBankCAScraper("any")._parse_page(html_text)
+    assert [j.ats_id for j in jobs] == ["111", "222", "333"]
+    assert [j.title for j in jobs] == ["Welder", "Carpenter", "Plumber"]
+
+
+def test_parse_page_empty_returns_empty_list() -> None:
+    """A search page past the last result has zero ``<article>`` blocks."""
+    html_text = '<html><body><p>No results.</p></body></html>'
+    assert JobBankCAScraper("any")._parse_page(html_text) == []
+
+
+# --- pagination via fetch (httpx_mock) --------------------------------------
+
+
+def test_fetch_paginates_until_empty_page(httpx_mock) -> None:
+    """The scraper iterates pages and stops at the first empty one."""
+    httpx_mock.add_response(
+        url="https://www.jobbank.gc.ca/jobsearch/jobsearch",
+        match_params={"searchstring": "", "sort": "M", "page": "1"},
+        html=_page([_article(job_id="1001"), _article(job_id="1002")]),
+    )
+    httpx_mock.add_response(
+        url="https://www.jobbank.gc.ca/jobsearch/jobsearch",
+        match_params={"searchstring": "", "sort": "M", "page": "2"},
+        html=_page([_article(job_id="2001")]),
+    )
+    httpx_mock.add_response(
+        url="https://www.jobbank.gc.ca/jobsearch/jobsearch",
+        match_params={"searchstring": "", "sort": "M", "page": "3"},
+        html=_page([]),  # empty — termination signal
+    )
+    jobs = JobBankCAScraper("any").fetch()
+    assert {j.ats_id for j in jobs} == {"1001", "1002", "2001"}
+
+
+def test_fetch_deduplicates_repeated_ats_id(httpx_mock) -> None:
+    """Same ats_id appearing on two consecutive pages (timing race) is
+    only emitted once."""
+    httpx_mock.add_response(
+        url="https://www.jobbank.gc.ca/jobsearch/jobsearch",
+        match_params={"searchstring": "", "sort": "M", "page": "1"},
+        html=_page([_article(job_id="9999")]),
+    )
+    httpx_mock.add_response(
+        url="https://www.jobbank.gc.ca/jobsearch/jobsearch",
+        match_params={"searchstring": "", "sort": "M", "page": "2"},
+        html=_page([_article(job_id="9999")]),
+    )
+    httpx_mock.add_response(
+        url="https://www.jobbank.gc.ca/jobsearch/jobsearch",
+        match_params={"searchstring": "", "sort": "M", "page": "3"},
+        html=_page([]),
+    )
+    jobs = JobBankCAScraper("any").fetch()
+    assert [j.ats_id for j in jobs] == ["9999"]
+
+
+def test_fetch_respects_max_pages_cap(httpx_mock) -> None:
+    """``max_pages=1`` stops after a single page even if more remain."""
+    httpx_mock.add_response(
+        url="https://www.jobbank.gc.ca/jobsearch/jobsearch",
+        match_params={"searchstring": "", "sort": "M", "page": "1"},
+        html=_page([_article(job_id="42")]),
+    )
+    # Page 2 must NOT be requested — httpx_mock would error if it is.
+    jobs = JobBankCAScraper("any", max_pages=1).fetch()
+    assert [j.ats_id for j in jobs] == ["42"]
+
+
+def test_default_full_run_fails_at_safety_limit(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import ats_scrapers.scrapers.jobbankca as jobbank
+
+    monkeypatch.setattr(jobbank, "MAX_PAGES", 1)
+    httpx_mock.add_response(url=_SEARCH_RE, html=_page([_article(job_id="42")]))
+    with pytest.raises(ScraperError, match="safety limit"):
+        JobBankCAScraper("any").fetch()
+
+
+def test_unparseable_articles_raise_instead_of_ending(httpx_mock) -> None:
+    malformed = (
+        '<span class="found" id="results-count">1</span>'
+        '<article id="article-42"><div>changed markup</div></article>'
+    )
+    httpx_mock.add_response(url=_SEARCH_RE, html=malformed)
+    with pytest.raises(ScraperError, match="1 articles but parsed 0"):
+        JobBankCAScraper("any").fetch()
+
+
+def test_mixed_valid_and_unparseable_articles_raise(httpx_mock) -> None:
+    html_text = _page([_article(job_id="1")]).replace(
+        "</body>",
+        '<article id="article-2"><div>changed markup</div></article></body>',
+    )
+    httpx_mock.add_response(url=_SEARCH_RE, html=html_text)
+
+    with pytest.raises(ScraperError, match="2 articles but parsed 1"):
+        JobBankCAScraper("any").fetch()
+
+
+def test_full_catalogue_rejects_empty_first_page(httpx_mock) -> None:
+    httpx_mock.add_response(url=_SEARCH_RE, html=_page([]))
+
+    with pytest.raises(ScraperError, match="returned no jobs"):
+        JobBankCAScraper("any").fetch()
+
+
+def test_persistent_500_raises(httpx_mock) -> None:
+    httpx_mock.add_response(url=_SEARCH_RE, status_code=500, is_reusable=True)
+    with pytest.raises(ScraperError):
+        JobBankCAScraper("any").fetch()
+
+
+def test_block_page_with_no_result_marker_raises(httpx_mock) -> None:
+    httpx_mock.add_response(url=_SEARCH_RE, html="<html>blocked</html>")
+    with pytest.raises(ScraperError, match="lacked result markup"):
+        JobBankCAScraper("any").fetch()
+
+
+# --- module-level helpers ---------------------------------------------------
+
+
+@pytest.mark.parametrize("text,expected", [
+    ("May 08, 2026", (2026, 5, 8)),
+    ("January 1, 2026", (2026, 1, 1)),
+    ("Dec 31, 2025", (2025, 12, 31)),
+    ("May 08, 2026 Expires May 22, 2026", (2026, 5, 8)),
+])
+def test_parse_date_handles_english_formats(
+    text: str, expected: tuple[int, int, int]
+) -> None:
+    d = _parse_date(text)
+    assert d is not None
+    assert (d.year, d.month, d.day) == expected
+
+
+@pytest.mark.parametrize("text", [
+    None, "", "garbage",
+])
+def test_parse_date_returns_none_for_unparseable(text: str | None) -> None:
+    assert _parse_date(text) is None
+
+
+def test_parse_date_handles_french_format() -> None:
+    parsed = _parse_date("08 mai 2026")
+    assert parsed is not None
+    assert (parsed.year, parsed.month, parsed.day) == (2026, 5, 8)
+    assert parsed.tzinfo is not None
+
+
+def test_infer_is_remote_explicit_telework() -> None:
+    assert _infer_is_remote("Remote", "x") is True
+    assert _infer_is_remote("Telework", "x") is True
+    assert _infer_is_remote("On site", "x") is False
+    assert _infer_is_remote("Hybrid", "x") is None
+    assert _infer_is_remote("Hybrid", "Remote Support Engineer") is None
+    assert _infer_is_remote(None, "Senior Engineer") is None
+    assert _infer_is_remote(None, "Senior Engineer (Remote)") is True
+
+
+@pytest.mark.parametrize("location,expected", [
+    ("Calgary, AB", "CA"),
+    ("Burlington (ON)", "CA"),
+    ("Toronto, Canada", "CA"),
+    (None, "CA"),  # Job Bank is Canada-only.
+    ("Whitehorse, YT", "CA"),
+])
+def test_infer_country_iso(location: str | None, expected: str) -> None:
+    assert _infer_country_iso(location) == expected

--- a/tests/test_jobbankca.py
+++ b/tests/test_jobbankca.py
@@ -43,6 +43,7 @@ def _article(
     new_flag: bool = True,
     posted_on_jb: bool = True,
     job_number: str | None = "3571211",
+    posting_path: str = "jobposting",
 ) -> str:
     flags = []
     if new_flag:
@@ -70,7 +71,7 @@ def _article(
         )
     return (
         f'<article id="article-{job_id}" class="action-buttons">'
-        f'<a href="/jobsearch/jobposting/{job_id};jsessionid=ABC?source=searchresults"'
+        f'<a href="/jobsearch/{posting_path}/{job_id};jsessionid=ABC?source=searchresults"'
         ' class="resultJobItem">'
         f'<h3 class="title">{flag_block}'
         '<span class="job-source job-source-icon-16">'
@@ -148,6 +149,16 @@ def test_global_id_uses_jobbankca_prefix() -> None:
     job = JobBankCAScraper("any")._parse_job(_article(job_id="123"))
     assert job is not None
     assert job.global_id == "jobbankca:123"
+
+
+def test_preserves_temporary_foreign_worker_posting_path() -> None:
+    job = JobBankCAScraper("any")._parse_job(
+        _article(job_id="123", posting_path="jobpostingtfw")
+    )
+    assert job is not None
+    assert str(job.url) == (
+        "https://www.jobbank.gc.ca/jobsearch/jobpostingtfw/123"
+    )
 
 
 # --- parse_job: variations --------------------------------------------------

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -30,7 +30,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
         "jobs_cz", "manfred", "thehub", "ycombinator", "wellfound",
-        "infojobs_es",
+        "infojobs_es", "jobbankca", "seek",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr",
         "recruitee", "taleo", "teamtailor",

--- a/tests/test_public_jobboard_contracts.py
+++ b/tests/test_public_jobboard_contracts.py
@@ -1,0 +1,37 @@
+"""Shared contracts for the SEEK and Job Bank public-market scrapers."""
+
+from __future__ import annotations
+
+import pytest
+
+from ats_scrapers.scrapers.base import BaseScraper
+from ats_scrapers.scrapers.jobbankca import JobBankCAScraper
+from ats_scrapers.scrapers.seek import SeekScraper
+from pipeline.publisher import ATS_DEDUP_PRIORITY
+from scripts.run_pipeline import CONFIGS
+
+
+@pytest.mark.parametrize(
+    ("scraper_type", "slug"),
+    [(JobBankCAScraper, "all"), (SeekScraper, "au")],
+)
+def test_custom_scrapers_preserve_standard_options(
+    scraper_type: type[BaseScraper], slug: str
+) -> None:
+    scraper = scraper_type(
+        slug,
+        include_descriptions=False,
+        proxy="http://proxy.example:8080",
+    )
+
+    assert scraper.include_descriptions is False
+    assert scraper.proxy == "http://proxy.example:8080"
+
+
+def test_jobboard_dedup_priorities_prefer_employer_sources() -> None:
+    assert ATS_DEDUP_PRIORITY["seek"] > ATS_DEDUP_PRIORITY["workday"]
+    assert ATS_DEDUP_PRIORITY["jobbankca"] > ATS_DEDUP_PRIORITY["seek"]
+
+
+def test_jobbank_singleton_fails_closed_on_empty() -> None:
+    assert CONFIGS["jobbankca"]["fail_closed_on_empty"] is True

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -603,6 +603,44 @@ def test_cross_ats_dedup_keeps_higher_priority_ats(
     assert df["url"].str.contains("workday.com").all()
 
 
+def test_cross_ats_dedup_prefers_structured_country_iso(tmp_path) -> None:
+    import pipeline.publisher as publisher_module
+
+    workday_path = tmp_path / "workday.csv"
+    jobbank_path = tmp_path / "jobbankca.csv"
+    pd.DataFrame([
+        {
+            "url": "https://workday.example/job/1",
+            "title": "Backend Engineer",
+            "company": "Acme",
+            "location": "Toronto, Ontario",
+            "country_iso": "CA",
+            "ats_id": "wd-1",
+        },
+    ]).to_csv(workday_path, index=False)
+    pd.DataFrame([
+        {
+            "url": "https://jobbank.example/job/1",
+            "title": "Backend Engineer",
+            "company": "Acme",
+            "location": "Toronto (ON)",
+            "country_iso": "CA",
+            "ats_id": "jb-1",
+        },
+    ]).to_csv(jobbank_path, index=False)
+
+    survivors, raw_count, kept_count = (
+        publisher_module._dedup_from_per_ats_csvs(
+            {"workday": workday_path, "jobbankca": jobbank_path}
+        )
+    )
+
+    assert raw_count == 2
+    assert kept_count == 1
+    assert survivors["workday"].height == 1
+    assert "jobbankca" not in survivors
+
+
 # --- Phase 1 / Phase 2 cross-source fuzzy dedup -----------------------------
 
 

--- a/tests/test_run_pipeline_guards.py
+++ b/tests/test_run_pipeline_guards.py
@@ -804,6 +804,112 @@ def test_streaming_failure_preserves_previous_jobs_csv(
     assert not (out_dir / ".jobs.csv.tmp").exists()
 
 
+@pytest.mark.parametrize("has_previous", [True, False])
+def test_required_empty_output_removes_partial_file(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, has_previous: bool,
+) -> None:
+    out_dir = tmp_path / "empty"
+    out_dir.mkdir()
+    out_path = out_dir / "jobs.csv"
+    previous = (
+        "url,title,company,ats_type,ats_id\n"
+        "https://example.com/old,Old,Acme,custom,old\n"
+    )
+    if has_previous:
+        out_path.write_text(previous, encoding="utf-8")
+
+    class EmptyScraper:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def fetch(self):
+            return []
+
+    monkeypatch.setattr(runner, "DATA_ROOT", tmp_path)
+    monkeypatch.setitem(
+        runner.CONFIGS,
+        "empty",
+        {
+            "scraper": EmptyScraper,
+            "singleton": True,
+            "output": "empty/jobs.csv",
+            "fail_closed_on_empty": True,
+        },
+    )
+
+    rc = asyncio.run(
+        runner.run("empty", concurrency=1, max_tenants=None, timeout=1)
+    )
+
+    assert rc == 1
+    if has_previous:
+        assert out_path.read_text(encoding="utf-8") == previous
+    else:
+        assert not out_path.exists()
+    assert not (out_dir / ".jobs.csv.tmp").exists()
+
+
+@pytest.mark.parametrize("has_previous", [True, False])
+def test_required_shard_failure_removes_partial_output(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, has_previous: bool,
+) -> None:
+    (tmp_path / "ats-companies").mkdir()
+    (tmp_path / "ats-companies" / "shards.csv").write_text(
+        "name,slug,url\nGood,good,https://good\nBad,bad,https://bad\n",
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / "sharded"
+    out_dir.mkdir()
+    out_path = out_dir / "jobs.csv"
+    previous = (
+        "url,title,company,ats_type,ats_id\n"
+        "https://example.com/old,Old,Acme,custom,old\n"
+    )
+    if has_previous:
+        out_path.write_text(previous, encoding="utf-8")
+
+    class ShardedScraper:
+        def __init__(self, slug, **_kwargs) -> None:
+            self.slug = slug
+
+        def fetch(self):
+            if self.slug == "bad":
+                raise RuntimeError("shard failed")
+            return [
+                Job(
+                    url="https://example.com/new",
+                    title="New",
+                    company="Acme",
+                    ats_type=ATSType.CUSTOM,
+                    ats_id="new",
+                )
+            ]
+
+    monkeypatch.setattr(runner, "DATA_ROOT", tmp_path)
+    monkeypatch.setitem(
+        runner.CONFIGS,
+        "sharded",
+        {
+            "scraper": ShardedScraper,
+            "slug": lambda row: row["slug"],
+            "csv": "ats-companies/shards.csv",
+            "output": "sharded/jobs.csv",
+            "fail_closed_on_any_error": True,
+        },
+    )
+
+    rc = asyncio.run(
+        runner.run("sharded", concurrency=2, max_tenants=None, timeout=1)
+    )
+
+    assert rc == 1
+    if has_previous:
+        assert out_path.read_text(encoding="utf-8") == previous
+    else:
+        assert not out_path.exists()
+    assert not (out_dir / ".jobs.csv.tmp").exists()
+
+
 def test_streaming_pipeline_skips_capped_description_cache(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_run_pipeline_guards.py
+++ b/tests/test_run_pipeline_guards.py
@@ -910,6 +910,65 @@ def test_required_shard_failure_removes_partial_output(
     assert not (out_dir / ".jobs.csv.tmp").exists()
 
 
+def test_required_shard_limit_preserves_previous_output(
+    tmp_path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "ats-companies").mkdir()
+    (tmp_path / "ats-companies" / "shards.csv").write_text(
+        (
+            "name,slug,url\n"
+            "One,one,https://one\n"
+            "Two,two,https://two\n"
+            "Three,three,https://three\n"
+        ),
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / "sharded"
+    out_dir.mkdir()
+    out_path = out_dir / "jobs.csv"
+    previous = (
+        "url,title,company,ats_type,ats_id\n"
+        "https://example.com/old,Old,Acme,custom,old\n"
+    )
+    out_path.write_text(previous, encoding="utf-8")
+
+    class ShardedScraper:
+        def __init__(self, slug, **_kwargs) -> None:
+            self.slug = slug
+
+        def fetch(self):
+            return [
+                Job(
+                    url=f"https://example.com/{self.slug}",
+                    title="New",
+                    company="Acme",
+                    ats_type=ATSType.CUSTOM,
+                    ats_id=self.slug,
+                )
+            ]
+
+    monkeypatch.setattr(runner, "DATA_ROOT", tmp_path)
+    monkeypatch.setitem(
+        runner.CONFIGS,
+        "sharded",
+        {
+            "scraper": ShardedScraper,
+            "slug": lambda row: row["slug"],
+            "csv": "ats-companies/shards.csv",
+            "output": "sharded/jobs.csv",
+            "fail_closed_on_any_error": True,
+        },
+    )
+
+    rc = asyncio.run(
+        runner.run("sharded", concurrency=1, max_tenants=1, timeout=1)
+    )
+
+    assert rc == 1
+    assert out_path.read_text(encoding="utf-8") == previous
+    assert not (out_dir / ".jobs.csv.tmp").exists()
+
+
 def test_streaming_pipeline_skips_capped_description_cache(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_seek.py
+++ b/tests/test_seek.py
@@ -1,0 +1,569 @@
+"""Tests for the SEEK / JobsDB / JobStreet APAC scraper.
+
+The scraper covers eight regional sites (au, nz, hk, th, my, id, ph,
+sg) that all share the same ``chalice-search v5`` JSON API. Tests
+verify:
+
+- region → (host, siteKey, country_iso) mapping
+- ``_parse_job`` populates the canonical Job fields correctly
+- country_iso / salary_currency / region are inferred from the region
+- pagination follows ``totalCount`` and stops cleanly
+
+All network access is mocked via ``httpx_mock``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from datetime import UTC, datetime
+
+import pytest
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType
+from ats_scrapers.scrapers import ScraperRegistry, SeekScraper
+from ats_scrapers.scrapers.seek import SEEK_SITES, _parse_iso8601
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import ats_scrapers.scrapers.seek as seek_mod
+
+    monkeypatch.setattr(seek_mod, "MAX_RETRIES", 1)
+    monkeypatch.setattr(seek_mod, "RETRY_BASE_DELAY", 0.0)
+
+
+# --- fixtures ---------------------------------------------------------------
+
+
+def _au_job(**overrides) -> dict:
+    base = {
+        "id": "91798287",
+        "title": "Operations Manager",
+        "companyName": "Go 3 pl",
+        "advertiser": {"id": "63113577", "description": "Go 3 pl"},
+        "bulletPoints": [
+            "Large 30,000m² 3PL site",
+            "Fast-paced hands-on operations",
+        ],
+        "teaser": "Hands-on Warehouse Ops Manager for busy 3PL in Braeside.",
+        "classifications": [
+            {
+                "classification": {
+                    "id": "6092",
+                    "description": "Manufacturing, Transport & Logistics",
+                },
+                "subclassification": {
+                    "id": "6102",
+                    "description": "Management",
+                },
+            }
+        ],
+        "locations": [
+            {
+                "label": "Braeside, Melbourne VIC",
+                "countryCode": "AU",
+            }
+        ],
+        "salaryLabel": "$115,000 – $125,000 per year",
+        "listingDate": "2026-04-29T00:23:37Z",
+        "listingDateDisplay": "13d ago",
+        "workTypes": ["Full time"],
+        "workArrangements": {
+            "data": [{"id": "1", "label": {"text": "On-site"}}]
+        },
+        "roleId": "operations-manager",
+        "displayType": "standard",
+        "isFeatured": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def _sg_job(**overrides) -> dict:
+    base = {
+        "id": "78311013",
+        "title": "Backend Engineer",
+        "companyName": "Acme Pte Ltd",
+        "advertiser": {"id": "12345", "description": "Acme Pte Ltd"},
+        "bulletPoints": ["Modern stack", "Hybrid working"],
+        "teaser": "Join our growing backend team.",
+        "classifications": [
+            {
+                "classification": {
+                    "id": "6281",
+                    "description": "Information & Communication Technology",
+                },
+            }
+        ],
+        "locations": [
+            {"label": "Tampines North, East Region", "countryCode": "SG"}
+        ],
+        "salaryLabel": "S$8,000 - S$12,000 per month",
+        "listingDate": "2026-05-10T09:00:00Z",
+    }
+    base.update(overrides)
+    return base
+
+
+def _page(jobs: list[dict], total: int | None = None) -> dict:
+    return {
+        "data": jobs,
+        "totalCount": total if total is not None else len(jobs),
+        "info": {},
+        "facets": {},
+        "searchParams": {},
+        "sortModes": [],
+    }
+
+
+def _search_url(host: str, site_key: str, page: int) -> re.Pattern[str]:
+    """Match the search URL for a given host/siteKey/page regardless of
+    parameter order (httpx serializes querystring deterministically but
+    the test should not depend on it)."""
+    return re.compile(
+        rf"^https://{re.escape(host)}/api/jobsearch/v5/search\?"
+        rf"(?=.*siteKey={re.escape(site_key)})"
+        rf"(?=.*page={page}\b)"
+    )
+
+
+# --- registry / wiring ------------------------------------------------------
+
+
+def test_registry_resolves_seek() -> None:
+    assert ScraperRegistry.get(ATSType.SEEK) is SeekScraper
+
+
+def test_eight_regions_in_sites_map() -> None:
+    """If somebody drops a region, the dataset coverage shrinks
+    silently. Pin the eight regions explicitly."""
+    assert set(SEEK_SITES) == {
+        "au", "nz", "hk", "th", "my", "id", "ph", "sg",
+    }
+
+
+def test_unknown_region_rejected() -> None:
+    with pytest.raises(ScraperError, match="Unknown SEEK region"):
+        SeekScraper("zz")
+
+
+def test_all_region_expands_to_every_site() -> None:
+    s = SeekScraper("all")
+    assert set(s.regions) == set(SEEK_SITES)
+
+
+def test_single_region_is_singleton_tuple() -> None:
+    s = SeekScraper("au")
+    assert s.regions == ("au",)
+
+
+def test_region_is_case_insensitive() -> None:
+    assert SeekScraper("AU").regions == ("au",)
+    assert set(SeekScraper("ALL").regions) == set(SEEK_SITES)
+
+
+# --- _parse_iso8601 ---------------------------------------------------------
+
+
+def test_parse_iso8601_handles_z_suffix() -> None:
+    dt = _parse_iso8601("2026-04-29T00:23:37Z")
+    assert dt == datetime(2026, 4, 29, 0, 23, 37, tzinfo=UTC)
+
+
+def test_parse_iso8601_handles_offset() -> None:
+    dt = _parse_iso8601("2026-04-29T03:23:37+03:00")
+    assert dt == datetime(2026, 4, 29, 0, 23, 37, tzinfo=UTC)
+
+
+def test_parse_iso8601_rejects_naive_timestamp() -> None:
+    assert _parse_iso8601("2026-04-29T00:23:37") is None
+
+
+def test_parse_iso8601_returns_none_for_garbage() -> None:
+    assert _parse_iso8601("not a date") is None
+    assert _parse_iso8601(None) is None
+    assert _parse_iso8601("") is None
+
+
+# --- _parse_job per region --------------------------------------------------
+
+
+def test_parse_au_job_populates_canonical_fields() -> None:
+    scraper = SeekScraper("au")
+    job = scraper._parse_job(
+        _au_job(), host="au.seek.com", country_iso="AU"
+    )
+    assert job is not None
+    assert job.ats_type is ATSType.SEEK
+    assert job.ats_id == "91798287"
+    assert job.global_id == "seek:91798287"
+    assert job.title == "Operations Manager"
+    assert job.company == "Go 3 pl"
+    assert str(job.url) == "https://au.seek.com/job/91798287"
+    assert job.location == "Braeside, Melbourne VIC"
+    assert job.country_iso == "AU"
+    assert job.region == "Oceania"
+    assert job.language is None
+    # Salary label + AU region → AUD currency, period YEAR.
+    assert job.salary_currency == "AUD"
+    assert job.salary_period == "YEAR"
+    assert job.salary_summary == "$115,000 – $125,000 per year"
+    assert job.department == "Manufacturing, Transport & Logistics"
+    # Description: teaser + bullets, no HTML.
+    assert job.description is not None
+    assert "Hands-on Warehouse Ops Manager" in job.description
+    assert "Large 30,000m" in job.description
+    assert job.posted_at == datetime(
+        2026, 4, 29, 0, 23, 37, tzinfo=UTC
+    )
+
+
+def test_parse_sg_job_uses_sgd_currency() -> None:
+    scraper = SeekScraper("sg")
+    job = scraper._parse_job(
+        _sg_job(), host="sg.jobstreet.com", country_iso="SG"
+    )
+    assert job is not None
+    assert job.country_iso == "SG"
+    assert job.region == "Asia"
+    assert job.salary_currency == "SGD"
+    assert str(job.url) == "https://sg.jobstreet.com/job/78311013"
+
+
+@pytest.mark.parametrize(
+    "region,host,country,currency,continent",
+    [
+        ("au", "au.seek.com", "AU", "AUD", "Oceania"),
+        ("nz", "www.seek.co.nz", "NZ", "NZD", "Oceania"),
+        ("hk", "hk.jobsdb.com", "HK", "HKD", "Asia"),
+        ("th", "th.jobsdb.com", "TH", "THB", "Asia"),
+        ("my", "my.jobstreet.com", "MY", "MYR", "Asia"),
+        ("id", "id.jobstreet.com", "ID", "IDR", "Asia"),
+        ("ph", "ph.jobstreet.com", "PH", "PHP", "Asia"),
+        ("sg", "sg.jobstreet.com", "SG", "SGD", "Asia"),
+    ],
+)
+def test_parse_job_per_region_iso_and_currency(
+    region: str, host: str, country: str, currency: str, continent: str,
+) -> None:
+    """Every region resolves to the right country code, ISO 4217 currency,
+    and Oceania/Asia continent."""
+    mapped_host, _site_key, mapped_country = SEEK_SITES[region]
+    assert host == mapped_host
+    assert country == mapped_country
+    scraper = SeekScraper(region)
+    payload = _au_job(
+        id=f"id-{region}",
+        locations=[{"label": "Somewhere", "countryCode": country}],
+        salaryLabel="some salary",
+    )
+    job = scraper._parse_job(payload, host=host, country_iso=country)
+    assert job is not None
+    assert job.country_iso == country
+    assert job.salary_currency == currency
+    assert job.region == continent
+    assert str(job.url).startswith(f"https://{host}/job/")
+
+
+def test_parse_job_no_salary_means_no_currency() -> None:
+    """``salary_currency`` is only set when a salary label is present —
+    we don't invent a currency for empty rows."""
+    scraper = SeekScraper("au")
+    payload = _au_job(salaryLabel="")
+    job = scraper._parse_job(payload, host="au.seek.com", country_iso="AU")
+    assert job is not None
+    assert job.salary_summary is None
+    assert job.salary_currency is None
+    assert job.salary_period is None
+
+
+def test_parse_job_falls_back_to_company_name_when_advertiser_missing() -> None:
+    scraper = SeekScraper("au")
+    payload = _au_job(advertiser={})
+    job = scraper._parse_job(payload, host="au.seek.com", country_iso="AU")
+    assert job is not None
+    assert job.company == "Go 3 pl"  # from companyName
+
+
+def test_parse_job_unknown_company_when_both_advertiser_and_name_missing() -> None:
+    scraper = SeekScraper("au")
+    payload = _au_job(advertiser={}, companyName=None)
+    job = scraper._parse_job(payload, host="au.seek.com", country_iso="AU")
+    assert job is not None
+    assert job.company == "Unknown"
+
+
+def test_parse_job_uses_location_country_when_present() -> None:
+    """Some postings carry a location countryCode that differs from
+    the region — pass-through that value rather than the region's
+    default."""
+    scraper = SeekScraper("au")
+    payload = _au_job(
+        locations=[{"label": "Auckland", "countryCode": "NZ"}],
+    )
+    job = scraper._parse_job(payload, host="au.seek.com", country_iso="AU")
+    assert job is not None
+    assert job.country_iso == "NZ"
+    # NZ has its own currency mapping even though we're on the AU site.
+    assert job.salary_currency == "NZD"
+
+
+def test_parse_job_overseas_country_does_not_claim_asia() -> None:
+    scraper = SeekScraper("sg")
+    payload = _sg_job(
+        locations=[{"label": "London", "countryCode": "GB"}],
+    )
+    job = scraper._parse_job(
+        payload,
+        host="sg.jobstreet.com",
+        country_iso="SG",
+    )
+    assert job is not None
+    assert job.country_iso == "GB"
+    assert job.region is None
+
+
+def test_parse_job_returns_none_for_empty_id() -> None:
+    scraper = SeekScraper("au")
+    assert scraper._parse_job(
+        _au_job(id=""), host="au.seek.com", country_iso="AU"
+    ) is None
+    assert scraper._parse_job(
+        _au_job(title=""), host="au.seek.com", country_iso="AU"
+    ) is None
+
+
+def test_parse_job_raw_payload_is_compact() -> None:
+    scraper = SeekScraper("au")
+    job = scraper._parse_job(
+        _au_job(), host="au.seek.com", country_iso="AU"
+    )
+    assert job is not None and job.raw is not None
+    # Heavy fields like solMetadata / tracking should NOT appear.
+    assert "solMetadata" not in job.raw
+    assert "tracking" not in job.raw
+    # Identifier fields we do keep.
+    assert job.raw.get("advertiserId") == "63113577"
+    assert job.raw.get("workArrangements") == ["On-site"]
+
+
+def test_parse_job_description_handles_missing_bullets() -> None:
+    scraper = SeekScraper("au")
+    payload = _au_job(bulletPoints=[])
+    job = scraper._parse_job(payload, host="au.seek.com", country_iso="AU")
+    assert job is not None
+    assert job.description == "Hands-on Warehouse Ops Manager for busy 3PL in Braeside."
+
+
+def test_parse_job_description_handles_missing_teaser() -> None:
+    scraper = SeekScraper("au")
+    payload = _au_job(teaser="")
+    job = scraper._parse_job(payload, host="au.seek.com", country_iso="AU")
+    assert job is not None
+    assert job.description is not None
+    assert job.description.startswith("- ")
+
+
+def test_description_uses_canonical_25k_cap() -> None:
+    scraper = SeekScraper("au")
+    job = scraper._parse_job(
+        _au_job(teaser="x" * 30_000, bulletPoints=[]),
+        host="au.seek.com",
+        country_iso="AU",
+    )
+    assert job is not None and job.description is not None
+    assert len(job.description) == 25_000
+
+
+# --- end-to-end pagination via httpx_mock -----------------------------------
+
+
+def test_fetch_single_page(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_search_url("au.seek.com", "AU-Main", 1),
+        json=_page([_au_job(id="1"), _au_job(id="2")], total=2),
+    )
+    jobs = SeekScraper("au").fetch()
+    assert len(jobs) == 2
+    assert {j.ats_id for j in jobs} == {"1", "2"}
+
+
+@pytest.mark.parametrize("invalid_total", [None, True, "2", -1])
+def test_fetch_rejects_invalid_total_count(httpx_mock, invalid_total) -> None:
+    payload = _page([_au_job(id="1")], total=1)
+    payload["totalCount"] = invalid_total
+    httpx_mock.add_response(
+        url=_search_url("au.seek.com", "AU-Main", 1),
+        json=payload,
+    )
+    with pytest.raises(ScraperError, match="valid totalCount"):
+        SeekScraper("au").fetch()
+
+
+@pytest.mark.parametrize("invalid_data", [None, {}, [None]])
+def test_fetch_rejects_invalid_data(httpx_mock, invalid_data) -> None:
+    payload = _page([_au_job(id="1")], total=1)
+    payload["data"] = invalid_data
+    httpx_mock.add_response(
+        url=_search_url("au.seek.com", "AU-Main", 1),
+        json=payload,
+    )
+    with pytest.raises(ScraperError, match="invalid data"):
+        SeekScraper("au").fetch()
+
+
+def test_fetch_rejects_empty_first_page_with_positive_total(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_search_url("au.seek.com", "AU-Main", 1),
+        json=_page([], total=10),
+    )
+    with pytest.raises(ScraperError, match="before totalCount"):
+        SeekScraper("au").fetch()
+
+
+def test_fetch_rejects_empty_region_catalogue(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_search_url("au.seek.com", "AU-Main", 1),
+        json=_page([], total=0),
+    )
+    with pytest.raises(ScraperError, match="empty catalogue"):
+        SeekScraper("au").fetch()
+
+
+def test_fetch_rejects_partial_parser_drift(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_search_url("au.seek.com", "AU-Main", 1),
+        json=_page([_au_job(id="1"), _au_job(id="")], total=2),
+    )
+    with pytest.raises(ScraperError, match="unparseable jobs"):
+        SeekScraper("au").fetch()
+
+
+def test_fetch_rejects_zero_total_with_jobs(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_search_url("au.seek.com", "AU-Main", 1),
+        json=_page([_au_job(id="1")], total=0),
+    )
+    with pytest.raises(ScraperError, match="beyond its totalCount"):
+        SeekScraper("au").fetch()
+
+
+def test_fetch_rejects_empty_later_page_before_total(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_search_url("au.seek.com", "AU-Main", 1),
+        json=_page([_au_job(id=f"p1-{i}") for i in range(100)], total=200),
+    )
+    httpx_mock.add_response(
+        url=_search_url("au.seek.com", "AU-Main", 2),
+        json=_page([], total=200),
+    )
+    with pytest.raises(ScraperError, match="before totalCount"):
+        SeekScraper("au").fetch()
+
+
+def test_fetch_paginates_until_total_reached(httpx_mock) -> None:
+    # Total 150 → 2 pages of 100. With ``is_reusable=True`` we let
+    # httpx_mock match by page index in the URL.
+    httpx_mock.add_response(
+        url=_search_url("au.seek.com", "AU-Main", 1),
+        json=_page(
+            [_au_job(id=f"p1-{i}") for i in range(100)], total=150,
+        ),
+    )
+    httpx_mock.add_response(
+        url=_search_url("au.seek.com", "AU-Main", 2),
+        json=_page(
+            [_au_job(id=f"p2-{i}") for i in range(50)], total=150,
+        ),
+    )
+    jobs = SeekScraper("au").fetch()
+    assert len(jobs) == 150
+    ids = {j.ats_id for j in jobs}
+    assert "p1-0" in ids and "p2-49" in ids
+
+
+def test_short_page_stops_scheduling_later_pages(httpx_mock, monkeypatch) -> None:
+    import ats_scrapers.scrapers.seek as module
+
+    monkeypatch.setattr(module, "MAX_CONCURRENCY", 1)
+    httpx_mock.add_response(
+        url=_search_url("au.seek.com", "AU-Main", 1),
+        json=_page([_au_job(id=f"p1-{i}") for i in range(100)], total=300),
+    )
+    httpx_mock.add_response(
+        url=_search_url("au.seek.com", "AU-Main", 2),
+        json=_page([_au_job(id="p2")], total=101),
+    )
+    jobs = SeekScraper("au").fetch()
+    assert len(jobs) == 101
+    assert len(httpx_mock.get_requests()) == 2
+
+
+def test_batch_failure_raises_even_when_earlier_page_is_short(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_search_url("au.seek.com", "AU-Main", 1),
+        json=_page([_au_job(id=f"p1-{i}") for i in range(100)], total=300),
+    )
+    httpx_mock.add_response(
+        url=_search_url("au.seek.com", "AU-Main", 2),
+        json=_page([_au_job(id="p2")], total=101),
+    )
+    httpx_mock.add_response(
+        url=_search_url("au.seek.com", "AU-Main", 3),
+        status_code=503,
+    )
+
+    with pytest.raises(ScraperError, match="503"):
+        SeekScraper("au").fetch()
+
+
+def test_batch_failure_cancels_sibling_tasks(monkeypatch) -> None:
+    scraper = SeekScraper("au")
+    sibling_cancelled = False
+
+    async def fake_search(_client, _sem, *, page: int, **_kwargs):
+        nonlocal sibling_cancelled
+        if page == 1:
+            return _page(
+                [_au_job(id=f"p1-{idx}") for idx in range(100)],
+                total=300,
+            )
+        if page == 2:
+            await asyncio.sleep(0)
+            raise ScraperError("page 2 failed")
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            sibling_cancelled = True
+            raise
+
+    monkeypatch.setattr(scraper, "_search", fake_search)
+
+    with pytest.raises(ScraperError, match="page 2 failed"):
+        scraper.fetch()
+    assert sibling_cancelled is True
+
+
+def test_fetch_dedupes_cross_region_for_all(httpx_mock) -> None:
+    """Two regions both return job id=999 — only one survives the
+    cross-region dedup in ``_fetch_async``."""
+    shared = _au_job(id="999")
+    for region, (host, site_key, _) in SEEK_SITES.items():
+        httpx_mock.add_response(
+            url=_search_url(host, site_key, 1),
+            json=_page([shared], total=1),
+        )
+        del region  # only the URL matters
+    jobs = SeekScraper("all").fetch()
+    # All 8 regions returned the same row → only one in the final list.
+    assert len(jobs) == 1
+    assert len(httpx_mock.get_requests()) == len(SEEK_SITES)
+    assert jobs[0].ats_id == "999"
+
+
+@pytest.mark.parametrize("max_pages", [0, -1])
+def test_invalid_max_pages_is_rejected(max_pages: int) -> None:
+    with pytest.raises(ScraperError, match="max_pages must be positive"):
+        SeekScraper("au", max_pages=max_pages)


### PR DESCRIPTION
## Sources

- Government of Canada Job Bank
- SEEK Australia and New Zealand, plus JobStreet/JobsDB regional sites

## Data-quality safeguards

- public credential-free endpoints only; no API keys, paid proxies, or browser automation
- every configured SEEK region is required; shard, empty-catalogue, pagination, and parser drift fail closed
- Job Bank full runs preserve prior data on empty or partially parseable catalogues
- government and marketplace rows remain below canonical employer ATS rows in dedup priority

## Validation

- `uv run ruff check .`
- `uv run pytest -q` — 1,392 passed, 2 skipped, 22 deselected
- live production probes — 2 passed, both returning non-empty real jobs with unique IDs and valid source domains

This is a two-source-family replacement for the oversized #214.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds credential-free scrapers for Job Bank Canada and the SEEK-family boards, with fail‑closed publishing and lower dedup priority than employer ATS. Also fixes Job Bank links and ensures sharded runs can’t publish partial SEEK datasets.

- **New Features**
  - Added Job Bank Canada scraper (server‑rendered HTML; 25/page; summary fields; en/fr date parsing).
  - Added SEEK-family scraper (JSON search API v5; `pageSize=100`; eight regions plus `"all"`; cross‑region dedup).
  - Registered sources via CSVs and pipeline guards: `jobbankca` uses `fail_closed_on_empty`; `seek` uses `fail_closed_on_any_error`. Set dedup priorities below employer ATS (`seek`: 4, `jobbankca`: 6). Added unit, contract, and live smoke tests.

- **Bug Fixes**
  - Preserve Job Bank posting paths when building job URLs.
  - Protect required shard completeness: `--max-tenants` no longer bypasses `fail_closed_on_any_error`; omitted shards or errors keep the previous `jobs.csv` and block publishing.
  - Dedup prefers structured `country_iso` when present, improving cross‑source duplicate detection.

<sup>Written for commit ef948a10328d73f403336bebceebad0ad35ce0fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds credential-free Job Bank Canada and SEEK-family sources.
- Registers both scraper families and their regional source configurations.
- Adds fail-closed handling for empty catalogues, shard errors, and shards omitted by tenant limits.
- Extends cross-source deduplication to use structured country codes and assigns lower priority to marketplace and government rows.
- Adds parser, pipeline-guard, publisher, contract, and live-probe coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no blocking failures remaining from the previously reported shard-completeness issues.

The updated runner accounts for required shards omitted by tenant limiting and preserves the existing output whenever a required SEEK shard errors or is omitted.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/run_pipeline.py | Registers both sources and preserves the prior output when required SEEK shards fail or are omitted. |
| src/ats_scrapers/scrapers/seek.py | Implements regional SEEK-family API pagination, strict response validation, parsing, and cross-region deduplication. |
| src/ats_scrapers/scrapers/jobbankca.py | Implements paginated Job Bank HTML scraping with catalogue-completeness and parser-drift safeguards. |
| pipeline/publisher.py | Adds source priorities and prefers structured country codes during cross-source deduplication. |
| tests/test_run_pipeline_guards.py | Covers preservation of existing output when a required shard errors or is excluded by a tenant limit. |

<sub>Reviews (4): Last reviewed commit: ["fix: protect required shard completeness"](https://github.com/kalil0321/ats-scrapers/commit/ef948a10328d73f403336bebceebad0ad35ce0fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47034373)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Run Pipeline: Tenant List → Flat Jobs CSV](https://app.greptile.com/kalil0321/-/custom-context/knowledge-base/kalil0321/ats-scrapers/-/docs/run-pipeline-script.md)
- Knowledge Base — [Publishing pipeline](https://app.greptile.com/kalil0321/-/custom-context/knowledge-base/kalil0321/ats-scrapers/-/docs/publishing-pipeline.md)
- Knowledge Base — [Scraper Adapters](https://app.greptile.com/kalil0321/-/custom-context/knowledge-base/kalil0321/ats-scrapers/-/docs/scraper-adapters.md)
</details>

<!-- /greptile_comment -->