### PR TITLE
Add PageUp ATS scraper

### DIFF
--- a/ats-companies/pageup.csv
+++ b/ats-companies/pageup.csv
@@ -1,0 +1,14 @@
+name,slug,url
+Arts Centre Melbourne,902/cw/en,https://careers.pageuppeople.com/902/cw/en
+Bed Bath N' Table,940/cw/en,https://careers.pageuppeople.com/940/cw/en
+California State University,873/cw/en-us,https://careers.pageuppeople.com/873/cw/en-us
+Indiana Wesleyan University,1053/cw/en,https://careers.pageuppeople.com/1053/cw/en
+Johnson & Wales University,859/cw/en-us,https://careers.pageuppeople.com/859/cw/en-us
+Lehigh University,865/cw/en-us,https://careers.pageuppeople.com/865/cw/en-us
+Mercedes-AMG High Performance Powertrains,920/cw/en,https://careers.pageuppeople.com/920/cw/en
+Monash University,513/cw/en,https://careers.pageuppeople.com/513/cw/en
+NSW Department of Climate Change Energy the Environment and Water,795/cw/en,https://careers.pageuppeople.com/795/cw/en
+Quinnipiac University,871/cw/en-us,https://careers.pageuppeople.com/871/cw/en-us
+South Carolina State University,1078/cw/en,https://careers.pageuppeople.com/1078/cw/en
+University of Dayton,875/cw/en-us,https://careers.pageuppeople.com/875/cw/en-us
+Western Washington University,793/cw/en-us,https://careers.pageuppeople.com/793/cw/en-us

