### PR TITLE
Disable SEEK scheduled ingestion

### DIFF
--- a/.github/scripts/publish_companies.py
+++ b/.github/scripts/publish_companies.py
@@ -176,6 +176,7 @@ def delete_legacy(client, bucket: str) -> None:
         f"{PREFIX}/companies/by-ats/",
         f"{PREFIX}/companies/all.csv",
         f"{PREFIX}/ats-companies/",  # transient prefix from an earlier draft
+        f"{PREFIX}/seek/companies.csv",  # disabled scheduled source
     ]
     paginator = client.get_paginator("list_objects_v2")
     for prefix in legacy_prefixes:

--- a/ats-companies/seek.csv
+++ b/ats-companies/seek.csv
@@ -1,9 +1,0 @@
-name,slug,url
-JobStreet Indonesia,id,https://id.jobstreet.com
-JobStreet Malaysia,my,https://my.jobstreet.com
-JobStreet Philippines,ph,https://ph.jobstreet.com
-JobStreet Singapore,sg,https://sg.jobstreet.com
-JobsDB Hong Kong,hk,https://hk.jobsdb.com
-JobsDB Thailand,th,https://th.jobsdb.com
-SEEK Australia,au,https://www.seek.com.au
-SEEK New Zealand,nz,https://www.seek.co.nz

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -81,7 +81,6 @@ from ats_scrapers.scrapers import (
     RecruiterboxScraper,
     RemoteOKScraper,
     RipplingScraper,
-    SeekScraper,
     SmartRecruitersScraper,
     SuccessFactorsScraper,
     TaleoScraper,
@@ -719,13 +718,6 @@ CONFIGS: dict[str, dict[str, Any]] = {
         "scraper": JobBankCAScraper, "singleton": True,
         "output": "jobbankca/jobs.csv",
         "fail_closed_on_empty": True,
-    },
-    "seek": {
-        "scraper": SeekScraper,
-        "slug": lambda r: _slug_col(r) or None,
-        "csv": "ats-companies/seek.csv",
-        "output": "seek/jobs.csv",
-        "fail_closed_on_any_error": True,
     },
     "jobs_cz": {
         # jobs.cz - Czech Republic's largest direct-posting board. ~10k live via seeded search.

--- a/tests/test_run_pipeline_guards.py
+++ b/tests/test_run_pipeline_guards.py
@@ -10,6 +10,11 @@ from ats_scrapers.exceptions import CompanyNotFoundError
 from ats_scrapers.models import ATSType, Job
 
 
+def test_seek_is_not_scheduled_for_pipeline_ingestion() -> None:
+    assert "seek" not in runner.CONFIGS
+    assert "jobbankca" in runner.CONFIGS
+
+
 def test_job_to_row_preserves_structured_location_metadata() -> None:
     row = runner._job_to_row(
         Job(


### PR DESCRIPTION
## Summary

- remove SEEK from scheduled pipeline ingestion
- remove the SEEK tenant seed file
- retain the SEEK library scraper for manual and discovery use
- keep Job Bank Canada scheduled

## Validation

- `uv run --extra test pytest -q tests/test_run_pipeline_guards.py tests/test_seek.py tests/test_jobbankca.py` — 120 passed
- `uv run --with ruff ruff check scripts/run_pipeline.py tests/test_run_pipeline_guards.py` — passed
- `uv run --no-sync pytest -q` — 1,607 passed, 2 skipped, 29 deselected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable scheduled ingestion for `seek` while keeping the `seek` scraper available for manual and discovery use. Removed `ats-companies/seek.csv` and the `seek` pipeline config, added a guard test, and updated `.github/scripts/publish_companies.py` to delete `seek/companies.csv`; `jobbankca` scheduling remains unchanged.

<sup>Written for commit d5828fc18f02326a7808a6bc790a18e8fa381e70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Disable SEEK scheduled ingestion while retaining its scraper for manual and discovery use.
- Removes SEEK from the scheduled pipeline configuration and deletes its tenant seed file.
- Adds cleanup for the legacy published SEEK companies artifact.
- Adds a guard test confirming SEEK is disabled while Job Bank Canada remains scheduled.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the general-contract-validation-proof that documents the full focused-suite output and the runnable scheduler assertion for the scheduled pipeline regressions.
- Verified that the two artifacts exist and are linked to the proof, enabling focused review of the scheduled pipeline regressions results.
- Noted that the artifacts provide the relevant outputs: the after-log for the focused suite and the proof text with the scheduler assertion and suite total.

<a href="https://app.greptile.com/trex/runs/16039223/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/run_pipeline.py | Removes the SEEK scraper import and scheduled pipeline configuration while leaving Job Bank Canada unchanged. |
| ats-companies/seek.csv | Removes the SEEK tenant seed list formerly used by scheduled ingestion. |
| .github/scripts/publish_companies.py | Adds the disabled SEEK companies artifact to legacy publication cleanup. |
| tests/test_run_pipeline_guards.py | Adds a regression guard asserting that SEEK is unscheduled and Job Bank Canada remains configured. |

<sub>Reviews (2): Last reviewed commit: ["Disable SEEK scheduled ingestion"](https://github.com/kalil0321/ats-scrapers/commit/d5828fc18f02326a7808a6bc790a18e8fa381e70) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47556392)</sub>

<!-- /greptile_comment -->