### PR TITLE
Add 8 validated PageUp employers

### DIFF
--- a/ats-companies/pageup.csv
+++ b/ats-companies/pageup.csv
@@ -18,5 +18,5 @@ South Carolina State University,1078/cw/en,https://careers.pageuppeople.com/1078
 University of Dayton,875/cw/en-us,https://careers.pageuppeople.com/875/cw/en-us
 University of North Texas System,1151/cw/en-us,https://careers.pageuppeople.com/1151/cw/en-us
 University of Toledo,1086/cw/en-us,https://careers.pageuppeople.com/1086/cw/en-us
-Virginia Information Technologies Agency - DHRM,1125/cw/en-us,https://careers.pageuppeople.com/1125/cw/en-us
+Commonwealth of Virginia (DHRM),1125/cw/en-us,https://careers.pageuppeople.com/1125/cw/en-us
 Western Washington University,793/cw/en-us,https://careers.pageuppeople.com/793/cw/en-us

--- a/ats-companies/pageup.csv
+++ b/ats-companies/pageup.csv
@@ -2,13 +2,21 @@ name,slug,url
 Arts Centre Melbourne,902/cw/en,https://careers.pageuppeople.com/902/cw/en
 Bed Bath N' Table,940/cw/en,https://careers.pageuppeople.com/940/cw/en
 California State University,873/cw/en-us,https://careers.pageuppeople.com/873/cw/en-us
+Defence Housing Australia,1041/cw/en,https://careers.pageuppeople.com/1041/cw/en
 Indiana Wesleyan University,1053/cw/en,https://careers.pageuppeople.com/1053/cw/en
 Johnson & Wales University,859/cw/en-us,https://careers.pageuppeople.com/859/cw/en-us
+Kinetic IT,1083/cw/en,https://careers.pageuppeople.com/1083/cw/en
+Knox City Council,1000/cw/en,https://careers.pageuppeople.com/1000/cw/en
 Lehigh University,865/cw/en-us,https://careers.pageuppeople.com/865/cw/en-us
+Melbourne Water,391/cw/en,https://careers.pageuppeople.com/391/cw/en
 Mercedes-AMG High Performance Powertrains,920/cw/en,https://careers.pageuppeople.com/920/cw/en
 Monash University,513/cw/en,https://careers.pageuppeople.com/513/cw/en
+North Idaho College,1027/cw/en,https://careers.pageuppeople.com/1027/cw/en
 NSW Department of Climate Change Energy the Environment and Water,795/cw/en,https://careers.pageuppeople.com/795/cw/en
 Quinnipiac University,871/cw/en-us,https://careers.pageuppeople.com/871/cw/en-us
 South Carolina State University,1078/cw/en,https://careers.pageuppeople.com/1078/cw/en
 University of Dayton,875/cw/en-us,https://careers.pageuppeople.com/875/cw/en-us
+University of North Texas System,1151/cw/en-us,https://careers.pageuppeople.com/1151/cw/en-us
+University of Toledo,1086/cw/en-us,https://careers.pageuppeople.com/1086/cw/en-us
+Virginia Information Technologies Agency - DHRM,1125/cw/en-us,https://careers.pageuppeople.com/1125/cw/en-us
 Western Washington University,793/cw/en-us,https://careers.pageuppeople.com/793/cw/en-us


### PR DESCRIPTION
## Summary
- add 8 direct-employer PageUp tenants
- expand US coverage with North Idaho College, University of Toledo, Commonwealth of Virginia (DHRM), and University of North Texas System
- expand Australian coverage with Defence Housing Australia, Kinetic IT, Knox City Council, and Melbourne Water
- exclude discovered Monash International and Schindler boards because those employers are already represented elsewhere in the catalogue

## Live validation (2026-07-27)
- 8/8 boards returned non-empty real listings through `PageUpScraper`
- 1,339 jobs after full detail validation
- 1,339 unique ATS IDs and job URLs
- 1,339/1,339 descriptions populated
- 1,089/1,339 locations populated

## Tests
- `PYTHONPATH=src uv run --extra test --with-requirements pipeline/requirements.txt pytest -q tests/test_pageup_contracts.py tests/test_pageup.py`
- 40 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added 8 validated PageUp direct-employer tenants to expand US and Australian coverage. Excluded Monash International and Schindler because they’re already covered elsewhere.

- **New Features**
  - US: North Idaho College, University of Toledo, Commonwealth of Virginia (DHRM), University of North Texas System
  - Australia: Defence Housing Australia, Kinetic IT, Knox City Council, Melbourne Water
  - Validation: 8/8 boards returned listings via `PageUpScraper`; 1,339 unique jobs with descriptions; most locations populated
  - Exclusions: Monash International, Schindler (duplicates)

<sup>Written for commit 90d8fb4b60fb981743fef6e8f5a7ed84c6b6073c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