--- a/pipeline/publisher.py
+++ b/pipeline/publisher.py
@@ -538,7 +538,7 @@ ATS_DEDUP_PRIORITY: dict[str, int] = {
     "breezy": 1, "cornerstone": 1,
     "darwinbox": 1,
     "greenhouse": 1, "gupy": 1, "icims": 1, "jazzhr": 1, "join_com": 1, "lever": 1,
-    "moka": 1, "oracle": 1, "personio": 1, "phenom": 1, "pinpoint": 1, "recruitee": 1,
+    "moka": 1, "oracle": 1, "pageup": 1, "personio": 1, "phenom": 1, "pinpoint": 1, "recruitee": 1,
     "recruiterbox": 1, "rippling": 1, "smartrecruiters": 1,
     "successfactors": 1, "taleo": 1, "teamtailor": 1, "workable": 1,
     "workday": 1,

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -70,6 +70,7 @@ from ats_scrapers.scrapers import (
     MetaScraper,
     MokaScraper,
     OracleScraper,
+    PageUpScraper,
     PersonioScraper,
     PhenomScraper,
     PinpointScraper,
@@ -466,6 +467,15 @@ CONFIGS: dict[str, dict[str, Any]] = {
         "slug": lambda r: _slug_col(r) or (r.get("name") or "").strip() or None,
         "csv": "ats-companies/jazzhr.csv",
         "output": "jazzhr/jobs.csv",
+    },
+    "pageup": {
+        "scraper": PageUpScraper,
+        "slug": lambda r: _slug_col(r) or (r.get("name") or "").strip() or None,
+        "kwargs": lambda r: {"company_name": (r.get("name") or "").strip()},
+        "csv": "ats-companies/pageup.csv",
+        "output": "pageup/jobs.csv",
+        "fail_closed_on_any_error": True,
+        "fail_closed_on_empty": True,
     },
     "recruitee": {
         "scraper": RecruiteeScraper,

--- a/src/ats_scrapers/models.py
+++ b/src/ats_scrapers/models.py
@@ -49,6 +49,7 @@ class ATSType(StrEnum):
     MERCOR = "mercor"
     MOKA = "moka"
     ORACLE = "oracle"
+    PAGEUP = "pageup"
     PERSONIO = "personio"
     PHENOM = "phenom"
     PINPOINT = "pinpoint"

--- a/src/ats_scrapers/resolve.py
+++ b/src/ats_scrapers/resolve.py
@@ -88,6 +88,9 @@ _SUBDOMAIN_SUFFIXES: dict[str, ATSType] = {
 _WORKDAY_HOST_RE = re.compile(r"^[^.]+\.wd\d+\.myworkdayjobs\.com$")
 _TALEO_HOST_RE = re.compile(r"^[^.]+\.tbe\.taleo\.net$")
 _ICIMS_HOST_RE = re.compile(r"^(?P<prefix>[a-z0-9-]+)\.icims\.com$", re.IGNORECASE)
+_PAGEUP_CLIENT_RE = re.compile(r"^\d+$")
+_PAGEUP_SEGMENT_RE = re.compile(r"^[A-Za-z0-9-]+$")
+_PAGEUP_LOCALE_RE = re.compile(r"^[A-Za-z]{2}(?:-[A-Za-z]{2})?$")
 
 
 def resolve_careers_url(url: str) -> ResolvedCareersUrl | None:
@@ -108,6 +111,22 @@ def resolve_careers_url(url: str) -> ResolvedCareersUrl | None:
         slug = _first_path_segment(parsed)
         if slug and _SLUG_RE.match(slug):
             return ResolvedCareersUrl(_PATH_HOSTS[host], slug)
+        return None
+
+    if host == "careers.pageuppeople.com":
+        segments = [segment for segment in parsed.path.split("/") if segment]
+        if segments and segments[0].lower() == "mob":
+            segments.pop(0)
+        if (
+            len(segments) >= 3
+            and _PAGEUP_CLIENT_RE.fullmatch(segments[0])
+            and _PAGEUP_SEGMENT_RE.fullmatch(segments[1])
+            and _PAGEUP_LOCALE_RE.fullmatch(segments[2])
+        ):
+            return ResolvedCareersUrl(
+                ATSType.PAGEUP,
+                "/".join(segments[:3]),
+            )
         return None
 
     # join.com/companies/{slug}

--- a/src/ats_scrapers/scrapers/__init__.py
+++ b/src/ats_scrapers/scrapers/__init__.py
@@ -43,6 +43,7 @@ from ats_scrapers.scrapers.mercor import MercorScraper
 from ats_scrapers.scrapers.meta import MetaScraper
 from ats_scrapers.scrapers.moka import MokaScraper
 from ats_scrapers.scrapers.oracle import OracleScraper
+from ats_scrapers.scrapers.pageup import PageUpScraper
 from ats_scrapers.scrapers.personio import PersonioScraper
 from ats_scrapers.scrapers.phenom import PhenomScraper
 from ats_scrapers.scrapers.pinpoint import PinpointScraper
@@ -104,6 +105,7 @@ __all__ = [
     "MetaScraper",
     "MokaScraper",
     "OracleScraper",
+    "PageUpScraper",
     "PersonioScraper",
     "PhenomScraper",
     "PinpointScraper",

--- a/src/ats_scrapers/scrapers/pageup.py
+++ b/src/ats_scrapers/scrapers/pageup.py
@@ -1,0 +1,549 @@
+"""PageUp public careers scraper."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import html
+import logging
+import re
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, ClassVar
+from urllib.parse import urljoin, urlparse
+
+from pydantic import HttpUrl
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType, EmploymentType, Job
+from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from bs4 import BeautifulSoup, Tag
+
+    from ats_scrapers.fetch import Fetcher
+
+BASE_URL = "https://careers.pageuppeople.com"
+PAGE_SIZE = 1000
+DETAIL_CONCURRENCY = 8
+_TENANT_RE = re.compile(
+    r"^(?P<client>\d+)/(?P<channel>[A-Za-z0-9-]+)/"
+    r"(?P<locale>[A-Za-z]{2}(?:-[A-Za-z]{2})?)$"
+)
+_JOB_ID_RE = re.compile(r"/job/(\d+)(?:/|$)", re.IGNORECASE)
+_COUNT_RE = re.compile(r"\d[\d,]*")
+_NO_JOBS_MARKERS = (
+    "no jobs matched",
+    "no jobs available",
+    "there are no jobs available",
+    "no current opportunities",
+)
+_EMPLOYMENT_PATTERNS: tuple[tuple[str, EmploymentType], ...] = (
+    ("intern", "INTERN"),
+    ("casual", "TEMPORARY"),
+    ("temporary", "TEMPORARY"),
+    ("fixed term", "CONTRACT"),
+    ("fixed-term", "CONTRACT"),
+    ("contract", "CONTRACT"),
+    ("part time", "PART_TIME"),
+    ("part-time", "PART_TIME"),
+    ("full time", "FULL_TIME"),
+    ("full-time", "FULL_TIME"),
+    ("ongoing", "FULL_TIME"),
+    ("permanent", "FULL_TIME"),
+)
+_DATE_FORMATS = (
+    "%Y-%m-%d",
+    "%d %b %Y",
+    "%d %B %Y",
+    "%B %d, %Y",
+    "%b %d, %Y",
+)
+logger = logging.getLogger(__name__)
+
+
+@ScraperRegistry.register(ATSType.PAGEUP)
+class PageUpScraper(BaseScraper):
+    """Scrape one public ``careers.pageuppeople.com`` tenant."""
+
+    ats = ATSType.PAGEUP
+    default_headers: ClassVar[dict[str, str]] = {
+        "Accept": "text/html,application/xhtml+xml",
+        "User-Agent": "Mozilla/5.0",
+    }
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        include_descriptions: bool = True,
+        proxy: str | None = None,
+        company_name: str | None = None,
+    ) -> None:
+        super().__init__(
+            company_slug,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        self.tenant_path = _normalize_tenant_path(company_slug)
+        match = _TENANT_RE.fullmatch(self.tenant_path)
+        if match is None:
+            raise ValueError(f"Invalid PageUp tenant path: {company_slug!r}")
+        self.language = match.group("locale").split("-", 1)[0].lower()
+        self.company_name = (
+            company_name.strip()
+            if isinstance(company_name, str) and company_name.strip()
+            else f"PageUp {match.group('client')}"
+        )
+        self.base_url = f"{BASE_URL}/{self.tenant_path}"
+
+    async def afetch(self) -> list[Job]:
+        jobs: list[Job] = []
+        seen_ids: set[str] = set()
+        visited_urls: set[str] = set()
+        expected_total: int | None = None
+        next_url: str | None = (
+            f"{self.base_url}/listing/?page=1&page-items={PAGE_SIZE}"
+        )
+
+        async with self.make_fetcher() as fetch:
+            while next_url is not None:
+                if next_url in visited_urls:
+                    raise ScraperError(
+                        f"PageUp ({self.tenant_path}) repeated a pagination URL"
+                    )
+                visited_urls.add(next_url)
+                listing_html = await fetch.get_text(next_url)
+                page_jobs, next_url, remaining = self._parse_listing(listing_html)
+                if not jobs and remaining is not None:
+                    expected_total = len(page_jobs) + remaining
+                for job in page_jobs:
+                    if not job.ats_id or job.ats_id in seen_ids:
+                        raise ScraperError(
+                            f"PageUp returned duplicate job id {job.ats_id!r}"
+                        )
+                    seen_ids.add(job.ats_id)
+                    jobs.append(job)
+
+            if expected_total is not None and len(jobs) != expected_total:
+                raise ScraperError(
+                    "PageUp catalogue ended before the reported total "
+                    f"({len(jobs)}/{expected_total})"
+                )
+            if not self.include_descriptions or not jobs:
+                return jobs
+
+            semaphore = asyncio.Semaphore(DETAIL_CONCURRENCY)
+            enriched = await asyncio.gather(
+                *(self._enrich_detail(fetch, semaphore, job) for job in jobs)
+            )
+        return [job for job in enriched if job is not None]
+
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        copy = job.model_copy(deep=True)
+
+        async def run() -> str | None:
+            async with self.make_fetcher() as fetch:
+                enriched = await self._enrich_detail(
+                    fetch,
+                    asyncio.Semaphore(1),
+                    copy,
+                )
+            return enriched.description if enriched is not None else None
+
+        return self._run_sync(run())
+
+    async def _enrich_detail(
+        self,
+        fetch: Fetcher,
+        semaphore: asyncio.Semaphore,
+        job: Job,
+    ) -> Job | None:
+        try:
+            async with semaphore:
+                response = await fetch.request(
+                    "GET",
+                    str(job.url),
+                    handled={404, 410},
+                )
+        except ScraperError as exc:
+            logger.warning(
+                "Dropping PageUp job %s after detail failure: %s",
+                job.ats_id,
+                exc,
+            )
+            return None
+        if response.status_code in {404, 410}:
+            return None
+        try:
+            _apply_detail(job, response.text)
+        except ScraperError as exc:
+            logger.warning(
+                "Dropping PageUp job %s after detail parse failure: %s",
+                job.ats_id,
+                exc,
+            )
+            return None
+        if not job.description:
+            logger.warning(
+                "Dropping PageUp job %s because its detail page omitted "
+                "a description",
+                job.ats_id,
+            )
+            return None
+        return job
+
+    def _parse_listing(
+        self,
+        html_text: str,
+    ) -> tuple[list[Job], str | None, int | None]:
+        soup = _parse_html(html_text)
+        container = soup.select_one("#search-results-content")
+        if container is None:
+            page_text = _clean_text(soup.get_text(" ", strip=True)).lower()
+            if any(marker in page_text for marker in _NO_JOBS_MARKERS):
+                return [], None, None
+            raise ScraperError(
+                f"PageUp ({self.tenant_path}) omitted search results"
+            )
+
+        anchors = container.select('a.job-link[href*="/job/"]')
+        if not anchors:
+            page_text = _clean_text(container.get_text(" ", strip=True)).lower()
+            if any(marker in page_text for marker in _NO_JOBS_MARKERS):
+                return [], None, None
+            raise ScraperError(
+                f"PageUp ({self.tenant_path}) returned an empty job list"
+            )
+
+        anchors_by_id: dict[str, Tag] = {}
+        for anchor in anchors:
+            href = anchor.get("href")
+            if not isinstance(href, str):
+                continue
+            match = _JOB_ID_RE.search(href)
+            title = _clean_text(anchor.get_text(" ", strip=True))
+            if match is None or not title:
+                continue
+            job_id = match.group(1)
+            existing = anchors_by_id.get(job_id)
+            if existing is None:
+                anchors_by_id[job_id] = anchor
+                continue
+            existing_title = _clean_text(existing.get_text(" ", strip=True))
+            if _is_generic_link_text(existing_title):
+                anchors_by_id[job_id] = anchor
+            elif not _is_generic_link_text(title):
+                raise ScraperError(
+                    f"PageUp returned duplicate job id {job_id!r}"
+                )
+
+        jobs: list[Job] = []
+        for job_id, anchor in anchors_by_id.items():
+            href = anchor.get("href")
+            if not isinstance(href, str):
+                continue
+            title = _clean_text(anchor.get_text(" ", strip=True))
+            if _is_generic_link_text(title):
+                continue
+            detail_url = self._tenant_url(href, expected_segment="job")
+            row = anchor.find_parent("tr") or anchor.find_parent(class_="card")
+            location_node = row.select_one(".location") if row else None
+            location = (
+                _clean_text(location_node.get_text(" ", strip=True))
+                if location_node is not None
+                else ""
+            )
+            work_type_node = row.select_one(".work-type") if row else None
+            work_type = (
+                _clean_text(work_type_node.get_text(" ", strip=True))
+                if work_type_node is not None
+                else ""
+            )
+            department_node = row.select_one(".department") if row else None
+            department = (
+                _clean_text(department_node.get_text(" ", strip=True))
+                if department_node is not None
+                else ""
+            )
+            raw: dict[str, Any] = {}
+            if row is not None:
+                closing = row.select_one(".close-date time")
+                if closing is not None:
+                    closes_at = closing.get("datetime")
+                    if isinstance(closes_at, str) and closes_at:
+                        raw["closes_at"] = closes_at
+                summary = row.find_next_sibling("tr", class_="summary")
+                if summary is not None:
+                    summary_text = _clean_text(summary.get_text(" ", strip=True))
+                    if summary_text:
+                        raw["listing_summary"] = summary_text
+            jobs.append(
+                Job(
+                    url=HttpUrl(detail_url),
+                    title=title,
+                    company=self.company_name,
+                    ats_type=ATSType.PAGEUP,
+                    ats_id=job_id,
+                    location=location or None,
+                    is_remote=(
+                        True if location and "remote" in location.lower() else None
+                    ),
+                    employment_type=_employment_type(work_type),
+                    department=department or None,
+                    commitment=work_type or None,
+                    language=self.language,
+                    fetched_at=datetime.now(UTC),
+                    raw=raw or None,
+                )
+            )
+
+        table = container.find_parent("table")
+        sibling = table.find_next_sibling() if table is not None else None
+        more_link = (
+            sibling.select_one("a.more-link[href]")
+            if sibling is not None and sibling.name == "p"
+            else None
+        )
+        if more_link is None:
+            return jobs, None, None
+        href = more_link.get("href")
+        if not isinstance(href, str) or not href:
+            raise ScraperError(
+                f"PageUp ({self.tenant_path}) returned an invalid next page"
+            )
+        count_node = more_link.select_one(".count")
+        count_match = _COUNT_RE.search(
+            count_node.get_text(" ", strip=True) if count_node else ""
+        )
+        if count_match is None:
+            raise ScraperError(
+                f"PageUp ({self.tenant_path}) omitted remaining-job count"
+            )
+        remaining = int(count_match.group(0).replace(",", ""))
+        if remaining <= 0:
+            raise ScraperError(
+                f"PageUp ({self.tenant_path}) returned invalid remaining count"
+            )
+        return jobs, self._tenant_url(
+            href,
+            expected_segment="listing",
+        ), remaining
+
+    def _tenant_url(self, href: str, *, expected_segment: str) -> str:
+        resolved = urljoin(f"{BASE_URL}/", href)
+        parsed = urlparse(resolved)
+        expected_prefix = (
+            f"/{self.tenant_path}/{expected_segment}"
+        ).casefold()
+        normalized_path = parsed.path.casefold().rstrip("/")
+        if (
+            parsed.scheme != "https"
+            or parsed.hostname != "careers.pageuppeople.com"
+            or not (
+                normalized_path == expected_prefix
+                or normalized_path.startswith(f"{expected_prefix}/")
+            )
+        ):
+            raise ScraperError(
+                f"PageUp ({self.tenant_path}) returned an unsafe "
+                f"{expected_segment} URL"
+            )
+        return resolved
+
+
+def _normalize_tenant_path(value: str) -> str:
+    raw = value.strip().rstrip("/")
+    if not raw:
+        raise ValueError("PageUp tenant path cannot be empty")
+    if raw.startswith(("http://", "https://")):
+        parsed = urlparse(raw)
+        if (
+            parsed.scheme != "https"
+            or parsed.hostname != "careers.pageuppeople.com"
+        ):
+            raise ValueError(
+                "PageUp tenant URL must use https://careers.pageuppeople.com"
+            )
+        raw = parsed.path.strip("/")
+    segments = [segment for segment in raw.split("/") if segment]
+    if segments and segments[0].lower() == "mob":
+        segments.pop(0)
+    while segments and segments[-1].lower() in {
+        "listing",
+        "search",
+        "job",
+    }:
+        segments.pop()
+    normalized = "/".join(segments)
+    if _TENANT_RE.fullmatch(normalized) is None:
+        raise ValueError(f"Invalid PageUp tenant path: {value!r}")
+    return normalized
+
+
+def _apply_detail(job: Job, html_text: str) -> None:
+    soup = _parse_html(html_text)
+    container = soup.select_one("#job-content")
+    if container is None:
+        raise ScraperError(f"PageUp detail page missing content for {job.ats_id}")
+
+    metadata = _extract_metadata(container)
+    if requisition_id := _first_metadata(
+        metadata,
+        "job no",
+        "job no.",
+        "job number",
+        "position number",
+    ):
+        job.requisition_id = requisition_id
+    if location := _first_metadata(metadata, "location", "locations"):
+        job.location = location
+        if "remote" in location.lower():
+            job.is_remote = True
+    if work_type := _first_metadata(
+        metadata,
+        "work type",
+        "employment type",
+        "position type",
+        "appointment type",
+    ):
+        job.employment_type = _employment_type(work_type)
+        job.commitment = work_type
+    if commitment := _first_metadata(
+        metadata,
+        "duration",
+        "job duration",
+    ):
+        job.commitment = (
+            f"{job.commitment}; {commitment}"
+            if job.commitment
+            else commitment
+        )
+    if department := _first_metadata(
+        metadata,
+        "department",
+        "category",
+        "categories",
+        "division/organization",
+        "faculty / portfolio",
+    ):
+        job.department = department
+    if salary := _first_metadata(
+        metadata,
+        "salary",
+        "salary range",
+        "salary/wage range or lump sum",
+        "remuneration",
+        "level / salary",
+    ):
+        job.salary_summary = salary
+    if posted := _first_metadata(
+        metadata,
+        "open date",
+        "date advertised",
+        "posting date",
+        "posted",
+    ):
+        job.posted_at = _parse_date(posted)
+
+    apply_link = container.select_one("a.apply-link[href]")
+    if apply_link is not None:
+        href = apply_link.get("href")
+        if isinstance(href, str) and href:
+            job.apply_url = HttpUrl(urljoin(str(job.url), href))
+
+    description_soup = _parse_html(str(container))
+    description = description_soup.select_one("#job-content")
+    if description is None:
+        return
+    for node in description.select(
+        "script, style, noscript, .social-share-kit, "
+        "a.apply-link, a.back-link, a.employee-referral-link"
+    ):
+        node.decompose()
+    job.description = _clean_text(
+        description.get_text("\n", strip=True)
+    )[:25_000] or None
+
+
+def _extract_metadata(container: Tag) -> dict[str, list[str]]:
+    values: dict[str, list[str]] = {}
+    for label_node in container.select("strong"):
+        label = _clean_text(label_node.get_text(" ", strip=True))
+        normalized = label.lower().strip(" :.")
+        if not normalized or len(normalized) > 40:
+            continue
+        parent = label_node.parent
+        if parent is None:
+            continue
+        full_text = _clean_text(parent.get_text(" ", strip=True))
+        if not full_text.lower().startswith(label.lower()):
+            continue
+        value = full_text[len(label) :].lstrip(" :.-")
+        if value and value not in values.setdefault(normalized, []):
+            values[normalized].append(value)
+    return values
+
+
+def _first_metadata(
+    metadata: dict[str, list[str]],
+    *keys: str,
+) -> str | None:
+    for key in keys:
+        values = metadata.get(key)
+        if values:
+            return "; ".join(values)
+    return None
+
+
+def _employment_type(value: str) -> EmploymentType | None:
+    normalized = value.lower().replace("_", " ")
+    for needle, mapped in _EMPLOYMENT_PATTERNS:
+        if needle in normalized:
+            return mapped
+    return None
+
+
+def _is_generic_link_text(value: str) -> bool:
+    return value.lower().strip(" .:") in {
+        "apply",
+        "apply now",
+        "details",
+        "learn more",
+        "view",
+        "view job",
+    }
+
+
+def _parse_date(value: str) -> datetime | None:
+    candidate = value.strip()
+    with contextlib.suppress(ValueError):
+        parsed = datetime.fromisoformat(candidate.replace("Z", "+00:00"))
+        return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+    for date_format in _DATE_FORMATS:
+        with contextlib.suppress(ValueError):
+            return datetime.strptime(candidate, date_format).replace(tzinfo=UTC)
+    return None
+
+
+def _parse_html(html_text: str) -> BeautifulSoup:
+    try:
+        from bs4 import BeautifulSoup
+    except ImportError as exc:
+        raise ScraperError(
+            "PageUp scraper requires beautifulsoup4; "
+            "install `ats-scrapers[scrapers]`"
+        ) from exc
+    return BeautifulSoup(html_text, "html.parser")
+
+
+def _clean_text(value: str) -> str:
+    unescaped = html.unescape(value)
+    lines = [
+        re.sub(r"[ \t\r\f\v]+", " ", line).strip()
+        for line in unescaped.splitlines()
+    ]
+    return "\n".join(line for line in lines if line).strip()

--- a/src/ats_scrapers/scrapers/pageup.py
+++ b/src/ats_scrapers/scrapers/pageup.py
@@ -138,7 +138,13 @@ class PageUpScraper(BaseScraper):
             enriched = await asyncio.gather(
                 *(self._enrich_detail(fetch, semaphore, job) for job in jobs)
             )
-        return [job for job in enriched if job is not None]
+        completed = [job for job in enriched if job is not None]
+        if jobs and not completed:
+            raise ScraperError(
+                f"PageUp ({self.tenant_path}) lost every listed job "
+                "during detail validation"
+            )
+        return completed
 
     def get_description(self, job: Job) -> str | None:
         if job.description:
@@ -162,21 +168,15 @@ class PageUpScraper(BaseScraper):
         semaphore: asyncio.Semaphore,
         job: Job,
     ) -> Job | None:
-        try:
-            async with semaphore:
-                response = await fetch.request(
-                    "GET",
-                    str(job.url),
-                    handled={404, 410},
-                )
-        except ScraperError as exc:
-            logger.warning(
-                "Dropping PageUp job %s after detail failure: %s",
-                job.ats_id,
-                exc,
+        async with semaphore:
+            response = await fetch.request(
+                "GET",
+                str(job.url),
+                handled={404, 410},
             )
-            return None
         if response.status_code in {404, 410}:
+            return None
+        if "jobnotfound=true" in response.text.lower():
             return None
         try:
             _apply_detail(job, response.text)
@@ -301,11 +301,15 @@ class PageUpScraper(BaseScraper):
                 )
             )
 
-        table = container.find_parent("table")
-        sibling = table.find_next_sibling() if table is not None else None
+        if not jobs:
+            raise ScraperError(
+                f"PageUp ({self.tenant_path}) returned no usable jobs"
+            )
+
+        results_wrapper = container.find_parent(id="search-results")
         more_link = (
-            sibling.select_one("a.more-link[href]")
-            if sibling is not None and sibling.name == "p"
+            results_wrapper.select_one("a.more-link[href]")
+            if results_wrapper is not None
             else None
         )
         if more_link is None:

--- a/src/ats_scrapers/scrapers/pageup.py
+++ b/src/ats_scrapers/scrapers/pageup.py
@@ -414,8 +414,7 @@ def _apply_detail(job: Job, html_text: str) -> None:
         job.requisition_id = requisition_id
     if location := _first_metadata(metadata, "location", "locations"):
         job.location = location
-        if "remote" in location.lower():
-            job.is_remote = True
+        job.is_remote = True if "remote" in location.lower() else None
     if work_type := _first_metadata(
         metadata,
         "work type",

--- a/src/ats_scrapers/scrapers/pageup.py
+++ b/src/ats_scrapers/scrapers/pageup.py
@@ -347,8 +347,15 @@ class PageUpScraper(BaseScraper):
         ), remaining
 
     def _tenant_url(self, href: str, *, expected_segment: str) -> str:
-        resolved = urljoin(f"{BASE_URL}/", href)
-        parsed = urlparse(resolved)
+        try:
+            resolved = urljoin(f"{BASE_URL}/", href)
+            parsed = urlparse(resolved)
+            port = parsed.port
+        except ValueError as exc:
+            raise ScraperError(
+                f"PageUp ({self.tenant_path}) returned an unsafe "
+                f"{expected_segment} URL"
+            ) from exc
         expected_prefix = (
             f"/{self.tenant_path}/{expected_segment}"
         ).casefold()
@@ -356,6 +363,7 @@ class PageUpScraper(BaseScraper):
         if (
             parsed.scheme != "https"
             or parsed.hostname != "careers.pageuppeople.com"
+            or port not in (None, 443)
             or not (
                 normalized_path == expected_prefix
                 or normalized_path.startswith(f"{expected_prefix}/")
@@ -377,6 +385,7 @@ def _normalize_tenant_path(value: str) -> str:
         if (
             parsed.scheme != "https"
             or parsed.hostname != "careers.pageuppeople.com"
+            or parsed.port not in (None, 443)
         ):
             raise ValueError(
                 "PageUp tenant URL must use https://careers.pageuppeople.com"

--- a/src/ats_scrapers/scrapers/pageup.py
+++ b/src/ats_scrapers/scrapers/pageup.py
@@ -11,7 +11,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, ClassVar
 from urllib.parse import urljoin, urlparse
 
-from pydantic import HttpUrl
+from pydantic import HttpUrl, ValidationError
 
 from ats_scrapers.exceptions import ScraperError
 from ats_scrapers.models import ATSType, EmploymentType, Job
@@ -466,7 +466,13 @@ def _apply_detail(job: Job, html_text: str) -> None:
     if apply_link is not None:
         href = apply_link.get("href")
         if isinstance(href, str) and href:
-            job.apply_url = HttpUrl(urljoin(str(job.url), href))
+            try:
+                job.apply_url = HttpUrl(urljoin(str(job.url), href))
+            except ValidationError:
+                logger.warning(
+                    "Ignoring invalid PageUp apply URL for job %s",
+                    job.ats_id,
+                )
 
     description_soup = _parse_html(str(container))
     description = description_soup.select_one("#job-content")

--- a/src/ats_scrapers/scrapers/pageup.py
+++ b/src/ats_scrapers/scrapers/pageup.py
@@ -168,12 +168,20 @@ class PageUpScraper(BaseScraper):
         semaphore: asyncio.Semaphore,
         job: Job,
     ) -> Job | None:
-        async with semaphore:
-            response = await fetch.request(
-                "GET",
-                str(job.url),
-                handled={404, 410},
+        try:
+            async with semaphore:
+                response = await fetch.request(
+                    "GET",
+                    str(job.url),
+                    handled={404, 410},
+                )
+        except ScraperError as exc:
+            logger.warning(
+                "Dropping PageUp job %s after detail failure: %s",
+                job.ats_id,
+                exc,
             )
+            return None
         if response.status_code in {404, 410}:
             return None
         if "jobnotfound=true" in response.text.lower():
@@ -287,7 +295,8 @@ class PageUpScraper(BaseScraper):
                     title=title,
                     company=self.company_name,
                     ats_type=ATSType.PAGEUP,
-                    ats_id=job_id,
+                    ats_id=f"{self.tenant_path}:{job_id}",
+                    requisition_id=job_id,
                     location=location or None,
                     is_remote=(
                         True if location and "remote" in location.lower() else None

--- a/src/ats_scrapers/scrapers/pageup.py
+++ b/src/ats_scrapers/scrapers/pageup.py
@@ -466,7 +466,20 @@ def _apply_detail(job: Job, html_text: str) -> None:
         href = apply_link.get("href")
         if isinstance(href, str) and href:
             try:
-                job.apply_url = HttpUrl(urljoin(str(job.url), href))
+                apply_url = urljoin(str(job.url), href)
+                parsed_apply = urlparse(apply_url)
+                if (
+                    parsed_apply.scheme != "https"
+                    or parsed_apply.hostname is None
+                    or not (
+                        parsed_apply.hostname == "careers.pageuppeople.com"
+                        or parsed_apply.hostname.endswith(".pageuppeople.com")
+                    )
+                    or parsed_apply.username is not None
+                    or parsed_apply.password is not None
+                ):
+                    raise ValueError("unsafe PageUp apply URL")
+                job.apply_url = HttpUrl(apply_url)
             except (ValidationError, ValueError):
                 logger.warning(
                     "Ignoring invalid PageUp apply URL for job %s",

--- a/src/ats_scrapers/scrapers/pageup.py
+++ b/src/ats_scrapers/scrapers/pageup.py
@@ -477,6 +477,7 @@ def _apply_detail(job: Job, html_text: str) -> None:
                     )
                     or parsed_apply.username is not None
                     or parsed_apply.password is not None
+                    or parsed_apply.port not in (None, 443)
                 ):
                     raise ValueError("unsafe PageUp apply URL")
                 job.apply_url = HttpUrl(apply_url)

--- a/src/ats_scrapers/scrapers/pageup.py
+++ b/src/ats_scrapers/scrapers/pageup.py
@@ -468,7 +468,7 @@ def _apply_detail(job: Job, html_text: str) -> None:
         if isinstance(href, str) and href:
             try:
                 job.apply_url = HttpUrl(urljoin(str(job.url), href))
-            except ValidationError:
+            except (ValidationError, ValueError):
                 logger.warning(
                     "Ignoring invalid PageUp apply URL for job %s",
                     job.ats_id,

--- a/tests/e2e/test_live_pageup.py
+++ b/tests/e2e/test_live_pageup.py
@@ -29,7 +29,7 @@ async def test_live_pageup_smoke() -> None:
     assert len({job.ats_id for job in jobs}) == len(jobs)
     assert all(job.title.strip() for job in jobs)
     assert all(job.description for job in jobs)
-    assert all(":" in job.global_id for job in jobs)
+    assert all(job.ats_id.startswith("902/cw/en:") for job in jobs)
     assert all("careers.pageuppeople.com" in str(job.url) for job in jobs)
 
 

--- a/tests/e2e/test_live_pageup.py
+++ b/tests/e2e/test_live_pageup.py
@@ -1,0 +1,44 @@
+"""Live smoke test for PageUp."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+from ats_scrapers.scrapers.pageup import PageUpScraper
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.skipif(
+        not os.getenv("ATS_SCRAPERS_LIVE_E2E"),
+        reason="set ATS_SCRAPERS_LIVE_E2E=1 to hit real PageUp endpoints",
+    ),
+]
+
+
+async def test_live_pageup_smoke() -> None:
+    async with asyncio.timeout(180):
+        jobs = await PageUpScraper(
+            "902/cw/en",
+            company_name="Arts Centre Melbourne",
+        ).afetch()
+
+    assert jobs
+    assert len({job.ats_id for job in jobs}) == len(jobs)
+    assert all(job.title.strip() for job in jobs)
+    assert all(job.description for job in jobs)
+    assert all("careers.pageuppeople.com" in str(job.url) for job in jobs)
+
+
+async def test_live_pageup_large_catalog_paginates() -> None:
+    async with asyncio.timeout(180):
+        jobs = await PageUpScraper(
+            "873/cw/en-us",
+            company_name="California State University",
+            include_descriptions=False,
+        ).afetch()
+
+    assert len(jobs) > 1000
+    assert len({job.ats_id for job in jobs}) == len(jobs)

--- a/tests/e2e/test_live_pageup.py
+++ b/tests/e2e/test_live_pageup.py
@@ -29,6 +29,7 @@ async def test_live_pageup_smoke() -> None:
     assert len({job.ats_id for job in jobs}) == len(jobs)
     assert all(job.title.strip() for job in jobs)
     assert all(job.description for job in jobs)
+    assert all(":" in job.global_id for job in jobs)
     assert all("careers.pageuppeople.com" in str(job.url) for job in jobs)
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -18,7 +18,8 @@ def test_ats_type_includes_every_supported_platform() -> None:
     expected = {
         # Multi-tenant ATS systems
             "ashby", "avature", "beisen", "beisen_legacy", "cornerstone", "darwinbox", "eightfold", "gem", "greenhouse", "gupy",
-        "icims", "join_com", "lever", "mercor", "moka", "oracle", "personio", "phenom",
+        "icims", "join_com", "lever", "mercor", "moka", "oracle", "pageup",
+        "personio", "phenom",
         "pinpoint", "recruiterbox", "rippling", "smartrecruiters",
         "successfactors", "workable", "workday",
         # Big-tech custom careers systems

--- a/tests/test_pageup.py
+++ b/tests/test_pageup.py
@@ -365,7 +365,14 @@ def test_descriptionless_detail_is_dropped_without_aborting(httpx_mock) -> None:
     assert [job.ats_id for job in jobs] == ["513/cw/en:101"]
 
 
-def test_invalid_apply_link_does_not_abort_detail_batch(httpx_mock) -> None:
+@pytest.mark.parametrize(
+    "invalid_apply_url",
+    ["javascript:void(0)", "https://["],
+)
+def test_invalid_apply_link_does_not_abort_detail_batch(
+    httpx_mock,
+    invalid_apply_url: str,
+) -> None:
     httpx_mock.add_response(
         url="https://careers.pageuppeople.com/513/cw/en/listing/?page=1&page-items=1000",
         text=_listing(
@@ -384,7 +391,7 @@ def test_invalid_apply_link_does_not_abort_detail_batch(httpx_mock) -> None:
         text=_detail("102").replace(
             "https://secure.dc2.pageuppeople.com/apply/513/"
             "gateway/default.aspx?c=apply&amp;lJobID=102",
-            "javascript:void(0)",
+            invalid_apply_url,
         ),
     )
 

--- a/tests/test_pageup.py
+++ b/tests/test_pageup.py
@@ -1,0 +1,355 @@
+"""Tests for the PageUp public careers scraper."""
+
+from __future__ import annotations
+
+import pytest
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType
+from ats_scrapers.scrapers.pageup import PageUpScraper, _normalize_tenant_path
+
+
+def _listing(
+    rows: list[tuple[str, str, str]],
+    *,
+    next_page: int | None = None,
+    remaining: int | None = None,
+) -> str:
+    rendered = "".join(
+        f"""
+        <tr>
+          <td><a class="job-link" href="/513/cw/en/job/{job_id}/{slug}">
+            {title}
+          </a></td>
+          <td><span class="location">{location}</span></td>
+          <td><span class="close-date">
+            <time datetime="2026-08-07T13:55:00Z">7 Aug 2026</time>
+          </span></td>
+        </tr>
+        <tr class="summary"><td colspan="3">Summary for {title}</td></tr>
+        """
+        for job_id, title, location in rows
+        for slug in [title.lower().replace(" ", "-")]
+    )
+    more = (
+        f"""
+        <p><a class="more-link" href="/513/cw/en/listing/?page={next_page}&amp;page-items=1000">
+          More Jobs <span class="count">{remaining}</span>
+        </a></p>
+        """
+        if next_page is not None
+        else ""
+    )
+    return f"""
+    <html><body>
+      <div id="search-results">
+        <table><tbody id="search-results-content">{rendered}</tbody></table>
+        {more}
+      </div>
+      <div id="recent-jobs">
+        <a class="job-link" href="/513/cw/en/job/999/duplicate">Duplicate</a>
+      </div>
+    </body></html>
+    """
+
+
+def _detail(job_id: str) -> str:
+    return f"""
+    <html><body><div id="job"><div id="job-content">
+      <h3>Platform Engineer</h3>
+      <p><strong>Job No.:</strong> {job_id}</p>
+      <p><strong>Location:</strong> Remote - Australia</p>
+      <p><strong>Employment Type:</strong> Full-time fixed term</p>
+      <p><strong>Duration:</strong> 12 months</p>
+      <p><strong>Department:</strong> Engineering</p>
+      <p><strong>Remuneration:</strong> AUD 100,000 - 120,000 per year</p>
+      <p><strong>Open Date:</strong> July 20, 2026</p>
+      <p>Build reliable systems.</p>
+      <a class="back-link" href="/listing">Back</a>
+      <a class="apply-link" href="https://secure.dc2.pageuppeople.com/apply/513/gateway/default.aspx?c=apply&amp;lJobID={job_id}">
+        Apply now
+      </a>
+    </div></div></body></html>
+    """
+
+
+def test_fetches_all_pages_and_enriches_details(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/listing/?page=1&page-items=1000",
+        text=_listing(
+            [
+                ("101", "Platform Engineer", "Melbourne"),
+                ("102", "Data Analyst", "Sydney"),
+            ],
+            next_page=2,
+            remaining=1,
+        ),
+    )
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/listing/?page=2&page-items=1000",
+        text=_listing([("103", "Product Manager", "Remote")]),
+    )
+    for job_id, title in (
+        ("101", "platform-engineer"),
+        ("102", "data-analyst"),
+        ("103", "product-manager"),
+    ):
+        httpx_mock.add_response(
+            url=f"https://careers.pageuppeople.com/513/cw/en/job/{job_id}/{title}",
+            text=_detail(job_id),
+        )
+
+    jobs = PageUpScraper("513/cw/en", company_name="Monash").fetch()
+
+    assert [job.ats_id for job in jobs] == ["101", "102", "103"]
+    assert all(job.ats_type is ATSType.PAGEUP for job in jobs)
+    assert all(job.company == "Monash" for job in jobs)
+    assert all(job.language == "en" for job in jobs)
+    assert jobs[0].location == "Remote - Australia"
+    assert jobs[0].is_remote is True
+    assert jobs[0].employment_type == "CONTRACT"
+    assert jobs[0].commitment == "Full-time fixed term; 12 months"
+    assert jobs[0].department == "Engineering"
+    assert jobs[0].salary_summary == "AUD 100,000 - 120,000 per year"
+    assert jobs[0].posted_at is not None
+    assert jobs[0].posted_at.tzinfo is not None
+    assert jobs[0].requisition_id == "101"
+    assert jobs[0].description
+    assert "Build reliable systems." in jobs[0].description
+    assert "Apply now" not in jobs[0].description
+    assert str(jobs[0].apply_url).startswith(
+        "https://secure.dc2.pageuppeople.com/apply/513/"
+    )
+    assert jobs[0].raw == {
+        "closes_at": "2026-08-07T13:55:00Z",
+        "listing_summary": "Summary for Platform Engineer",
+    }
+
+
+def test_include_descriptions_false_skips_detail_requests(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/listing/?page=1&page-items=1000",
+        text=_listing([("101", "Engineer", "Melbourne")]),
+    )
+
+    jobs = PageUpScraper(
+        "513/cw/en",
+        company_name="Monash",
+        include_descriptions=False,
+    ).fetch()
+
+    assert len(jobs) == 1
+    assert jobs[0].description is None
+
+
+def test_card_layout_ignores_duplicate_apply_link(httpx_mock) -> None:
+    html_text = """
+    <div id="search-results">
+      <div id="search-results-content">
+        <div class="card">
+          <p class="h1">
+            <a class="job-link" href="/920/cw/en/job/498105/technical-author">
+              Engineering Trainee - Technical Author
+            </a>
+          </p>
+          <p>Work Type: <span class="work-type">Student</span></p>
+          <p>Location: <span class="location">Brixworth</span></p>
+          <p>Department: <span class="department">Assembly Systems</span></p>
+          <a class="job-link" href="/920/cw/en/job/498105/technical-author">
+            Apply
+          </a>
+        </div>
+      </div>
+      <p></p>
+    </div>
+    """
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/920/cw/en/listing/?page=1&page-items=1000",
+        text=html_text,
+    )
+
+    jobs = PageUpScraper(
+        "920/cw/en",
+        include_descriptions=False,
+    ).fetch()
+
+    assert len(jobs) == 1
+    assert jobs[0].ats_id == "498105"
+    assert jobs[0].title == "Engineering Trainee - Technical Author"
+    assert jobs[0].location == "Brixworth"
+    assert jobs[0].department == "Assembly Systems"
+    assert jobs[0].commitment == "Student"
+
+
+def test_closed_job_between_listing_and_detail_is_dropped(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/listing/?page=1&page-items=1000",
+        text=_listing(
+            [
+                ("101", "Engineer", "Melbourne"),
+                ("102", "Designer", "Sydney"),
+            ]
+        ),
+    )
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/job/101/engineer",
+        text=_detail("101"),
+    )
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/job/102/designer",
+        status_code=410,
+    )
+
+    jobs = PageUpScraper("513/cw/en").fetch()
+
+    assert [job.ats_id for job in jobs] == ["101"]
+
+
+def test_descriptionless_detail_is_dropped_without_aborting(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/listing/?page=1&page-items=1000",
+        text=_listing(
+            [
+                ("101", "Engineer", "Melbourne"),
+                ("102", "Designer", "Sydney"),
+            ]
+        ),
+    )
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/job/101/engineer",
+        text=_detail("101"),
+    )
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/job/102/designer",
+        text="<html><body><h1>Designer</h1></body></html>",
+    )
+
+    jobs = PageUpScraper("513/cw/en").fetch()
+
+    assert [job.ats_id for job in jobs] == ["101"]
+
+
+@pytest.mark.parametrize(
+    "href",
+    [
+        "https://evil.example/513/cw/en/job/101/engineer",
+        "//127.0.0.1/513/cw/en/job/101/engineer",
+        "https://careers.pageuppeople.com/999/cw/en/job/101/engineer",
+    ],
+)
+def test_rejects_unsafe_detail_urls(httpx_mock, href: str) -> None:
+    html_text = _listing(
+        [("101", "Engineer", "Melbourne")]
+    ).replace("/513/cw/en/job/101/engineer", href)
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/listing/?page=1&page-items=1000",
+        text=html_text,
+    )
+
+    with pytest.raises(ScraperError, match="unsafe job URL"):
+        PageUpScraper("513/cw/en", include_descriptions=False).fetch()
+
+
+def test_rejects_unsafe_pagination_url(httpx_mock) -> None:
+    html_text = _listing(
+        [("101", "Engineer", "Melbourne")],
+        next_page=2,
+        remaining=1,
+    ).replace(
+        "/513/cw/en/listing/?page=2&amp;page-items=1000",
+        "https://evil.example/513/cw/en/listing/?page=2",
+    )
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/listing/?page=1&page-items=1000",
+        text=html_text,
+    )
+
+    with pytest.raises(ScraperError, match="unsafe listing URL"):
+        PageUpScraper("513/cw/en", include_descriptions=False).fetch()
+
+
+def test_reported_total_mismatch_fails_closed(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/listing/?page=1&page-items=1000",
+        text=_listing(
+            [("101", "Engineer", "Melbourne")],
+            next_page=2,
+            remaining=2,
+        ),
+    )
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/listing/?page=2&page-items=1000",
+        text=_listing([("102", "Designer", "Sydney")]),
+    )
+
+    with pytest.raises(ScraperError, match="reported total"):
+        PageUpScraper("513/cw/en", include_descriptions=False).fetch()
+
+
+def test_duplicate_job_ids_fail_closed(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/listing/?page=1&page-items=1000",
+        text=_listing(
+            [
+                ("101", "Engineer", "Melbourne"),
+                ("101", "Engineer", "Sydney"),
+            ]
+        ),
+    )
+
+    with pytest.raises(ScraperError, match="duplicate job id"):
+        PageUpScraper("513/cw/en", include_descriptions=False).fetch()
+
+
+def test_explicit_no_jobs_returns_empty(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/listing/?page=1&page-items=1000",
+        text="<html><body>There are no jobs available.</body></html>",
+    )
+
+    assert PageUpScraper("513/cw/en").fetch() == []
+
+
+def test_missing_results_container_fails_closed(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/listing/?page=1&page-items=1000",
+        text="<html><body>Maintenance</body></html>",
+    )
+
+    with pytest.raises(ScraperError, match="omitted search results"):
+        PageUpScraper("513/cw/en").fetch()
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("513/cw/en", "513/cw/en"),
+        (
+            "https://careers.pageuppeople.com/865/cw/en-us/Listing/",
+            "865/cw/en-us",
+        ),
+        (
+            "https://careers.pageuppeople.com/mob/1078/cw/en/listing/",
+            "1078/cw/en",
+        ),
+    ],
+)
+def test_normalizes_supported_tenant_paths(value: str, expected: str) -> None:
+    assert _normalize_tenant_path(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "careers.pageuppeople.com/513/cw/en",
+        "http://careers.pageuppeople.com/513/cw/en",
+        "https://evil.example/513/cw/en",
+        "513/cw",
+        "abc/cw/en",
+        "513/cw/en/job/123/title",
+    ],
+)
+def test_rejects_invalid_tenant_paths(value: str) -> None:
+    with pytest.raises(ValueError):
+        _normalize_tenant_path(value)

