### PR TITLE
Handle Dayforce feed variants and add 27 employers

### DIFF
--- a/ats-companies/dayforce.csv
+++ b/ats-companies/dayforce.csv
@@ -1,22 +1,47 @@
 name,slug,url
 GBank,gbank/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/gbank/CANDIDATEPORTAL
+4Wall Entertainment,acadia/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/acadia/CANDIDATEPORTAL
 A New Leaf,leaf/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/leaf/CANDIDATEPORTAL
 "A. Duda and Sons, Inc.",duda/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/duda/CANDIDATEPORTAL
 "Aaron's, Inc.",aan/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/aan/CANDIDATEPORTAL
 Abilities Centre,abilities/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/abilities/CANDIDATEPORTAL
+AbleLight,ablelight/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/ablelight/CANDIDATEPORTAL
 Accent Group ,accentdayforce/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/accentdayforce/CANDIDATEPORTAL
+Accuris,accuris/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/accuris/CANDIDATEPORTAL
 Accurus Aerospace,accurusaero/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/accurusaero/CANDIDATEPORTAL
 Achēv,achev/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/achev/CANDIDATEPORTAL
+Active Day,activeday/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/activeday/CANDIDATEPORTAL
+ACV Auctions,acv/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/acv/CANDIDATEPORTAL
 Adara Home Health,adarahome/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/adarahome/CANDIDATEPORTAL
+Advanced Dermatology and Cosmetic Surgery,adcs/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/adcs/CANDIDATEPORTAL
+AdvaCare Systems,advacare2939/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/advacare2939/CANDIDATEPORTAL
+AdvanSix,advansix/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/advansix/CANDIDATEPORTAL
+Advocacy and Resource Center,arcnewyork/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/arcnewyork/CANDIDATEPORTAL
 AirBoss of America Corp.,airboss/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/airboss/CANDIDATEPORTAL
+AirSprint,airsprint/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/airsprint/CANDIDATEPORTAL
 Alberta Pensions Services Corporation (APS),apsc/EXTERNALCANDIDATEPORTAL,https://jobs.dayforcehcm.com/apsc/EXTERNALCANDIDATEPORTAL
 Alectra Utilities,alectra/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/alectra/CANDIDATEPORTAL
+Allegiance Trucks,allegiance/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/allegiance/CANDIDATEPORTAL
 Allen County Government,allencounty/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/allencounty/CANDIDATEPORTAL
+Alliant Insurance Services,allianthcm/Alliant,https://jobs.dayforcehcm.com/allianthcm/Alliant
 Alma Mater Society of UBC Vancouver,almamater/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/almamater/CANDIDATEPORTAL
+Alta Equipment Group,altg/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/altg/CANDIDATEPORTAL
 Alta Resources,altaresourceshcm/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/altaresourceshcm/CANDIDATEPORTAL
+Alvin Ailey Dance Foundation,alvinailey/AlvinAileyWebsiteFulltime,https://jobs.dayforcehcm.com/alvinailey/AlvinAileyWebsiteFulltime
+American Bar Association,aba/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/aba/CANDIDATEPORTAL
 Amphenol CMT,amphenol/AMPHENOLCMTCAREERS,https://jobs.dayforcehcm.com/amphenol/AMPHENOLCMTCAREERS
+Andrew Peller Limited,andrewpeller/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/andrewpeller/CANDIDATEPORTAL
+Aquent,aquent/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/aquent/CANDIDATEPORTAL
+ArchWell Health,archwellhealth/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/archwellhealth/CANDIDATEPORTAL
+Arrowhead Engineered Products,aep/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/aep/CANDIDATEPORTAL
+Asbury Automotive Group,asburyauto/ASBURYCAREERSITE,https://jobs.dayforcehcm.com/asburyauto/ASBURYCAREERSITE
+Ascendance Truck Centers,ascendance/candidateportal,https://jobs.dayforcehcm.com/ascendance/candidateportal
+Ashley Stewart,ashleystewart/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/ashleystewart/CANDIDATEPORTAL
+ASRC Federal,asrcfh/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/asrcfh/CANDIDATEPORTAL
 "Associated Students Inc, Sacramento State University",asi/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/asi/CANDIDATEPORTAL
 "Associated Students, Inc., California State University Fullerton",asicsuf/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/asicsuf/CANDIDATEPORTAL
