### PR TITLE
Serialize R2 dataset publication

### DIFF
--- a/.github/scripts/publish_companies.py
+++ b/.github/scripts/publish_companies.py
@@ -27,16 +27,11 @@ Notes:
   migrated yet (still ``name,url``) get an empty ``slug`` column in
   the aggregate so the published schema stays uniform.
 
-Known limitation — manifest read-modify-write race:
-  This script and ``DatasetPublisher`` both read+modify+write
-  ``manifest.json``. The workflow's ``concurrency`` group prevents two
-  CI runs from overlapping, but a manual publisher run that fires while
-  CI is in flight would each read the same manifest version and the
-  later writer would clobber the earlier writer's fields. Practical
-  risk is low (manual publisher runs are rare and operator-driven), but
-  if it ever bites, swap the final ``put_object`` for a conditional
-  ``put_object(IfMatch=etag)`` retry loop using the etag from the
-  ``get_object`` response.
+Manifest safety:
+  This script and ``DatasetPublisher`` both patch ``manifest.json``.
+  The final write uses the ETag read with the manifest and retries a
+  lost compare-and-swap, so either writer preserves fields committed
+  by the other.
 """
 
 from __future__ import annotations
@@ -62,6 +57,7 @@ PREFIX = "jobhive/v1"
 # jobs-side publisher independently moves the manifest to a newer
 # version, that wins until this constant catches up.
 MIN_MANIFEST_VERSION = "2.0"
+MANIFEST_WRITE_ATTEMPTS = 5
 
 
 def env(name: str) -> str:
@@ -155,8 +151,11 @@ def build_aggregated(ats_files: dict[str, bytes]) -> tuple[bytes, bytes, int]:
     return csv_buf.getvalue(), parquet_buf.getvalue(), len(combined)
 
 
-def fetch_existing_manifest(client, bucket: str) -> dict[str, Any]:
-    """Return the manifest if it exists, else a fresh-template dict."""
+def fetch_existing_manifest(
+    client,
+    bucket: str,
+) -> tuple[dict[str, Any], str | None]:
+    """Return the current manifest and its ETag."""
     key = f"{PREFIX}/manifest.json"
     try:
         obj = client.get_object(Bucket=bucket, Key=key)
@@ -164,9 +163,81 @@ def fetch_existing_manifest(client, bucket: str) -> dict[str, Any]:
         code = exc.response.get("Error", {}).get("Code", "")
         if code in ("NoSuchKey", "404"):
             print("  no existing manifest — starting fresh")
-            return {}
+            return {}, None
         raise
-    return json.loads(obj["Body"].read().decode("utf-8"))
+    etag = obj.get("ETag")
+    return (
+        json.loads(obj["Body"].read().decode("utf-8")),
+        etag if isinstance(etag, str) and etag else None,
+    )
+
+
+def patch_manifest(
+    client,
+    bucket: str,
+    *,
+    aggregate_entry: dict[str, Any],
+    by_ats_entries: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    key = f"{PREFIX}/manifest.json"
+    for attempt in range(1, MANIFEST_WRITE_ATTEMPTS + 1):
+        manifest, etag = fetch_existing_manifest(client, bucket)
+        manifest["companies"] = aggregate_entry
+        manifest["by_ats_companies"] = by_ats_entries
+        manifest["updated_at"] = datetime.now(tz=UTC).isoformat(
+            timespec="seconds"
+        ).replace("+00:00", "Z")
+        existing_version = manifest.get("version")
+        if (
+            existing_version is None
+            or _parse_version(existing_version)
+            < _parse_version(MIN_MANIFEST_VERSION)
+        ):
+            manifest["version"] = MIN_MANIFEST_VERSION
+        manifest.pop("companies_by_ats", None)
+        body = json.dumps(manifest, indent=2, sort_keys=True).encode("utf-8")
+        condition = (
+            {"IfMatch": etag}
+            if etag is not None
+            else {"IfNoneMatch": "*"}
+        )
+        try:
+            client.put_object(
+                Bucket=bucket,
+                Key=key,
+                Body=body,
+                ContentType="application/json",
+                **condition,
+            )
+        except ClientError as exc:
+            current, _current_etag = fetch_existing_manifest(client, bucket)
+            if (
+                current.get("companies") == aggregate_entry
+                and current.get("by_ats_companies") == by_ats_entries
+            ):
+                print("  manifest write response was ambiguous; update is current")
+                return current
+            code = exc.response.get("Error", {}).get("Code", "")
+            status = exc.response.get("ResponseMetadata", {}).get(
+                "HTTPStatusCode"
+            )
+            if status not in {409, 412} and code not in {
+                "ConditionalRequestConflict",
+                "PreconditionFailed",
+            }:
+                raise
+            if attempt == MANIFEST_WRITE_ATTEMPTS:
+                raise RuntimeError(
+                    "manifest kept changing during companies publication"
+                ) from exc
+            print(
+                "  manifest changed during companies patch; "
+                f"retrying ({attempt}/{MANIFEST_WRITE_ATTEMPTS})"
+            )
+            continue
+        print(f"  put s3://{bucket}/{key} ({len(body):,} bytes, application/json)")
+        return manifest
+    raise AssertionError("unreachable")
 
 
 def delete_legacy(client, bucket: str) -> None:
@@ -176,6 +247,7 @@ def delete_legacy(client, bucket: str) -> None:
         f"{PREFIX}/companies/by-ats/",
         f"{PREFIX}/companies/all.csv",
         f"{PREFIX}/ats-companies/",  # transient prefix from an earlier draft
+        f"{PREFIX}/seek/companies.csv",  # disabled scheduled source
     ]
     paginator = client.get_paginator("list_objects_v2")
     for prefix in legacy_prefixes:
@@ -270,36 +342,11 @@ def main() -> None:
     }
 
     print("\n== Step 3: patch manifest.json")
-    manifest = fetch_existing_manifest(client, bucket)
-    manifest["companies"] = aggregate_entry
-    manifest["by_ats_companies"] = by_ats_entries
-    manifest["updated_at"] = datetime.now(tz=UTC).isoformat(
-        timespec="seconds"
-    ).replace("+00:00", "Z")
-    # Monotonic floor: bump up to MIN_MANIFEST_VERSION if absent or
-    # below, leave anything higher untouched. Prevents this script
-    # from silently downgrading a manifest that a newer publisher
-    # has already moved forward (e.g. publisher moves to "3.0",
-    # next companies-side run preserves it).
-    existing_version = manifest.get("version")
-    if existing_version is None or _parse_version(existing_version) < _parse_version(
-        MIN_MANIFEST_VERSION
-    ):
-        manifest["version"] = MIN_MANIFEST_VERSION
-    # Drop the legacy companies-side field. It pointed at
-    # `<prefix>/companies/by-ats/<ats>.csv` URLs that we deleted in
-    # `delete_legacy(...)` below, and its name is one underscore away
-    # from `by_ats_companies` so leaving it behind invites confusion.
-    # Jobs-side legacy fields (`by_date`) are publisher-owned — that
-    # cleanup happens in DatasetPublisher.
-    manifest.pop("companies_by_ats", None)
-    manifest_bytes = json.dumps(manifest, indent=2, sort_keys=True).encode("utf-8")
-    upload(
+    patch_manifest(
         client,
         bucket,
-        f"{PREFIX}/manifest.json",
-        manifest_bytes,
-        "application/json",
+        aggregate_entry=aggregate_entry,
+        by_ats_entries=by_ats_entries,
     )
 
     print("\n== Step 4: cleanup legacy paths")

--- a/pipeline/publisher.py
+++ b/pipeline/publisher.py
@@ -3,9 +3,10 @@
 Layout produced under ``<prefix>`` (default ``jobhive/v1``):
 
     jobhive/v1/manifest.json
-    jobhive/v1/all.{csv,parquet}     # full snapshot, both formats
-    jobhive/v1/<ats>/jobs.csv        # per-ATS jobs slice
-    jobhive/v1/<ats>/jobs.parquet    # idem in parquet
+    jobhive/v1/job-snapshots/<sha>.{csv,parquet}
+    jobhive/v1/<ats>/job-snapshots/<sha>.{csv,parquet}
+    jobhive/v1/all.{csv,parquet}     # compatibility aliases
+    jobhive/v1/<ats>/jobs.{csv,parquet}  # compatibility aliases
 
 Tenant lists (``<ats>/companies.csv`` and the aggregated
 ``companies.{csv,parquet}``) are owned by the GitHub Actions workflow
@@ -49,17 +50,20 @@ import logging
 import os
 import re
 import tempfile
+import time
 from contextlib import ExitStack, contextmanager, suppress
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
+from math import ceil
 from pathlib import Path
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 import polars as pl
 
 from ats_scrapers._version import __version__
 from ats_scrapers.enrichment import infer_is_remote, parse_salary_range
-from ats_scrapers.exceptions import StorageError
+from ats_scrapers.exceptions import StorageConflictError, StorageError
 from ats_scrapers.models import ATSType
 
 # Pull the keyword list used by ``infer_is_remote`` so the lazy
@@ -73,7 +77,7 @@ except ImportError:
     _REMOTE_KEYWORDS = ()
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
 
     from pipeline.r2 import R2Client
 
@@ -81,6 +85,18 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_PREFIX = "jobhive/v1"
 CACHE_CONTROL_LATEST = "public, max-age=300"  # manifest + latest data files
+CACHE_CONTROL_IMMUTABLE = "public, max-age=31536000, immutable"
+MANIFEST_WRITE_ATTEMPTS = 5
+ALIAS_COPY_ATTEMPTS = 3
+PUBLICATION_LEASE_TTL = timedelta(minutes=20)
+PUBLICATION_LEASE_POLL_SECONDS = 5.0
+PUBLICATION_LEASE_WAIT_ATTEMPTS = (
+    ceil(
+        PUBLICATION_LEASE_TTL.total_seconds()
+        / PUBLICATION_LEASE_POLL_SECONDS
+    )
+    + 1
+)
 
 # ``all`` ships both formats — parquet for typed pandas / DuckDB
 # consumers, CSV (~2.3 GB at the current ~4M-row corpus) for
@@ -110,6 +126,13 @@ class PublishResult:
     total_jobs_raw: int = 0
     ats_count: int = 0
     duration_seconds: float = 0.0
+
+
+@dataclass(frozen=True)
+class AliasCopy:
+    source_key: str
+    destination_key: str
+    content_type: str
 
 
 class DatasetPublisher:
@@ -181,6 +204,7 @@ class DatasetPublisher:
         with ExitStack() as stack:
             per_ats_csv_paths: dict[str, Path] = {}
             per_ats_entries: dict[ATSType, dict[str, object]] = {}
+            alias_copies: list[AliasCopy] = []
             schema_union: list[str] = []
             seen_cols: set[str] = set()
 
@@ -231,11 +255,12 @@ class DatasetPublisher:
                 lf.sink_csv(csv_path)
                 per_ats_csv_paths[ats.value] = csv_path
 
-                entry, _ = self._upload_per_ats_streaming(
+                entry, _, aliases = self._upload_per_ats_streaming(
                     csv_path=csv_path,
                     base_key=f"{self._prefix}/{ats.value}/jobs",
                 )
                 per_ats_entries[ats] = entry
+                alias_copies.extend(aliases)
                 files_uploaded.extend(_collect_uploaded_keys(entry))
 
             if not any_csv_found:
@@ -258,15 +283,16 @@ class DatasetPublisher:
             )
 
             # ---- Pass 3: stream all.parquet from the per-ATS temp CSVs ------
-            all_entry = self._stream_write_all_polars(
+            all_entry, all_aliases = self._stream_write_all_polars(
                 per_ats_csv_paths=per_ats_csv_paths,
                 survivors=survivors,
                 schema_union=schema_union,
                 rows_total=n_kept,
             )
+            alias_copies.extend(all_aliases)
             files_uploaded.extend(_collect_uploaded_keys(all_entry))
 
-            manifest_key = self._patch_and_upload_manifest(
+            manifest_key = self._commit_job_publication(
                 generated_at=started,
                 stats_factory=lambda existing: {
                     "total_jobs": n_kept,
@@ -279,8 +305,12 @@ class DatasetPublisher:
                 all_entry=all_entry,
                 by_ats=per_ats_entries,
                 existing_manifest=existing_manifest,
+                aliases=alias_copies,
             )
             files_uploaded.append(manifest_key)
+            files_uploaded.extend(
+                alias.destination_key for alias in alias_copies
+            )
 
             deleted = self.prune_legacy_paths()
             if deleted:
@@ -324,7 +354,7 @@ class DatasetPublisher:
         *,
         csv_path: Path,
         base_key: str,
-    ) -> tuple[dict[str, object], int]:
+    ) -> tuple[dict[str, object], int, list[AliasCopy]]:
         """Upload a per-ATS slice from a sunk temp CSV.
 
         Hashes + uploads the CSV, then ``scan_csv`` → ``sink_parquet``