--- a/tests/test_pageup.py
+++ b/tests/test_pageup.py
@@ -442,6 +442,7 @@ def test_invalid_apply_link_does_not_abort_detail_batch(
         "https://evil.example/513/cw/en/job/101/engineer",
         "//127.0.0.1/513/cw/en/job/101/engineer",
         "https://careers.pageuppeople.com/999/cw/en/job/101/engineer",
+        "https://careers.pageuppeople.com:444/513/cw/en/job/101/engineer",
     ],
 )
 def test_rejects_unsafe_detail_urls(httpx_mock, href: str) -> None:
@@ -569,6 +570,7 @@ def test_normalizes_supported_tenant_paths(value: str, expected: str) -> None:
         "",
         "careers.pageuppeople.com/513/cw/en",
         "http://careers.pageuppeople.com/513/cw/en",
+        "https://careers.pageuppeople.com:444/513/cw/en",
         "https://evil.example/513/cw/en",
         "513/cw",
         "abc/cw/en",

--- a/tests/test_pageup.py
+++ b/tests/test_pageup.py
@@ -397,6 +397,7 @@ def test_descriptionless_detail_is_dropped_without_aborting(httpx_mock) -> None:
         "https://[",
         "https://evil.example/apply",
         "//evil.example/apply",
+        "https://secure.dc2.pageuppeople.com:444/apply",
     ],
 )
 def test_invalid_apply_link_does_not_abort_detail_batch(

--- a/tests/test_pageup.py
+++ b/tests/test_pageup.py
@@ -124,6 +124,31 @@ def test_fetches_all_pages_and_enriches_details(httpx_mock) -> None:
     assert str(jobs[0].apply_url).startswith(
         "https://secure.dc2.pageuppeople.com/apply/513/"
     )
+
+
+def test_detail_location_resets_listing_remote_status(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=(
+            "https://careers.pageuppeople.com/513/cw/en/listing/"
+            "?page=1&page-items=1000"
+        ),
+        text=_listing([("101", "Platform Engineer", "Remote")]),
+    )
+    httpx_mock.add_response(
+        url=(
+            "https://careers.pageuppeople.com/513/cw/en/job/"
+            "101/platform-engineer"
+        ),
+        text=_detail("101").replace(
+            "Remote - Australia",
+            "Sydney, Australia",
+        ),
+    )
+
+    jobs = PageUpScraper("513/cw/en").fetch()
+
+    assert jobs[0].location == "Sydney, Australia"
+    assert jobs[0].is_remote is None
     assert jobs[0].raw == {
         "closes_at": "2026-08-07T13:55:00Z",
         "listing_summary": "Summary for Platform Engineer",

--- a/tests/test_pageup.py
+++ b/tests/test_pageup.py
@@ -181,6 +181,58 @@ def test_card_layout_ignores_duplicate_apply_link(httpx_mock) -> None:
     assert jobs[0].commitment == "Student"
 
 
+def test_card_layout_follows_pagination(httpx_mock) -> None:
+    first_page = """
+    <div id="search-results">
+      <div id="search-results-content">
+        <div class="card">
+          <a class="job-link" href="/920/cw/en/job/101/engineer">Engineer</a>
+        </div>
+      </div>
+      <p><a class="more-link" href="/920/cw/en/listing/?page=2&amp;page-items=1000">
+        More Jobs <span class="count">1</span>
+      </a></p>
+    </div>
+    """
+    second_page = """
+    <div id="search-results">
+      <div id="search-results-content">
+        <div class="card">
+          <a class="job-link" href="/920/cw/en/job/102/designer">Designer</a>
+        </div>
+      </div>
+    </div>
+    """
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/920/cw/en/listing/?page=1&page-items=1000",
+        text=first_page,
+    )
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/920/cw/en/listing/?page=2&page-items=1000",
+        text=second_page,
+    )
+
+    jobs = PageUpScraper("920/cw/en", include_descriptions=False).fetch()
+
+    assert [job.ats_id for job in jobs] == ["101", "102"]
+
+
+def test_generic_job_links_fail_closed(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/listing/?page=1&page-items=1000",
+        text="""
+        <div id="search-results">
+          <div id="search-results-content">
+            <a class="job-link" href="/513/cw/en/job/101/engineer">Apply</a>
+          </div>
+        </div>
+        """,
+    )
+
+    with pytest.raises(ScraperError, match="no usable jobs"):
+        PageUpScraper("513/cw/en", include_descriptions=False).fetch()
+
+
 def test_closed_job_between_listing_and_detail_is_dropped(httpx_mock) -> None:
     httpx_mock.add_response(
         url="https://careers.pageuppeople.com/513/cw/en/listing/?page=1&page-items=1000",
@@ -203,6 +255,58 @@ def test_closed_job_between_listing_and_detail_is_dropped(httpx_mock) -> None:
     jobs = PageUpScraper("513/cw/en").fetch()
 
     assert [job.ats_id for job in jobs] == ["101"]
+
+
+def test_job_not_found_redirect_is_dropped(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/listing/?page=1&page-items=1000",
+        text=_listing(
+            [
+                ("101", "Engineer", "Melbourne"),
+                ("102", "Designer", "Sydney"),
+            ]
+        ),
+    )
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/job/101/engineer",
+        text=_detail("101"),
+    )
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/job/102/designer",
+        status_code=301,
+        headers={
+            "Location": (
+                "https://careers.pageuppeople.com/513/cw/en/listing/"
+                "?jobnotfound=true"
+            )
+        },
+    )
+    httpx_mock.add_response(
+        url=(
+            "https://careers.pageuppeople.com/513/cw/en/listing/"
+            "?jobnotfound=true"
+        ),
+        text='<a href="/513/cw/en/listing/?jobnotfound=true">Jobs</a>',
+    )
+
+    jobs = PageUpScraper("513/cw/en").fetch()
+
+    assert [job.ats_id for job in jobs] == ["101"]
+
+
+def test_systemic_detail_request_failure_fails_closed(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/listing/?page=1&page-items=1000",
+        text=_listing([("101", "Engineer", "Melbourne")]),
+    )
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/job/101/engineer",
+        status_code=500,
+        is_reusable=True,
+    )
+
+    with pytest.raises(ScraperError, match="returned 500"):
+        PageUpScraper("513/cw/en").fetch()
 
 
 def test_descriptionless_detail_is_dropped_without_aborting(httpx_mock) -> None:

