### PR TITLE
Add UKG Pro Recruiting scraper

### DIFF
--- a/ats-companies/ukg.csv
+++ b/ats-companies/ukg.csv
@@ -1,0 +1,20 @@
+name,slug,url
+Akin,https://recruiting.ultipro.com/CHI1020/JobBoard/548fb303-9b4b-c600-6802-1df2ed6c6aaa,https://recruiting.ultipro.com/CHI1020/JobBoard/548fb303-9b4b-c600-6802-1df2ed6c6aaa
+Bergen New Bridge Medical Center,https://recruiting.ultipro.com/BER1003BRMC/JobBoard/7362b0d4-9214-406f-86b5-85f44c6f1238,https://recruiting.ultipro.com/BER1003BRMC/JobBoard/7362b0d4-9214-406f-86b5-85f44c6f1238
+Building Material Distributors,https://recruiting.ultipro.com/BUI1004BMDI/JobBoard/6b442184-52a5-4635-8db5-5aa4bed2a563,https://recruiting.ultipro.com/BUI1004BMDI/JobBoard/6b442184-52a5-4635-8db5-5aa4bed2a563
+City of Ann Arbor,https://recruiting.ultipro.com/CIT1009CA2/JobBoard/f90d5294-f62d-4de2-9878-31193309121c,https://recruiting.ultipro.com/CIT1009CA2/JobBoard/f90d5294-f62d-4de2-9878-31193309121c
+Comprehensive Logistics,https://recruiting.ultipro.com/com1074clcl/JobBoard/8a0d300a-f96c-4397-8ab4-86c9c5e8ab57,https://recruiting.ultipro.com/com1074clcl/JobBoard/8a0d300a-f96c-4397-8ab4-86c9c5e8ab57
+E Ink,https://recruiting.ultipro.com/EIN1000EINK/JobBoard/a41773f4-adab-4192-88a9-8bc27fbad529,https://recruiting.ultipro.com/EIN1000EINK/JobBoard/a41773f4-adab-4192-88a9-8bc27fbad529
+Explore St. Louis,https://recruiting.ultipro.com/STL1001STLC/JobBoard/a420e1a5-49da-4a4a-bd17-330f039c4fa9,https://recruiting.ultipro.com/STL1001STLC/JobBoard/a420e1a5-49da-4a4a-bd17-330f039c4fa9
+Fortegra Europe,https://recruiting.ultipro.com/FOR1024FRTF/JobBoard/f4673aa1-86d7-4bb3-b04f-7e14715cc4c7,https://recruiting.ultipro.com/FOR1024FRTF/JobBoard/f4673aa1-86d7-4bb3-b04f-7e14715cc4c7
+Fusable,https://recruiting.ultipro.com/RAN1004/JobBoard/c4a6f199-4067-786a-1f9d-9fa3d8111d01,https://recruiting.ultipro.com/RAN1004/JobBoard/c4a6f199-4067-786a-1f9d-9fa3d8111d01
+Hensel Phelps,https://recruiting2.ultipro.com/HEN1009HPCC/JobBoard/b27ab828-18a9-4f10-8ee1-8259de6c9e73,https://recruiting2.ultipro.com/HEN1009HPCC/JobBoard/b27ab828-18a9-4f10-8ee1-8259de6c9e73
+Indelible,https://recruiting.ultipro.com/IND1018IDBS/JobBoard/3a98c28a-7062-48c1-94d5-c02f29bf8eb0,https://recruiting.ultipro.com/IND1018IDBS/JobBoard/3a98c28a-7062-48c1-94d5-c02f29bf8eb0
+Octapharma Plasma,https://recruiting.ultipro.com/OCT1000OCTPL/JobBoard/4e94a157-04c3-4e65-8698-f4e41066e5b6,https://recruiting.ultipro.com/OCT1000OCTPL/JobBoard/4e94a157-04c3-4e65-8698-f4e41066e5b6
+RealTruck,https://recruiting.ultipro.com/TRU1016TRKH/JobBoard/8457004c-183a-4d47-967d-c7961234886e,https://recruiting.ultipro.com/TRU1016TRKH/JobBoard/8457004c-183a-4d47-967d-c7961234886e
+Royal College,https://recruiting.ultipro.ca/ROY5000RCPS/JobBoard/9a9d6241-e23f-47c0-80f3-e43a148972a0,https://recruiting.ultipro.ca/ROY5000RCPS/JobBoard/9a9d6241-e23f-47c0-80f3-e43a148972a0
+Save the Children,https://recruiting.ultipro.com/SAV1002STCF/JobBoard/7d92e82b-af74-464d-859b-c5b8cba6e92e,https://recruiting.ultipro.com/SAV1002STCF/JobBoard/7d92e82b-af74-464d-859b-c5b8cba6e92e
+Sportsman's Guide,https://recruiting.ultipro.com/WIN1014WINDQ/JobBoard/08eb8299-5b26-4208-adb7-897aa42c6959,https://recruiting.ultipro.com/WIN1014WINDQ/JobBoard/08eb8299-5b26-4208-adb7-897aa42c6959
+Surgery Partners,https://recruiting.ultipro.com/SUR1004SRGY/JobBoard/aa616d8f-f2a8-46c2-8f8e-1ca56e162ffd,https://recruiting.ultipro.com/SUR1004SRGY/JobBoard/aa616d8f-f2a8-46c2-8f8e-1ca56e162ffd
+United Nations Foundation,https://recruiting.ultipro.com/UNI1076UNFI/JobBoard/86df2700-c124-49b9-b096-7cacea55e9dd,https://recruiting.ultipro.com/UNI1076UNFI/JobBoard/86df2700-c124-49b9-b096-7cacea55e9dd
+Upstate Niagara Cooperative,https://recruiting.ultipro.com/ups1000upnc/JobBoard/8278ab32-7638-486b-a889-8265d76f85da,https://recruiting.ultipro.com/ups1000upnc/JobBoard/8278ab32-7638-486b-a889-8265d76f85da