@@ -332,15 +362,21 @@ class DatasetPublisher:
         table in RAM). Returns the manifest entry and the row count.
         """
         entry: dict[str, object] = {}
+        aliases: list[AliasCopy] = []
 
-        csv_key = f"{base_key}.csv"
+        stable_csv_key = f"{base_key}.csv"
         csv_sha, csv_size = _file_sha_size(csv_path)
+        snapshot_prefix = (
+            f"{base_key.removesuffix('/jobs')}/job-snapshots"
+        )
+        csv_key = f"{snapshot_prefix}/{csv_sha}.csv"
         self._r2.upload(
             csv_path,
             csv_key,
             content_type="text/csv",
-            cache_control=CACHE_CONTROL_LATEST,
+            cache_control=CACHE_CONTROL_IMMUTABLE,
         )
+        aliases.append(AliasCopy(csv_key, stable_csv_key, "text/csv"))
         entry["csv"] = self._public_or_key(csv_key)
         entry["size_bytes"] = csv_size
         entry["sha256"] = csv_sha
@@ -356,23 +392,31 @@ class DatasetPublisher:
         entry["rows"] = n_rows
 
         if self._write_parquet:
-            parquet_key = f"{base_key}.parquet"
+            stable_parquet_key = f"{base_key}.parquet"
             with _temp_file(".parquet") as pq_path:
                 pl.scan_csv(csv_path, **_SCAN_CSV_KWARGS).sink_parquet(
                     pq_path, compression="zstd"
                 )
                 pq_sha, pq_size = _file_sha_size(pq_path)
+                parquet_key = f"{snapshot_prefix}/{pq_sha}.parquet"
                 self._r2.upload(
                     pq_path,
                     parquet_key,
                     content_type="application/vnd.apache.parquet",
-                    cache_control=CACHE_CONTROL_LATEST,
+                    cache_control=CACHE_CONTROL_IMMUTABLE,
                 )
+            aliases.append(
+                AliasCopy(
+                    parquet_key,
+                    stable_parquet_key,
+                    "application/vnd.apache.parquet",
+                )
+            )
             entry["parquet"] = self._public_or_key(parquet_key)
             entry["parquet_size_bytes"] = pq_size
             entry["parquet_sha256"] = pq_sha
 
-        return entry, n_rows
+        return entry, n_rows, aliases
 
     def _stream_write_all_polars(
         self,
@@ -381,7 +425,7 @@ class DatasetPublisher:
         survivors: dict[str, pl.DataFrame],
         schema_union: list[str],
         rows_total: int,
-    ) -> dict[str, object]:
+    ) -> tuple[dict[str, object], list[AliasCopy]]:
         """Stream the global ``all.parquet`` from the per-ATS temp CSVs.
 
         Three stages, all streaming:
@@ -403,6 +447,7 @@ class DatasetPublisher:
            materialized whole.
         """
         all_entry: dict[str, object] = {"rows": rows_total}
+        aliases: list[AliasCopy] = []
 
         with ExitStack() as stage_stack:
             per_ats_parquets: list[Path] = []
@@ -438,13 +483,23 @@ class DatasetPublisher:
                 ).write_parquet(all_pq, compression="zstd")
 
             if "parquet" in FORMATS_ALL and self._write_parquet:
-                pq_key = f"{self._prefix}/all.parquet"
+                stable_pq_key = f"{self._prefix}/all.parquet"
                 pq_sha, pq_size = _file_sha_size(all_pq)
+                pq_key = (
+                    f"{self._prefix}/job-snapshots/{pq_sha}.parquet"
+                )
                 self._r2.upload(
                     all_pq,
                     pq_key,
                     content_type="application/vnd.apache.parquet",
-                    cache_control=CACHE_CONTROL_LATEST,
+                    cache_control=CACHE_CONTROL_IMMUTABLE,
+                )
+                aliases.append(
+                    AliasCopy(
+                        pq_key,
+                        stable_pq_key,
+                        "application/vnd.apache.parquet",
+                    )
                 )
                 all_entry["parquet"] = self._public_or_key(pq_key)
                 all_entry["parquet_size_bytes"] = pq_size
@@ -453,16 +508,22 @@ class DatasetPublisher:
                 all_entry["sha256"] = pq_sha
 
             if "csv" in FORMATS_ALL and self._write_all_csv:
-                csv_key = f"{self._prefix}/all.csv"
+                stable_csv_key = f"{self._prefix}/all.csv"
                 with _temp_file(".csv") as all_csv:
                     pl.scan_parquet(all_pq).sink_csv(all_csv)
                     csv_sha, csv_size = _file_sha_size(all_csv)
+                    csv_key = (
+                        f"{self._prefix}/job-snapshots/{csv_sha}.csv"
+                    )
                     self._r2.upload(
                         all_csv,
                         csv_key,
                         content_type="text/csv",
-                        cache_control=CACHE_CONTROL_LATEST,
+                        cache_control=CACHE_CONTROL_IMMUTABLE,
                     )
+                aliases.append(
+                    AliasCopy(csv_key, stable_csv_key, "text/csv")
+                )
                 all_entry["csv"] = self._public_or_key(csv_key)
                 # CSV's size + sha live in the canonical ``size_bytes``
                 # / ``sha256`` slots (consumers default-fetching the
@@ -471,7 +532,86 @@ class DatasetPublisher:
                 all_entry["size_bytes"] = csv_size
                 all_entry["sha256"] = csv_sha
 
-        return all_entry
+        return all_entry, aliases
+
+    def _commit_job_publication(
+        self,
+        *,
+        generated_at: datetime,
+        stats_factory,
+        all_entry: dict[str, object],
+        by_ats: dict[ATSType, dict[str, object]],
+        existing_manifest: dict[str, object],
+        aliases: list[AliasCopy],
+    ) -> str:
+        """Commit one jobs generation and refresh compatibility aliases.
+
+        The manifest is the atomic contract: it references only immutable
+        content-addressed objects. Stable paths are compatibility aliases,
+        refreshed after the manifest commit without trying to make a set of
+        independent R2 objects transactional.
+        """
+        with _distributed_publication_lease(
+            self._r2,
+            prefix=self._prefix,
+        ) as renew_lease:
+            renew_lease()
+            manifest_key = self._patch_and_upload_manifest(
+                generated_at=generated_at,
+                stats_factory=stats_factory,
+                all_entry=all_entry,
+                by_ats=by_ats,
+                existing_manifest=existing_manifest,
+            )
+            try:
+                self._refresh_job_aliases(
+                    aliases,
+                    renew_lease=renew_lease,
+                )
+            except StorageError as exc:
+                raise StorageError(
+                    "Jobs manifest committed to immutable artifacts, but "
+                    "stable compatibility aliases could not be refreshed"
+                ) from exc
+            return manifest_key
+
+    def _refresh_job_aliases(
+        self,
+        aliases: list[AliasCopy],
+        *,
+        renew_lease: Callable[[], None],
+    ) -> None:
+        for attempt in range(1, ALIAS_COPY_ATTEMPTS + 1):
+            try:
+                for alias in aliases:
+                    renew_lease()
+                    destination = self._r2.head(alias.destination_key)
+                    expected_etag: str | None = None
+                    if destination is not None:
+                        expected_etag = destination.get("ETag")
+                        if not isinstance(expected_etag, str) or not expected_etag:
+                            raise StorageError(
+                                "R2 alias destination omitted ETag for "
+                                f"{alias.destination_key}"
+                            )
+                    self._r2.copy(
+                        alias.source_key,
+                        alias.destination_key,
+                        expected_destination_etag=expected_etag,
+                        content_type=alias.content_type,
+                        cache_control=CACHE_CONTROL_LATEST,
+                    )
+            except StorageError:
+                if attempt == ALIAS_COPY_ATTEMPTS:
+                    raise
+                logger.warning(
+                    "Stable job alias refresh failed; retrying (%d/%d)",
+                    attempt,
+                    ALIAS_COPY_ATTEMPTS,
+                )
+                continue
+            return
+        raise AssertionError("unreachable")
 
     def _patch_and_upload_manifest(
         self,
@@ -482,46 +622,85 @@ class DatasetPublisher:
         by_ats: dict[ATSType, dict[str, object]],
         existing_manifest: dict[str, object] | None = None,
     ) -> str:
-        """Read existing manifest, replace jobs-related fields, preserve
-        the companies block written by the CI."""
+        """CAS-update jobs fields while preserving the latest CI fields."""
         key = f"{self._prefix}/manifest.json"
-        existing = (
-            existing_manifest
-            if existing_manifest is not None
-            else _load_existing_manifest(self._r2, key)
-        )
+        del existing_manifest
+        intended_by_ats = {
+            ats.value: entry for ats, entry in by_ats.items()
+        }
 
-        manifest: dict[str, object] = {**existing}
-        manifest["version"] = "2.0"
-        manifest["generator"] = f"ats-scrapers/{__version__}"
-        manifest["generated_at"] = generated_at.isoformat()
-        # ``updated_at`` is the "manifest last touched" timestamp; both
-        # writers (publisher + CI companies workflow) bump it so a
-        # client like the homepage that reads only ``updated_at`` for
-        # the freshness badge sees the latest write regardless of which
-        # writer ran most recently. Format matches what the CI script
-        # writes: UTC ``Z``-suffixed seconds.
-        manifest["updated_at"] = generated_at.strftime("%Y-%m-%dT%H:%M:%SZ")
-        manifest["stats"] = stats_factory(existing)
-        manifest["all"] = all_entry
-        manifest["by_ats"] = {ats.value: entry for ats, entry in by_ats.items()}
+        for attempt in range(1, MANIFEST_WRITE_ATTEMPTS + 1):
+            existing, etag = _load_existing_manifest_with_etag(
+                self._r2,
+                key,
+            )
+            current_generated_at = _manifest_generated_at(existing)
+            if (
+                current_generated_at is not None
+                and current_generated_at > generated_at
+            ):
+                raise StorageConflictError(
+                    "Refusing to replace a newer jobs generation "
+                    f"({current_generated_at.isoformat()}) with "
+                    f"{generated_at.isoformat()}"
+                )
+            manifest: dict[str, object] = {**existing}
+            manifest["version"] = "2.0"
+            manifest["generator"] = f"ats-scrapers/{__version__}"
+            manifest["generated_at"] = generated_at.isoformat()
+            manifest["updated_at"] = generated_at.strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            )
+            manifest["stats"] = stats_factory(existing)
+            manifest["all"] = all_entry
+            manifest["by_ats"] = intended_by_ats
 
-        # Drop fields from the pre-2.0 layout if they survived the
-        # legacy-path prune. Their data is gone so the entries point
-        # nowhere.
-        for legacy in ("by_date", "companies_by_ats"):
-            manifest.pop(legacy, None)
+            for legacy in ("by_date", "companies_by_ats"):
+                manifest.pop(legacy, None)
 
-        body = json.dumps(manifest, indent=2, sort_keys=True, default=str).encode(
-            "utf-8"
-        )
-        self._r2.upload_bytes(
-            body,
-            key,
-            content_type="application/json",
-            cache_control=CACHE_CONTROL_LATEST,
-        )
-        return key
+            body = json.dumps(
+                manifest,
+                indent=2,
+                sort_keys=True,
+                default=str,
+            ).encode("utf-8")
+            try:
+                self._r2.upload_bytes_if_current(
+                    body,
+                    key,
+                    expected_etag=etag,
+                    content_type="application/json",
+                    cache_control=CACHE_CONTROL_LATEST,
+                )
+            except StorageError as exc:
+                current, _current_etag = _load_existing_manifest_with_etag(
+                    self._r2,
+                    key,
+                )
+                if _jobs_manifest_matches(
+                    current,
+                    all_entry=all_entry,
+                    by_ats=intended_by_ats,
+                ):
+                    logger.warning(
+                        "Manifest write response was ambiguous, but the "
+                        "intended jobs generation is current"
+                    )
+                    return key
+                if not isinstance(exc, StorageConflictError):
+                    raise
+                if attempt == MANIFEST_WRITE_ATTEMPTS:
+                    raise StorageError(
+                        "Manifest kept changing during jobs publication"
+                    ) from exc
+                logger.warning(
+                    "Manifest changed during jobs patch; retrying (%d/%d)",
+                    attempt,
+                    MANIFEST_WRITE_ATTEMPTS,
+                )
+                continue
+            return key
+        raise AssertionError("unreachable")
 
     def _public_or_key(self, key: str) -> str:
         return self._r2.public_url(key) or key
@@ -1236,6 +1415,210 @@ def _load_existing_manifest(r2_client: R2Client, key: str) -> dict[str, object]:
         )
         return {}
     return loaded
+
+
+def _load_existing_manifest_with_etag(
+    r2_client: R2Client,
+    key: str,
+) -> tuple[dict[str, object], str | None]:
+    body, etag = r2_client.get_bytes_with_etag(key)
+    if not body:
+        return {}, etag
+    try:
+        loaded = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "Existing manifest %s did not parse as JSON (%s); starting fresh",
+            key,
+            exc,
+        )
+        return {}, etag
+    if not isinstance(loaded, dict):
+        logger.warning(
+            "Existing manifest %s root is not an object; starting fresh", key
+        )
+        return {}, etag
+    return loaded, etag
+
+
+def _jobs_manifest_matches(
+    manifest: dict[str, object],
+    *,
+    all_entry: dict[str, object],
+    by_ats: dict[str, dict[str, object]],
+) -> bool:
+    return (
+        manifest.get("all") == all_entry
+        and manifest.get("by_ats") == by_ats
+    )
+
+
+def _manifest_generated_at(
+    manifest: dict[str, object],
+) -> datetime | None:
+    value = manifest.get("generated_at")
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        generated_at = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        logger.warning("Existing manifest has invalid generated_at: %r", value)
+        return None
+    if generated_at.tzinfo is None:
+        generated_at = generated_at.replace(tzinfo=UTC)
+    return generated_at.astimezone(UTC)
+
+
+@contextmanager
+def _distributed_publication_lease(
+    r2_client: R2Client,
+    *,
+    prefix: str,
+) -> Iterator[Callable[[], None]]:
+    """Serialize the short jobs commit phase across pipeline hosts.
+
+    Missing leases are created with ``If-None-Match``. Expired leases
+    are replaced with ``If-Match``. Release is also a conditional
+    overwrite, so an expired owner can never delete or release a newer
+    owner's lease.
+    """
+    key = f"{prefix}/.locks/jobs-publication.json"
+    owner = uuid4().hex
+    lease_etag: str | None = None
+
+    for attempt in range(1, PUBLICATION_LEASE_WAIT_ATTEMPTS + 1):
+        body, etag = r2_client.get_bytes_with_etag(key)
+        now = datetime.now(tz=UTC)
+        if body is not None:
+            lease_owner, expires_at = _parse_publication_lease(body, key)
+            if lease_owner != owner and expires_at > now:
+                if attempt == PUBLICATION_LEASE_WAIT_ATTEMPTS:
+                    raise StorageError(
+                        "Timed out waiting for the distributed jobs "
+                        "publication lease"
+                    )
+                time.sleep(PUBLICATION_LEASE_POLL_SECONDS)
+                continue
+
+        lease = json.dumps(
+            {
+                "owner": owner,
+                "expires_at": (now + PUBLICATION_LEASE_TTL).isoformat(),
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+        try:
+            lease_etag = r2_client.upload_bytes_if_current(
+                lease,
+                key,
+                expected_etag=etag,
+                content_type="application/json",
+                cache_control="no-store",
+            )
+        except StorageConflictError as exc:
+            if attempt == PUBLICATION_LEASE_WAIT_ATTEMPTS:
+                raise StorageError(
+                    "Could not acquire the distributed jobs publication "
+                    "lease because it kept changing"
+                ) from exc
+            continue
+        break
+    else:
+        raise AssertionError("unreachable")
+
+    def renew() -> None:
+        nonlocal lease_etag
+
+        body, current_etag = r2_client.get_bytes_with_etag(key)
+        if body is None or current_etag is None:
+            raise StorageConflictError(
+                "Distributed jobs publication lease disappeared"
+            )
+        lease_owner, _expires_at = _parse_publication_lease(body, key)
+        if lease_owner != owner or current_etag != lease_etag:
+            raise StorageConflictError(
+                "Distributed jobs publication lease ownership changed"
+            )
+        renewed = json.dumps(
+            {
+                "owner": owner,
+                "expires_at": (
+                    datetime.now(tz=UTC) + PUBLICATION_LEASE_TTL
+                ).isoformat(),
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+        lease_etag = r2_client.upload_bytes_if_current(
+            renewed,
+            key,
+            expected_etag=current_etag,
+            content_type="application/json",
+            cache_control="no-store",
+        )
+
+    try:
+        yield renew
+    finally:
+        try:
+            body, current_etag = r2_client.get_bytes_with_etag(key)
+            if body is None or current_etag is None:
+                logger.warning(
+                    "Distributed jobs publication lease disappeared "
+                    "before release"
+                )
+            else:
+                lease_owner, _expires_at = _parse_publication_lease(
+                    body,
+                    key,
+                )
+                if lease_owner != owner or current_etag != lease_etag:
+                    logger.warning(
+                        "Distributed jobs publication lease ownership "
+                        "changed before release"
+                    )
+                else:
+                    released = json.dumps(
+                        {
+                            "owner": owner,
+                            "expires_at": datetime.now(tz=UTC).isoformat(),
+                        },
+                        sort_keys=True,
+                    ).encode("utf-8")
+                    r2_client.upload_bytes_if_current(
+                        released,
+                        key,
+                        expected_etag=current_etag,
+                        content_type="application/json",
+                        cache_control="no-store",
+                    )
+        except StorageError:
+            logger.warning(
+                "Could not release the distributed jobs publication lease",
+                exc_info=True,
+            )
+
+
+def _parse_publication_lease(
+    body: bytes,
+    key: str,
+) -> tuple[str, datetime]:
+    try:
+        payload = json.loads(body)
+        owner = payload["owner"]
+        expires_at = datetime.fromisoformat(payload["expires_at"])
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise StorageError(
+            f"Distributed jobs publication lease is invalid: {key}"
+        ) from exc
+    if (
+        not isinstance(owner, str)
+        or not owner
+        or expires_at.tzinfo is None
+    ):
+        raise StorageError(
+            f"Distributed jobs publication lease is invalid: {key}"
+        )
+    return owner, expires_at
 
 
 @contextmanager

--- a/pipeline/r2.py
+++ b/pipeline/r2.py
@@ -8,11 +8,12 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from ats_scrapers.exceptions import StorageError
+from ats_scrapers.exceptions import StorageConflictError, StorageError
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -107,6 +108,11 @@ class R2Client:
             aws_secret_access_key=config.secret_access_key,
             region_name="auto",
         )
+        self._copy_destination_condition = threading.local()
+        self._client.meta.events.register(
+            "before-call.s3.CopyObject",
+            self._add_copy_destination_condition,
+        )
 
     @property
     def bucket(self) -> str:
@@ -158,11 +164,140 @@ class R2Client:
             raise StorageError(f"R2 upload failed for {key}: {exc}") from exc
         return key
 
+    def upload_bytes_if_current(
+        self,
+        data: bytes,
+        key: str,
+        *,
+        expected_etag: str | None,
+        content_type: str | None = None,
+        cache_control: str | None = None,
+    ) -> str:
+        """Conditionally replace ``key`` and return its new ETag.
+
+        ``expected_etag=None`` means the key must not exist. Otherwise
+        the current object must match that exact ETag.
+        """
+        from botocore.exceptions import ClientError
+
+        extra: dict[str, Any] = (
+            {"IfMatch": expected_etag}
+            if expected_etag is not None
+            else {"IfNoneMatch": "*"}
+        )
+        if content_type:
+            extra["ContentType"] = content_type
+        if cache_control:
+            extra["CacheControl"] = cache_control
+        try:
+            response = self._client.put_object(
+                Bucket=self.bucket,
+                Key=key,
+                Body=data,
+                **extra,
+            )
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            status = exc.response.get("ResponseMetadata", {}).get(
+                "HTTPStatusCode"
+            )
+            if status in {409, 412} or code in {
+                "ConditionalRequestConflict",
+                "PreconditionFailed",
+            }:
+                raise StorageConflictError(
+                    f"R2 conditional write lost a race for {key}"
+                ) from exc
+            raise StorageError(f"R2 upload failed for {key}: {exc}") from exc
+        except Exception as exc:
+            raise StorageError(f"R2 upload failed for {key}: {exc}") from exc
+        etag = response.get("ETag")
+        if not isinstance(etag, str) or not etag:
+            raise StorageError(f"R2 conditional write omitted ETag for {key}")
+        return etag
+
+    def copy(
+        self,
+        source_key: str,
+        destination_key: str,
+        *,
+        expected_destination_etag: str | None,
+        content_type: str | None = None,
+        cache_control: str | None = None,
+    ) -> str:
+        """Conditionally copy an immutable object to a compatibility alias."""
+        from botocore.exceptions import ClientError
+
+        condition = (
+            {"cf-copy-destination-if-match": expected_destination_etag}
+            if expected_destination_etag is not None
+            else {"cf-copy-destination-if-none-match": "*"}
+        )
+        extra: dict[str, Any] = {
+            "CopySource": {
+                "Bucket": self.bucket,
+                "Key": source_key,
+            },
+            "MetadataDirective": "REPLACE",
+        }
+        if content_type:
+            extra["ContentType"] = content_type
+        if cache_control:
+            extra["CacheControl"] = cache_control
+        try:
+            self._copy_destination_condition.headers = condition
+            self._client.copy_object(
+                Bucket=self.bucket,
+                Key=destination_key,
+                **extra,
+            )
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            status = exc.response.get("ResponseMetadata", {}).get(
+                "HTTPStatusCode"
+            )
+            if status in {409, 412} or code in {
+                "ConditionalRequestConflict",
+                "PreconditionFailed",
+            }:
+                raise StorageConflictError(
+                    f"R2 conditional copy lost a race for {destination_key}"
+                ) from exc
+            raise StorageError(
+                f"R2 copy failed for {source_key} → {destination_key}: {exc}"
+            ) from exc
+        except Exception as exc:
+            raise StorageError(
+                f"R2 copy failed for {source_key} → {destination_key}: {exc}"
+            ) from exc
+        finally:
+            self._copy_destination_condition.headers = None
+        return destination_key
+
+    def _add_copy_destination_condition(
+        self,
+        params: dict[str, Any],
+        **_kwargs: Any,
+    ) -> None:
+        headers = getattr(self._copy_destination_condition, "headers", None)
+        if headers:
+            params["headers"].update(headers)
+
     def head(self, key: str) -> dict[str, Any] | None:
+        from botocore.exceptions import ClientError
+
         try:
             return self._client.head_object(Bucket=self.bucket, Key=key)
-        except Exception:
-            return None
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            status = exc.response.get("ResponseMetadata", {}).get(
+                "HTTPStatusCode"
+            )
+            if status == 404 or code in {"404", "NoSuchKey", "NotFound"}:
+                return None
+            raise StorageError(f"R2 head failed for {key}: {exc}") from exc
+        except Exception as exc:
+            raise StorageError(f"R2 head failed for {key}: {exc}") from exc
 
     def get_bytes(self, key: str) -> bytes | None:
         """Return the object body, or ``None`` if the key doesn't exist.
