### PR TITLE
Retry transient Workday HTML outage responses

### DIFF
--- a/src/ats_scrapers/scrapers/workday.py
+++ b/src/ats_scrapers/scrapers/workday.py
@@ -439,7 +439,32 @@ class WorkdayScraper(BaseScraper):
                     f"Workday site not found: {self.company_slug}"
                 )
             if response.status_code == 200:
-                return response.json()
+                try:
+                    payload = response.json()
+                except ValueError:
+                    content_type = response.headers.get(
+                        "Content-Type",
+                        "unknown",
+                    )
+                    last_exc = ScraperError(
+                        "Workday returned a non-JSON success response for "
+                        f"{self.company_slug} (offset={offset}, "
+                        f"content-type={content_type})"
+                    )
+                    await asyncio.sleep(
+                        min(MAX_RETRY_DELAY, RETRY_BACKOFF ** attempt)
+                    )
+                    continue
+                if not isinstance(payload, dict):
+                    last_exc = ScraperError(
+                        "Workday returned an unexpected JSON payload for "
+                        f"{self.company_slug} (offset={offset})"
+                    )
+                    await asyncio.sleep(
+                        min(MAX_RETRY_DELAY, RETRY_BACKOFF ** attempt)
+                    )
+                    continue
+                return payload
             if response.status_code in retryable_statuses:
                 # Exponential backoff respects Retry-After when present.
                 retry_after = response.headers.get("Retry-After")

--- a/tests/test_workday_guards.py
+++ b/tests/test_workday_guards.py
@@ -59,6 +59,93 @@ def test_workday_retry_after_is_capped(monkeypatch: pytest.MonkeyPatch) -> None:
     assert delays == [7.0, 7.0, 7.0]
 
 
+def test_workday_retries_html_outage_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    delays: list[float] = []
+    calls = 0
+
+    async def fake_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    class FakeResponse:
+        def __init__(self, payload: dict[str, object] | None) -> None:
+            self.status_code = 200
+            self.headers = {"Content-Type": "text/html; charset=utf-8"}
+            self.payload = payload
+
+        def json(self) -> dict[str, object]:
+            if self.payload is None:
+                raise ValueError("outage page is HTML")
+            return self.payload
+
+    class FakeClient:
+        async def post(self, *_args, **_kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return FakeResponse(None)
+            return FakeResponse({"jobPostings": [], "total": 0})
+
+    monkeypatch.setattr("ats_scrapers.scrapers.workday.asyncio.sleep", fake_sleep)
+
+    scraper = WorkdayScraper(
+        "https://2020companies.wd1.myworkdayjobs.com/external_careers",
+    )
+
+    async def run() -> None:
+        payload = await scraper._request(
+            FakeClient(),
+            "https://example.com/wday/cxs/2020companies/site/jobs",
+            asyncio.Semaphore(1),
+            applied_facets={},
+            offset=0,
+        )
+        assert payload == {"jobPostings": [], "total": 0}
+
+    asyncio.run(run())
+
+    assert calls == 2
+    assert delays == [1.0]
+
+
+def test_workday_persistent_html_outage_raises_scraper_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_sleep(_delay: float) -> None:
+        return None
+
+    class FakeResponse:
+        def __init__(self) -> None:
+            self.status_code = 200
+            self.headers = {"Content-Type": "text/html; charset=utf-8"}
+
+        def json(self) -> dict[str, object]:
+            raise ValueError("outage page is HTML")
+
+    class FakeClient:
+        async def post(self, *_args, **_kwargs):
+            return FakeResponse()
+
+    monkeypatch.setattr("ats_scrapers.scrapers.workday.asyncio.sleep", fake_sleep)
+
+    scraper = WorkdayScraper(
+        "https://2020companies.wd1.myworkdayjobs.com/external_careers",
+    )
+
+    async def run() -> None:
+        with pytest.raises(ScraperError, match="non-JSON success response"):
+            await scraper._request(
+                FakeClient(),
+                "https://example.com/wday/cxs/2020companies/site/jobs",
+                asyncio.Semaphore(1),
+                applied_facets={},
+                offset=0,
+            )
+
+    asyncio.run(run())
+
+
 def test_workday_from_url_delegates_to_constructor() -> None:
     """`from_url` is the explicit full-careers-URL entry point; it must
     behave exactly like passing the URL as `company_slug`."""


### PR DESCRIPTION
## What the live E2E job does

The scheduled `live-e2e` workflow runs `pytest tests/e2e -m live -q` against real ATS endpoints (no mocks) so provider API drift is detected daily without blocking normal PR CI.

## Observed failure

- Run: https://github.com/kalil0321/ats-scrapers/actions/runs/30148813166
- Result: 24 passed, 1 failed
- Workday tenant `2020companies` returned an HTTP 200 HTML outage page instead of JSON
- `WorkdayScraper._request()` called `response.json()` directly, leaking `JSONDecodeError`

The next scheduled run passed, confirming the provider outage was transient, but the scraper still needed to handle this response safely.

## Fix

- retry HTTP 200 responses whose body is not valid JSON
- retry unexpected non-object JSON payloads through the same bounded Workday retry loop
- raise a clear `ScraperError` if the invalid response persists
- add recovery and persistent-outage regression tests

## Validation

- `uv run ruff check src/ats_scrapers/scrapers/workday.py tests/test_workday_guards.py`
- focused Workday tests: 34 passed
- full suite: 1,606 passed, 2 skipped, 29 deselected
- exact live canary: 1 passed (`workday-2020companies`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retry transient Workday “success” responses that return HTML or invalid JSON to prevent crashes and improve live E2E stability.

- **Bug Fixes**
  - In `_request`, retry HTTP 200 responses that aren’t valid JSON.
  - Retry when JSON is not an object, using the same backoff.
  - After retries, raise a clear `ScraperError` with tenant, offset, and content type.
  - Added tests for recovery and persistent outage cases.

<sup>Written for commit 4d9a684ad4ef85769c402dfa7c0063c3688a5343. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds bounded retries for transient Workday HTTP 200 responses that contain malformed or unexpected JSON.
- Converts persistent invalid payloads into clear `ScraperError` failures.
- Adds regression coverage for recovery from transient HTML responses and persistent outages.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The new branches preserve the existing retry limits, validate payload shape before callers consume it, and raise a clear scraper-level error when malformed responses persist.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified the post-change canary by inspecting the log to confirm the exact command, working directory, complete pytest output, and that the test exited with code 0.

<a href="https://app.greptile.com/trex/runs/15949443/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/ats_scrapers/scrapers/workday.py | Safely retries malformed and non-object success payloads through the existing bounded Workday retry loop. |
| tests/test_workday_guards.py | Adds focused regression tests for transient recovery and persistent malformed-response failure. |

<sub>Reviews (1): Last reviewed commit: ["Retry Workday HTML outage responses"](https://github.com/kalil0321/ats-scrapers/commit/4d9a684ad4ef85769c402dfa7c0063c3688a5343) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47426196)</sub>

<!-- /greptile_comment -->