--- a/tests/test_pageup.py
+++ b/tests/test_pageup.py
@@ -392,7 +392,12 @@ def test_descriptionless_detail_is_dropped_without_aborting(httpx_mock) -> None:
 
 @pytest.mark.parametrize(
     "invalid_apply_url",
-    ["javascript:void(0)", "https://["],
+    [
+        "javascript:void(0)",
+        "https://[",
+        "https://evil.example/apply",
+        "//evil.example/apply",
+    ],
 )
 def test_invalid_apply_link_does_not_abort_detail_batch(
     httpx_mock,

--- a/tests/test_pageup.py
+++ b/tests/test_pageup.py
@@ -101,7 +101,11 @@ def test_fetches_all_pages_and_enriches_details(httpx_mock) -> None:
 
     jobs = PageUpScraper("513/cw/en", company_name="Monash").fetch()
 
-    assert [job.ats_id for job in jobs] == ["101", "102", "103"]
+    assert [job.ats_id for job in jobs] == [
+        "513/cw/en:101",
+        "513/cw/en:102",
+        "513/cw/en:103",
+    ]
     assert all(job.ats_type is ATSType.PAGEUP for job in jobs)
     assert all(job.company == "Monash" for job in jobs)
     assert all(job.language == "en" for job in jobs)
@@ -174,7 +178,7 @@ def test_card_layout_ignores_duplicate_apply_link(httpx_mock) -> None:
     ).fetch()
 
     assert len(jobs) == 1