@@ -172,16 +307,31 @@ class R2Client:
         ``companies`` block; the publisher patches the ``by_ats`` jobs
         block; both must coexist in one manifest.json).
         """
+        body, _etag = self.get_bytes_with_etag(key)
+        return body
+
+    def get_bytes_with_etag(
+        self,
+        key: str,
+    ) -> tuple[bytes | None, str | None]:
+        """Return object bytes and ETag, or ``(None, None)`` if absent."""
         from botocore.exceptions import ClientError
 
         try:
             response = self._client.get_object(Bucket=self.bucket, Key=key)
         except ClientError as exc:
             code = exc.response.get("Error", {}).get("Code", "")
-            if code in ("NoSuchKey", "404"):
-                return None
+            status = exc.response.get("ResponseMetadata", {}).get(
+                "HTTPStatusCode"
+            )
+            if status == 404 or code in {"404", "NoSuchKey", "NotFound"}:
+                return None, None
             raise StorageError(f"R2 get failed for {key}: {exc}") from exc
-        return response["Body"].read()
+        etag = response.get("ETag")
+        return (
+            response["Body"].read(),
+            etag if isinstance(etag, str) and etag else None,
+        )
 
     def list(self, prefix: str = "") -> Iterator[dict[str, Any]]:
         paginator = self._client.get_paginator("list_objects_v2")

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,7 +1,7 @@
 # Dependencies for the repo-only ops pipeline (pipeline/ and scripts/).
 # Not part of the installable ats-scrapers package — install with:
 #   pip install -r pipeline/requirements.txt
-boto3>=1.34
+boto3>=1.35.69
 pyarrow>=15.0
 # Cross-ATS dedup operates on a 3M+-row keys frame and writes the
 # global all.parquet. Polars keeps the working set Arrow-backed so peak

--- a/src/ats_scrapers/exceptions.py
+++ b/src/ats_scrapers/exceptions.py
@@ -13,6 +13,10 @@ class StorageError(ATSScrapersError):
     """Raised when reading from or writing to remote storage fails."""
 
 
+class StorageConflictError(StorageError):
+    """Raised when a conditional storage write loses a race."""
+
+
 class ScraperError(ATSScrapersError):
     """Raised when an ATS scraper fails to fetch or parse jobs."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -9,6 +10,8 @@ from typing import Any
 
 import pandas as pd
 import pytest
