### PR TITLE
Add 81 validated Jobvite employers

### DIFF
--- a/ats-companies/jobvite.csv
+++ b/ats-companies/jobvite.csv
@@ -79,7 +79,7 @@ The Wills Group,willsgroup,https://jobs.jobvite.com/willsgroup
 TiVo,tivo,https://jobs.jobvite.com/tivo
 Torex Gold Resources Inc.,torexgold,https://jobs.jobvite.com/torexgold
 Traffic Tech Inc.,traffictech,https://jobs.jobvite.com/traffictech
-Trekor Metals Limited,tasekomines,https://jobs.jobvite.com/tasekomines
+Taseko Mines Limited,tasekomines,https://jobs.jobvite.com/tasekomines
 Tyler Technologies,tylertech,https://jobs.jobvite.com/tylertech
 Uniqlo Canada,uniqloca,https://jobs.jobvite.com/uniqloca
 VetPartners,careers/vetpartners,https://jobs.jobvite.com/careers/vetpartners

--- a/ats-companies/jobvite.csv
+++ b/ats-companies/jobvite.csv
@@ -10,3 +10,84 @@ Maples Group,maplesgroup,https://jobs.jobvite.com/maplesgroup
 Sikich,sikichcareers,https://jobs.jobvite.com/sikichcareers
 Sitecore,sitecore,https://jobs.jobvite.com/sitecore
 TAIT,tait-internal,https://jobs.jobvite.com/tait-internal
+Absolute Dental,absolutedental,https://jobs.jobvite.com/absolutedental
+"ActioNet, Inc.",actionet,https://jobs.jobvite.com/actionet
+Ainsworth,ainsworth,https://jobs.jobvite.com/ainsworth
+Altamira Technologies Corp.,altamiracorps,https://jobs.jobvite.com/altamiracorps
+Amber Studio,amberstudiocareers,https://jobs.jobvite.com/amberstudiocareers
+ARRISE,pragmaticplay,https://jobs.jobvite.com/pragmaticplay
+BAART Programs,baart-programs,https://jobs.jobvite.com/baart-programs
+Barracuda Networks Inc.,barracuda-networks-inc,https://jobs.jobvite.com/barracuda-networks-inc
+BioMarin Pharmaceutical Inc.,biomarin,https://jobs.jobvite.com/biomarin
+bioMérieux,biofiredx,https://jobs.jobvite.com/biofiredx
+"CICONIX, LLC",ciconix,https://jobs.jobvite.com/ciconix
+CJ Logistics,cjlogisticsamerica,https://jobs.jobvite.com/cjlogisticsamerica
+CMG Financial,cmgfi,https://jobs.jobvite.com/cmgfi
+CMI Media Group,careers/cmimedia,https://jobs.jobvite.com/careers/cmimedia
+Colorado Christian University,ccu,https://jobs.jobvite.com/ccu
+Conair LLC,conair,https://jobs.jobvite.com/conair
+Consumers Credit Union,consumerscu,https://jobs.jobvite.com/consumerscu
+CRISTA Ministries,cristaministries,https://jobs.jobvite.com/cristaministries
+DEX Imaging,deximaging,https://jobs.jobvite.com/deximaging
+ECC,ecc,https://jobs.jobvite.com/ecc
+Egnyte,egnyte,https://jobs.jobvite.com/egnyte
+Enphase Energy,enphase-energy,https://jobs.jobvite.com/enphase-energy
+Excel Academy Charter Schools,excel,https://jobs.jobvite.com/excel
+Forescout Technologies Inc.,forescout,https://jobs.jobvite.com/forescout
+Funko,careers/funko,https://jobs.jobvite.com/careers/funko
+Gigamon,gigamon,https://jobs.jobvite.com/gigamon
+Glidewell Dental,glidewelldental,https://jobs.jobvite.com/glidewelldental
+IDEA Public Schools,ideapublicschools-english,https://jobs.jobvite.com/ideapublicschools-english
+Impact Networking,impactnetworking,https://jobs.jobvite.com/impactnetworking
+INNIO,innio,https://jobs.jobvite.com/innio
+Internet Brands,internetbrands,https://jobs.jobvite.com/internetbrands
+InVue,invue,https://jobs.jobvite.com/invue
+Jackson Family Wines,jacksonfamilywines,https://jobs.jobvite.com/jacksonfamilywines
+JBS USA,jbs,https://jobs.jobvite.com/jbs
+Jet Linx Aviation,jetlinx,https://jobs.jobvite.com/jetlinx
+KIPP Public Schools Northern California,kippnorcal,https://jobs.jobvite.com/kippnorcal
+Kitsap Mental Health Services,kitsapmentalhealth,https://jobs.jobvite.com/kitsapmentalhealth
+Knight-Swift Transportation,swifttrans,https://jobs.jobvite.com/swifttrans
+Lincoln Industries,lincolnindustries,https://jobs.jobvite.com/lincolnindustries
+Lordco Auto Parts,lordco,https://jobs.jobvite.com/lordco
+Mac Properties,macapartments,https://jobs.jobvite.com/macapartments
+Mattamy Homes,mattamyhomes,https://jobs.jobvite.com/mattamyhomes
+"Mother's Market & Kitchen, Inc.",mothersmarket,https://jobs.jobvite.com/mothersmarket
+"MyHR Partner, Inc",myhrpartnerinc,https://jobs.jobvite.com/myhrpartnerinc
+NBBJ,nbbj,https://jobs.jobvite.com/nbbj
+NinjaOne,ninjaone,https://jobs.jobvite.com/ninjaone
+Northwell Health (Nuvance Health),nuvance,https://jobs.jobvite.com/nuvance
+OMNIVISION,ovt,https://jobs.jobvite.com/ovt
+OneCo,oneco,https://jobs.jobvite.com/oneco
+Palomar Health,palomarhealth,https://jobs.jobvite.com/palomarhealth
+Parkland Corporation,parkland,https://jobs.jobvite.com/parkland
+Pet Paradise,petparadiseresort,https://jobs.jobvite.com/petparadiseresort
+Progress,progress,https://jobs.jobvite.com/progress
+Recurrent Energy,recurrent-energy,https://jobs.jobvite.com/recurrent-energy
+Red Alpha,redalpha,https://jobs.jobvite.com/redalpha
+Redwire Defense Tech,edgeautonomy-careers,https://jobs.jobvite.com/edgeautonomy-careers
+RES Group,resgroup,https://jobs.jobvite.com/resgroup
+"RK Industries, LLC",rkmi,https://jobs.jobvite.com/rkmi
+Salsa Jeans,salsa,https://jobs.jobvite.com/salsa
+Skyservice Business Aviation,skyservice,https://jobs.jobvite.com/skyservice
+"SRC, Inc",src-inc,https://jobs.jobvite.com/src-inc
+St. HOPE Public Schools,sthope,https://jobs.jobvite.com/sthope
+Sumitomo Electric Group,sumitomo-electric,https://jobs.jobvite.com/sumitomo-electric
+The Opus Group,theopusgroup,https://jobs.jobvite.com/theopusgroup
+The PENTA Building Group,pentabuildinggroup,https://jobs.jobvite.com/pentabuildinggroup
+The Wills Group,willsgroup,https://jobs.jobvite.com/willsgroup
+TiVo,tivo,https://jobs.jobvite.com/tivo
+Torex Gold Resources Inc.,torexgold,https://jobs.jobvite.com/torexgold
+Traffic Tech Inc.,traffictech,https://jobs.jobvite.com/traffictech
+Trekor Metals Limited,tasekomines,https://jobs.jobvite.com/tasekomines
+Tyler Technologies,tylertech,https://jobs.jobvite.com/tylertech
+Uniqlo Canada,uniqloca,https://jobs.jobvite.com/uniqloca
+VetPartners,careers/vetpartners,https://jobs.jobvite.com/careers/vetpartners
+"Visionist, Inc.",visionist,https://jobs.jobvite.com/visionist
+VON Canada,von,https://jobs.jobvite.com/von
+Washington Hospital,washingtonhospital,https://jobs.jobvite.com/washingtonhospital
+WebMD,webmd,https://jobs.jobvite.com/webmd
+Weston Solutions,weston,https://jobs.jobvite.com/weston
+Xcelerate Solutions,xceleratesolutions,https://jobs.jobvite.com/xceleratesolutions
+YMCA of Greater Dayton,daytonymca,https://jobs.jobvite.com/daytonymca
+Ziff Davis,ziffdavis,https://jobs.jobvite.com/ziffdavis