-    assert jobs[0].ats_id == "498105"
+    assert jobs[0].ats_id == "920/cw/en:498105"
     assert jobs[0].title == "Engineering Trainee - Technical Author"
     assert jobs[0].location == "Brixworth"
     assert jobs[0].department == "Assembly Systems"
@@ -214,7 +218,10 @@ def test_card_layout_follows_pagination(httpx_mock) -> None:
 
     jobs = PageUpScraper("920/cw/en", include_descriptions=False).fetch()
 
-    assert [job.ats_id for job in jobs] == ["101", "102"]
+    assert [job.ats_id for job in jobs] == [
+        "920/cw/en:101",
+        "920/cw/en:102",
+    ]
 
 
 def test_generic_job_links_fail_closed(httpx_mock) -> None:
@@ -254,7 +261,7 @@ def test_closed_job_between_listing_and_detail_is_dropped(httpx_mock) -> None:
 
     jobs = PageUpScraper("513/cw/en").fetch()
 
-    assert [job.ats_id for job in jobs] == ["101"]
+    assert [job.ats_id for job in jobs] == ["513/cw/en:101"]
 
 
 def test_job_not_found_redirect_is_dropped(httpx_mock) -> None:
@@ -291,7 +298,7 @@ def test_job_not_found_redirect_is_dropped(httpx_mock) -> None:
 
     jobs = PageUpScraper("513/cw/en").fetch()
 