+
+from ats_scrapers.exceptions import StorageConflictError
 
 
 @dataclass
@@ -33,12 +36,35 @@ class FakeR2:
         content_type: str | None = None,
         cache_control: str | None = None,
     ) -> str:
+        etag = f'"{hashlib.sha256(data).hexdigest()}"'
         self.uploads[key] = {
             "data": data,
             "content_type": content_type,
             "cache_control": cache_control,
+            "etag": etag,
         }
         return key
+
+    def upload_bytes_if_current(
+        self,
+        data: bytes,
+        key: str,
+        *,
+        expected_etag: str | None,
+        content_type: str | None = None,
+        cache_control: str | None = None,
+    ) -> str:
+        current = self.uploads.get(key)
+        current_etag = current["etag"] if current else None
+        if current_etag != expected_etag:
+            raise StorageConflictError(f"conditional write conflict for {key}")
+        self.upload_bytes(
+            data,
+            key,
+            content_type=content_type,
+            cache_control=cache_control,
+        )
+        return self.uploads[key]["etag"]
 
     def upload(
         self,
@@ -56,6 +82,36 @@ class FakeR2:
             cache_control=cache_control,
         )
 
+    def copy(
+        self,
+        source_key: str,
+        destination_key: str,
+        *,
+        expected_destination_etag: str | None,
+        content_type: str | None = None,
+        cache_control: str | None = None,
+    ) -> str:
+        destination = self.uploads.get(destination_key)
+        current_etag = destination["etag"] if destination else None
+        if current_etag != expected_destination_etag:
+            raise StorageConflictError(
+                f"conditional copy conflict for {destination_key}"
+            )
+        source = self.uploads[source_key]
+        self.upload_bytes(
+            source["data"],
+            destination_key,
+            content_type=content_type,
+            cache_control=cache_control,
+        )
+        return destination_key
+
+    def head(self, key: str) -> dict[str, Any] | None:
+        entry = self.uploads.get(key)
+        if entry is None:
+            return None
+        return {"ETag": entry["etag"], "ContentLength": len(entry["data"])}
+
     def list(self, prefix: str = ""):
         for key in self.uploads:
             if key.startswith(prefix):
@@ -64,6 +120,15 @@ class FakeR2:
     def get_bytes(self, key: str) -> bytes | None:
         entry = self.uploads.get(key)
         return entry["data"] if entry else None
+
+    def get_bytes_with_etag(
+        self,
+        key: str,
+    ) -> tuple[bytes | None, str | None]:
+        entry = self.uploads.get(key)
+        if entry is None:
+            return None, None
+        return entry["data"], entry["etag"]
 
     def delete_many(self, keys: list[str]) -> int:
         for k in keys:

--- a/tests/test_publish_companies.py
+++ b/tests/test_publish_companies.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import io
+import json
+import runpy
+from pathlib import Path
+
+from botocore.exceptions import ClientError
+
+SCRIPT = runpy.run_path(
+    Path(__file__).parents[1] / ".github/scripts/publish_companies.py"
+)
+patch_manifest = SCRIPT["patch_manifest"]
+
+
+class FakeClient:
+    def __init__(
+        self,
+        manifest: dict[str, object] | None = None,
+        *,
+        conflict_once: dict[str, object] | None = None,
+    ) -> None:
+        self.manifest = manifest
+        self.etag = '"etag-1"' if manifest is not None else None
+        self.conflict_once = conflict_once
+        self.puts: list[dict[str, object]] = []
+
+    def get_object(self, *, Bucket: str, Key: str):  # noqa: N803
+        if self.manifest is None:
+            raise ClientError(
+                {
+                    "Error": {"Code": "NoSuchKey"},
+                    "ResponseMetadata": {"HTTPStatusCode": 404},
+                },
+                "GetObject",
+            )
+        return {
+            "Body": io.BytesIO(json.dumps(self.manifest).encode()),
+            "ETag": self.etag,
+        }
+
+    def put_object(self, **kwargs):
+        self.puts.append(kwargs)
+        if self.conflict_once is not None:
+            self.manifest = self.conflict_once
+            self.conflict_once = None
+            self.etag = '"etag-2"'
+            raise ClientError(
+                {
+                    "Error": {"Code": "PreconditionFailed"},
+                    "ResponseMetadata": {"HTTPStatusCode": 412},
+                },
+                "PutObject",
+            )
+        self.manifest = json.loads(kwargs["Body"])
+        self.etag = '"etag-3"'
+        return {"ETag": self.etag}
+
+
+def test_patch_manifest_preserves_jobs_fields() -> None:
+    jobs = {"all": {"csv": "snapshot.csv"}, "by_ats": {"greenhouse": {}}}
+    client = FakeClient({"version": "2.0", **jobs})
+
+    result = patch_manifest(
+        client,
+        "bucket",
+        aggregate_entry={"csv": "companies.csv", "rows": 2},
+        by_ats_entries={"greenhouse": {"rows": 2}},
+    )
+
+    assert result["all"] == jobs["all"]
+    assert result["by_ats"] == jobs["by_ats"]
+    assert client.puts[0]["IfMatch"] == '"etag-1"'
+
+
+def test_patch_manifest_retries_conflict_with_latest_jobs_fields() -> None:
+    old_jobs = {"all": {"csv": "old.csv"}, "by_ats": {"greenhouse": {}}}
+    new_jobs = {"all": {"csv": "new.csv"}, "by_ats": {"lever": {}}}
+    client = FakeClient(
+        {"version": "2.0", **old_jobs},
+        conflict_once={"version": "2.0", **new_jobs},
+    )
+
+    result = patch_manifest(
+        client,
+        "bucket",
+        aggregate_entry={"csv": "companies.csv", "rows": 2},
+        by_ats_entries={"greenhouse": {"rows": 2}},
+    )
+
+    assert len(client.puts) == 2
+    assert client.puts[1]["IfMatch"] == '"etag-2"'
+    assert result["all"] == new_jobs["all"]
+    assert result["by_ats"] == new_jobs["by_ats"]
+
+
+def test_patch_manifest_uses_create_precondition() -> None:
+    client = FakeClient()
+
+    patch_manifest(
+        client,
+        "bucket",
+        aggregate_entry={"csv": "companies.csv", "rows": 2},
+        by_ats_entries={},
+    )
+
+    assert client.puts[0]["IfNoneMatch"] == "*"

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -3,7 +3,9 @@
 Covers the v2.0 layout:
 
     jobhive/v1/manifest.json