--- a/pipeline/publisher.py
+++ b/pipeline/publisher.py
@@ -540,7 +540,7 @@ ATS_DEDUP_PRIORITY: dict[str, int] = {
     "greenhouse": 1, "gupy": 1, "icims": 1, "jazzhr": 1, "join_com": 1, "lever": 1,
     "moka": 1, "oracle": 1, "personio": 1, "phenom": 1, "pinpoint": 1, "recruitee": 1,
     "recruiterbox": 1, "rippling": 1, "smartrecruiters": 1,
-    "successfactors": 1, "taleo": 1, "teamtailor": 1, "workable": 1,
+    "successfactors": 1, "taleo": 1, "teamtailor": 1, "ukg": 1, "workable": 1,
     "workday": 1,
     # Big-tech bespoke careers — also priority 1 (single-tenant, canonical)
     "amazon": 1, "apple": 1, "bytedance": 1, "google": 1, "meta": 1,

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -87,6 +87,7 @@ from ats_scrapers.scrapers import (
     TheHubScraper,
     TikTokScraper,
     UberScraper,
+    UKGProScraper,
     WantedScraper,
     WellfoundScraper,
     WeWorkRemotelyScraper,
@@ -458,6 +459,15 @@ CONFIGS: dict[str, dict[str, Any]] = {
         "slug": lambda r: _slug_col(r) or (r.get("name") or "").strip() or None,
         "csv": "ats-companies/teamtailor.csv",
         "output": "teamtailor/jobs.csv",
+    },
+    "ukg": {
+        "scraper": UKGProScraper,
+        "slug": lambda r: _slug_col(r) or (r.get("url") or "").strip() or None,
+        "kwargs": lambda r: {"company_name": (r.get("name") or "").strip()},
+        "csv": "ats-companies/ukg.csv",
+        "output": "ukg/jobs.csv",
+        "fail_closed_on_any_error": True,
+        "fail_closed_on_empty": True,
     },
     "jazzhr": {
         "scraper": JazzHRScraper,

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -467,6 +467,7 @@ CONFIGS: dict[str, dict[str, Any]] = {
         "csv": "ats-companies/ukg.csv",
         "output": "ukg/jobs.csv",
         "fail_closed_on_any_error": True,
+        "fail_closed_on_not_found": True,
         "fail_closed_on_empty": True,
     },
     "jazzhr": {
@@ -1498,13 +1499,25 @@ async def run(ats: str, concurrency: int, max_tenants: int | None, timeout: floa
                 )
             return 1
 
+        required_not_found = (
+            counts["not_found"]
+            if cfg.get("fail_closed_on_not_found")
+            else 0
+        )
         sharded_failure = (
-            bool(cfg.get("fail_closed_on_any_error"))
-            and (counts["error"] > 0 or omitted_required_shards > 0)
+            (
+                bool(cfg.get("fail_closed_on_any_error"))
+                and (counts["error"] > 0 or omitted_required_shards > 0)
+            )
+            or required_not_found > 0
         )
         if sharded_failure:
             tmp_output_path.unlink(missing_ok=True)
-            required_failures = counts["error"] + omitted_required_shards
+            required_failures = (
+                counts["error"]
+                + omitted_required_shards
+                + required_not_found
+            )
             if output_path.exists():
                 print(
                     f"[{ats}] ACTION keep_previous: {required_failures}/"

--- a/src/ats_scrapers/models.py
+++ b/src/ats_scrapers/models.py
@@ -56,6 +56,7 @@ class ATSType(StrEnum):
     RIPPLING = "rippling"
     SMARTRECRUITERS = "smartrecruiters"
     SUCCESSFACTORS = "successfactors"
+    UKG = "ukg"
     WORKABLE = "workable"
     WORKDAY = "workday"
     # Big-tech custom careers systems (single-tenant, bespoke APIs)

--- a/src/ats_scrapers/resolve.py
+++ b/src/ats_scrapers/resolve.py
@@ -88,6 +88,12 @@ _SUBDOMAIN_SUFFIXES: dict[str, ATSType] = {
 _WORKDAY_HOST_RE = re.compile(r"^[^.]+\.wd\d+\.myworkdayjobs\.com$")
 _TALEO_HOST_RE = re.compile(r"^[^.]+\.tbe\.taleo\.net$")
 _ICIMS_HOST_RE = re.compile(r"^(?P<prefix>[a-z0-9-]+)\.icims\.com$", re.IGNORECASE)
+_UKG_HOST_RE = re.compile(r"^recruiting\d*\.ultipro\.(?:com|ca)$", re.IGNORECASE)
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
+    r"[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
 
 
 def resolve_careers_url(url: str) -> ResolvedCareersUrl | None:
@@ -108,6 +114,20 @@ def resolve_careers_url(url: str) -> ResolvedCareersUrl | None:
         slug = _first_path_segment(parsed)
         if slug and _SLUG_RE.match(slug):
             return ResolvedCareersUrl(_PATH_HOSTS[host], slug)
+        return None
+
+    if _UKG_HOST_RE.fullmatch(host):
+        segments = [segment for segment in parsed.path.split("/") if segment]
+        if (
+            len(segments) >= 3
+            and _DNS_LABEL_RE.fullmatch(segments[0])
+            and segments[1].casefold() == "jobboard"
+            and _UUID_RE.fullmatch(segments[2])
+        ):
+            return ResolvedCareersUrl(
+                ATSType.UKG,
+                f"https://{host}/{segments[0]}/JobBoard/{segments[2]}",
+            )
         return None
 
     # join.com/companies/{slug}

--- a/src/ats_scrapers/resolve.py
+++ b/src/ats_scrapers/resolve.py
@@ -89,6 +89,7 @@ _WORKDAY_HOST_RE = re.compile(r"^[^.]+\.wd\d+\.myworkdayjobs\.com$")
 _TALEO_HOST_RE = re.compile(r"^[^.]+\.tbe\.taleo\.net$")
 _ICIMS_HOST_RE = re.compile(r"^(?P<prefix>[a-z0-9-]+)\.icims\.com$", re.IGNORECASE)
 _UKG_HOST_RE = re.compile(r"^recruiting\d*\.ultipro\.(?:com|ca)$", re.IGNORECASE)
+_UKG_TENANT_RE = re.compile(r"^[A-Za-z0-9]+$")
 _UUID_RE = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
     r"[0-9a-f]{4}-[0-9a-f]{12}$",
@@ -120,7 +121,7 @@ def resolve_careers_url(url: str) -> ResolvedCareersUrl | None:
         segments = [segment for segment in parsed.path.split("/") if segment]
         if (
             len(segments) >= 3
-            and _DNS_LABEL_RE.fullmatch(segments[0])
+            and _UKG_TENANT_RE.fullmatch(segments[0])
             and segments[1].casefold() == "jobboard"
             and _UUID_RE.fullmatch(segments[2])
         ):

--- a/src/ats_scrapers/scrapers/__init__.py
+++ b/src/ats_scrapers/scrapers/__init__.py
@@ -60,6 +60,7 @@ from ats_scrapers.scrapers.tesla import TeslaScraper
 from ats_scrapers.scrapers.thehub import TheHubScraper
 from ats_scrapers.scrapers.tiktok import TikTokScraper
 from ats_scrapers.scrapers.uber import UberScraper
+from ats_scrapers.scrapers.ukg import UKGProScraper
 from ats_scrapers.scrapers.usajobs import USAJobsScraper
 from ats_scrapers.scrapers.wanted import WantedScraper
 from ats_scrapers.scrapers.welcometothejungle import WTTJScraper
@@ -121,6 +122,7 @@ __all__ = [
     "TeslaScraper",
     "TheHubScraper",
     "TikTokScraper",
+    "UKGProScraper",
     "USAJobsScraper",
     "UberScraper",
     "WTTJScraper",

--- a/src/ats_scrapers/scrapers/ukg.py
+++ b/src/ats_scrapers/scrapers/ukg.py
@@ -1,0 +1,548 @@
+"""UKG Pro Recruiting public careers scraper."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import html
+import json
+import logging
+import re
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, ClassVar
+from urllib.parse import urljoin, urlparse
+
+from pydantic import HttpUrl
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from ats_scrapers.fetch import Fetcher
+
+PAGE_SIZE = 50
+DETAIL_CONCURRENCY = 8
+_HOST_RE = re.compile(r"^recruiting\d*\.ultipro\.(?:com|ca)$", re.IGNORECASE)
+_TENANT_RE = re.compile(r"^[A-Za-z0-9]+$")
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
+    r"[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+_LOAD_URL_RE = re.compile(r'\bloadUrl:\s*"([^"]+)"')
+_DETAIL_MARKER = "new US.Opportunity.CandidateOpportunityDetail("
+_COUNTRY_CODES = {
+    "AUS": "AU",
+    "AUT": "AT",
+    "BEL": "BE",
+    "BRA": "BR",
+    "CAN": "CA",
+    "CHE": "CH",
+    "CHN": "CN",
+    "DEU": "DE",
+    "DNK": "DK",
+    "ESP": "ES",
+    "FIN": "FI",
+    "FRA": "FR",
+    "GBR": "GB",
+    "IND": "IN",
+    "IRL": "IE",
+    "ITA": "IT",
+    "JPN": "JP",
+    "MEX": "MX",
+    "NLD": "NL",
+    "NOR": "NO",
+    "NZL": "NZ",
+    "POL": "PL",
+    "PRT": "PT",
+    "SWE": "SE",
+    "USA": "US",
+}
+logger = logging.getLogger(__name__)
+
+
+@ScraperRegistry.register(ATSType.UKG)
+class UKGProScraper(BaseScraper):
+    """Scrape one public UKG Pro Recruiting job board."""
+
+    ats = ATSType.UKG
+    default_headers: ClassVar[dict[str, str]] = {
+        "Accept": "text/html,application/xhtml+xml",
+        "User-Agent": "Mozilla/5.0",
+    }
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        include_descriptions: bool = True,
+        proxy: str | None = None,
+        company_name: str | None = None,
+    ) -> None:
+        super().__init__(
+            company_slug,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        self.board_url = _normalize_board_url(company_slug)
+        parsed = urlparse(self.board_url)
+        segments = [segment for segment in parsed.path.split("/") if segment]
+        self.host = parsed.hostname or ""
+        self.tenant = segments[0]
+        self.board_id = segments[2]
+        self.company_name = (
+            company_name.strip()
+            if isinstance(company_name, str) and company_name.strip()
+            else self.tenant
+        )
+
+    async def afetch(self) -> list[Job]:
+        jobs: list[Job] = []
+        seen_ids: set[str] = set()
+        reported_total: int | None = None
+
+        async with self.make_fetcher() as fetch:
+            board_html = await fetch.get_text(self.board_url)
+            internal_base = self._parse_internal_base(board_html)
+            load_url = f"{internal_base}/JobBoardView/LoadSearchResults"
+            skip = 0
+
+            while True:
+                payload = await fetch.post_json(
+                    load_url,
+                    json={"opportunitySearch": _search_payload(skip)},
+                    headers={
+                        "Accept": "application/json",
+                        "X-Requested-With": "XMLHttpRequest",
+                    },
+                )
+                page_jobs, total = self._parse_listing(
+                    payload,
+                    internal_base=internal_base,
+                    skip=skip,
+                )
+                if reported_total is None:
+                    reported_total = total
+                elif total != reported_total:
+                    raise ScraperError(
+                        "UKG total changed during pagination "
+                        f"({reported_total} to {total})"
+                    )
+                for job in page_jobs:
+                    if not job.ats_id or job.ats_id in seen_ids:
+                        raise ScraperError(
+                            f"UKG returned duplicate job id {job.ats_id!r}"
+                        )
+                    seen_ids.add(job.ats_id)
+                    jobs.append(job)
+                skip += len(page_jobs)
+                if skip >= total:
+                    break
+                if not page_jobs:
+                    raise ScraperError(
+                        f"UKG ({self.tenant}) pagination ended before total"
+                    )
+
+            if reported_total is None or len(jobs) != reported_total:
+                raise ScraperError(
+                    "UKG catalogue ended before the reported total "
+                    f"({len(jobs)}/{reported_total})"
+                )
+            if not self.include_descriptions or not jobs:
+                return jobs
+
+            semaphore = asyncio.Semaphore(DETAIL_CONCURRENCY)
+            enriched = await asyncio.gather(
+                *(self._enrich_detail(fetch, semaphore, job) for job in jobs)
+            )
+
+        completed = [job for job in enriched if job is not None]
+        if jobs and not completed:
+            raise ScraperError(
+                f"UKG ({self.tenant}) lost every listed job "
+                "during detail validation"
+            )
+        return completed
+
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        copy = job.model_copy(deep=True)
+
+        async def run() -> str | None:
+            async with self.make_fetcher() as fetch:
+                enriched = await self._enrich_detail(
+                    fetch,
+                    asyncio.Semaphore(1),
+                    copy,
+                )
+            return enriched.description if enriched is not None else None
+
+        return self._run_sync(run())
+
+    async def _enrich_detail(
+        self,
+        fetch: Fetcher,
+        semaphore: asyncio.Semaphore,
+        job: Job,
+    ) -> Job | None:
+        async with semaphore:
+            response = await fetch.request(
+                "GET",
+                str(job.url),
+                handled={404, 410},
+            )
+        if response.status_code in {404, 410}:
+            return None
+        detail = _extract_detail_payload(response.text)
+        if detail.get("OpportunityIsClosed") is True:
+            return None
+        if detail.get("Id") != job.ats_id:
+            raise ScraperError(
+                f"UKG detail id did not match listing id {job.ats_id}"
+            )
+        _apply_detail(job, detail)
+        if not job.description:
+            logger.warning(
+                "Dropping UKG job %s because its detail page omitted "
+                "a description",
+                job.ats_id,
+            )
+            return None
+        return job
+
+    def _parse_internal_base(self, html_text: str) -> str:
+        match = _LOAD_URL_RE.search(html_text)
+        if match is None:
+            raise ScraperError(
+                f"UKG ({self.tenant}) omitted its public search endpoint"
+            )
+        load_url = urljoin(f"https://{self.host}/", html.unescape(match.group(1)))
+        parsed = urlparse(load_url)
+        segments = [segment for segment in parsed.path.split("/") if segment]
+        if (
+            parsed.scheme != "https"
+            or parsed.hostname != self.host
+            or len(segments) != 5
+            or segments[0].casefold() != self.tenant.casefold()
+            or segments[1].casefold() != "jobboard"
+            or _UUID_RE.fullmatch(segments[2]) is None
+            or segments[3:] != ["JobBoardView", "LoadSearchResults"]
+        ):
+            raise ScraperError(
+                f"UKG ({self.tenant}) returned an unsafe search endpoint"
+            )
+        return (
+            f"https://{self.host}/{segments[0]}/JobBoard/{segments[2]}"
+        )
+
+    def _parse_listing(
+        self,
+        payload: object,
+        *,
+        internal_base: str,
+        skip: int,
+    ) -> tuple[list[Job], int]:
+        if not isinstance(payload, dict):
+            raise ScraperError(f"UKG ({self.tenant}) returned invalid JSON")
+        items = payload.get("opportunities")
+        total = payload.get("totalCount")
+        if (
+            not isinstance(items, list)
+            or not isinstance(total, int)
+            or isinstance(total, bool)
+            or total < 0
+        ):
+            raise ScraperError(
+                f"UKG ({self.tenant}) returned an invalid result envelope"
+            )
+        expected = min(PAGE_SIZE, max(total - skip, 0))
+        if len(items) != expected:
+            raise ScraperError(
+                "UKG listing count did not match the reported total "
+                f"({len(items)} rows at offset {skip}, expected {expected})"
+            )
+        jobs = [
+            self._job_from_listing(item, internal_base=internal_base)
+            for item in items
+        ]
+        return jobs, total
+
+    def _job_from_listing(
+        self,
+        item: object,
+        *,
+        internal_base: str,
+    ) -> Job:
+        if not isinstance(item, dict):
+            raise ScraperError(f"UKG ({self.tenant}) returned a non-object job")
+        job_id = _required_string(item, "Id")
+        title = _required_string(item, "Title")
+        if _UUID_RE.fullmatch(job_id) is None:
+            raise ScraperError(f"UKG returned an invalid job id {job_id!r}")
+
+        location, country_iso, lat, lon = _locations(item.get("Locations"))
+        location_type = item.get("JobLocationType")
+        is_remote = (
+            True
+            if location_type == 2
+            or (location is not None and "remote" in location.casefold())
+            else None
+        )
+        full_time = item.get("FullTime")
+        employment_type = (
+            "FULL_TIME"
+            if full_time is True
+            else "PART_TIME" if full_time is False else None
+        )
+        detail_url = (
+            f"{internal_base}/OpportunityDetail?opportunityId={job_id}"
+        )
+        requisition = item.get("RequisitionNumber")
+        department = item.get("JobCategoryName")
+        return Job(
+            url=HttpUrl(detail_url),
+            title=title,
+            company=self.company_name,
+            ats_type=ATSType.UKG,
+            ats_id=job_id,
+            location=location,
+            country_iso=country_iso,
+            lat=lat,
+            lon=lon,
+            is_remote=is_remote,
+            employment_type=employment_type,
+            commitment=(
+                "Full Time"
+                if full_time is True
+                else "Part Time" if full_time is False else None
+            ),
+            department=(
+                department.strip()
+                if isinstance(department, str) and department.strip()
+                else None
+            ),
+            requisition_id=(
+                requisition.strip()
+                if isinstance(requisition, str) and requisition.strip()
+                else None
+            ),
+            posted_at=_parse_date(item.get("PostedDate")),
+            fetched_at=datetime.now(UTC),
+            raw={
+                "featured": item.get("Featured"),
+                "job_location_type": location_type,
+                "opportunity_type": item.get("OpportunityType"),
+            },
+        )
+
+
+def _normalize_board_url(value: str) -> str:
+    raw = value.strip().rstrip("/")
+    if not raw:
+        raise ValueError("UKG board URL cannot be empty")
+    parsed = urlparse(raw if "://" in raw else f"https://{raw}")
+    host = (parsed.hostname or "").lower()
+    segments = [segment for segment in parsed.path.split("/") if segment]
+    if (
+        parsed.scheme != "https"
+        or _HOST_RE.fullmatch(host) is None
+        or len(segments) < 3
+        or _TENANT_RE.fullmatch(segments[0]) is None
+        or segments[1].casefold() != "jobboard"
+        or _UUID_RE.fullmatch(segments[2]) is None
+    ):
+        raise ValueError(f"Invalid UKG board URL: {value!r}")
+    return f"https://{host}/{segments[0]}/JobBoard/{segments[2]}"
+
+
+def _search_payload(skip: int) -> dict[str, object]:
+    return {
+        "Top": PAGE_SIZE,
+        "Skip": skip,
+        "QueryString": "",
+        "OrderBy": [
+            {
+                "Value": "postedDateDesc",
+                "PropertyName": "PostedDate",
+                "Ascending": False,
+            }
+        ],
+        "OrderByKey": None,
+        "Filters": [],
+        "Coordinates": None,
+        "Extent": None,
+        "ProximitySearchType": 0,
+    }
+
+
+def _extract_detail_payload(html_text: str) -> dict[str, Any]:
+    start = html_text.find(_DETAIL_MARKER)
+    if start < 0:
+        raise ScraperError("UKG detail page omitted opportunity data")
+    start += len(_DETAIL_MARKER)
+    try:
+        payload, _ = json.JSONDecoder().raw_decode(html_text[start:])
+    except json.JSONDecodeError as exc:
+        raise ScraperError(f"UKG detail data was invalid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ScraperError("UKG detail data was not an object")
+    return payload
+
+
+def _apply_detail(job: Job, detail: dict[str, Any]) -> None:
+    description = detail.get("Description")
+    if isinstance(description, str) and description.strip():
+        job.description = _html_to_text(description)[:25_000] or None
+    if updated := _parse_date(detail.get("UpdatedDate")):
+        raw = dict(job.raw or {})
+        raw["updated_at"] = updated.isoformat()
+        job.raw = raw
+    location, country_iso, lat, lon = _locations(detail.get("Locations"))
+    if location:
+        job.location = location
+    if country_iso:
+        job.country_iso = country_iso
+    if lat is not None and lon is not None:
+        job.lat = lat
+        job.lon = lon
+    if detail.get("JobLocationType") == 2:
+        job.is_remote = True
+    _apply_compensation(job, detail)
+
+
+def _locations(
+    value: object,
+) -> tuple[str | None, str | None, float | None, float | None]:
+    if not isinstance(value, list):
+        return None, None, None, None
+    rendered: list[str] = []
+    country_codes: set[str] = set()
+    coordinates: list[tuple[float, float]] = []
+    for entry in value:
+        if not isinstance(entry, dict):
+            continue
+        address = entry.get("Address")
+        address = address if isinstance(address, dict) else {}
+        parts: list[str] = []
+        localized = entry.get("LocalizedName")
+        if isinstance(localized, str) and localized.strip():
+            parts.append(localized.strip())
+        for key in ("City", "State", "Country"):
+            item = address.get(key)
+            if isinstance(item, dict):
+                item = item.get("Code") if key == "State" else item.get("Name")
+            if isinstance(item, str) and item.strip():
+                parts.append(item.strip())
+        location = ", ".join(_dedupe_strings(parts))
+        if location and location.casefold() not in {
+            existing.casefold() for existing in rendered
+        }:
+            rendered.append(location)
+
+        country = address.get("Country")
+        if isinstance(country, dict):
+            code = country.get("Code")
+            if isinstance(code, str):
+                normalized = _normalize_country_code(code)
+                if normalized:
+                    country_codes.add(normalized)
+        point = entry.get("Coordinates")
+        if isinstance(point, dict):
+            latitude = _to_float(point.get("Latitude"))
+            longitude = _to_float(point.get("Longitude"))
+            if latitude is not None and longitude is not None:
+                coordinates.append((latitude, longitude))
+
+    country_iso = next(iter(country_codes)) if len(country_codes) == 1 else None
+    lat = lon = None
+    if len(coordinates) == 1:
+        lat, lon = coordinates[0]
+    return "; ".join(rendered) or None, country_iso, lat, lon
+
+
+def _apply_compensation(job: Job, detail: dict[str, Any]) -> None:
+    annual_min = _to_float(detail.get("CompensationAnnualMinimum"))
+    annual_max = _to_float(detail.get("CompensationAnnualMaximum"))
+    hourly_min = _to_float(detail.get("CompensationHourlyMinimum"))
+    hourly_max = _to_float(detail.get("CompensationHourlyMaximum"))
+    period = None
+    minimum = maximum = None
+    if annual_min is not None or annual_max is not None:
+        period, minimum, maximum = "YEAR", annual_min, annual_max
+    elif hourly_min is not None or hourly_max is not None:
+        period, minimum, maximum = "HOUR", hourly_min, hourly_max
+    else:
+        pay_range = detail.get("PayRange")
+        if isinstance(pay_range, dict):
+            minimum = _to_float(pay_range.get("PayRangeMinimum"))
+            maximum = _to_float(pay_range.get("PayRangeMaximum"))
+    currency = (
+        detail.get("CompensationCurrencyCode")
+        or detail.get("PayRangeCurrencyCode")
+    )
+    if minimum is not None:
+        job.salary_min = minimum
+    if maximum is not None:
+        job.salary_max = maximum
+    if isinstance(currency, str) and len(currency.strip()) == 3:
+        job.salary_currency = currency.strip().upper()
+    if period is not None:
+        job.salary_period = period
+
+
+def _required_string(item: dict[str, Any], key: str) -> str:
+    value = item.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ScraperError(f"UKG job omitted {key}")
+    return value.strip()
+
+
+def _normalize_country_code(value: str) -> str | None:
+    code = value.strip().upper()
+    if len(code) == 2:
+        return code
+    return _COUNTRY_CODES.get(code)
+
+
+def _dedupe_strings(values: list[str]) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        key = value.casefold()
+        if key not in seen:
+            seen.add(key)
+            result.append(value)
+    return result
+
+
+def _parse_date(value: object) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    with contextlib.suppress(ValueError):
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+    return None
+
+
+def _html_to_text(value: str) -> str:
+    try:
+        from bs4 import BeautifulSoup
+    except ImportError as exc:
+        raise ScraperError(
+            "UKG scraper requires beautifulsoup4; "
+            "install `ats-scrapers[scrapers]`"
+        ) from exc
+    text = BeautifulSoup(value, "html.parser").get_text("\n", strip=True)
+    return re.sub(r"[ \t\r\f\v]+", " ", html.unescape(text)).strip()
+
+
+def _to_float(value: object) -> float | None:
+    if value is None or value == "":
+        return None
+    with contextlib.suppress(TypeError, ValueError):
+        return float(value)  # type: ignore[arg-type]
+    return None

--- a/src/ats_scrapers/scrapers/ukg.py
+++ b/src/ats_scrapers/scrapers/ukg.py
@@ -189,29 +189,36 @@ class UKGProScraper(BaseScraper):
         semaphore: asyncio.Semaphore,
         job: Job,
     ) -> Job | None:
-        async with semaphore:
-            response = await fetch.request(
-                "GET",
-                str(job.url),
-                handled={404, 410},
+        try:
+            async with semaphore:
+                response = await fetch.request(
+                    "GET",
+                    str(job.url),
+                    handled={404, 410},
+                )
+            if response.status_code in {404, 410}:
+                return None
+            detail = _extract_detail_payload(response.text)
+            if detail.get("OpportunityIsClosed") is True:
+                return None
+            if detail.get("Id") != job.ats_id:
+                raise ScraperError(
+                    f"UKG detail id did not match listing id {job.ats_id}"
+                )
+            _apply_detail(job, detail)
+        except ScraperError as exc:
+            logger.warning(
+                "Keeping UKG listing job %s after optional detail failure: %s",
+                job.ats_id,
+                exc,
             )
-        if response.status_code in {404, 410}:
-            return None
-        detail = _extract_detail_payload(response.text)
-        if detail.get("OpportunityIsClosed") is True:
-            return None
-        if detail.get("Id") != job.ats_id:
-            raise ScraperError(
-                f"UKG detail id did not match listing id {job.ats_id}"
-            )
-        _apply_detail(job, detail)
+            return job
         if not job.description:
             logger.warning(
-                "Dropping UKG job %s because its detail page omitted "
+                "Keeping UKG job %s although its detail page omitted "
                 "a description",
                 job.ats_id,
             )
-            return None
         return job
 
     def _parse_internal_base(self, html_text: str) -> str:

--- a/tests/e2e/test_live_ukg.py
+++ b/tests/e2e/test_live_ukg.py
@@ -1,0 +1,47 @@
+"""Live smoke tests for UKG Pro Recruiting."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+from ats_scrapers.scrapers.ukg import UKGProScraper
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.skipif(
+        not os.getenv("ATS_SCRAPERS_LIVE_E2E"),
+        reason="set ATS_SCRAPERS_LIVE_E2E=1 to hit real UKG endpoints",
+    ),
+]
+
+
+async def test_live_ukg_smoke() -> None:
+    async with asyncio.timeout(180):
+        jobs = await UKGProScraper(
+            "https://recruiting.ultipro.com/com1074clcl/JobBoard/"
+            "8a0d300a-f96c-4397-8ab4-86c9c5e8ab57",
+            company_name="Comprehensive Logistics",
+        ).afetch()
+
+    assert jobs
+    assert len({job.ats_id for job in jobs}) == len(jobs)
+    assert all(job.title.strip() for job in jobs)
+    assert all(job.description for job in jobs)
+    assert all(":" in job.global_id for job in jobs)
+    assert all("ultipro.com" in str(job.url) for job in jobs)
+
+
+async def test_live_ukg_large_catalog_paginates() -> None:
+    async with asyncio.timeout(180):
+        jobs = await UKGProScraper(
+            "https://recruiting.ultipro.com/SUR1004SRGY/JobBoard/"
+            "aa616d8f-f2a8-46c2-8f8e-1ca56e162ffd",
+            company_name="Surgery Partners",
+            include_descriptions=False,
+        ).afetch()
+
+    assert len(jobs) > 50
+    assert len({job.ats_id for job in jobs}) == len(jobs)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -20,7 +20,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
             "ashby", "avature", "beisen", "beisen_legacy", "cornerstone", "darwinbox", "eightfold", "gem", "greenhouse", "gupy",
         "icims", "join_com", "lever", "mercor", "moka", "oracle", "personio", "phenom",
         "pinpoint", "recruiterbox", "rippling", "smartrecruiters",
-        "successfactors", "workable", "workday",
+        "successfactors", "ukg", "workable", "workday",
         # Big-tech custom careers systems
         "amazon", "apple", "bytedance", "google", "meta",
         "tesla", "tiktok", "uber", "usajobs",

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -15,6 +15,7 @@ from ats_scrapers.scrapers import (
     GreenhouseScraper,
     GupyScraper,
     MokaScraper,
+    UKGProScraper,
     WorkdayScraper,
 )
 
@@ -31,6 +32,13 @@ RESOLVES = [
     ("https://careers.smartrecruiters.com/10Pearls", ATSType.SMARTRECRUITERS, "10Pearls"),
     ("https://jobs.gem.com/accel", ATSType.GEM, "accel"),
     ("https://ats.rippling.com/acme/jobs", ATSType.RIPPLING, "acme"),
+    (
+        "https://recruiting2.ultipro.com/HEN1009HPCC/JobBoard/"
+        "b27ab828-18a9-4f10-8ee1-8259de6c9e73/OpportunityDetail",
+        ATSType.UKG,
+        "https://recruiting2.ultipro.com/HEN1009HPCC/JobBoard/"
+        "b27ab828-18a9-4f10-8ee1-8259de6c9e73",
+    ),
     ("https://join.com/companies/acme", ATSType.JOIN_COM, "acme"),
     (
         "https://app.mokahr.com/social-recruitment/trip/70415/job/123",
@@ -140,6 +148,13 @@ def test_get_scraper_for_url_builds_scraper() -> None:
         GreenhouseScraper,
     )
     assert isinstance(get_scraper_for_url("https://petz.gupy.io"), GupyScraper)
+    assert isinstance(
+        get_scraper_for_url(
+            "https://recruiting.ultipro.ca/ROY5000RCPS/JobBoard/"
+            "9a9d6241-e23f-47c0-80f3-e43a148972a0"
+        ),
+        UKGProScraper,
+    )
     assert isinstance(
         get_scraper_for_url(
             "https://app.mokahr.com/social-recruitment/trip/70415"

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -127,6 +127,8 @@ def test_icims_nonstandard_prefix_keeps_full_url() -> None:
         f"https://{'a' * 64}.darwinbox.com/ms/candidate/careers",
         "https://trailing-.darwinbox.in/ms/candidate/careers",
         "https://bad_slug.zhiye.com/social/jobs",
+        "https://recruiting.ultipro.com/bad-tenant/JobBoard/"
+        "11111111-2222-3333-4444-555555555555",
         f"https://{'a' * 64}.zhiye.com/social/jobs",
         "not a url at all",
     ],

--- a/tests/test_run_pipeline_guards.py
+++ b/tests/test_run_pipeline_guards.py
@@ -6,6 +6,7 @@ import csv
 import pytest
 
 import scripts.run_pipeline as runner
+from ats_scrapers.exceptions import CompanyNotFoundError
 from ats_scrapers.models import ATSType, Job
 
 
@@ -966,6 +967,70 @@ def test_required_shard_limit_preserves_previous_output(
 
     assert rc == 1
     assert out_path.read_text(encoding="utf-8") == previous
+    assert not (out_dir / ".jobs.csv.tmp").exists()
+
+
+@pytest.mark.parametrize("has_previous", [True, False])
+def test_required_not_found_shard_removes_partial_output(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    has_previous: bool,
+) -> None:
+    (tmp_path / "ats-companies").mkdir()
+    (tmp_path / "ats-companies" / "shards.csv").write_text(
+        "name,slug,url\nGood,good,https://good\nMissing,missing,https://missing\n",
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / "sharded"
+    out_dir.mkdir()
+    out_path = out_dir / "jobs.csv"
+    previous = (
+        "url,title,company,ats_type,ats_id\n"
+        "https://example.com/old,Old,Acme,custom,old\n"
+    )
+    if has_previous:
+        out_path.write_text(previous, encoding="utf-8")
+
+    class ShardedScraper:
+        def __init__(self, slug, **_kwargs) -> None:
+            self.slug = slug
+
+        def fetch(self):
+            if self.slug == "missing":
+                raise CompanyNotFoundError("board missing")
+            return [
+                Job(
+                    url="https://example.com/new",
+                    title="New",
+                    company="Acme",
+                    ats_type=ATSType.CUSTOM,
+                    ats_id="new",
+                )
+            ]
+
+    monkeypatch.setattr(runner, "DATA_ROOT", tmp_path)
+    monkeypatch.setitem(
+        runner.CONFIGS,
+        "sharded",
+        {
+            "scraper": ShardedScraper,
+            "slug": lambda row: row["slug"],
+            "csv": "ats-companies/shards.csv",
+            "output": "sharded/jobs.csv",
+            "fail_closed_on_any_error": True,
+            "fail_closed_on_not_found": True,
+        },
+    )
+
+    rc = asyncio.run(
+        runner.run("sharded", concurrency=2, max_tenants=None, timeout=1)
+    )
+
+    assert rc == 1
+    if has_previous:
+        assert out_path.read_text(encoding="utf-8") == previous
+    else:
+        assert not out_path.exists()
     assert not (out_dir / ".jobs.csv.tmp").exists()
 
 

--- a/tests/test_ukg.py
+++ b/tests/test_ukg.py
@@ -198,6 +198,17 @@ def test_reported_total_mismatch_fails_closed(httpx_mock) -> None:
         UKGProScraper(BOARD, include_descriptions=False).fetch()
 
 
+def test_explicit_zero_result_catalogue_returns_empty(httpx_mock) -> None:
+    httpx_mock.add_response(url=BOARD, text=_board_page())
+    httpx_mock.add_response(
+        method="POST",
+        url=LOAD_URL,
+        json={"opportunities": [], "totalCount": 0},
+    )
+
+    assert UKGProScraper(BOARD).fetch() == []
+
+
 def test_closed_job_between_listing_and_detail_is_dropped(httpx_mock) -> None:
     ids = [
         "aaaaaaaa-1111-2222-3333-444444444444",
@@ -223,7 +234,7 @@ def test_closed_job_between_listing_and_detail_is_dropped(httpx_mock) -> None:
     assert [job.ats_id for job in jobs] == [ids[0]]
 
 
-def test_systemic_detail_request_failure_fails_closed(httpx_mock) -> None:
+def test_detail_request_failure_keeps_listing_job(httpx_mock) -> None:
     job_id = "aaaaaaaa-1111-2222-3333-444444444444"
     httpx_mock.add_response(url=BOARD, text=_board_page())
     httpx_mock.add_response(
@@ -237,8 +248,59 @@ def test_systemic_detail_request_failure_fails_closed(httpx_mock) -> None:
         is_reusable=True,
     )
 
-    with pytest.raises(ScraperError, match="returned 500"):
-        UKGProScraper(BOARD).fetch()
+    jobs = UKGProScraper(BOARD).fetch()
+
+    assert [job.ats_id for job in jobs] == [job_id]
+    assert jobs[0].description is None
+
+
+def test_malformed_detail_keeps_listing_job(httpx_mock) -> None:
+    ids = [
+        "aaaaaaaa-1111-2222-3333-444444444444",
+        "bbbbbbbb-1111-2222-3333-444444444444",
+    ]
+    httpx_mock.add_response(url=BOARD, text=_board_page())
+    httpx_mock.add_response(
+        method="POST",
+        url=LOAD_URL,
+        json={
+            "opportunities": [_listing(job_id) for job_id in ids],
+            "totalCount": 2,
+        },
+    )
+    httpx_mock.add_response(
+        url=f"{INTERNAL_BASE}/OpportunityDetail?opportunityId={ids[0]}",
+        text=_detail(ids[0]),
+    )
+    httpx_mock.add_response(
+        url=f"{INTERNAL_BASE}/OpportunityDetail?opportunityId={ids[1]}",
+        text="<html><body>Malformed detail</body></html>",
+    )
+
+    jobs = UKGProScraper(BOARD).fetch()
+
+    assert [job.ats_id for job in jobs] == ids
+    assert jobs[0].description == "Build systems."
+    assert jobs[1].description is None
+
+
+def test_empty_description_keeps_listing_job(httpx_mock) -> None:
+    job_id = "aaaaaaaa-1111-2222-3333-444444444444"
+    httpx_mock.add_response(url=BOARD, text=_board_page())
+    httpx_mock.add_response(
+        method="POST",
+        url=LOAD_URL,
+        json={"opportunities": [_listing(job_id)], "totalCount": 1},
+    )
+    httpx_mock.add_response(
+        url=f"{INTERNAL_BASE}/OpportunityDetail?opportunityId={job_id}",
+        text=_detail(job_id, description=""),
+    )
+
+    jobs = UKGProScraper(BOARD).fetch()
+
+    assert [job.ats_id for job in jobs] == [job_id]
+    assert jobs[0].description is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ukg.py
+++ b/tests/test_ukg.py
@@ -1,0 +1,269 @@
+"""Tests for the UKG Pro Recruiting scraper."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType
+from ats_scrapers.scrapers import ukg
+from ats_scrapers.scrapers.ukg import UKGProScraper, _normalize_board_url
+
+BOARD = (
+    "https://recruiting.ultipro.com/ACM1000/JobBoard/"
+    "11111111-2222-3333-4444-555555555555"
+)
+INTERNAL_BASE = BOARD
+LOAD_URL = f"{INTERNAL_BASE}/JobBoardView/LoadSearchResults"
+
+
+def _board_page(load_url: str = "") -> str:
+    target = load_url or (
+        "/ACM1000/JobBoard/11111111-2222-3333-4444-555555555555/"
+        "JobBoardView/LoadSearchResults"
+    )
+    return f'<script>var model = {{ loadUrl: "{target}" }};</script>'
+
+
+def _listing(job_id: str, title: str = "Engineer") -> dict[str, object]:
+    return {
+        "Id": job_id,
+        "Featured": False,
+        "Title": title,
+        "RequisitionNumber": f"REQ-{job_id[:4]}",
+        "FullTime": True,
+        "JobCategoryName": "Engineering",
+        "Locations": [
+            {
+                "LocalizedName": "Remote",
+                "Address": {
+                    "City": "Remote",
+                    "State": None,
+                    "Country": {"Code": "USA", "Name": "United States"},
+                },
+                "Coordinates": {"Latitude": 40.0, "Longitude": -75.0},
+            }
+        ],
+        "PostedDate": "2026-07-20T12:00:00Z",
+        "JobLocationType": 2,
+        "OpportunityType": 0,
+    }
+
+
+def _detail(job_id: str, *, description: str = "<p>Build systems.</p>") -> str:
+    payload = {
+        "Id": job_id,
+        "Description": description,
+        "Locations": _listing(job_id)["Locations"],
+        "UpdatedDate": "2026-07-21T12:00:00Z",
+        "OpportunityIsClosed": False,
+        "JobLocationType": 2,
+        "CompensationAnnualMinimum": 100000,
+        "CompensationAnnualMaximum": 125000,
+        "CompensationCurrencyCode": "USD",
+    }
+    return (
+        "<script>var opportunity = new "
+        "US.Opportunity.CandidateOpportunityDetail("
+        f"{json.dumps(payload)}"
+        ");</script>"
+    )
+
+
+def test_fetches_all_pages_and_enriches_details(
+    httpx_mock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(ukg, "PAGE_SIZE", 2)
+    ids = [
+        "aaaaaaaa-1111-2222-3333-444444444444",
+        "bbbbbbbb-1111-2222-3333-444444444444",
+        "cccccccc-1111-2222-3333-444444444444",
+    ]
+    httpx_mock.add_response(url=BOARD, text=_board_page())
+    httpx_mock.add_response(
+        method="POST",
+        url=LOAD_URL,
+        json={"opportunities": [_listing(ids[0]), _listing(ids[1])], "totalCount": 3},
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=LOAD_URL,
+        json={"opportunities": [_listing(ids[2])], "totalCount": 3},
+    )
+    for job_id in ids:
+        httpx_mock.add_response(
+            url=f"{INTERNAL_BASE}/OpportunityDetail?opportunityId={job_id}",
+            text=_detail(job_id),
+        )
+
+    jobs = UKGProScraper(BOARD, company_name="Acme").fetch()
+
+    assert [job.ats_id for job in jobs] == ids
+    assert all(job.ats_type is ATSType.UKG for job in jobs)
+    assert all(job.company == "Acme" for job in jobs)
+    assert jobs[0].location == "Remote, United States"
+    assert jobs[0].country_iso == "US"
+    assert jobs[0].lat == 40.0
+    assert jobs[0].lon == -75.0
+    assert jobs[0].is_remote is True
+    assert jobs[0].employment_type == "FULL_TIME"
+    assert jobs[0].department == "Engineering"
+    assert jobs[0].description == "Build systems."
+    assert jobs[0].salary_min == 100000
+    assert jobs[0].salary_max == 125000
+    assert jobs[0].salary_currency == "USD"
+    assert jobs[0].salary_period == "YEAR"
+
+    post_requests = [
+        request
+        for request in httpx_mock.get_requests()
+        if request.method == "POST"
+    ]
+    assert [request.read().decode() for request in post_requests] == [
+        json.dumps(
+            {"opportunitySearch": ukg._search_payload(0)},
+            separators=(",", ":"),
+        ),
+        json.dumps(
+            {"opportunitySearch": ukg._search_payload(2)},
+            separators=(",", ":"),
+        ),
+    ]
+
+
+def test_include_descriptions_false_skips_detail(httpx_mock) -> None:
+    job_id = "aaaaaaaa-1111-2222-3333-444444444444"
+    httpx_mock.add_response(url=BOARD, text=_board_page())
+    httpx_mock.add_response(
+        method="POST",
+        url=LOAD_URL,
+        json={"opportunities": [_listing(job_id)], "totalCount": 1},
+    )
+
+    jobs = UKGProScraper(BOARD, include_descriptions=False).fetch()
+
+    assert len(jobs) == 1
+    assert jobs[0].description is None
+
+
+def test_internal_board_id_from_page_is_used(httpx_mock) -> None:
+    internal_id = "99999999-2222-3333-4444-555555555555"
+    internal_base = f"https://recruiting.ultipro.com/ACM1000/JobBoard/{internal_id}"
+    job_id = "aaaaaaaa-1111-2222-3333-444444444444"
+    httpx_mock.add_response(
+        url=BOARD,
+        text=_board_page(
+            f"/ACM1000/JobBoard/{internal_id}/JobBoardView/LoadSearchResults"
+        ),
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{internal_base}/JobBoardView/LoadSearchResults",
+        json={"opportunities": [_listing(job_id)], "totalCount": 1},
+    )
+
+    jobs = UKGProScraper(BOARD, include_descriptions=False).fetch()
+
+    assert str(jobs[0].url).startswith(
+        f"{internal_base}/OpportunityDetail"
+    )
+
+
+def test_unsafe_search_endpoint_fails_closed(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=BOARD,
+        text=_board_page(
+            "https://evil.example/ACM1000/JobBoard/"
+            "11111111-2222-3333-4444-555555555555/"
+            "JobBoardView/LoadSearchResults"
+        ),
+    )
+
+    with pytest.raises(ScraperError, match="unsafe search endpoint"):
+        UKGProScraper(BOARD).fetch()
+
+
+def test_reported_total_mismatch_fails_closed(httpx_mock) -> None:
+    httpx_mock.add_response(url=BOARD, text=_board_page())
+    httpx_mock.add_response(
+        method="POST",
+        url=LOAD_URL,
+        json={"opportunities": [], "totalCount": 1},
+    )
+
+    with pytest.raises(ScraperError, match="reported total"):
+        UKGProScraper(BOARD, include_descriptions=False).fetch()
+
+
+def test_closed_job_between_listing_and_detail_is_dropped(httpx_mock) -> None:
+    ids = [
+        "aaaaaaaa-1111-2222-3333-444444444444",
+        "bbbbbbbb-1111-2222-3333-444444444444",
+    ]
+    httpx_mock.add_response(url=BOARD, text=_board_page())
+    httpx_mock.add_response(
+        method="POST",
+        url=LOAD_URL,
+        json={"opportunities": [_listing(job_id) for job_id in ids], "totalCount": 2},
+    )
+    httpx_mock.add_response(
+        url=f"{INTERNAL_BASE}/OpportunityDetail?opportunityId={ids[0]}",
+        text=_detail(ids[0]),
+    )
+    httpx_mock.add_response(
+        url=f"{INTERNAL_BASE}/OpportunityDetail?opportunityId={ids[1]}",
+        status_code=404,
+    )
+
+    jobs = UKGProScraper(BOARD).fetch()
+
+    assert [job.ats_id for job in jobs] == [ids[0]]
+
+
+def test_systemic_detail_request_failure_fails_closed(httpx_mock) -> None:
+    job_id = "aaaaaaaa-1111-2222-3333-444444444444"
+    httpx_mock.add_response(url=BOARD, text=_board_page())
+    httpx_mock.add_response(
+        method="POST",
+        url=LOAD_URL,
+        json={"opportunities": [_listing(job_id)], "totalCount": 1},
+    )
+    httpx_mock.add_response(
+        url=f"{INTERNAL_BASE}/OpportunityDetail?opportunityId={job_id}",
+        status_code=500,
+        is_reusable=True,
+    )
+
+    with pytest.raises(ScraperError, match="returned 500"):
+        UKGProScraper(BOARD).fetch()
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "http://recruiting.ultipro.com/ACM1000/JobBoard/"
+        "11111111-2222-3333-4444-555555555555",
+        "https://evil.example/ACM1000/JobBoard/"
+        "11111111-2222-3333-4444-555555555555",
+        "https://recruiting.ultipro.com/bad_slug/JobBoard/"
+        "11111111-2222-3333-4444-555555555555",
+        "https://recruiting.ultipro.com/ACM1000/JobBoard/not-a-uuid",
+    ],
+)
+def test_rejects_invalid_board_urls(value: str) -> None:
+    with pytest.raises(ValueError):
+        _normalize_board_url(value)
+
+
+def test_normalizes_supported_hosts() -> None:
+    assert _normalize_board_url(
+        "recruiting2.ultipro.com/ACM1000/JobBoard/"
+        "11111111-2222-3333-4444-555555555555/"
+    ) == (
+        "https://recruiting2.ultipro.com/ACM1000/JobBoard/"
+        "11111111-2222-3333-4444-555555555555"
+    )

--- a/tests/test_ukg_contracts.py
+++ b/tests/test_ukg_contracts.py
@@ -1,0 +1,31 @@
+"""Pipeline contracts for UKG Pro Recruiting."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ats_scrapers.scrapers.ukg import UKGProScraper
+from pipeline.publisher import ATS_DEDUP_PRIORITY
+from scripts.run_pipeline import CONFIGS
+
+
+def test_ukg_pipeline_contract() -> None:
+    config = CONFIGS["ukg"]
+
+    assert config["scraper"] is UKGProScraper
+    assert config["csv"] == "ats-companies/ukg.csv"
+    assert config["output"] == "ukg/jobs.csv"
+    assert config["fail_closed_on_any_error"] is True
+    assert config["fail_closed_on_empty"] is True
+    assert config["kwargs"]({"name": "Acme"}) == {"company_name": "Acme"}
+
+
+def test_ukg_has_direct_employer_dedup_priority() -> None:
+    assert ATS_DEDUP_PRIORITY["ukg"] == ATS_DEDUP_PRIORITY["workday"]
+
+
+def test_ukg_seed_catalogue_is_provider_only() -> None:
+    rows = Path("ats-companies/ukg.csv").read_text().splitlines()
+
+    assert len(rows) == 20
+    assert all("ultipro." in row for row in rows[1:])

--- a/tests/test_ukg_contracts.py
+++ b/tests/test_ukg_contracts.py
@@ -16,6 +16,7 @@ def test_ukg_pipeline_contract() -> None:
     assert config["csv"] == "ats-companies/ukg.csv"
     assert config["output"] == "ukg/jobs.csv"
     assert config["fail_closed_on_any_error"] is True
+    assert config["fail_closed_on_not_found"] is True
     assert config["fail_closed_on_empty"] is True
     assert config["kwargs"]({"name": "Acme"}) == {"company_name": "Acme"}
 


### PR DESCRIPTION
## Summary

- add a credential-free UKG Pro Recruiting scraper for `recruiting*.ultipro.com` and `.ca` boards
- discover the board's embedded public search endpoint, including tenants whose internal board ID differs from the public URL
- count-check 50-row pagination and hydrate full descriptions, structured locations, dates, requisitions, employment type, and compensation
- add 19 live-verified employer boards with 1,751 current jobs measured during discovery
- register URL resolution, direct-employer dedup priority, fail-closed pipeline guards, unit/contracts, and live smoke coverage

## Validation

- `uv run ruff check ...` — clean
- focused unit/contracts suite — 160 passed
- `ATS_SCRAPERS_LIVE_E2E=1 uv run --extra test pytest -q -m live tests/e2e/test_live_ukg.py` — 2 passed
  - Comprehensive Logistics full-detail smoke
  - Surgery Partners large-catalog pagination (>50 jobs)

No credentials, API keys, proxy, or browser automation are required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a credential-free UKG Pro Recruiting scraper with safe pagination and full detail hydration, integrated into URL resolution, pipeline config, and dedup. Also tightens URL resolver validation to canonicalize UKG links and fail-closed on required not-found shards.

- **New Features**
  - Added `UKGProScraper` for `recruiting*.ultipro.com` and `.ca` with 50-row pagination, total count checks, and detail hydration (description, location, dates, requisition, employment type, compensation).
  - Normalized UKG URLs; added `ATSType.UKG`. Registered pipeline config with fail-closed guards (any error, empty, not-found) and direct-employer dedup. Seeded 19 employer boards and added unit and live tests.

- **Bug Fixes**
  - Preserve listing rows when a detail request fails or is malformed; drop only 404/410 or closed postings.
  - Keep jobs with empty descriptions as valid listing-only rows.
  - Aligned URL resolver validation with scraper normalization: strict host/tenant/UUID checks and canonicalization from `OpportunityDetail` to the board URL.

<sup>Written for commit c2d389d2703d7549d7fdd14b33498b8470164109. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds and integrates a UKG Pro Recruiting scraper.
- Discovers UKG public search endpoints, paginates listings, and enriches jobs with detail data.
- Preserves listing-only jobs when optional detail retrieval fails or descriptions are empty.
- Registers UKG URL resolution, pipeline safeguards, deduplication priority, employer boards, and test coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with both previously reported failures addressed.

No blocking failures remain.

**Files Needing Attention:** No files require additional attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the PR’s test suite with Pytest and confirmed the run completed with exit code 0.
- Noted the UTC execution window for the run as 2026-07-24T22:18:23Z–22:18:30Z.
- Inspected the attached log to verify the exact command, timing, and pytest output from the run.

<a href="https://app.greptile.com/trex/runs/15814899/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/ats_scrapers/scrapers/ukg.py | Implements UKG listing pagination and detail enrichment while fully addressing both previous review threads by retaining listing rows after optional detail failures and empty descriptions. |
| scripts/run_pipeline.py | Registers UKG with fail-closed pipeline guards and adds configurable handling for required not-found shards. |
| src/ats_scrapers/resolve.py | Adds strict UKG host, tenant, board-ID validation and canonical URL resolution. |
| tests/test_ukg.py | Covers pagination, endpoint discovery, malformed or failed details, closed postings, empty descriptions, and URL validation. |

<sub>Reviews (3): Last reviewed commit: ["Align UKG URL resolver validation"](https://github.com/kalil0321/ats-scrapers/commit/c2d389d2703d7549d7fdd14b33498b8470164109) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47127939)</sub>

<!-- /greptile_comment -->