### PR TITLE
Add ByteDance careers source

### DIFF
--- a/ats-companies/bytedance.csv
+++ b/ats-companies/bytedance.csv
@@ -1,0 +1,2 @@
+name,slug,url
+ByteDance,bytedance,https://joinbytedance.com

--- a/pipeline/publisher.py
+++ b/pipeline/publisher.py
@@ -544,7 +544,7 @@ ATS_DEDUP_PRIORITY: dict[str, int] = {
     "workday": 1,
     # Big-tech bespoke careers — also priority 1 (single-tenant, canonical)
     "amazon": 1, "apple": 1, "google": 1, "meta": 1, "tesla": 1,
-    "tiktok": 1, "uber": 1,
+    "bytedance": 1, "tiktok": 1, "uber": 1,
     # Hybrid jobboards
     "welcometothejungle": 3, "mercor": 3, "gem": 3,
     "seek": 4,

--- a/pipeline/publisher.py
+++ b/pipeline/publisher.py
@@ -543,8 +543,8 @@ ATS_DEDUP_PRIORITY: dict[str, int] = {
     "successfactors": 1, "taleo": 1, "teamtailor": 1, "workable": 1,
     "workday": 1,
     # Big-tech bespoke careers — also priority 1 (single-tenant, canonical)
-    "amazon": 1, "apple": 1, "google": 1, "meta": 1, "tesla": 1,
-    "bytedance": 1, "tiktok": 1, "uber": 1,
+    "amazon": 1, "apple": 1, "bytedance": 1, "google": 1, "meta": 1,
+    "tesla": 1, "tiktok": 1, "uber": 1,
     # Hybrid jobboards
     "welcometothejungle": 3, "mercor": 3, "gem": 3,
     "seek": 4,

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -48,6 +48,7 @@ from ats_scrapers.scrapers import (
     BreezyScraper,
     BuiltInScraper,
     BundesagenturScraper,
+    BytedanceScraper,
     CornerstoneScraper,
     DarwinboxScraper,
     EightfoldScraper,
@@ -678,6 +679,11 @@ CONFIGS: dict[str, dict[str, Any]] = {
         "csv": "ats-companies/seek.csv",
         "output": "seek/jobs.csv",
         "fail_closed_on_any_error": True,
+    },
+    "bytedance": {
+        "scraper": BytedanceScraper, "singleton": True,
+        "output": "bytedance/jobs.csv",
+        "fail_closed_on_empty": True,
     },
     "jobs_cz": {
         # jobs.cz - Czech Republic's largest direct-posting board. ~10k live via seeded search.

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -600,6 +600,11 @@ CONFIGS: dict[str, dict[str, Any]] = {
         "scraper": AppleScraper, "singleton": True,
         "output": "apple/jobs.csv",
     },
+    "bytedance": {
+        "scraper": BytedanceScraper, "singleton": True,
+        "output": "bytedance/jobs.csv",
+        "fail_closed_on_empty": True,
+    },
     "google": {
         "scraper": GoogleScraper, "singleton": True,
         "output": "google/jobs.csv",
@@ -679,11 +684,6 @@ CONFIGS: dict[str, dict[str, Any]] = {
         "csv": "ats-companies/seek.csv",
         "output": "seek/jobs.csv",
         "fail_closed_on_any_error": True,
-    },
-    "bytedance": {
-        "scraper": BytedanceScraper, "singleton": True,
-        "output": "bytedance/jobs.csv",
-        "fail_closed_on_empty": True,
     },
     "jobs_cz": {
         # jobs.cz - Czech Republic's largest direct-posting board. ~10k live via seeded search.

--- a/src/ats_scrapers/models.py
+++ b/src/ats_scrapers/models.py
@@ -61,6 +61,7 @@ class ATSType(StrEnum):
     # Big-tech custom careers systems (single-tenant, bespoke APIs)
     AMAZON = "amazon"
     APPLE = "apple"
+    BYTEDANCE = "bytedance"
     GOOGLE = "google"
     META = "meta"
     TESLA = "tesla"
@@ -89,7 +90,6 @@ class ATSType(StrEnum):
     INFOJOBSES = "infojobs_es"
     JOBBANKCA = "jobbankca"
     SEEK = "seek"
-    BYTEDANCE = "bytedance"
     # Additional multi-tenant ATSes (post-0.1)
     BAMBOOHR = "bamboohr"
     BREEZY = "breezy"

--- a/src/ats_scrapers/models.py
+++ b/src/ats_scrapers/models.py
@@ -89,6 +89,7 @@ class ATSType(StrEnum):
     INFOJOBSES = "infojobs_es"
     JOBBANKCA = "jobbankca"
     SEEK = "seek"
+    BYTEDANCE = "bytedance"
     # Additional multi-tenant ATSes (post-0.1)
     BAMBOOHR = "bamboohr"
     BREEZY = "breezy"

--- a/src/ats_scrapers/scrapers/__init__.py
+++ b/src/ats_scrapers/scrapers/__init__.py
@@ -20,6 +20,7 @@ from ats_scrapers.scrapers.beisen_legacy import BeisenLegacyScraper
 from ats_scrapers.scrapers.breezy import BreezyScraper
 from ats_scrapers.scrapers.builtin import BuiltInScraper
 from ats_scrapers.scrapers.bundesagentur import BundesagenturScraper
+from ats_scrapers.scrapers.bytedance import BytedanceScraper
 from ats_scrapers.scrapers.cornerstone import CornerstoneScraper
 from ats_scrapers.scrapers.darwinbox import DarwinboxScraper
 from ats_scrapers.scrapers.eightfold import EightfoldScraper
@@ -81,6 +82,7 @@ __all__ = [
     "BreezyScraper",
     "BuiltInScraper",
     "BundesagenturScraper",
+    "BytedanceScraper",
     "CornerstoneScraper",
     "DarwinboxScraper",
     "EightfoldScraper",

--- a/src/ats_scrapers/scrapers/_throne.py
+++ b/src/ats_scrapers/scrapers/_throne.py
@@ -76,10 +76,12 @@ def extract_location(item: dict[str, Any]) -> str | None:
         if parts:
             return ", ".join(parts)
     city_list = item.get("city_list") or []
-    if city_list and isinstance(city_list[0], dict):
-        name = city_list[0].get("name")
-        return name if isinstance(name, str) else None
-    return None
+    locations = [
+        label
+        for entry in city_list
+        if (label := extract_label(entry)) is not None
+    ]
+    return "; ".join(dict.fromkeys(locations)) or None
 
 
 def to_float(value: object) -> float | None:

--- a/src/ats_scrapers/scrapers/_throne.py
+++ b/src/ats_scrapers/scrapers/_throne.py
@@ -1,0 +1,92 @@
+"""Shared parsing helpers for ByteDance's ATSx/Throne careers backend."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from ats_scrapers.models import EmploymentType
+
+_EMPLOYMENT_TYPE_PATTERNS: dict[str, EmploymentType] = {
+    "intern": "INTERN",
+    "internship": "INTERN",
+    "contract": "CONTRACT",
+    "contractor": "CONTRACT",
+    "temporary": "TEMPORARY",
+    "part-time": "PART_TIME",
+    "part time": "PART_TIME",
+    "parttime": "PART_TIME",
+    "full-time": "FULL_TIME",
+    "full time": "FULL_TIME",
+    "fulltime": "FULL_TIME",
+    "regular": "FULL_TIME",
+    "permanent": "FULL_TIME",
+}
+
+
+def compose_description(*sources: object) -> str | None:
+    """Concatenate description fields using the repository's 25k limit."""
+    parts = [
+        source.strip()
+        for source in sources
+        if isinstance(source, str) and source.strip()
+    ]
+    if not parts:
+        return None
+    text = re.sub(r"\n{3,}", "\n\n", "\n\n".join(parts)).strip()
+    return text[:25_000] or None
+
+
+def extract_label(value: object) -> str | None:
+    """Extract the preferred English label from a Throne field."""
+    if not isinstance(value, dict):
+        return None
+    for key in ("en_name", "i18n_name", "name"):
+        label = value.get(key)
+        if isinstance(label, str) and label.strip():
+            return label.strip()
+    return None
+
+
+def map_recruit_type(
+    value: object,
+) -> tuple[EmploymentType | None, str | None]:
+    """Map a Throne recruit type to employment type and commitment."""
+    label = extract_label(value)
+    if not label:
+        return None, None
+    normalized = label.lower()
+    for needle, mapped in _EMPLOYMENT_TYPE_PATTERNS.items():
+        if needle in normalized:
+            return mapped, label
+    return None, label
+
+
+def extract_location(item: dict[str, Any]) -> str | None:
+    """Walk the current city parent chain, with legacy city-list fallback."""
+    city_info = item.get("city_info")
+    if isinstance(city_info, dict):
+        parts: list[str] = []
+        node: object = city_info
+        while isinstance(node, dict):
+            name = node.get("en_name") or node.get("name")
+            if isinstance(name, str) and name:
+                parts.append(name)
+            node = node.get("parent")
+        if parts:
+            return ", ".join(parts)
+    city_list = item.get("city_list") or []
+    if city_list and isinstance(city_list[0], dict):
+        name = city_list[0].get("name")
+        return name if isinstance(name, str) else None
+    return None
+
+
+def to_float(value: object) -> float | None:
+    """Return a numeric API field as float when possible."""
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None

--- a/src/ats_scrapers/scrapers/bytedance.py
+++ b/src/ats_scrapers/scrapers/bytedance.py
@@ -1,0 +1,312 @@
+"""ByteDance / joinbytedance.com careers scraper.
+
+    POST https://jobs.bytedance.com/api/v1/public/supplier/search/job/posts
+
+Requires ``website-path: en`` plus the standard origin/referer headers
+from ``https://joinbytedance.com``; otherwise the endpoint refuses with
+400.
+
+This is the same ATSx/Throne SaaS backend that powers TikTok's
+``api.lifeattiktok.com``, just a different tenant — schema is identical.
+We concatenate ``description`` + ``requirement`` for the canonical
+description, map ``recruit_type.en_name`` to the employment-type enum,
+and walk ``city_info.parent`` for the location string.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, ClassVar
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from ats_scrapers.fetch import Fetcher
+
+API_URL = "https://jobs.bytedance.com/api/v1/public/supplier/search/job/posts"
+PAGE_SIZE = 100
+MAX_RETRIES = 4
+
+_EMPLOYMENT_TYPE_PATTERNS = {
+    "intern": "INTERN",
+    "internship": "INTERN",
+    "contract": "CONTRACT",
+    "contractor": "CONTRACT",
+    "temporary": "TEMPORARY",
+    "part-time": "PART_TIME",
+    "part time": "PART_TIME",
+    "parttime": "PART_TIME",
+    "full-time": "FULL_TIME",
+    "full time": "FULL_TIME",
+    "fulltime": "FULL_TIME",
+    "regular": "FULL_TIME",
+    "permanent": "FULL_TIME",
+}
+
+HEADERS = {
+    "accept": "*/*",
+    "accept-language": "en-US",
+    "content-type": "application/json",
+    "website-path": "en",
+    "origin": "https://joinbytedance.com",
+    "referer": "https://joinbytedance.com/",
+    "user-agent": "Mozilla/5.0",
+}
+
+
+@ScraperRegistry.register(ATSType.BYTEDANCE)
+class BytedanceScraper(BaseScraper):
+    """ByteDance scraper — `company_slug` is informational; jobs are global."""
+
+    ats = ATSType.BYTEDANCE
+    default_headers: ClassVar[dict[str, str]] = HEADERS
+
+    async def afetch(self) -> list[Job]:
+        all_jobs: list[Job] = []
+        seen_ids: set[str] = set()
+        reported_total: int | None = None
+        offset = 0
+        async with self.make_fetcher(retries=MAX_RETRIES) as fetch:
+            while True:
+                payload = {
+                    "limit": PAGE_SIZE,
+                    "offset": offset,
+                    "keyword": "",
+                    "category_id_list": [],
+                    "subject_id_list": [],
+                    "location_code_list": [],
+                    "job_function_id_list": [],
+                }
+                body = await self._post_page(fetch, payload)
+                code = body.get("code")
+                if code:
+                    raise ScraperError(
+                        f"ByteDance API error code {code}: {body.get('message')}"
+                    )
+                payload_data = body.get("data")
+                if not isinstance(payload_data, dict):
+                    raise ScraperError("ByteDance response omitted data object")
+                if not isinstance(payload_data.get("job_post_list"), list):
+                    raise ScraperError(
+                        "ByteDance response omitted job_post_list"
+                    )
+                total = payload_data.get("count")
+                if not isinstance(total, int) or total < 0:
+                    raise ScraperError("ByteDance response had invalid count")
+                if reported_total is None:
+                    reported_total = total
+                elif total != reported_total:
+                    raise ScraperError(
+                        "ByteDance response changed count during pagination "
+                        f"({reported_total} to {total})"
+                    )
+                jobs = payload_data["job_post_list"]
+                if not all(isinstance(job, dict) for job in jobs):
+                    raise ScraperError(
+                        "ByteDance job_post_list contained a non-object row"
+                    )
+                if not jobs:
+                    if not all_jobs:
+                        raise ScraperError(
+                            "ByteDance full-catalogue scrape returned no jobs"
+                        )
+                    if offset < total:
+                        raise ScraperError(
+                            "ByteDance returned an empty page before count "
+                            f"was reached ({offset}/{total})"
+                        )
+                    break
+                parsed = [self._parse_job(job) for job in jobs]
+                if any(job is None for job in parsed):
+                    raise ScraperError(
+                        "ByteDance could not parse every returned job row"
+                    )
+                for job in parsed:
+                    if job is None or job.ats_id in seen_ids:
+                        continue
+                    seen_ids.add(job.ats_id)
+                    all_jobs.append(job)
+                offset += len(jobs)
+                if offset >= total:
+                    break
+                if len(jobs) < PAGE_SIZE:
+                    raise ScraperError(
+                        "ByteDance returned a short page before count "
+                        f"was reached ({offset}/{total})"
+                    )
+        if reported_total is None or len(seen_ids) != reported_total:
+            raise ScraperError(
+                "ByteDance catalogue ended before the reported count "
+                f"({len(seen_ids)}/{reported_total} unique jobs)"
+            )
+        return all_jobs
+
+    def fetch(self) -> list[Job]:
+        return self._run_sync(self.afetch())
+
+    async def _post_page(
+        self,
+        fetch: Fetcher,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        body = await fetch.post_json(API_URL, json=payload)
+        if not isinstance(body, dict):
+            raise ScraperError(
+                "ByteDance returned a non-object JSON response"
+            )
+        return body
+
+    def _parse_job(self, item: dict[str, Any]) -> Job | None:
+        ats_id = str(item.get("id") or "")
+        title = (item.get("title") or item.get("name") or "").strip()
+        if not ats_id or not title:
+            return None
+        post_info = item.get("job_post_info") or {}
+
+        # Description: concatenate ``description`` + ``requirement``
+        # (the API splits the body into two fields). Strip and cap.
+        description = _compose_description(
+            item.get("description"),
+            item.get("requirement"),
+        )
+
+        # ``recruit_type.en_name`` is the canonical employment-type label
+        # ("Intern" / "Regular" / "Contract") — map to our enum.
+        employment_type, commitment = _map_recruit_type(item.get("recruit_type"))
+
+        # ``job_category.en_name`` is the high-level area
+        # ("Algorithm" / "Engineering"); ``job_subject.en_name`` is the
+        # team/role family ("PhD Graduates- 2026 Start", etc.).
+        department = _extract_label(item.get("job_category"))
+        team = _extract_label(item.get("job_subject"))
+
+        # Use the employer-set ``code`` (e.g. "A72890A") as the
+        # requisition id when present; fall back to the numeric ats_id.
+        requisition_id = (
+            item["code"].strip()
+            if isinstance(item.get("code"), str) and item["code"].strip()
+            else (ats_id or None)
+        )
+
+        raw: dict[str, Any] = {}
+        for k in ("job_category", "job_subject", "recruit_type",
+                  "experience", "department_info", "skill_list",
+                  "tag_list", "process_type"):
+            v = item.get(k)
+            if v:
+                raw[k] = v
+
+        return Job(
+            url=f"https://joinbytedance.com/search/{ats_id}",
+            title=title,
+            company="ByteDance",
+            ats_type=ATSType.BYTEDANCE,
+            ats_id=ats_id,
+            location=_extract_location(item),
+            department=department,
+            team=team if team and team != department else None,
+            employment_type=employment_type,
+            commitment=commitment,
+            description=description if self.include_descriptions else None,
+            requisition_id=requisition_id,
+            salary_min=_to_float(post_info.get("min_salary")),
+            salary_max=_to_float(post_info.get("max_salary")),
+            salary_currency=post_info.get("currency"),
+            posted_at=_parse_ts(item.get("publish_time") or item.get("post_time")),
+            fetched_at=datetime.now(tz=UTC),
+            raw=raw or None,
+        )
+
+
+def _compose_description(*sources: object) -> str | None:
+    """Concatenate description-like fields and cap at 10kB.
+
+    The body sometimes contains repeated whitespace from the API; we
+    collapse runs of blank lines to keep storage tight.
+    """
+    parts: list[str] = []
+    for source in sources:
+        if isinstance(source, str) and source.strip():
+            parts.append(source.strip())
+    if not parts:
+        return None
+    text = "\n\n".join(parts)
+    text = re.sub(r"\n{3,}", "\n\n", text).strip()
+    return text[:10_000] or None
+
+
+def _extract_label(value: object) -> str | None:
+    """ByteDance wraps category-style fields as
+    ``{"en_name": "Algorithm", "i18n_name": "Algorithm", ...}``.
+    Prefer ``en_name``; fall through to ``i18n_name`` / ``name``."""
+    if not isinstance(value, dict):
+        return None
+    for key in ("en_name", "i18n_name", "name"):
+        v = value.get(key)
+        if isinstance(v, str) and v.strip():
+            return v.strip()
+    return None
+
+
+def _map_recruit_type(value: object) -> tuple[str | None, str | None]:
+    """Map ``recruit_type`` to ``(employment_type, commitment)``.
+
+    The API ships ``{"en_name": "Regular", "i18n_name": "Regular", ...}``.
+    We surface the human label in ``commitment`` and translate to the
+    canonical FT/PT/CONTRACT/INTERN/TEMPORARY enum.
+    """
+    label = _extract_label(value)
+    if not label:
+        return None, None
+    norm = label.lower()
+    for needle, mapped in _EMPLOYMENT_TYPE_PATTERNS.items():
+        if needle in norm:
+            return mapped, label
+    return None, label
+
+
+def _extract_location(item: dict) -> str | None:
+    """ByteDance's `city_info` is a nested location object with parent chain.
+
+    The current API exposes a single `city_info` dict whose `parent` chain
+    walks up to country. Legacy `city_list` is handled as a fallback.
+    """
+    city_info = item.get("city_info")
+    if isinstance(city_info, dict):
+        parts = []
+        node = city_info
+        while isinstance(node, dict):
+            name = node.get("en_name") or node.get("name")
+            if name:
+                parts.append(name)
+            node = node.get("parent")
+        if parts:
+            return ", ".join(parts)
+    # Legacy: city_list[0].name
+    city_list = item.get("city_list") or []
+    if city_list and isinstance(city_list[0], dict):
+        return city_list[0].get("name")
+    return None
+
+
+def _to_float(value: object) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_ts(value: int | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromtimestamp(value, tz=UTC)
+    except (ValueError, OSError):
+        return None

--- a/src/ats_scrapers/scrapers/bytedance.py
+++ b/src/ats_scrapers/scrapers/bytedance.py
@@ -15,12 +15,28 @@ and walk ``city_info.parent`` for the location string.
 
 from __future__ import annotations
 
-import re
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, ClassVar
 
+from pydantic import HttpUrl
+
 from ats_scrapers.exceptions import ScraperError
 from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers._throne import (
+    compose_description as _compose_description,
+)
+from ats_scrapers.scrapers._throne import (
+    extract_label as _extract_label,
+)
+from ats_scrapers.scrapers._throne import (
+    extract_location as _extract_location,
+)
+from ats_scrapers.scrapers._throne import (
+    map_recruit_type as _map_recruit_type,
+)
+from ats_scrapers.scrapers._throne import (
+    to_float as _to_float,
+)
 from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
 
 if TYPE_CHECKING:
@@ -31,22 +47,6 @@ if TYPE_CHECKING:
 API_URL = "https://jobs.bytedance.com/api/v1/public/supplier/search/job/posts"
 PAGE_SIZE = 100
 MAX_RETRIES = 4
-
-_EMPLOYMENT_TYPE_PATTERNS = {
-    "intern": "INTERN",
-    "internship": "INTERN",
-    "contract": "CONTRACT",
-    "contractor": "CONTRACT",
-    "temporary": "TEMPORARY",
-    "part-time": "PART_TIME",
-    "part time": "PART_TIME",
-    "parttime": "PART_TIME",
-    "full-time": "FULL_TIME",
-    "full time": "FULL_TIME",
-    "fulltime": "FULL_TIME",
-    "regular": "FULL_TIME",
-    "permanent": "FULL_TIME",
-}
 
 HEADERS = {
     "accept": "*/*",
@@ -127,7 +127,11 @@ class BytedanceScraper(BaseScraper):
                         "ByteDance could not parse every returned job row"
                     )
                 for job in parsed:
-                    if job is None or job.ats_id in seen_ids:
+                    if (
+                        job is None
+                        or not job.ats_id
+                        or job.ats_id in seen_ids
+                    ):
                         continue
                     seen_ids.add(job.ats_id)
                     all_jobs.append(job)
@@ -167,6 +171,8 @@ class BytedanceScraper(BaseScraper):
         if not ats_id or not title:
             return None
         post_info = item.get("job_post_info") or {}
+        salary_min = _to_float(post_info.get("min_salary"))
+        salary_max = _to_float(post_info.get("max_salary"))
 
         # Description: concatenate ``description`` + ``requirement``
         # (the API splits the body into two fields). Strip and cap.
@@ -202,7 +208,7 @@ class BytedanceScraper(BaseScraper):
                 raw[k] = v
 
         return Job(
-            url=f"https://joinbytedance.com/search/{ats_id}",
+            url=HttpUrl(f"https://joinbytedance.com/search/{ats_id}"),
             title=title,
             company="ByteDance",
             ats_type=ATSType.BYTEDANCE,
@@ -214,93 +220,18 @@ class BytedanceScraper(BaseScraper):
             commitment=commitment,
             description=description if self.include_descriptions else None,
             requisition_id=requisition_id,
-            salary_min=_to_float(post_info.get("min_salary")),
-            salary_max=_to_float(post_info.get("max_salary")),
+            salary_min=salary_min,
+            salary_max=salary_max,
             salary_currency=post_info.get("currency"),
+            salary_period=(
+                "YEAR"
+                if salary_min is not None or salary_max is not None
+                else None
+            ),
             posted_at=_parse_ts(item.get("publish_time") or item.get("post_time")),
             fetched_at=datetime.now(tz=UTC),
             raw=raw or None,
         )
-
-
-def _compose_description(*sources: object) -> str | None:
-    """Concatenate description-like fields and cap at 10kB.
-
-    The body sometimes contains repeated whitespace from the API; we
-    collapse runs of blank lines to keep storage tight.
-    """
-    parts: list[str] = []
-    for source in sources:
-        if isinstance(source, str) and source.strip():
-            parts.append(source.strip())
-    if not parts:
-        return None
-    text = "\n\n".join(parts)
-    text = re.sub(r"\n{3,}", "\n\n", text).strip()
-    return text[:10_000] or None
-
-
-def _extract_label(value: object) -> str | None:
-    """ByteDance wraps category-style fields as
-    ``{"en_name": "Algorithm", "i18n_name": "Algorithm", ...}``.
-    Prefer ``en_name``; fall through to ``i18n_name`` / ``name``."""
-    if not isinstance(value, dict):
-        return None
-    for key in ("en_name", "i18n_name", "name"):
-        v = value.get(key)
-        if isinstance(v, str) and v.strip():
-            return v.strip()
-    return None
-
-
-def _map_recruit_type(value: object) -> tuple[str | None, str | None]:
-    """Map ``recruit_type`` to ``(employment_type, commitment)``.
-
-    The API ships ``{"en_name": "Regular", "i18n_name": "Regular", ...}``.
-    We surface the human label in ``commitment`` and translate to the
-    canonical FT/PT/CONTRACT/INTERN/TEMPORARY enum.
-    """
-    label = _extract_label(value)
-    if not label:
-        return None, None
-    norm = label.lower()
-    for needle, mapped in _EMPLOYMENT_TYPE_PATTERNS.items():
-        if needle in norm:
-            return mapped, label
-    return None, label
-
-
-def _extract_location(item: dict) -> str | None:
-    """ByteDance's `city_info` is a nested location object with parent chain.
-
-    The current API exposes a single `city_info` dict whose `parent` chain
-    walks up to country. Legacy `city_list` is handled as a fallback.
-    """
-    city_info = item.get("city_info")
-    if isinstance(city_info, dict):
-        parts = []
-        node = city_info
-        while isinstance(node, dict):
-            name = node.get("en_name") or node.get("name")
-            if name:
-                parts.append(name)
-            node = node.get("parent")
-        if parts:
-            return ", ".join(parts)
-    # Legacy: city_list[0].name
-    city_list = item.get("city_list") or []
-    if city_list and isinstance(city_list[0], dict):
-        return city_list[0].get("name")
-    return None
-
-
-def _to_float(value: object) -> float | None:
-    if value is None or value == "":
-        return None
-    try:
-        return float(value)  # type: ignore[arg-type]
-    except (TypeError, ValueError):
-        return None
 
 
 def _parse_ts(value: int | None) -> datetime | None:

--- a/src/ats_scrapers/scrapers/tiktok.py
+++ b/src/ats_scrapers/scrapers/tiktok.py
@@ -14,11 +14,25 @@ and pull ``job_category.en_name`` as the department.
 
 from __future__ import annotations
 
-import re
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers._throne import (
+    compose_description as _compose_description,
+)
+from ats_scrapers.scrapers._throne import (
+    extract_label as _extract_label,
+)
+from ats_scrapers.scrapers._throne import (
+    extract_location as _extract_location,
+)
+from ats_scrapers.scrapers._throne import (
+    map_recruit_type as _map_recruit_type,
+)
+from ats_scrapers.scrapers._throne import (
+    to_float as _to_float,
+)
 from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
 
 if TYPE_CHECKING:
@@ -26,22 +40,6 @@ if TYPE_CHECKING:
 
 API_URL = "https://api.lifeattiktok.com/api/v1/public/supplier/search/job/posts"
 PAGE_SIZE = 100
-
-_EMPLOYMENT_TYPE_PATTERNS = {
-    "intern": "INTERN",
-    "internship": "INTERN",
-    "contract": "CONTRACT",
-    "contractor": "CONTRACT",
-    "temporary": "TEMPORARY",
-    "part-time": "PART_TIME",
-    "part time": "PART_TIME",
-    "parttime": "PART_TIME",
-    "full-time": "FULL_TIME",
-    "full time": "FULL_TIME",
-    "fulltime": "FULL_TIME",
-    "regular": "FULL_TIME",
-    "permanent": "FULL_TIME",
-}
 
 HEADERS = {
     "accept": "*/*",
@@ -146,86 +144,6 @@ class TikTokScraper(BaseScraper):
             fetched_at=datetime.now(UTC),
             raw=raw or None,
         )
-
-
-def _compose_description(*sources: object) -> str | None:
-    """Concatenate description-like fields and cap at 25k chars.
-
-    The body sometimes contains repeated whitespace from the API; we
-    collapse runs of blank lines to keep storage tight.
-    """
-    parts: list[str] = []
-    for source in sources:
-        if isinstance(source, str) and source.strip():
-            parts.append(source.strip())
-    if not parts:
-        return None
-    text = "\n\n".join(parts)
-    text = re.sub(r"\n{3,}", "\n\n", text).strip()
-    return text[:25_000] or None
-
-
-def _extract_label(value: object) -> str | None:
-    """TikTok wraps category-style fields as
-    ``{"en_name": "Operations", "i18n_name": "Operations", ...}``.
-    Prefer ``en_name``; fall through to ``i18n_name`` / ``name``."""
-    if not isinstance(value, dict):
-        return None
-    for key in ("en_name", "i18n_name", "name"):
-        v = value.get(key)
-        if isinstance(v, str) and v.strip():
-            return v.strip()
-    return None
-
-
-def _map_recruit_type(value: object) -> tuple[str | None, str | None]:
-    """Map ``recruit_type`` to ``(employment_type, commitment)``.
-
-    The API ships ``{"en_name": "Intern", "i18n_name": "Intern", ...}``.
-    We surface the human label in ``commitment`` and translate to the
-    canonical FT/PT/CONTRACT/INTERN/TEMPORARY enum.
-    """
-    label = _extract_label(value)
-    if not label:
-        return None, None
-    norm = label.lower()
-    for needle, mapped in _EMPLOYMENT_TYPE_PATTERNS.items():
-        if needle in norm:
-            return mapped, label
-    return None, label
-
-
-def _extract_location(item: dict) -> str | None:
-    """TikTok's `city_info` is a nested location object with parent chain.
-
-    Older API versions used `city_list` (an array); the current API exposes
-    a single `city_info` dict whose `parent` chain walks up to country.
-    """
-    city_info = item.get("city_info")
-    if isinstance(city_info, dict):
-        parts = []
-        node = city_info
-        while isinstance(node, dict):
-            name = node.get("en_name") or node.get("name")
-            if name:
-                parts.append(name)
-            node = node.get("parent")
-        if parts:
-            return ", ".join(parts)
-    # Legacy: city_list[0].name
-    city_list = item.get("city_list") or []
-    if city_list and isinstance(city_list[0], dict):
-        return city_list[0].get("name")
-    return None
-
-
-def _to_float(value: object) -> float | None:
-    if value is None or value == "":
-        return None
-    try:
-        return float(value)  # type: ignore[arg-type]
-    except (TypeError, ValueError):
-        return None
 
 
 def _parse_ts(value: int | None) -> datetime | None:

--- a/tests/e2e/test_live_bytedance.py
+++ b/tests/e2e/test_live_bytedance.py
@@ -11,6 +11,7 @@ import pytest
 
 from ats_scrapers.models import Job
 from ats_scrapers.scrapers import BytedanceScraper
+from ats_scrapers.scrapers.base import BaseScraper
 
 pytestmark = [
     pytest.mark.live,
@@ -20,7 +21,7 @@ pytestmark = [
     ),
 ]
 
-CASES: list[tuple[str, Callable[[], object], str]] = [
+CASES: list[tuple[str, Callable[[], BaseScraper], str]] = [
     ("bytedance", lambda: BytedanceScraper("bytedance"), "joinbytedance.com"),
 ]
 
@@ -30,7 +31,7 @@ CASES: list[tuple[str, Callable[[], object], str]] = [
     [pytest.param(factory, domain, id=name) for name, factory, domain in CASES],
 )
 async def test_live_jobboard_smoke(
-    factory: Callable[[], object], expected_domain: str
+    factory: Callable[[], BaseScraper], expected_domain: str
 ) -> None:
     async with asyncio.timeout(180):
         jobs = await factory().afetch()

--- a/tests/e2e/test_live_bytedance.py
+++ b/tests/e2e/test_live_bytedance.py
@@ -1,0 +1,46 @@
+"""Live smoke test for ByteDance careers."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Callable
+from urllib.parse import urlparse
+
+import pytest
+
+from ats_scrapers.models import Job
+from ats_scrapers.scrapers import BytedanceScraper
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.skipif(
+        not os.getenv("ATS_SCRAPERS_LIVE_E2E"),
+        reason="set ATS_SCRAPERS_LIVE_E2E=1 to hit real job-board endpoints",
+    ),
+]
+
+CASES: list[tuple[str, Callable[[], object], str]] = [
+    ("bytedance", lambda: BytedanceScraper("bytedance"), "joinbytedance.com"),
+]
+
+
+@pytest.mark.parametrize(
+    ("factory", "expected_domain"),
+    [pytest.param(factory, domain, id=name) for name, factory, domain in CASES],
+)
+async def test_live_jobboard_smoke(
+    factory: Callable[[], object], expected_domain: str
+) -> None:
+    async with asyncio.timeout(180):
+        jobs = await factory().afetch()
+    assert jobs
+    sample: list[Job] = jobs[:50]
+    assert len({job.global_id for job in sample}) == len(sample)
+    for job in sample:
+        assert job.title.strip()
+        assert job.company.strip()
+        assert job.ats_id
+        host = (urlparse(str(job.url)).hostname or "").lower()
+        assert expected_domain in host
+        assert not host.endswith((".local", ".internal"))

--- a/tests/test_bytedance.py
+++ b/tests/test_bytedance.py
@@ -145,6 +145,7 @@ def test_salary_fields_absent_when_missing() -> None:
     assert job.salary_min is None
     assert job.salary_max is None
     assert job.salary_currency is None
+    assert job.salary_period is None
     assert job.salary is None
 
 
@@ -161,6 +162,7 @@ def test_salary_fields_parsed_when_present() -> None:
     assert job.salary_min == 120000.0
     assert job.salary_max == 180000.0
     assert job.salary_currency == "USD"
+    assert job.salary_period == "YEAR"
 
 
 def test_raw_keeps_only_truthy_fields() -> None:
@@ -349,11 +351,11 @@ def test_compose_description_returns_none_for_empty() -> None:
     assert _compose_description(None, "", "   ") is None
 
 
-def test_compose_description_caps_at_10kb() -> None:
-    big = "x" * 20_000
+def test_compose_description_caps_at_25kb() -> None:
+    big = "x" * 30_000
     out = _compose_description(big)
     assert out is not None
-    assert len(out) == 10_000
+    assert len(out) == 25_000
 
 
 def test_extract_label_prefers_en_name() -> None:

--- a/tests/test_bytedance.py
+++ b/tests/test_bytedance.py
@@ -134,10 +134,15 @@ def test_location_handles_legacy_city_list_shape() -> None:
     item = {
         **_FIXTURE,
         "city_info": None,
-        "city_list": [{"name": "Tokyo"}],
+        "city_list": [
+            {"name": "東京", "en_name": "Tokyo"},
+            {"name": "Osaka"},
+            {"name": "Osaka"},
+            None,
+        ],
     }
     job = BytedanceScraper("bytedance")._parse_job(item)
-    assert job.location == "Tokyo"
+    assert job.location == "Tokyo; Osaka"
 
 
 def test_salary_fields_absent_when_missing() -> None:

--- a/tests/test_bytedance.py
+++ b/tests/test_bytedance.py
@@ -1,0 +1,397 @@
+"""Tests for the ByteDance scraper.
+
+Scope: parser behaviour against a fixed fixture mirroring the live
+``/api/v1/public/supplier/search/job/posts`` response. The HTTP layer
+is shared verbatim with the TikTok scraper (same ATSx/Throne backend)
+and is not exercised here — those tests would re-cover identical code.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType
+from ats_scrapers.scrapers.bytedance import (
+    API_URL,
+    PAGE_SIZE,
+    BytedanceScraper,
+    _compose_description,
+    _extract_label,
+    _extract_location,
+    _map_recruit_type,
+)
+
+# A realistic single job_post_list entry — fields and nesting shape
+# verified against the live endpoint on 2026-05-12.
+_FIXTURE = {
+    "id": "7607020417963968773",
+    "code": "A72890A",
+    "title": "Machine Learning Engineer Graduate (Recommendation) - 2026 Start",
+    "description": "Team Introduction\nWe build recommendation systems.",
+    "requirement": "Minimum Qualifications\n- PhD or Masters in CS",
+    "recruit_type": {
+        "id": "201",
+        "name": "正式",
+        "en_name": "Regular",
+        "i18n_name": "正式",
+    },
+    "job_category": {
+        "id": "6704215862603155720",
+        "name": "算法",
+        "en_name": "Algorithm",
+        "i18n_name": "Algorithm",
+    },
+    "city_info": {
+        "code": "CT_163",
+        "location_type": 3,
+        "name": "新加坡",
+        "en_name": "Singapore",
+        "i18n_name": "Singapore",
+        "parent": {
+            "code": "CT_SG",
+            "name": "新加坡",
+            "en_name": "Singapore",
+            "i18n_name": "Singapore",
+        },
+    },
+    "tag_list": None,
+    "job_subject": {
+        "id": "7100000000000000001",
+        "name": "PhD Graduates- 2026 Start",
+        "en_name": "PhD Graduates- 2026 Start",
+        "i18n_name": "PhD Graduates- 2026 Start",
+    },
+    "vacancies": None,
+    "department_info": None,
+    "job_post_info": {
+        "min_salary": None,
+        "max_salary": None,
+        "currency": None,
+    },
+    "process_type": None,
+    "publish_time": 1715500000,
+}
+
+
+def test_parses_fixture_into_job() -> None:
+    job = BytedanceScraper("bytedance")._parse_job(_FIXTURE)
+    assert job.ats_id == "7607020417963968773"
+    assert job.ats_type is ATSType.BYTEDANCE
+    assert job.company == "ByteDance"
+    assert job.title.startswith("Machine Learning Engineer Graduate")
+    assert str(job.url) == "https://joinbytedance.com/search/7607020417963968773"
+    assert job.global_id == "bytedance:7607020417963968773"
+    # ``code`` becomes ``requisition_id``; ``ats_id`` keeps the numeric id.
+    assert job.requisition_id == "A72890A"
+
+
+def test_description_concatenates_description_and_requirement() -> None:
+    job = BytedanceScraper("bytedance")._parse_job(_FIXTURE)
+    assert job.description is not None
+    assert "Team Introduction" in job.description
+    assert "Minimum Qualifications" in job.description
+    # Two-newline separator between the two source fields.
+    assert "We build recommendation systems.\n\nMinimum Qualifications" in job.description
+
+
+def test_employment_type_mapped_from_recruit_type() -> None:
+    """``recruit_type.en_name == 'Regular'`` → FULL_TIME, label preserved."""
+    job = BytedanceScraper("bytedance")._parse_job(_FIXTURE)
+    assert job.employment_type == "FULL_TIME"
+    assert job.commitment == "Regular"
+
+
+def test_intern_recruit_type_maps_to_intern() -> None:
+    item = {**_FIXTURE, "recruit_type": {"en_name": "Intern", "name": "实习"}}
+    job = BytedanceScraper("bytedance")._parse_job(item)
+    assert job.employment_type == "INTERN"
+    assert job.commitment == "Intern"
+
+
+def test_department_and_team_from_category_and_subject() -> None:
+    job = BytedanceScraper("bytedance")._parse_job(_FIXTURE)
+    assert job.department == "Algorithm"
+    assert job.team == "PhD Graduates- 2026 Start"
+
+
+def test_team_suppressed_when_equal_to_department() -> None:
+    item = {
+        **_FIXTURE,
+        "job_subject": {"en_name": "Algorithm", "name": "算法"},
+    }
+    job = BytedanceScraper("bytedance")._parse_job(item)
+    assert job.team is None
+
+
+def test_location_walks_city_info_parent_chain() -> None:
+    job = BytedanceScraper("bytedance")._parse_job(_FIXTURE)
+    # Singapore (city) + Singapore (country parent) — comma-joined.
+    assert job.location == "Singapore, Singapore"
+
+
+def test_location_handles_legacy_city_list_shape() -> None:
+    item = {
+        **_FIXTURE,
+        "city_info": None,
+        "city_list": [{"name": "Tokyo"}],
+    }
+    job = BytedanceScraper("bytedance")._parse_job(item)
+    assert job.location == "Tokyo"
+
+
+def test_salary_fields_absent_when_missing() -> None:
+    job = BytedanceScraper("bytedance")._parse_job(_FIXTURE)
+    assert job.salary_min is None
+    assert job.salary_max is None
+    assert job.salary_currency is None
+    assert job.salary is None
+
+
+def test_salary_fields_parsed_when_present() -> None:
+    item = {
+        **_FIXTURE,
+        "job_post_info": {
+            "min_salary": 120000,
+            "max_salary": 180000,
+            "currency": "USD",
+        },
+    }
+    job = BytedanceScraper("bytedance")._parse_job(item)
+    assert job.salary_min == 120000.0
+    assert job.salary_max == 180000.0
+    assert job.salary_currency == "USD"
+
+
+def test_raw_keeps_only_truthy_fields() -> None:
+    job = BytedanceScraper("bytedance")._parse_job(_FIXTURE)
+    assert job.raw is not None
+    # ``tag_list``, ``department_info``, ``process_type`` are null → omitted.
+    assert "tag_list" not in job.raw
+    assert "department_info" not in job.raw
+    assert "process_type" not in job.raw
+    # ``job_category`` / ``job_subject`` / ``recruit_type`` survive.
+    assert "job_category" in job.raw
+    assert "job_subject" in job.raw
+    assert "recruit_type" in job.raw
+
+
+def test_ats_type_registered_for_bytedance() -> None:
+    """The decorator wires the scraper into the registry."""
+    from ats_scrapers.scrapers.base import ScraperRegistry
+
+    assert ScraperRegistry.get(ATSType.BYTEDANCE) is BytedanceScraper
+
+
+def test_fetch_retries_transient_response(httpx_mock, monkeypatch) -> None:
+    import ats_scrapers.scrapers.bytedance as module
+
+    monkeypatch.setattr(module, "MAX_RETRIES", 2)
+    httpx_mock.add_response(url=API_URL, status_code=503)
+    httpx_mock.add_response(
+        url=API_URL,
+        json={
+            "code": 0,
+            "data": {"job_post_list": [_FIXTURE], "count": 1},
+        },
+    )
+    assert [job.ats_id for job in BytedanceScraper("any").fetch()] == [
+        "7607020417963968773"
+    ]
+
+
+@pytest.mark.parametrize("status", [408, 429, 503])
+def test_fetch_retries_transient_statuses(httpx_mock, monkeypatch, status) -> None:
+    import ats_scrapers.fetch as fetch_module
+
+    delays = []
+
+    async def fake_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    monkeypatch.setattr(
+        "ats_scrapers.scrapers.bytedance.MAX_RETRIES", 2,
+    )
+    monkeypatch.setattr(fetch_module.asyncio, "sleep", fake_sleep)
+    httpx_mock.add_response(
+        url=API_URL,
+        status_code=status,
+        headers={"Retry-After": "1"},
+    )
+    httpx_mock.add_response(
+        url=API_URL,
+        json={
+            "code": 0,
+            "data": {"job_post_list": [_FIXTURE], "count": 1},
+        },
+    )
+
+    assert len(BytedanceScraper("any").fetch()) == 1
+    assert delays == [1.0]
+
+
+def test_fetch_rejects_non_object_json(httpx_mock) -> None:
+    httpx_mock.add_response(url=API_URL, json=[])
+    with pytest.raises(ScraperError, match="non-object"):
+        BytedanceScraper("any").fetch()
+
+
+def test_fetcher_uses_explicit_proxy() -> None:
+    fetcher = BytedanceScraper(
+        "any", proxy="http://proxy.example:8080",
+    ).make_fetcher()
+    assert fetcher.proxy == "http://proxy.example:8080"
+
+
+def test_fetcher_uses_proxy_from_environment(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "ATS_SCRAPERS_PROXY", "http://env-proxy.example:8080",
+    )
+    fetcher = BytedanceScraper("any").make_fetcher()
+    assert fetcher.proxy == "http://env-proxy.example:8080"
+
+
+def test_fetch_rejects_empty_full_catalogue(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json={"code": 0, "data": {"job_post_list": [], "count": 0}},
+    )
+
+    with pytest.raises(ScraperError, match="returned no jobs"):
+        BytedanceScraper("any").fetch()
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        None,
+        {},
+        {"job_post_list": []},
+        {"job_post_list": [], "count": None},
+    ],
+)
+def test_fetch_rejects_incomplete_result_envelope(httpx_mock, data) -> None:
+    httpx_mock.add_response(url=API_URL, json={"code": 0, "data": data})
+
+    with pytest.raises(ScraperError):
+        BytedanceScraper("any").fetch()
+
+
+def test_fetch_rejects_unparseable_job_row(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json={
+            "code": 0,
+            "data": {"job_post_list": [{"id": "missing-title"}], "count": 1},
+        },
+    )
+
+    with pytest.raises(ScraperError, match="parse every returned job"):
+        BytedanceScraper("any").fetch()
+
+
+def test_fetch_rejects_short_page_before_reported_count(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=API_URL,
+        json={
+            "code": 0,
+            "data": {"job_post_list": [_FIXTURE], "count": 2},
+        },
+    )
+
+    with pytest.raises(ScraperError, match="short page before count"):
+        BytedanceScraper("any").fetch()
+
+
+def test_fetch_rejects_overlapping_pages_before_reported_count(
+    httpx_mock,
+) -> None:
+    first_page = [
+        {**_FIXTURE, "id": str(index)}
+        for index in range(PAGE_SIZE)
+    ]
+    overlapping_page = [
+        {**_FIXTURE, "id": str(index)}
+        for index in range(PAGE_SIZE // 2, PAGE_SIZE + PAGE_SIZE // 2)
+    ]
+    total = PAGE_SIZE * 2
+    httpx_mock.add_response(
+        url=API_URL,
+        json={
+            "code": 0,
+            "data": {"job_post_list": first_page, "count": total},
+        },
+    )
+    httpx_mock.add_response(
+        url=API_URL,
+        json={
+            "code": 0,
+            "data": {"job_post_list": overlapping_page, "count": total},
+        },
+    )
+
+    with pytest.raises(
+        ScraperError,
+        match=rf"{PAGE_SIZE + PAGE_SIZE // 2}/{total} unique jobs",
+    ):
+        BytedanceScraper("any").fetch()
+
+
+# --- Helper-function units --------------------------------------------------
+
+
+def test_compose_description_collapses_blank_runs() -> None:
+    out = _compose_description("Para one\n\n\n\nPara two", "Para three")
+    assert out == "Para one\n\nPara two\n\nPara three"
+
+
+def test_compose_description_returns_none_for_empty() -> None:
+    assert _compose_description(None, "", "   ") is None
+
+
+def test_compose_description_caps_at_10kb() -> None:
+    big = "x" * 20_000
+    out = _compose_description(big)
+    assert out is not None
+    assert len(out) == 10_000
+
+
+def test_extract_label_prefers_en_name() -> None:
+    assert _extract_label({"name": "算法", "en_name": "Algorithm"}) == "Algorithm"
+
+
+def test_extract_label_falls_through_to_name() -> None:
+    assert _extract_label({"name": "算法"}) == "算法"
+
+
+def test_extract_label_returns_none_for_non_dict() -> None:
+    assert _extract_label(None) is None
+    assert _extract_label("Algorithm") is None
+
+
+def test_map_recruit_type_unknown_label_kept_as_commitment() -> None:
+    """Unknown labels fall through to ``commitment`` with no enum."""
+    emp, com = _map_recruit_type({"en_name": "Apprentice"})
+    assert emp is None
+    assert com == "Apprentice"
+
+
+def test_map_recruit_type_missing_returns_none_pair() -> None:
+    assert _map_recruit_type(None) == (None, None)
+
+
+def test_extract_location_country_only_walks_parent() -> None:
+    item = {
+        "city_info": {
+            "en_name": "Mountain View",
+            "parent": {
+                "en_name": "California",
+                "parent": {"en_name": "United States"},
+            },
+        }
+    }
+    assert _extract_location(item) == "Mountain View, California, United States"
+
+
+def test_extract_location_returns_none_when_absent() -> None:
+    assert _extract_location({}) is None

--- a/tests/test_bytedance_contracts.py
+++ b/tests/test_bytedance_contracts.py
@@ -1,0 +1,14 @@
+"""Integration contracts for the ByteDance scraper."""
+
+from __future__ import annotations
+
+from pipeline.publisher import ATS_DEDUP_PRIORITY
+from scripts.run_pipeline import CONFIGS
+
+
+def test_bytedance_dedup_priority_matches_employer_sources() -> None:
+    assert ATS_DEDUP_PRIORITY["bytedance"] == ATS_DEDUP_PRIORITY["workday"]
+
+
+def test_bytedance_singleton_fails_closed_on_empty() -> None:
+    assert CONFIGS["bytedance"]["fail_closed_on_empty"] is True

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,7 +22,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "pinpoint", "recruiterbox", "rippling", "smartrecruiters",
         "successfactors", "workable", "workday",
         # Big-tech custom careers systems
-        "amazon", "apple", "google", "meta",
+        "amazon", "apple", "bytedance", "google", "meta",
         "tesla", "tiktok", "uber", "usajobs",
         # National / supranational public-sector aggregators
         "bundesagentur", "arbetsformedlingen", "eures",
@@ -30,7 +30,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
         "jobs_cz", "manfred", "thehub", "ycombinator", "wellfound",
-        "infojobs_es", "jobbankca", "seek", "bytedance",
+        "infojobs_es", "jobbankca", "seek",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr",
         "recruitee", "taleo", "teamtailor",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -30,7 +30,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "welcometothejungle", "getonbrd", "wanted", "remoteok",
         "weworkremotely", "programathor", "builtin", "jobsch",
         "jobs_cz", "manfred", "thehub", "ycombinator", "wellfound",
-        "infojobs_es", "jobbankca", "seek",
+        "infojobs_es", "jobbankca", "seek", "bytedance",
         # Additional multi-tenant ATSes
         "bamboohr", "breezy", "jazzhr",
         "recruitee", "taleo", "teamtailor",


### PR DESCRIPTION
## Source

ByteDance global careers, using its public credential-free careers API. This is a direct employer careers system, not a job board.

## Safeguards

- full-catalogue runs fail closed on empty, malformed, short, overlapping, or count-changing pages
- duplicate page overlap cannot mask truncation
- source job IDs, descriptions, requirements, locations, timestamps, and canonical URLs are preserved
- scheduled output is retained when a scrape fails

## Validation

- focused Ruff checks passed
- `uv run pytest -q ...` — 101 passed, 1 deselected
- live credential-free probe — 1 passed against the public ByteDance API

Provider-only replacement for the ByteDance half of #217.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new ByteDance careers scraper using their public API, with strict pagination and a 25k-safe description body. Registers `bytedance` as a first-class ATS source and shares parsing with `tiktok`, now preserving legacy location fields.

- **New Features**
  - Added `BytedanceScraper` (hits `jobs.bytedance.com`), builds description from description + requirement, maps `recruit_type` to employment type, and derives location from `city_info` with legacy `city_list` fallback.
  - Registered `ATSType.BYTEDANCE`, exported the scraper, added `ats-companies/bytedance.csv`, and wired pipeline (`singleton`, output `bytedance/jobs.csv`, `fail_closed_on_empty: true`). Set dedup priority to 1.
  - Robust pagination: stable total validation, short/empty/overlap detection, and unique-ID count checks.
  - Added unit, contract, and live smoke tests.

- **Refactors**
  - Introduced shared Throne helpers (`_throne`) for description composition (25k cap), label/location mapping (including legacy `city_list`), and salary parsing; switched `tiktok` to use them, removing duplicate code and fixing prior 10k body truncation.

<sup>Written for commit 8a271f7013d94c044ce64ba65e3d92afceaaaca0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds ByteDance as a first-class careers source.
- Registers the ByteDance scraper and pipeline configuration.
- Introduces shared ByteDance/TikTok parsing helpers with the intended 25,000-character description limit.
- Adds pagination safeguards, source metadata mapping, and focused contract and live tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain; the ByteDance description-truncation issue is fully addressed by the shared 25,000-character helper.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Baseline live test was executed before the change and passed in 13.01s, the endpoint returned 200 OK, and the record was normalized with ID, title, company, URL, location, and employment type.
- Post-change live test was executed after the change and passed in 60.53s, the endpoint returned 200 OK, and the same record was normalized correctly.
- The validation run did not use credentials, mocks, local services, or unrelated suites.
- Evidence artifacts consisting of two test logs were collected and attached for review.

<a href="https://app.greptile.com/trex/runs/15788509/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/ats_scrapers/scrapers/_throne.py | Centralizes shared Throne parsing and preserves posting descriptions up to the repository’s 25,000-character limit. |
| src/ats_scrapers/scrapers/bytedance.py | Adds the ByteDance adapter with validated full-catalogue pagination and delegates description composition to the corrected shared helper. |
| src/ats_scrapers/scrapers/tiktok.py | Replaces local parsing helpers with behaviorally equivalent shared Throne helpers. |
| scripts/run_pipeline.py | Registers ByteDance as a fail-closed singleton pipeline source. |
| tests/test_bytedance.py | Covers ByteDance parsing, pagination failure modes, retries, and the corrected 25,000-character description cap. |

<sub>Reviews (4): Last reviewed commit: ["Preserve legacy Throne job locations"](https://github.com/kalil0321/ats-scrapers/commit/8a271f7013d94c044ce64ba65e3d92afceaaaca0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47069350)</sub>

<!-- /greptile_comment -->