-    jobhive/v1/all.parquet
+    jobhive/v1/job-snapshots/<sha>.{csv,parquet}
+    jobhive/v1/<ats>/job-snapshots/<sha>.{csv,parquet}
+    jobhive/v1/all.{csv,parquet}
     jobhive/v1/<ats>/jobs.{csv,parquet}
 
 The publisher owns jobs entries in ``manifest.json``. Companies (top-level
@@ -18,15 +20,21 @@ import csv
 import hashlib
 import io
 import json
+from datetime import UTC, datetime, timedelta
 
 import pandas as pd
 import pytest
 
-from ats_scrapers.exceptions import StorageError
+from ats_scrapers.exceptions import StorageConflictError, StorageError
 from pipeline.publisher import (
+    CACHE_CONTROL_IMMUTABLE,
     CACHE_CONTROL_LATEST,
     DEFAULT_PREFIX,
+    PUBLICATION_LEASE_POLL_SECONDS,
+    PUBLICATION_LEASE_TTL,
+    PUBLICATION_LEASE_WAIT_ATTEMPTS,
     DatasetPublisher,
+    _distributed_publication_lease,
 )
 
 # --- Layout -----------------------------------------------------------------
@@ -103,9 +111,10 @@ def test_manifest_contains_expected_structure(ats_csv_dir, fake_r2) -> None:
     assert manifest["stats"]["ats_count"] == 3
     assert "greenhouse" in manifest["by_ats"]
     assert manifest["by_ats"]["greenhouse"]["rows"] == 3
-    # `all` lives at the top level now and ships both formats.
-    assert manifest["all"]["parquet"].endswith("/all.parquet")
-    assert manifest["all"]["csv"].endswith("/all.csv")
+    assert "/job-snapshots/" in manifest["all"]["parquet"]
+    assert manifest["all"]["parquet"].endswith(".parquet")
+    assert "/job-snapshots/" in manifest["all"]["csv"]
+    assert manifest["all"]["csv"].endswith(".csv")
 
 
 def test_manifest_includes_generator_string(ats_csv_dir, fake_r2) -> None:
@@ -144,8 +153,12 @@ def test_manifest_falls_back_to_keys_when_no_public_url(
     manifest = json.loads(
         fake_r2_no_public.uploads["jobhive/v1/manifest.json"]["data"]
     )
-    assert manifest["all"]["parquet"] == "jobhive/v1/all.parquet"
-    assert manifest["by_ats"]["greenhouse"]["csv"] == "jobhive/v1/greenhouse/jobs.csv"
+    assert manifest["all"]["parquet"].startswith(
+        "jobhive/v1/job-snapshots/"
+    )
+    assert manifest["by_ats"]["greenhouse"]["csv"].startswith(
+        "jobhive/v1/greenhouse/job-snapshots/"
+    )
 
 
 def test_manifest_includes_schema_version_and_columns(ats_csv_dir, fake_r2) -> None:
@@ -234,7 +247,106 @@ def test_manifest_patch_preserves_companies_block(ats_csv_dir, fake_r2) -> None:
     assert manifest["by_ats_companies"] == pre_existing["by_ats_companies"]
     # And jobs entries got refreshed.
     assert manifest["by_ats"]["greenhouse"]["rows"] == 3
-    assert manifest["all"]["parquet"].endswith("/all.parquet")
+    assert "/job-snapshots/" in manifest["all"]["parquet"]
+
+
+def test_manifest_cas_retry_preserves_concurrent_company_update(
+    ats_csv_dir,
+    fake_r2,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_upload = fake_r2.upload_bytes_if_current
+    injected = False
+    companies = {
+        "csv": "jobhive/v1/company-snapshots/new.csv",
+        "rows": 42,
+    }
+
+    def race_once(data, key, **kwargs):
+        nonlocal injected
+        if key.endswith("/manifest.json") and not injected:
+            injected = True
+            fake_r2.upload_bytes(
+                json.dumps(
+                    {
+                        "version": "2.0",
+                        "companies": companies,
+                        "by_ats_companies": {},
+                    }
+                ).encode(),
+                key,
+                content_type="application/json",
+            )
+            raise StorageConflictError("companies writer won")
+        return original_upload(data, key, **kwargs)
+
+    monkeypatch.setattr(
+        fake_r2,
+        "upload_bytes_if_current",
+        race_once,
+    )
+
+    DatasetPublisher(fake_r2, write_parquet=True).publish_from_directory(
+        ats_csv_dir
+    )
+
+    manifest = json.loads(fake_r2.uploads["jobhive/v1/manifest.json"]["data"])
+    assert injected is True
+    assert manifest["companies"] == companies
+    assert manifest["stats"]["total_jobs"] == 9
+
+
+def test_older_run_cannot_replace_newer_jobs_generation(
+    ats_csv_dir,
+    fake_r2,
+) -> None:
+    future = datetime.now(tz=UTC) + timedelta(days=1)
+    current = {
+        "version": "2.0",
+        "generated_at": future.isoformat(),
+        "all": {"csv": "jobhive/v1/job-snapshots/current.csv"},
+        "by_ats": {},
+    }
+    fake_r2.upload_bytes(
+        json.dumps(current).encode(),
+        "jobhive/v1/manifest.json",
+        content_type="application/json",
+    )
+
+    with pytest.raises(StorageConflictError, match="newer jobs generation"):
+        DatasetPublisher(fake_r2, write_parquet=True).publish_from_directory(
+            ats_csv_dir
+        )
+
+    manifest = json.loads(fake_r2.uploads["jobhive/v1/manifest.json"]["data"])
+    assert manifest == current
+    assert "jobhive/v1/all.csv" not in fake_r2.uploads
+
+
+def test_alias_failure_does_not_invalidate_committed_manifest(
+    ats_csv_dir,
+    fake_r2,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_copy(*_args, **_kwargs):
+        raise StorageError("copy unavailable")
+
+    monkeypatch.setattr(fake_r2, "copy", fail_copy)
+
+    with pytest.raises(
+        StorageError,
+        match="manifest committed to immutable artifacts",
+    ):
+        DatasetPublisher(fake_r2, write_parquet=True).publish_from_directory(
+            ats_csv_dir
+        )
+
+    manifest = json.loads(fake_r2.uploads["jobhive/v1/manifest.json"]["data"])
+    csv_key = manifest["all"]["csv"].removeprefix(
+        "https://cdn.example.com/"
+    )
+    assert "/job-snapshots/" in csv_key
+    assert fake_r2.uploads[csv_key]["data"]
 
 
 def test_manifest_patch_drops_legacy_fields(ats_csv_dir, fake_r2) -> None:
@@ -340,6 +452,22 @@ def test_cache_control_short_for_latest_files(ats_csv_dir, fake_r2) -> None:
     )
 
 
+def test_manifest_artifacts_are_immutable(ats_csv_dir, fake_r2) -> None:
+    publisher = DatasetPublisher(fake_r2, write_parquet=True)
+    publisher.publish_from_directory(ats_csv_dir)
+    manifest = json.loads(fake_r2.uploads["jobhive/v1/manifest.json"]["data"])
+
+    for entry in [
+        manifest["all"],
+        *manifest["by_ats"].values(),
+    ]:
+        for field in ("csv", "parquet"):
+            key = entry[field].removeprefix("https://cdn.example.com/")
+            assert fake_r2.uploads[key]["cache_control"] == (
+                CACHE_CONTROL_IMMUTABLE
+            )
+
+
 def test_per_ats_csv_content_type(ats_csv_dir, fake_r2) -> None:
     publisher = DatasetPublisher(fake_r2, write_parquet=True)
     publisher.publish_from_directory(ats_csv_dir)
@@ -370,28 +498,198 @@ def test_manifest_content_type(ats_csv_dir, fake_r2) -> None:
 # --- Ordering ---------------------------------------------------------------
 
 
-def test_manifest_uploaded_after_data_files(ats_csv_dir, fake_r2) -> None:
-    """The manifest must be uploaded last — a half-finished publish must
-    never expose a manifest pointing at missing files."""
+def test_manifest_uploaded_after_immutable_artifacts(
+    ats_csv_dir,
+    fake_r2,
+) -> None:
+    """Canonical immutable artifacts exist before the manifest switches."""
     publisher = DatasetPublisher(fake_r2, write_parquet=True)
     publisher.publish_from_directory(ats_csv_dir)
-    keys = [
+    immutable_keys = [
         k
         for k in fake_r2.uploads
-        # Ignore the pre-existing manifest seeded by other tests'
-        # paths through this fixture.
-        if not k.endswith("/manifest.json")
+        if "/job-snapshots/" in k
     ]
     assert "jobhive/v1/manifest.json" in fake_r2.uploads
-    last_manifest_index = max(
+    manifest_index = max(
         i
         for i, k in enumerate(fake_r2.uploads)
         if k == "jobhive/v1/manifest.json"
     )
-    last_data_index = max(
-        i for i, k in enumerate(fake_r2.uploads) if k in keys
+    last_immutable_index = max(
+        i for i, k in enumerate(fake_r2.uploads) if k in immutable_keys
     )
-    assert last_manifest_index > last_data_index
+    assert manifest_index > last_immutable_index
+
+
+# --- Publication lease ------------------------------------------------------
+
+
+def test_default_lease_wait_reaches_expiry_boundary() -> None:
+    available_wait = (
+        PUBLICATION_LEASE_WAIT_ATTEMPTS - 1
+    ) * PUBLICATION_LEASE_POLL_SECONDS
+    assert available_wait >= PUBLICATION_LEASE_TTL.total_seconds()
+
+
+def test_distributed_publication_lease_releases_after_success(fake_r2) -> None:
+    key = "jobhive/v1/.locks/jobs-publication.json"
+
+    with _distributed_publication_lease(fake_r2, prefix="jobhive/v1"):
+        active = json.loads(fake_r2.uploads[key]["data"])
+        assert datetime.fromisoformat(active["expires_at"]) > datetime.now(
+            tz=UTC
+        )
+
+    released = json.loads(fake_r2.uploads[key]["data"])
+    assert released["owner"] == active["owner"]
+    assert datetime.fromisoformat(released["expires_at"]) <= datetime.now(
+        tz=UTC
+    )
+
+
+def test_distributed_publication_lease_takes_over_expired_owner(
+    fake_r2,
+) -> None:
+    key = "jobhive/v1/.locks/jobs-publication.json"
+    fake_r2.upload_bytes(
+        json.dumps(
+            {
+                "owner": "dead-publisher",
+                "expires_at": (
+                    datetime.now(tz=UTC) - timedelta(minutes=1)
+                ).isoformat(),
+            }
+        ).encode(),
+        key,
+    )
+
+    with _distributed_publication_lease(fake_r2, prefix="jobhive/v1"):
+        active = json.loads(fake_r2.uploads[key]["data"])
+        assert active["owner"] != "dead-publisher"
+
+
+def test_distributed_publication_lease_times_out_for_active_owner(
+    fake_r2,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import pipeline.publisher as publisher_module
+
+    key = "jobhive/v1/.locks/jobs-publication.json"
+    fake_r2.upload_bytes(
+        json.dumps(
+            {
+                "owner": "active-publisher",
+                "expires_at": (
+                    datetime.now(tz=UTC) + timedelta(minutes=1)
+                ).isoformat(),
+            }
+        ).encode(),
+        key,
+    )
+    monkeypatch.setattr(
+        publisher_module,
+        "PUBLICATION_LEASE_WAIT_ATTEMPTS",
+        2,
+    )
+    monkeypatch.setattr(
+        publisher_module,
+        "PUBLICATION_LEASE_POLL_SECONDS",
+        0.0,
+    )
+
+    with (
+        pytest.raises(StorageError, match="Timed out waiting"),
+        _distributed_publication_lease(
+            fake_r2,
+            prefix="jobhive/v1",
+        ),
+    ):
+        raise AssertionError("lease should not be acquired")
+
+
+def test_expired_owner_cannot_release_successor_lease(fake_r2) -> None:
+    key = "jobhive/v1/.locks/jobs-publication.json"
+
+    with _distributed_publication_lease(fake_r2, prefix="jobhive/v1"):
+        successor = {
+            "owner": "successor",
+            "expires_at": (
+                datetime.now(tz=UTC) + timedelta(minutes=20)
+            ).isoformat(),
+        }
+        fake_r2.upload_bytes(json.dumps(successor).encode(), key)
+
+    assert json.loads(fake_r2.uploads[key]["data"]) == successor
+
+
+def test_publisher_stops_alias_writes_after_lease_is_lost(
+    ats_csv_dir,
+    fake_r2,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    key = "jobhive/v1/.locks/jobs-publication.json"
+    original_copy = fake_r2.copy
+    copies = 0
+    successor = {
+        "owner": "successor",
+        "expires_at": (
+            datetime.now(tz=UTC) + timedelta(minutes=20)
+        ).isoformat(),
+    }
+
+    def steal_after_first_copy(*args, **kwargs):
+        nonlocal copies
+        copies += 1
+        result = original_copy(*args, **kwargs)
+        if copies == 1:
+            fake_r2.upload_bytes(json.dumps(successor).encode(), key)
+        return result
+
+    monkeypatch.setattr(fake_r2, "copy", steal_after_first_copy)
+
+    with pytest.raises(
+        StorageError,
+        match="stable compatibility aliases",
+    ):
+        DatasetPublisher(fake_r2, write_parquet=True).publish_from_directory(
+            ats_csv_dir
+        )
+
+    assert copies == 1
+    assert json.loads(fake_r2.uploads[key]["data"]) == successor
+
+
+def test_alias_copy_retries_when_destination_changes_after_head(
+    ats_csv_dir,
+    fake_r2,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_copy = fake_r2.copy
+    raced = False
+    raced_source = ""
+    raced_destination = ""
+
+    def race_once(source_key, destination_key, **kwargs):
+        nonlocal raced, raced_destination, raced_source
+        if not raced:
+            raced = True
+            raced_source = source_key
+            raced_destination = destination_key
+            fake_r2.upload_bytes(b"newer-owner", destination_key)
+        return original_copy(source_key, destination_key, **kwargs)
+
+    monkeypatch.setattr(fake_r2, "copy", race_once)
+
+    DatasetPublisher(fake_r2, write_parquet=True).publish_from_directory(
+        ats_csv_dir
+    )
+
+    assert raced is True
+    assert (
+        fake_r2.uploads[raced_destination]["data"]
+        == fake_r2.uploads[raced_source]["data"]
+    )
 
 
 # --- Legacy cleanup ---------------------------------------------------------
@@ -562,8 +860,8 @@ def test_result_reports_counts_and_duration(ats_csv_dir, fake_r2) -> None:
     assert result.ats_count == 3
     assert result.duration_seconds >= 0.0
     assert result.manifest_key == "jobhive/v1/manifest.json"
-    # 3 ATS slices × 2 formats + all.{csv,parquet} + manifest.json = 9 files
-    assert len(result.files) == 9
+    # 8 immutable artifacts + manifest + 8 compatibility aliases.
+    assert len(result.files) == 17
 
 
 # --- Cross-ATS deduplication ------------------------------------------------

--- a/tests/test_r2.py
+++ b/tests/test_r2.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import io
 from pathlib import Path
 
 import pytest
+from botocore.exceptions import ClientError
 
-from ats_scrapers.exceptions import StorageError
+from ats_scrapers.exceptions import StorageConflictError, StorageError
 from pipeline.r2 import R2Client, R2Config
 
 R2_VARS = (
@@ -142,18 +144,55 @@ class FakeBoto3Client:
     def __init__(self) -> None:
         self.uploaded_files: list[tuple[str, str, str, dict]] = []
         self.put_objects: list[dict] = []
+        self.copy_objects: list[dict] = []
         self.head_responses: dict[str, dict] = {}
+        self.get_responses: dict[str, dict] = {}
+        self.meta = FakeBoto3Meta()
 
     def upload_file(self, src: str, bucket: str, key: str, ExtraArgs=None) -> None:  # noqa: N803
         self.uploaded_files.append((src, bucket, key, ExtraArgs or {}))
 
-    def put_object(self, *, Bucket: str, Key: str, Body: bytes, **extra) -> None:  # noqa: N803
+    def put_object(self, *, Bucket: str, Key: str, Body: bytes, **extra):  # noqa: N803
         self.put_objects.append({"Bucket": Bucket, "Key": Key, "Body": Body, **extra})
+        return {"ETag": '"new-etag"'}
+
+    def copy_object(self, *, Bucket: str, Key: str, **extra):  # noqa: N803
+        params = {"headers": {}}
+        self.meta.events.emit(
+            "before-call.s3.CopyObject",
+            params=params,
+        )
+        self.copy_objects.append(
+            {
+                "Bucket": Bucket,
+                "Key": Key,
+                "headers": params["headers"],
+                **extra,
+            }
+        )
+        return {"CopyObjectResult": {"ETag": '"copied-etag"'}}
 
     def head_object(self, *, Bucket: str, Key: str):  # noqa: N803
         if Key in self.head_responses:
             return self.head_responses[Key]
-        raise Exception("404")
+        raise ClientError(
+            {
+                "Error": {"Code": "NoSuchKey"},
+                "ResponseMetadata": {"HTTPStatusCode": 404},
+            },
+            "HeadObject",
+        )
+
+    def get_object(self, *, Bucket: str, Key: str):  # noqa: N803
+        if Key in self.get_responses:
+            return self.get_responses[Key]
+        raise ClientError(
+            {
+                "Error": {"Code": "NoSuchKey"},
+                "ResponseMetadata": {"HTTPStatusCode": 404},
+            },
+            "GetObject",
+        )
 
     def get_paginator(self, _name: str):
         class P:
@@ -161,6 +200,23 @@ class FakeBoto3Client:
                 yield {"Contents": [{"Key": f"{kwargs.get('Prefix', '')}example"}]}
 
         return P()
+
+
+class FakeBoto3Events:
+    def __init__(self) -> None:
+        self.handlers: dict[str, list] = {}
+
+    def register(self, name: str, handler) -> None:
+        self.handlers.setdefault(name, []).append(handler)
+
+    def emit(self, name: str, **kwargs) -> None:
+        for handler in self.handlers.get(name, []):
+            handler(**kwargs)
+
+
+class FakeBoto3Meta:
+    def __init__(self) -> None:
+        self.events = FakeBoto3Events()
 
 
 @pytest.fixture
@@ -214,6 +270,145 @@ def test_upload_bytes_calls_put_object(
     client.upload_bytes(b"hello", "k", content_type="text/plain")
     assert fake.put_objects[0]["Body"] == b"hello"
     assert fake.put_objects[0]["Key"] == "k"
+
+
+def test_conditional_upload_uses_expected_etag(
+    fake_r2_client: tuple[R2Client, FakeBoto3Client],
+) -> None:
+    client, fake = fake_r2_client
+
+    etag = client.upload_bytes_if_current(
+        b"manifest",
+        "jobhive/v1/manifest.json",
+        expected_etag='"etag-1"',
+        content_type="application/json",
+    )
+
+    assert etag == '"new-etag"'
+    assert fake.put_objects[0]["IfMatch"] == '"etag-1"'
+    assert "IfNoneMatch" not in fake.put_objects[0]
+
+
+def test_conditional_upload_requires_absent_key_for_create(
+    fake_r2_client: tuple[R2Client, FakeBoto3Client],
+) -> None:
+    client, fake = fake_r2_client
+
+    client.upload_bytes_if_current(
+        b"lease",
+        "jobhive/v1/.locks/jobs-publication.json",
+        expected_etag=None,
+    )
+
+    assert fake.put_objects[0]["IfNoneMatch"] == "*"
+    assert "IfMatch" not in fake.put_objects[0]
+
+
+def test_conditional_upload_maps_precondition_failure(
+    fake_r2_client: tuple[R2Client, FakeBoto3Client],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, fake = fake_r2_client
+
+    def conflict(**_kwargs):
+        raise ClientError(
+            {
+                "Error": {"Code": "PreconditionFailed"},
+                "ResponseMetadata": {"HTTPStatusCode": 412},
+            },
+            "PutObject",
+        )
+
+    monkeypatch.setattr(fake, "put_object", conflict)
+
+    with pytest.raises(StorageConflictError):
+        client.upload_bytes_if_current(
+            b"manifest",
+            "jobhive/v1/manifest.json",
+            expected_etag='"stale"',
+        )
+
+
+def test_copy_uses_server_side_copy(
+    fake_r2_client: tuple[R2Client, FakeBoto3Client],
+) -> None:
+    client, fake = fake_r2_client
+
+    client.copy(
+        "jobhive/v1/job-snapshots/abc.csv",
+        "jobhive/v1/all.csv",
+        expected_destination_etag=None,
+        content_type="text/csv",
+        cache_control="public, max-age=300",
+    )
+
+    copied = fake.copy_objects[0]
+    assert copied["Key"] == "jobhive/v1/all.csv"
+    assert copied["CopySource"] == {
+        "Bucket": "bucket",
+        "Key": "jobhive/v1/job-snapshots/abc.csv",
+    }
+    assert copied["MetadataDirective"] == "REPLACE"
+    assert copied["ContentType"] == "text/csv"
+    assert copied["headers"] == {
+        "cf-copy-destination-if-none-match": "*",
+    }
+
+
+def test_copy_fences_existing_destination_with_etag(
+    fake_r2_client: tuple[R2Client, FakeBoto3Client],
+) -> None:
+    client, fake = fake_r2_client
+
+    client.copy(
+        "jobhive/v1/job-snapshots/abc.csv",
+        "jobhive/v1/all.csv",
+        expected_destination_etag='"previous"',
+    )
+
+    assert fake.copy_objects[0]["headers"] == {
+        "cf-copy-destination-if-match": '"previous"',
+    }
+
+
+def test_copy_maps_destination_precondition_failure(
+    fake_r2_client: tuple[R2Client, FakeBoto3Client],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, fake = fake_r2_client
+
+    def reject_copy(**_kwargs):
+        raise ClientError(
+            {
+                "Error": {"Code": "PreconditionFailed"},
+                "ResponseMetadata": {"HTTPStatusCode": 412},
+            },
+            "CopyObject",
+        )
+
+    monkeypatch.setattr(fake, "copy_object", reject_copy)
+
+    with pytest.raises(StorageConflictError, match="conditional copy"):
+        client.copy(
+            "jobhive/v1/job-snapshots/abc.csv",
+            "jobhive/v1/all.csv",
+            expected_destination_etag='"previous"',
+        )
+
+
+def test_get_bytes_with_etag(
+    fake_r2_client: tuple[R2Client, FakeBoto3Client],
+) -> None:
+    client, fake = fake_r2_client
+    fake.get_responses["manifest"] = {
+        "Body": io.BytesIO(b"{}"),
+        "ETag": '"etag-1"',
+    }
+
+    assert client.get_bytes_with_etag("manifest") == (
+        b"{}",
+        '"etag-1"',
+    )
 
 
 def test_public_url_returns_none_when_no_base() -> None:


### PR DESCRIPTION
## Summary

- publish jobs to immutable, content-addressed snapshot keys
- make the manifest the atomic generation pointer
- serialize the short jobs commit phase with a conditional R2 lease
- reject a slow run when the manifest already contains a newer generation
- fence every compatibility-alias copy against the destination ETag
- CAS-update the shared manifest from both jobs and companies publishers

## Safety invariant

1. Build and upload immutable artifacts without holding the lease.
2. Acquire the lease with `If-None-Match`, or take over an expired lease with `If-Match`.
3. Re-read the manifest and reject this run if its `generated_at` precedes the current jobs generation.
4. CAS the manifest so it points only to complete immutable artifacts.
5. Refresh each stable alias with R2's destination-conditional `CopyObject` headers. A copy that outlives its lease cannot overwrite an alias changed by a newer publisher; its destination precondition fails and the current owner retries.
6. Release by conditionally expiring the lease, never by deleting another owner's lock.

Stable aliases remain compatibility paths, not the transaction boundary. If an alias refresh persistently fails, the publisher reports failure while the committed manifest remains valid and verifiable.

## Validation

- focused publisher/R2/company publication suite — 85 passed
- Ruff on all changed Python files — passed
- full suite — 1,627 passed, 2 skipped, 29 deselected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes jobs to immutable, content‑addressed R2 snapshots and makes the manifest the single atomic pointer. Serializes the commit with a short distributed lease, fences alias copies, and CAS‑updates the manifest from both jobs and companies.

- **New Features**
  - Store jobs at content‑addressed `job-snapshots/<sha>.{csv,parquet}` (global and per‑ATS); keep `all.*` and `<ats>/jobs.*` as compatibility aliases.
  - Make the manifest the atomic pointer and CAS‑update it with ETags; refuse to overwrite a newer generation; jobs and companies writers preserve each other’s fields.
  - Add a distributed publication lease (`.locks/jobs-publication.json`) using conditional writes; renew before each alias copy and stop if ownership changes.
  - Refresh aliases via conditional server‑side copies fenced by destination ETags, with retries; manifest stays valid even if alias refresh fails.
  - Use immutable cache headers for snapshots and short TTL for manifest/aliases.
  - Extend the R2 client with `upload_bytes_if_current`, `get_bytes_with_etag`, `copy` (conditional), and improved `head`; map precondition failures to `StorageConflictError`.
  - Companies publisher now patches `manifest.json` with a bounded CAS retry loop and cleans additional legacy paths.

- **Dependencies**
  - Bump `boto3` to `>=1.35.69`.

<sup>Written for commit bcc4cfee8e52d1c696a5edbeb76f777e10bf6cb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements serialized R2 dataset publication.
- Publishes jobs as immutable, content-addressed snapshots while retaining stable compatibility aliases.
- Adds a conditional publication lease, manifest CAS updates, generation ordering, and destination-fenced alias copies.
- Makes the companies publisher CAS-update the shared manifest while preserving jobs fields.
- Extends the R2 client with conditional writes, ETag-aware reads, conditional copies, and conflict errors.
- Updates the pipeline boto3 requirement and expands publication, concurrency, and R2 tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no blocking failures remaining from the previously reported alias-copy race.

The destination-fenced copy implementation addresses the stale in-flight alias overwrite path, and no blocking failure remains.

**Files Needing Attention:** None identified.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the exact verbose pytest command from /home/user/repo using /home/user/repo/.venv/bin/python; the run exited with code 0 and 13 tests passed in 0.34s.
- Created a durable log that records the command, working directory, exit code, full verbose output, and a result note for future review.

<a href="https://app.greptile.com/trex/runs/16039235/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pipeline/publisher.py | Adds immutable snapshots, serialized manifest commits, lease management, generation checks, and destination-fenced compatibility-alias refreshes. |
| pipeline/r2.py | Adds conditional object writes, ETag-aware reads, destination-conditioned server-side copies, and explicit conflict handling. |
| .github/scripts/publish_companies.py | Replaces the manifest read-modify-write with a bounded CAS retry loop that preserves concurrent jobs updates. |
| pipeline/requirements.txt | Raises the minimum boto3 version required by the new conditional request parameters. |
| src/ats_scrapers/exceptions.py | Introduces a storage-conflict exception for conditional-write and conditional-copy races. |
| tests/test_publisher.py | Expands coverage for immutable publication, lease behavior, stale-generation rejection, and alias-copy races. |
| tests/test_r2.py | Covers conditional request headers, ETag handling, conflict mapping, and server-side copy behavior. |
| tests/test_publish_companies.py | Covers manifest field preservation, CAS conflict retries, and create preconditions. |

<sub>Reviews (2): Last reviewed commit: ["Serialize R2 dataset publication"](https://github.com/kalil0321/ats-scrapers/commit/bcc4cfee8e52d1c696a5edbeb76f777e10bf6cb0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47576287)</sub>

<!-- /greptile_comment -->