+ATIS Elevator Inspections,atis/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/atis/CANDIDATEPORTAL
+Atlas Healthcare Partners,atlashp/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/atlashp/CANDIDATEPORTAL
 Au Bon Pain,aubonpain/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/aubonpain/CANDIDATEPORTAL
 BAI Communications,baicomms/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/baicomms/CANDIDATEPORTAL
 Bank of Labor,bankoflabor/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/bankoflabor/CANDIDATEPORTAL
@@ -66,6 +91,7 @@ Colorado Access,coaccess/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/coaccess/C
 Columbia Association ,camd/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/camd/CANDIDATEPORTAL
 Commerce Casino,commercecasino/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/commercecasino/CANDIDATEPORTAL
 Community College of Beaver County,communitycollege/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/communitycollege/CANDIDATEPORTAL
+Community Hospice and Palliative Care,aliviacare/joinourteamcommunityhospiceandpalliativecare,https://jobs.dayforcehcm.com/aliviacare/joinourteamcommunityhospiceandpalliativecare
 Community Services Consortium,csc/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/csc/CANDIDATEPORTAL
 Compassion Canada,compassion/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/compassion/CANDIDATEPORTAL
 Concordia Lutheran Ministries,clh/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/clh/CANDIDATEPORTAL
@@ -129,6 +155,7 @@ Hoffmaster,hoffmaster/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/hoffmaster/CA
 Houston Zoo,houstonzoo/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/houstonzoo/CANDIDATEPORTAL
 Hutchens Law Firm,hutchens/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/hutchens/CANDIDATEPORTAL
 ICS,legence/ICSPORTAL,https://jobs.dayforcehcm.com/legence/ICSPORTAL
+Impact Fire Services,aifire/IMPACT,https://jobs.dayforcehcm.com/aifire/IMPACT
 Indianapolis Colts,indianapoliscolts/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/indianapoliscolts/CANDIDATEPORTAL
 Indwell,indwell/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/indwell/CANDIDATEPORTAL
 Inteplast Group,inteplast/CANDIDATEPORTAL,https://jobs.dayforcehcm.com/inteplast/CANDIDATEPORTAL