-    assert [job.ats_id for job in jobs] == ["101"]
+    assert [job.ats_id for job in jobs] == ["513/cw/en:101"]
 
 
 def test_systemic_detail_request_failure_fails_closed(httpx_mock) -> None:
@@ -305,8 +312,33 @@ def test_systemic_detail_request_failure_fails_closed(httpx_mock) -> None:
         is_reusable=True,
     )
 
-    with pytest.raises(ScraperError, match="returned 500"):
+    with pytest.raises(ScraperError, match="lost every listed job"):
         PageUpScraper("513/cw/en").fetch()
+
+
+def test_detail_request_failure_drops_only_failed_job(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/listing/?page=1&page-items=1000",
+        text=_listing(
+            [
+                ("101", "Engineer", "Melbourne"),
+                ("102", "Designer", "Sydney"),
+            ]
+        ),
+    )
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/job/101/engineer",
+        text=_detail("101"),
+    )
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/job/102/designer",
+        status_code=500,
+        is_reusable=True,
+    )
+
+    jobs = PageUpScraper("513/cw/en").fetch()
+
+    assert [job.ats_id for job in jobs] == ["513/cw/en:101"]
 
 
 def test_descriptionless_detail_is_dropped_without_aborting(httpx_mock) -> None:
@@ -330,7 +362,7 @@ def test_descriptionless_detail_is_dropped_without_aborting(httpx_mock) -> None:
 
     jobs = PageUpScraper("513/cw/en").fetch()
 