### PR DESCRIPTION
## Summary
- add 81 direct-employer Jobvite boards discovered from current public crawl evidence
- expand US and Canadian coverage while adding global employers such as Sumitomo Electric, INNIO, VON Canada, CJ Logistics, ARRISE, and bioMérieux

## Duplicate controls
- excluded Pilgrim's because all 374 jobs are already present on the broader JBS USA board with the same Jobvite IDs
- excluded duplicate aliases for YMCA of Greater Dayton and Jet Linx because each alias returned the exact same IDs and URLs
- excluded the legacy `drillinginfo` board because the same employer is already tracked as Enverus
- excluded Zones after full validation exposed an internal duplicate ID
- checked likely cross-ATS name collisions: Northwell/Nuvance had zero exact title-location overlap with the existing Oracle board; Parkland had zero overlap with existing Parkland feeds; NinjaOne's existing BambooHR feed is empty; RES and ECC candidates had no live title overlap with same-name feeds

## Live validation (2026-07-27)
- 81/81 added boards completed full listing and detail validation
- 8,213 jobs, 8,213 unique Jobvite IDs, and 8,213 unique URLs
- 8,213/8,213 descriptions populated
- 8,200/8,213 locations populated

## Tests
- `PYTHONPATH=src uv run --extra test --with-requirements pipeline/requirements.txt pytest -q tests/test_jobvite.py tests/test_jobvite_contracts.py tests/test_resolve.py`
- 112 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded Jobvite employer coverage by adding 81 validated direct-employer boards to `ats-companies/jobvite.csv`. This improves US, Canadian, and global coverage with fully validated listings, and fixes the Taseko Mines name to "Taseko Mines Limited".

- **New Features**
  - Validated 8,213 unique jobs, IDs, and URLs; 8,213 descriptions and 8,200 locations populated.
  - Excluded duplicates: Pilgrim’s (covered by JBS USA), alias duplicates for YMCA of Greater Dayton and Jet Linx, legacy `drillinginfo` (tracked as Enverus), and Zones (internal duplicate ID).
  - Checked cross-ATS collisions (Northwell/Nuvance, Parkland, NinjaOne, RES, ECC); no overlapping titles or IDs with existing feeds.

<sup>Written for commit 40c16ce46ccb9cf6080d5ea4fb0748a920003c80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