--- a/src/ats_scrapers/scrapers/dayforce.py
+++ b/src/ats_scrapers/scrapers/dayforce.py
@@ -233,7 +233,12 @@ def _select_job_variant(
         cultures_to_titles.setdefault(culture, set()).add(
             " ".join(job.title.split()).casefold()
         )
-        companies.add(" ".join(job.company.split()).casefold())
+        feed_company = (
+            _string(item.get("CompanyName"))
+            or _string(item.get("ParentCompanyName"))
+            or ""
+        )
+        companies.add(" ".join(feed_company.split()).casefold())
 
     if len(companies) != 1 or any(
         len(titles) != 1 for titles in cultures_to_titles.values()
@@ -271,10 +276,10 @@ def _variant_rank(job: Job, item: dict[str, Any]) -> tuple[bool, bool, bool, boo
     culture = (_string(item.get("CultureCode")) or "").casefold()
     country = (_string(item.get("Country")) or "").upper()
     return (
+        bool(job.description),
         culture == "en-us",
         culture.startswith("en-"),
         country in _COUNTRY_METADATA,
-        bool(job.description),
     )
 
 

--- a/src/ats_scrapers/scrapers/dayforce.py
+++ b/src/ats_scrapers/scrapers/dayforce.py
@@ -37,42 +37,47 @@ _EMPLOYMENT_TYPE_MAP: tuple[tuple[str, EmploymentType], ...] = (
     ("apprentice", "INTERN"),
 )
 
+_COUNTRY_CODES: tuple[tuple[str, str, str], ...] = (
+    ("AR", "ARG", "South America"),
+    ("AU", "AUS", "Oceania"),
+    ("AT", "AUT", "Europe"),
+    ("BE", "BEL", "Europe"),
+    ("BR", "BRA", "South America"),
+    ("CA", "CAN", "North America"),
+    ("CH", "CHE", "Europe"),
+    ("CL", "CHL", "South America"),
+    ("CN", "CHN", "Asia"),
+    ("CO", "COL", "South America"),
+    ("CZ", "CZE", "Europe"),
+    ("DE", "DEU", "Europe"),
+    ("DK", "DNK", "Europe"),
+    ("ES", "ESP", "Europe"),
+    ("FI", "FIN", "Europe"),
+    ("FR", "FRA", "Europe"),
+    ("GB", "GBR", "Europe"),
+    ("HK", "HKG", "Asia"),
+    ("IN", "IND", "Asia"),
+    ("IE", "IRL", "Europe"),
+    ("IT", "ITA", "Europe"),
+    ("JP", "JPN", "Asia"),
+    ("KR", "KOR", "Asia"),
+    ("MX", "MEX", "North America"),
+    ("MY", "MYS", "Asia"),
+    ("NL", "NLD", "Europe"),
+    ("NO", "NOR", "Europe"),
+    ("NZ", "NZL", "Oceania"),
+    ("PL", "POL", "Europe"),
+    ("PT", "PRT", "Europe"),
+    ("SG", "SGP", "Asia"),
+    ("SE", "SWE", "Europe"),
+    ("TH", "THA", "Asia"),
+    ("US", "USA", "North America"),
+    ("ZA", "ZAF", "Africa"),
+)
 _COUNTRY_METADATA: dict[str, tuple[str, str]] = {
-    "ARG": ("AR", "South America"),
-    "AUS": ("AU", "Oceania"),
-    "AUT": ("AT", "Europe"),
-    "BEL": ("BE", "Europe"),
-    "BRA": ("BR", "South America"),
-    "CAN": ("CA", "North America"),
-    "CHE": ("CH", "Europe"),
-    "CHL": ("CL", "South America"),
-    "CHN": ("CN", "Asia"),
-    "COL": ("CO", "South America"),
-    "CZE": ("CZ", "Europe"),
-    "DEU": ("DE", "Europe"),
-    "DNK": ("DK", "Europe"),
-    "ESP": ("ES", "Europe"),
-    "FIN": ("FI", "Europe"),
-    "FRA": ("FR", "Europe"),
-    "GBR": ("GB", "Europe"),
-    "HKG": ("HK", "Asia"),
-    "IND": ("IN", "Asia"),
-    "IRL": ("IE", "Europe"),
-    "ITA": ("IT", "Europe"),
-    "JPN": ("JP", "Asia"),
-    "KOR": ("KR", "Asia"),
-    "MEX": ("MX", "North America"),
-    "MYS": ("MY", "Asia"),
-    "NLD": ("NL", "Europe"),
-    "NOR": ("NO", "Europe"),
-    "NZL": ("NZ", "Oceania"),
-    "POL": ("PL", "Europe"),
-    "PRT": ("PT", "Europe"),
-    "SGP": ("SG", "Asia"),
-    "SWE": ("SE", "Europe"),
-    "THA": ("TH", "Asia"),
-    "USA": ("US", "North America"),
-    "ZAF": ("ZA", "Africa"),
+    code: (iso2, region)
+    for iso2, iso3, region in _COUNTRY_CODES
+    for code in (iso2, iso3)
 }
 
 
@@ -123,21 +128,20 @@ class DayforceScraper(BaseScraper):
                 f"Dayforce ({self.tenant}/{self.board}) returned a non-list feed"
             )
 
-        jobs: list[Job] = []
-        seen_ids: set[str] = set()
+        variants_by_id: dict[str, list[tuple[Job, dict[str, Any]]]] = {}
         for index, item in enumerate(payload):
             if not isinstance(item, dict):
                 raise ScraperError(
                     f"Dayforce feed row {index} was not an object"
                 )
             job = self._parse_job(item)
-            if job.ats_id in seen_ids:
-                raise ScraperError(
-                    f"Dayforce returned duplicate job id {job.ats_id!r}"
-                )
-            seen_ids.add(job.ats_id or "")
-            jobs.append(job)
-        return jobs
+            if not job.ats_id:
+                raise ScraperError(f"Dayforce feed row {index} omitted its job id")
+            variants_by_id.setdefault(job.ats_id, []).append((job, item))
+        return [
+            _select_job_variant(ats_id, variants)
+            for ats_id, variants in variants_by_id.items()
+        ]
 
     def _parse_job(self, item: dict[str, Any]) -> Job:
         reference = _required_string(item, "ReferenceNumber")
@@ -176,6 +180,7 @@ class DayforceScraper(BaseScraper):
             for key in (
                 "ClientSiteName",
                 "ClientSiteXRefCode",
+                "CultureCode",
                 "ParentCompanyName",
                 "ParentRequisitionCode",
                 "LastUpdated",
@@ -215,6 +220,62 @@ class DayforceScraper(BaseScraper):
             commitment=employment_label,
             raw=raw or None,
         )
+
+
+def _select_job_variant(
+    ats_id: str,
+    variants: list[tuple[Job, dict[str, Any]]],
+) -> Job:
+    cultures_to_titles: dict[str, set[str]] = {}
+    companies: set[str] = set()
+    for job, item in variants:
+        culture = (_string(item.get("CultureCode")) or "").casefold()
+        cultures_to_titles.setdefault(culture, set()).add(
+            " ".join(job.title.split()).casefold()
+        )
+        companies.add(" ".join(job.company.split()).casefold())
+
+    if len(companies) != 1 or any(
+        len(titles) != 1 for titles in cultures_to_titles.values()
+    ):
+        raise ScraperError(
+            f"Dayforce returned conflicting duplicate job id {ats_id!r}"
+        )
+
+    selected_job, _ = max(
+        variants,
+        key=lambda variant: _variant_rank(*variant),
+    )
+    cultures = sorted(
+        {
+            culture
+            for _, item in variants
+            if (culture := _string(item.get("CultureCode")))
+        }
+    )
+    locations = list(
+        dict.fromkeys(
+            job.location for job, _ in variants if job.location
+        )
+    )
+    raw = dict(selected_job.raw or {})
+    if len(cultures) > 1:
+        raw["AvailableCultures"] = cultures
+    if len(locations) > 1:
+        raw["AllLocations"] = locations
+    selected_job.raw = raw or None
+    return selected_job
+
+
+def _variant_rank(job: Job, item: dict[str, Any]) -> tuple[bool, bool, bool, bool]:
+    culture = (_string(item.get("CultureCode")) or "").casefold()
+    country = (_string(item.get("Country")) or "").upper()
+    return (
+        culture == "en-us",
+        culture.startswith("en-"),
+        country in _COUNTRY_METADATA,
+        bool(job.description),
+    )
 
 
 def _normalize_tenant_board(value: str) -> tuple[str, str]:

--- a/tests/test_dayforce.py
+++ b/tests/test_dayforce.py
@@ -150,6 +150,62 @@ def test_duplicate_references_fail_closed(httpx_mock) -> None:
         DayforceScraper("mayfair/CANDIDATEPORTAL").fetch()
 
 
+def test_equivalent_duplicate_references_are_collapsed(httpx_mock) -> None:
+    duplicate = {**FIXTURE, "Country": "CA"}
+    httpx_mock.add_response(url=API_URL, json=[FIXTURE, duplicate])
+
+    jobs = DayforceScraper("mayfair/CANDIDATEPORTAL").fetch()
+
+    assert len(jobs) == 1
+    assert jobs[0].country_iso == "CA"
+    assert jobs[0].region == "North America"
+
+
+def test_multilingual_duplicate_prefers_english(httpx_mock) -> None:
+    french = {
+        **FIXTURE,
+        "Title": "Gestionnaire de la comptabilité et de la paie",
+        "CultureCode": "fr-CA",
+        "JobDetailsUrl": (
+            "https://jobs.dayforcehcm.com/fr-CA/mayfair/"
+            "CANDIDATEPORTAL/jobs/3612"
+        ),
+        "ApplyUrl": (
+            "https://jobs.dayforcehcm.com/fr-CA/mayfair/"
+            "CANDIDATEPORTAL/jobs/3612/apply"
+        ),
+    }
+    httpx_mock.add_response(url=API_URL, json=[french, FIXTURE])
+
+    jobs = DayforceScraper("mayfair/CANDIDATEPORTAL").fetch()
+
+    assert len(jobs) == 1
+    assert jobs[0].title == FIXTURE["Title"]
+    assert jobs[0].language == "en"
+    assert jobs[0].raw is not None
+    assert jobs[0].raw["AvailableCultures"] == ["en-CA", "fr-CA"]
+
+
+def test_multi_location_duplicate_preserves_all_locations(httpx_mock) -> None:
+    edmonton = {
+        **FIXTURE,
+        "AddressLine1": "100 Main Street",
+        "City": "Edmonton",
+        "State": "AB",
+        "PostalCode": "T5J0N3",
+    }
+    httpx_mock.add_response(url=API_URL, json=[FIXTURE, edmonton])
+
+    jobs = DayforceScraper("mayfair/CANDIDATEPORTAL").fetch()
+
+    assert len(jobs) == 1
+    assert jobs[0].raw is not None
+    assert jobs[0].raw["AllLocations"] == [
+        "132, 6707 Elbow Drive SW, Calgary, AB, CAN",
+        "100 Main Street, Edmonton, AB, CAN",
+    ]
+
+
 @pytest.mark.parametrize(
     "url",
     [

--- a/tests/test_dayforce.py
+++ b/tests/test_dayforce.py
@@ -150,6 +150,23 @@ def test_duplicate_references_fail_closed(httpx_mock) -> None:
         DayforceScraper("mayfair/CANDIDATEPORTAL").fetch()
 
 
+def test_duplicate_feed_employers_fail_closed_with_seed_override(
+    httpx_mock,
+) -> None:
+    duplicate = {
+        **FIXTURE,
+        "CompanyName": "Another Employer",
+        "ParentCompanyName": "Another Employer",
+    }
+    httpx_mock.add_response(url=API_URL, json=[FIXTURE, duplicate])
+
+    with pytest.raises(ScraperError, match="duplicate job id"):
+        DayforceScraper(
+            "mayfair/CANDIDATEPORTAL",
+            company_name="Canonical Employer",
+        ).fetch()
+
+
 def test_equivalent_duplicate_references_are_collapsed(httpx_mock) -> None:
     duplicate = {**FIXTURE, "Country": "CA"}
     httpx_mock.add_response(url=API_URL, json=[FIXTURE, duplicate])
@@ -184,6 +201,30 @@ def test_multilingual_duplicate_prefers_english(httpx_mock) -> None:
     assert jobs[0].language == "en"
     assert jobs[0].raw is not None
     assert jobs[0].raw["AvailableCultures"] == ["en-CA", "fr-CA"]
+
+
+def test_multilingual_duplicate_keeps_available_description(httpx_mock) -> None:
+    english = {**FIXTURE, "Description": ""}
+    french = {
+        **FIXTURE,
+        "Title": "Gestionnaire de la comptabilité et de la paie",
+        "CultureCode": "fr-CA",
+        "JobDetailsUrl": (
+            "https://jobs.dayforcehcm.com/fr-CA/mayfair/"
+            "CANDIDATEPORTAL/jobs/3612"
+        ),
+        "ApplyUrl": (
+            "https://jobs.dayforcehcm.com/fr-CA/mayfair/"
+            "CANDIDATEPORTAL/jobs/3612/apply"
+        ),
+    }
+    httpx_mock.add_response(url=API_URL, json=[english, french])
+
+    jobs = DayforceScraper("mayfair/CANDIDATEPORTAL").fetch()
+
+    assert len(jobs) == 1
+    assert jobs[0].description == FIXTURE["Description"]
+    assert jobs[0].language == "fr"
 
 
 def test_multi_location_duplicate_preserves_all_locations(httpx_mock) -> None:


### PR DESCRIPTION
## Summary
- collapse equivalent multi-location and multilingual Dayforce feed rows by requisition instead of rejecting an otherwise valid board
- still fail closed when one culture reuses a requisition ID for conflicting titles or employers
- prefer English variants, preserve all exposed cultures and locations in `raw`, and recognize both ISO alpha-2 and alpha-3 country codes
- add 27 validated direct-employer Dayforce boards
- compare duplicate employers from the original feed before applying the canonical CSV name
- retain an available description when a preferred-language variant is empty

## Duplicate controls
- excluded five ACV subsidiary boards because 18/24 jobs overlapped the main ACV board
- excluded two secondary Alliant boards because their jobs overlapped the broader `Alliant` board
- excluded Aline, Adare Pharma Solutions, and AGCO because those employers already exist under BambooHR, Workable, and SuccessFactors
- did not add five empty boards or six boards that failed live API validation

## Live validation (2026-07-27)
- 27/27 added boards completed the full scraper path
- 3,232 jobs, 3,232 unique ATS IDs, and 3,232 unique URLs
- 3,232/3,232 descriptions populated
- 3,218/3,232 locations populated
- regional split: 3,184 North America, 28 Europe, 6 Asia, 14 unknown

## Tests
- `PYTHONPATH=src uv run --extra test --with-requirements pipeline/requirements.txt pytest -q tests/test_dayforce.py tests/test_dayforce_contracts.py tests/test_resolve.py`
- 110 passed
- `PYTHONPATH=src uv run --extra dev ruff check src/ats_scrapers/scrapers/dayforce.py tests/test_dayforce.py`
- all checks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapses multilingual and multi-location Dayforce feed rows into a single job per requisition, prioritizes populated descriptions before English, and adds 27 validated direct-employer boards to expand coverage.

- **New Features**
  - Collapse duplicate Dayforce rows by `ReferenceNumber`; return one job per requisition.
  - Select a variant with a description first; then prefer English. Preserve cultures in `raw.AvailableCultures` and locations in `raw.AllLocations`.
  - Accept ISO‑2 and ISO‑3 country codes for ISO/region normalization.
  - Add 27 validated direct-employer boards; exclude overlapping subsidiaries and invalid/empty boards.

- **Bug Fixes**
  - Preserve feed employer when checking duplicates; fail closed on conflicting titles or employers (even with a seed override).
  - Avoid dropping the only populated description when the English row is empty.
  - Add tests covering description-first selection, English preference, multi-location preservation, and duplicate-employer failure.

<sup>Written for commit 5ee3643b41ec6bb211d4ee5bf3d16e1881dee6c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands Dayforce coverage and changes duplicate requisition handling.
- Adds 27 Dayforce employer boards to the canonical tenant list.
- Collapses multilingual and multi-location feed rows by requisition.
- Prefers English variants and preserves available cultures and locations in raw data.
- Accepts ISO alpha-2 and alpha-3 country codes.
- Adds tests for equivalent, multilingual, and multi-location variants.

<h3>Confidence Score: 4/5</h3>

The description-loss path should be fixed before merging because valid multilingual requisitions can be published without their available job content.

English culture is ranked before description availability, and selection retains only one variant’s fields, so a populated non-English description is discarded when the preferred English row is empty.

**Files Needing Attention:** src/ats_scrapers/scrapers/dayforce.py

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/ats_scrapers/scrapers/dayforce.py | Adds variant grouping, conflict detection, selection ranking, aggregate raw metadata, and dual ISO-code normalization; ranking can discard the only populated description. |
| tests/test_dayforce.py | Covers duplicate collapsing, English selection, and location preservation, but not an empty preferred-language description. |
| ats-companies/dayforce.csv | Adds 27 canonical Dayforce tenant entries without an identified code-level defect. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/ats_scrapers/scrapers/dayforce.py:273-278
**Ranking discards available descriptions**

When an English variant has no description and a non-English variant has one, the culture-first ranking selects the empty English row and retains only that row’s fields, causing the published job to omit a description that Dayforce returned.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Handle Dayforce feed variants and add va..."](https://github.com/kalil0321/ats-scrapers/commit/53cd6661d0c0889dc42f99f571a894aae1c0e001) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47724510)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Scraper Adapters](https://app.greptile.com/kalil0321/-/custom-context/knowledge-base/kalil0321/ats-scrapers/-/docs/scraper-adapters.md)
- Knowledge Base — [Run Pipeline: Tenant List → Flat Jobs CSV](https://app.greptile.com/kalil0321/-/custom-context/knowledge-base/kalil0321/ats-scrapers/-/docs/run-pipeline-script.md)

<!-- /greptile_comment -->