-    assert [job.ats_id for job in jobs] == ["101"]
+    assert [job.ats_id for job in jobs] == ["513/cw/en:101"]
 
 
 @pytest.mark.parametrize(
@@ -403,6 +435,24 @@ def test_duplicate_job_ids_fail_closed(httpx_mock) -> None:
 
     with pytest.raises(ScraperError, match="duplicate job id"):
         PageUpScraper("513/cw/en", include_descriptions=False).fetch()
+
+
+def test_numeric_job_ids_are_namespaced_by_tenant() -> None:
+    first_jobs, _, _ = PageUpScraper("513/cw/en")._parse_listing(
+        _listing([("101", "Engineer", "Melbourne")])
+    )
+    second_jobs, _, _ = PageUpScraper("920/cw/en")._parse_listing(
+        _listing([("101", "Engineer", "Melbourne")]).replace(
+            "/513/cw/en/",
+            "/920/cw/en/",
+        )
+    )
+
+    assert first_jobs[0].ats_id == "513/cw/en:101"
+    assert second_jobs[0].ats_id == "920/cw/en:101"
+    assert first_jobs[0].global_id != second_jobs[0].global_id
+    assert first_jobs[0].requisition_id == "101"
+    assert second_jobs[0].requisition_id == "101"
 
 
 def test_explicit_no_jobs_returns_empty(httpx_mock) -> None:

--- a/tests/test_pageup.py
+++ b/tests/test_pageup.py
@@ -365,6 +365,39 @@ def test_descriptionless_detail_is_dropped_without_aborting(httpx_mock) -> None:
     assert [job.ats_id for job in jobs] == ["513/cw/en:101"]
 
 
+def test_invalid_apply_link_does_not_abort_detail_batch(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/listing/?page=1&page-items=1000",
+        text=_listing(
+            [
+                ("101", "Engineer", "Melbourne"),
+                ("102", "Designer", "Sydney"),
+            ]
+        ),
+    )
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/job/101/engineer",
+        text=_detail("101"),
+    )
+    httpx_mock.add_response(
+        url="https://careers.pageuppeople.com/513/cw/en/job/102/designer",
+        text=_detail("102").replace(
+            "https://secure.dc2.pageuppeople.com/apply/513/"
+            "gateway/default.aspx?c=apply&amp;lJobID=102",
+            "javascript:void(0)",
+        ),
+    )
+
+    jobs = PageUpScraper("513/cw/en").fetch()
+
+    assert [job.ats_id for job in jobs] == [
+        "513/cw/en:101",
+        "513/cw/en:102",
+    ]
+    assert jobs[0].apply_url is not None
+    assert jobs[1].apply_url is None
+
+
 @pytest.mark.parametrize(
     "href",
     [

--- a/tests/test_pageup_contracts.py
+++ b/tests/test_pageup_contracts.py
@@ -1,0 +1,39 @@
+"""Pipeline contracts for PageUp."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from ats_scrapers.scrapers.pageup import PageUpScraper
+from pipeline.publisher import ATS_DEDUP_PRIORITY
+from scripts.run_pipeline import CONFIGS
+
+
+def test_pageup_pipeline_contract() -> None:
+    config = CONFIGS["pageup"]
+
+    assert config["scraper"] is PageUpScraper
+    assert config["csv"] == "ats-companies/pageup.csv"
+    assert config["output"] == "pageup/jobs.csv"
+    assert config["fail_closed_on_any_error"] is True
+    assert config["fail_closed_on_empty"] is True
+    assert config["kwargs"]({"name": "Monash"}) == {
+        "company_name": "Monash"
+    }
+
+
+def test_pageup_has_direct_employer_dedup_priority() -> None:
+    assert ATS_DEDUP_PRIORITY["pageup"] == ATS_DEDUP_PRIORITY["workday"]
+
+
+def test_pageup_seed_catalogue_is_provider_only() -> None:
+    with Path("ats-companies/pageup.csv").open(newline="") as handle:
+        rows = list(csv.DictReader(handle))
+
+    assert len(rows) > 1
+    assert all(
+        row["url"].startswith("https://careers.pageuppeople.com/")
+        for row in rows
+    )
+    assert len({row["slug"] for row in rows}) == len(rows)

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -15,6 +15,7 @@ from ats_scrapers.scrapers import (
     GreenhouseScraper,
     GupyScraper,
     MokaScraper,
+    PageUpScraper,
     WorkdayScraper,
 )
 
@@ -31,6 +32,16 @@ RESOLVES = [
     ("https://careers.smartrecruiters.com/10Pearls", ATSType.SMARTRECRUITERS, "10Pearls"),
     ("https://jobs.gem.com/accel", ATSType.GEM, "accel"),
     ("https://ats.rippling.com/acme/jobs", ATSType.RIPPLING, "acme"),
+    (
+        "https://careers.pageuppeople.com/513/cw/en/listing/",
+        ATSType.PAGEUP,
+        "513/cw/en",
+    ),
+    (
+        "https://careers.pageuppeople.com/mob/1078/cw/en/job/123/title",
+        ATSType.PAGEUP,
+        "1078/cw/en",
+    ),
     ("https://join.com/companies/acme", ATSType.JOIN_COM, "acme"),
     (
         "https://app.mokahr.com/social-recruitment/trip/70415/job/123",
@@ -140,6 +151,12 @@ def test_get_scraper_for_url_builds_scraper() -> None:
         GreenhouseScraper,
     )
     assert isinstance(get_scraper_for_url("https://petz.gupy.io"), GupyScraper)
+    assert isinstance(
+        get_scraper_for_url(
+            "https://careers.pageuppeople.com/513/cw/en/listing/"
+        ),
+        PageUpScraper,
+    )
     assert isinstance(
         get_scraper_for_url(
             "https://app.mokahr.com/social-recruitment/trip/70415"


### PR DESCRIPTION
## Summary
- add a credential-free PageUp scraper with full count-checked pagination, including catalogs larger than 1,000 jobs
- support table and card listing layouts, concurrent detail hydration, metadata extraction, apply URLs, and closed-job races
- register PageUp in the pipeline and publisher with 13 currently verified direct-employer tenants

## Measured impact
- 2,984 live jobs across the 13 seed tenants
- 0 failed tenants
- California State University alone contributes 2,268 current jobs across three validated pages

## Validation
- `uv run ruff check ...` — passed
- focused unit/pipeline suite — 152 passed, 2 live tests deselected
- live Arts Centre Melbourne full-detail smoke — passed
- live CSU large-catalog pagination smoke (>1,000 jobs, unique ATS IDs) — passed

This PR intentionally contains one ATS provider only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a credential-free PageUp scraper for careers.pageuppeople.com with secure tenant URL handling, HTTPS-only fetches, count-verified pagination, resilient detail enrichment, and trusted apply-link enforcement. Integrates `pageup` into the pipeline and publisher, seeds 13 tenants, and reliably handles catalogs over 1,000 jobs.

- **New Features**
  - Supports table and card listings; de-duplicates by namespaced ATS ID `{tenant}:{id}`; fails closed on duplicate IDs or total mismatches.
  - Count-verified pagination with next-link validation; prevents repeats; scales past 1,000 jobs.
  - Concurrent detail fetch with per-job failure isolation; closed/not-found or parse errors drop only that job.
  - Strict tenant/URL validation (incl. `mob/`); extracts requisition ID, location, work type → `EmploymentType`, department, salary, posted date; cleans description; adds `pageup` to pipeline config and `ATS_DEDUP_PRIORITY`, seeds `ats-companies/pageup.csv`, writes `pageup/jobs.csv`.

- **Bug Fixes**
  - Restricts apply links to `careers.pageuppeople.com` and `*.pageuppeople.com`; rejects foreign or protocol-relative URLs, credentialed URLs, and nonstandard ports.
  - Restricts all fetched listing/detail/pagination URLs to `https://careers.pageuppeople.com` on standard HTTPS; rejects foreign, protocol-relative, non-tenant paths, and nonstandard ports.
  - Resets `is_remote` from the detail location to override a remote flag inferred from the listing when needed.

<sup>Written for commit 0b07733c3104eeae6a2f7193d930df8b617e6cf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds and integrates a credential-free PageUp scraper.
- Registers PageUp in URL resolution, scraper discovery, pipeline execution, and publisher deduplication.
- Supports table and card listings, count-checked pagination, concurrent detail enrichment, metadata extraction, and validated apply links.
- Adds 13 seed tenants and focused unit, contract, resolver, and live tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain in the fixes relevant to the previous review threads.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before: the merge-base checkout documented the absence of a PageUp live test, establishing a baseline before the PR.
- After: the exact pytest command exited with code 0 and reported 1 passed in 15.88s.
- After: the assertion capture identified the tenant and validated that len(jobs) \> 1000 and unique-ID checks.

<a href="https://app.greptile.com/trex/runs/15860063/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/ats_scrapers/scrapers/pageup.py | Implements PageUp listing pagination, isolated detail hydration, metadata parsing, and tenant-scoped URL validation; the fixes corresponding to previous review threads appear complete. |
| src/ats_scrapers/resolve.py | Adds PageUp URL recognition and preserves the complete three-segment tenant path required by the scraper. |
| scripts/run_pipeline.py | Registers PageUp as a fail-closed CSV-driven pipeline source. |
| pipeline/publisher.py | Adds PageUp to the direct-employer deduplication priority map. |
| tests/test_pageup.py | Covers pagination layouts, detail-failure isolation, unsafe URLs, apply-link validation, count mismatches, and tenant normalization. |
| tests/test_resolve.py | Verifies standard and mobile PageUp URLs resolve to the expected scraper and tenant slug. |

<sub>Reviews (12): Last reviewed commit: ["Restrict all fetched PageUp URLs to stan..."](https://github.com/kalil0321/ats-scrapers/commit/0b07733c3104eeae6a2f7193d930df8b617e6cf2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47114375)</sub>

<!-- /greptile_comment -->