### PR TITLE
Add 88 validated UKG employers

### DIFF
--- a/ats-companies/ukg.csv
+++ b/ats-companies/ukg.csv
@@ -1,20 +1,108 @@
 name,slug,url
+a.i. solutions,https://recruiting.ultipro.com/AIS1000AISI/JobBoard/b22b728d-47a6-4550-9005-01c83b9a527f,https://recruiting.ultipro.com/AIS1000AISI/JobBoard/b22b728d-47a6-4550-9005-01c83b9a527f
+ABX Air,https://recruiting.ultipro.com/AIR1013ATSG/JobBoard/7f7953dc-22ab-4b56-ad7a-2fe1ad00de22,https://recruiting.ultipro.com/AIR1013ATSG/JobBoard/7f7953dc-22ab-4b56-ad7a-2fe1ad00de22
+Acuren,https://recruiting.ultipro.com/ACU1004ACUIN/JobBoard/2eb4f178-3dbf-4b8a-9e01-2666bbe38d96,https://recruiting.ultipro.com/ACU1004ACUIN/JobBoard/2eb4f178-3dbf-4b8a-9e01-2666bbe38d96
+Advarra,https://recruiting.ultipro.com/ADV1023AVR/JobBoard/6051d363-03fe-4650-945e-f836306a8388,https://recruiting.ultipro.com/ADV1023AVR/JobBoard/6051d363-03fe-4650-945e-f836306a8388
+AHF Products,https://recruiting.ultipro.com/AHF1000AHFP/JobBoard/eb870e08-1b72-44d8-a4c4-d8b21f6f9297,https://recruiting.ultipro.com/AHF1000AHFP/JobBoard/eb870e08-1b72-44d8-a4c4-d8b21f6f9297
+AIPAC,https://recruiting.ultipro.com/AME1071/JobBoard/0ef31e79-3786-dcf1-5756-a5fc7f17ce54,https://recruiting.ultipro.com/AME1071/JobBoard/0ef31e79-3786-dcf1-5756-a5fc7f17ce54
 Akin,https://recruiting.ultipro.com/CHI1020/JobBoard/548fb303-9b4b-c600-6802-1df2ed6c6aaa,https://recruiting.ultipro.com/CHI1020/JobBoard/548fb303-9b4b-c600-6802-1df2ed6c6aaa
+Alchemy Global Solutions,https://recruiting.ultipro.com/ALC1004TELCO/JobBoard/e3a8eb11-96c0-4968-9120-a910524a61db,https://recruiting.ultipro.com/ALC1004TELCO/JobBoard/e3a8eb11-96c0-4968-9120-a910524a61db
+American Chemical Society,https://recruiting.ultipro.com/AME1095ACHM/JobBoard/c52f9a39-fdc5-4ae2-9eaf-cb8a7bda923e,https://recruiting.ultipro.com/AME1095ACHM/JobBoard/c52f9a39-fdc5-4ae2-9eaf-cb8a7bda923e
+AMIkids,https://recruiting.ultipro.com/AMI1003AMIK/JobBoard/132b6065-9187-4e0f-a292-4f67e675d1d0,https://recruiting.ultipro.com/AMI1003AMIK/JobBoard/132b6065-9187-4e0f-a292-4f67e675d1d0
+AMSURG,https://recruiting.ultipro.com/AMS1004AMSRG/JobBoard/94a3d750-7693-4943-8b5d-0a9b17bb4e4f,https://recruiting.ultipro.com/AMS1004AMSRG/JobBoard/94a3d750-7693-4943-8b5d-0a9b17bb4e4f
+Ansafone Contact Centers,https://recruiting.ultipro.com/ANS1003AFCC/JobBoard/44619740-8f91-47db-9505-86eb66e72774,https://recruiting.ultipro.com/ANS1003AFCC/JobBoard/44619740-8f91-47db-9505-86eb66e72774
+Archdiocese of Baltimore,https://recruiting.ultipro.com/ARC1013AOB/JobBoard/8888f6c2-d0b5-4f4b-ba2b-fa2ab452ce90,https://recruiting.ultipro.com/ARC1013AOB/JobBoard/8888f6c2-d0b5-4f4b-ba2b-fa2ab452ce90
+ARKA,https://recruiting.ultipro.com/DAN1006DMT/JobBoard/aab9b8ae-463c-48fc-8362-a25df8be0c77,https://recruiting.ultipro.com/DAN1006DMT/JobBoard/aab9b8ae-463c-48fc-8362-a25df8be0c77
+Arrivia,https://recruiting.ultipro.com/INT1043EXCUR/JobBoard/ad5e5978-552f-4ef7-90c8-70ebb0a57994,https://recruiting.ultipro.com/INT1043EXCUR/JobBoard/ad5e5978-552f-4ef7-90c8-70ebb0a57994
+Axia Women's Health,https://recruiting.ultipro.com/REG1001RWHM/JobBoard/3f9058a6-91f2-4cf1-bf33-bc76cb9f0522,https://recruiting.ultipro.com/REG1001RWHM/JobBoard/3f9058a6-91f2-4cf1-bf33-bc76cb9f0522
+Bay State Milling Company,https://recruiting.ultipro.com/BAY1002BAYSM/JobBoard/e59174da-c780-45f8-a72f-5b451eed285a,https://recruiting.ultipro.com/BAY1002BAYSM/JobBoard/e59174da-c780-45f8-a72f-5b451eed285a
+Behavioral Health System Baltimore,https://recruiting.ultipro.com/BEH1003BHSB/JobBoard/53e60eca-8a8b-438c-b09c-9cac8732ebf5,https://recruiting.ultipro.com/BEH1003BHSB/JobBoard/53e60eca-8a8b-438c-b09c-9cac8732ebf5
 Bergen New Bridge Medical Center,https://recruiting.ultipro.com/BER1003BRMC/JobBoard/7362b0d4-9214-406f-86b5-85f44c6f1238,https://recruiting.ultipro.com/BER1003BRMC/JobBoard/7362b0d4-9214-406f-86b5-85f44c6f1238
+Beyond Support Network,https://recruiting.ultipro.com/CAN1003CANTC/JobBoard/0366f2da-ba02-4088-9bac-d6d82bd2d43c,https://recruiting.ultipro.com/CAN1003CANTC/JobBoard/0366f2da-ba02-4088-9bac-d6d82bd2d43c
 Building Material Distributors,https://recruiting.ultipro.com/BUI1004BMDI/JobBoard/6b442184-52a5-4635-8db5-5aa4bed2a563,https://recruiting.ultipro.com/BUI1004BMDI/JobBoard/6b442184-52a5-4635-8db5-5aa4bed2a563
+Burns Engineering,https://recruiting.ultipro.com/BUR1010BUENI/JobBoard/303a4410-020e-4bfa-99ac-0777a9b8aaf0,https://recruiting.ultipro.com/BUR1010BUENI/JobBoard/303a4410-020e-4bfa-99ac-0777a9b8aaf0
+Capano Management Company,https://recruiting.ultipro.com/CAP1025CPMC/JobBoard/b745946e-beea-40dc-b83a-a5e875f6ebea,https://recruiting.ultipro.com/CAP1025CPMC/JobBoard/b745946e-beea-40dc-b83a-a5e875f6ebea
+Capital District YMCA,https://recruiting.ultipro.com/CAP1008TCDY/JobBoard/f49737cd-ba4e-44de-897b-1397ba20d917,https://recruiting.ultipro.com/CAP1008TCDY/JobBoard/f49737cd-ba4e-44de-897b-1397ba20d917
+CAR-FRESHNER Corporation (Little Trees),https://recruiting.ultipro.com/CAR1040/JobBoard/10974b53-44c0-c5fd-d617-7b89640464fa,https://recruiting.ultipro.com/CAR1040/JobBoard/10974b53-44c0-c5fd-d617-7b89640464fa
+Cary Academy,https://recruiting.ultipro.com/CAR1053CARY/JobBoard/12c1456c-229c-4e8c-a423-cf1b3dc93755,https://recruiting.ultipro.com/CAR1053CARY/JobBoard/12c1456c-229c-4e8c-a423-cf1b3dc93755
+Charlotte Hornets,https://recruiting.ultipro.com/HOR1011HORNT/JobBoard/5b257d2d-0813-4167-b64c-95fb001e0d96,https://recruiting.ultipro.com/HOR1011HORNT/JobBoard/5b257d2d-0813-4167-b64c-95fb001e0d96
+Christian Broadcasting Network,https://recruiting.ultipro.com/CHR1001CBN/JobBoard/eafebde8-bc33-4074-baca-15ec2ca2749b,https://recruiting.ultipro.com/CHR1001CBN/JobBoard/eafebde8-bc33-4074-baca-15ec2ca2749b
+CITY Furniture,https://recruiting.ultipro.com/CIT1035CIFR/JobBoard/9230cd8b-3a93-4eec-9a9f-13cc158230a6,https://recruiting.ultipro.com/CIT1035CIFR/JobBoard/9230cd8b-3a93-4eec-9a9f-13cc158230a6
 City of Ann Arbor,https://recruiting.ultipro.com/CIT1009CA2/JobBoard/f90d5294-f62d-4de2-9878-31193309121c,https://recruiting.ultipro.com/CIT1009CA2/JobBoard/f90d5294-f62d-4de2-9878-31193309121c
+Cleveland Museum of Art,https://recruiting.ultipro.com/CLE1004CMA/JobBoard/14a13635-e1f1-6802-5aba-82b151e8c57b,https://recruiting.ultipro.com/CLE1004CMA/JobBoard/14a13635-e1f1-6802-5aba-82b151e8c57b
+Co-operators,https://recruiting.ultipro.com/COO5000COOP/JobBoard/163383cc-cbae-4201-956e-c5e437bbfeb3,https://recruiting.ultipro.com/COO5000COOP/JobBoard/163383cc-cbae-4201-956e-c5e437bbfeb3
+Colonial Williamsburg Foundation,https://recruiting.ultipro.com/COL1030CWF/JobBoard/d1d83d8e-bd7f-41c5-ac90-f1b4796fa63f,https://recruiting.ultipro.com/COL1030CWF/JobBoard/d1d83d8e-bd7f-41c5-ac90-f1b4796fa63f
+Community Health Resources,https://recruiting.ultipro.com/COM1063CHRI/JobBoard/b94848f1-373d-444d-80f0-e324dae8d006,https://recruiting.ultipro.com/COM1063CHRI/JobBoard/b94848f1-373d-444d-80f0-e324dae8d006
 Comprehensive Logistics,https://recruiting.ultipro.com/com1074clcl/JobBoard/8a0d300a-f96c-4397-8ab4-86c9c5e8ab57,https://recruiting.ultipro.com/com1074clcl/JobBoard/8a0d300a-f96c-4397-8ab4-86c9c5e8ab57
+Concord Hospitality,https://recruiting.ultipro.com/CON1029CHEC/JobBoard/1d42a8b7-7823-4daa-bbbd-97ab3ca103de,https://recruiting.ultipro.com/CON1029CHEC/JobBoard/1d42a8b7-7823-4daa-bbbd-97ab3ca103de
+Crescent Hotels & Resorts,https://recruiting.ultipro.com/CRE1007CREHR/JobBoard/453ac982-2a83-4723-a69a-3dd3ff799d14,https://recruiting.ultipro.com/CRE1007CREHR/JobBoard/453ac982-2a83-4723-a69a-3dd3ff799d14
+DASNY,https://recruiting.ultipro.com/DOR1000DASNY/JobBoard/fa77be2f-2f91-4253-a56e-02d5460585df,https://recruiting.ultipro.com/DOR1000DASNY/JobBoard/fa77be2f-2f91-4253-a56e-02d5460585df
+Delkor Systems,https://recruiting.ultipro.com/DEL1008/JobBoard/b92cb60e-fbd2-b6fa-2da3-878e718d6dca,https://recruiting.ultipro.com/DEL1008/JobBoard/b92cb60e-fbd2-b6fa-2da3-878e718d6dca
 E Ink,https://recruiting.ultipro.com/EIN1000EINK/JobBoard/a41773f4-adab-4192-88a9-8bc27fbad529,https://recruiting.ultipro.com/EIN1000EINK/JobBoard/a41773f4-adab-4192-88a9-8bc27fbad529
+EOS Hospitality,https://recruiting.ultipro.com/EOS1000EOSI/JobBoard/1170f284-cf46-4ff7-b32f-76e224e7a2d4,https://recruiting.ultipro.com/EOS1000EOSI/JobBoard/1170f284-cf46-4ff7-b32f-76e224e7a2d4
 Explore St. Louis,https://recruiting.ultipro.com/STL1001STLC/JobBoard/a420e1a5-49da-4a4a-bd17-330f039c4fa9,https://recruiting.ultipro.com/STL1001STLC/JobBoard/a420e1a5-49da-4a4a-bd17-330f039c4fa9
+FirstKey Homes,https://recruiting.ultipro.com/FIR1053FKHL/JobBoard/7444bf90-0ee8-4709-8034-c72e6d60ea7f,https://recruiting.ultipro.com/FIR1053FKHL/JobBoard/7444bf90-0ee8-4709-8034-c72e6d60ea7f
 Fortegra Europe,https://recruiting.ultipro.com/FOR1024FRTF/JobBoard/f4673aa1-86d7-4bb3-b04f-7e14715cc4c7,https://recruiting.ultipro.com/FOR1024FRTF/JobBoard/f4673aa1-86d7-4bb3-b04f-7e14715cc4c7
+Franklin University,https://recruiting.ultipro.com/FRA1012FRANK/JobBoard/e51857cc-39da-44b8-a30e-839c982ff791,https://recruiting.ultipro.com/FRA1012FRANK/JobBoard/e51857cc-39da-44b8-a30e-839c982ff791
 Fusable,https://recruiting.ultipro.com/RAN1004/JobBoard/c4a6f199-4067-786a-1f9d-9fa3d8111d01,https://recruiting.ultipro.com/RAN1004/JobBoard/c4a6f199-4067-786a-1f9d-9fa3d8111d01
+Genesee & Wyoming,https://recruiting.ultipro.com/GEN1025/JobBoard/37481dc2-ddb2-1941-a0f9-befbbf45ab11,https://recruiting.ultipro.com/GEN1025/JobBoard/37481dc2-ddb2-1941-a0f9-befbbf45ab11
+Gray Local Media,https://recruiting.ultipro.com/GRA1017GRYT/JobBoard/ae441110-89bd-444d-8ad2-b76c7b9db7a9,https://recruiting.ultipro.com/GRA1017GRYT/JobBoard/ae441110-89bd-444d-8ad2-b76c7b9db7a9
+GZA GeoEnvironmental,https://recruiting.ultipro.com/GZA1000GZAE/JobBoard/4e8d2f3c-fad9-4c18-aa44-0e2f64a9bc41,https://recruiting.ultipro.com/GZA1000GZAE/JobBoard/4e8d2f3c-fad9-4c18-aa44-0e2f64a9bc41
 Hensel Phelps,https://recruiting2.ultipro.com/HEN1009HPCC/JobBoard/b27ab828-18a9-4f10-8ee1-8259de6c9e73,https://recruiting2.ultipro.com/HEN1009HPCC/JobBoard/b27ab828-18a9-4f10-8ee1-8259de6c9e73
+Holston Medical Group,https://recruiting.ultipro.com/HOL1003HOLST/JobBoard/29cfd9fc-f6cf-497a-850f-02fa9703fd30,https://recruiting.ultipro.com/HOL1003HOLST/JobBoard/29cfd9fc-f6cf-497a-850f-02fa9703fd30
+Hope Network,https://recruiting.ultipro.com/HOP1003HOPN/JobBoard/b3a1c5d7-6c5e-46f6-8478-cd649884f0ef,https://recruiting.ultipro.com/HOP1003HOPN/JobBoard/b3a1c5d7-6c5e-46f6-8478-cd649884f0ef
 Indelible,https://recruiting.ultipro.com/IND1018IDBS/JobBoard/3a98c28a-7062-48c1-94d5-c02f29bf8eb0,https://recruiting.ultipro.com/IND1018IDBS/JobBoard/3a98c28a-7062-48c1-94d5-c02f29bf8eb0
+International Republican Institute,https://recruiting.ultipro.com/INT1048/JobBoard/201c19d1-4b06-d159-bba4-6a102267f555,https://recruiting.ultipro.com/INT1048/JobBoard/201c19d1-4b06-d159-bba4-6a102267f555
+Johnson Health,https://recruiting.ultipro.com/JOH1014JHC/JobBoard/5507b538-c713-4874-a0c9-7b0358c3e5ec,https://recruiting.ultipro.com/JOH1014JHC/JobBoard/5507b538-c713-4874-a0c9-7b0358c3e5ec
+Little,https://recruiting.ultipro.com/LIT1004LDAC/JobBoard/30702fd2-636e-4886-b1ce-4fc3b07e37ec,https://recruiting.ultipro.com/LIT1004LDAC/JobBoard/30702fd2-636e-4886-b1ce-4fc3b07e37ec
+Marine Biological Laboratory,https://recruiting.ultipro.com/MAR1033MBL/JobBoard/4c3007c3-6354-41de-a13f-d95be60d91e9,https://recruiting.ultipro.com/MAR1033MBL/JobBoard/4c3007c3-6354-41de-a13f-d95be60d91e9
+Meritus Health,https://recruiting.ultipro.com/MER1012MERH/JobBoard/23a054d5-dd9d-4a01-ba62-0bc75b4673d6,https://recruiting.ultipro.com/MER1012MERH/JobBoard/23a054d5-dd9d-4a01-ba62-0bc75b4673d6
+Metropolitan Family Services,https://recruiting.ultipro.com/MET1011METRF/JobBoard/15c3e95c-3b21-790a-16f3-df13fbde06e5,https://recruiting.ultipro.com/MET1011METRF/JobBoard/15c3e95c-3b21-790a-16f3-df13fbde06e5
+Museum of Modern Art,https://recruiting.ultipro.com/MUS1002MOMA/JobBoard/9dbfa465-a36a-46c3-b31e-4929830ab266,https://recruiting.ultipro.com/MUS1002MOMA/JobBoard/9dbfa465-a36a-46c3-b31e-4929830ab266
+National Wildlife Federation,https://recruiting.ultipro.com/NAT1047NWF/JobBoard/1ca8346a-33cc-401d-90d9-d7f752fdfd7d,https://recruiting.ultipro.com/NAT1047NWF/JobBoard/1ca8346a-33cc-401d-90d9-d7f752fdfd7d
+Net Health,https://recruiting.ultipro.com/NET1005/JobBoard/b22acd37-08dd-cbc0-295a-dc154ea3fb93,https://recruiting.ultipro.com/NET1005/JobBoard/b22acd37-08dd-cbc0-295a-dc154ea3fb93
+NorthState Aviation,https://recruiting.ultipro.com/FLI1001/JobBoard/88225318-521d-4214-bb17-847dd1ed18cf,https://recruiting.ultipro.com/FLI1001/JobBoard/88225318-521d-4214-bb17-847dd1ed18cf
+NuCO2,https://recruiting.ultipro.com/NUC1003NUCOZ/JobBoard/3e9c1a5f-8442-4f1e-930d-a45e93201b9b,https://recruiting.ultipro.com/NUC1003NUCOZ/JobBoard/3e9c1a5f-8442-4f1e-930d-a45e93201b9b
+Oak Island Accommodations,https://recruiting.ultipro.com/TOW1004/JobBoard/e2693495-b0da-4c66-a7be-da9f6e3df952,https://recruiting.ultipro.com/TOW1004/JobBoard/e2693495-b0da-4c66-a7be-da9f6e3df952
+Ocean State Job Lot,https://recruiting.ultipro.com/OCE1003OCNS/JobBoard/758136e3-00bb-455c-a999-27d98172635d,https://recruiting.ultipro.com/OCE1003OCNS/JobBoard/758136e3-00bb-455c-a999-27d98172635d
 Octapharma Plasma,https://recruiting.ultipro.com/OCT1000OCTPL/JobBoard/4e94a157-04c3-4e65-8698-f4e41066e5b6,https://recruiting.ultipro.com/OCT1000OCTPL/JobBoard/4e94a157-04c3-4e65-8698-f4e41066e5b6
+Ollie's Bargain Outlet,https://recruiting.ultipro.com/OLL1000OLLIE/JobBoard/355913c1-206d-48a4-bb34-020064efe845,https://recruiting.ultipro.com/OLL1000OLLIE/JobBoard/355913c1-206d-48a4-bb34-020064efe845
+OneStream,https://recruiting.ultipro.com/ONE1018ONSO/JobBoard/1955ffa6-bda6-4c95-8412-2c731d693ab2,https://recruiting.ultipro.com/ONE1018ONSO/JobBoard/1955ffa6-bda6-4c95-8412-2c731d693ab2
+Partners Capital,https://recruiting.ultipro.com/PAR1038PCIGL/JobBoard/6a66e02d-11b7-4e70-974a-bbff974fd3d6,https://recruiting.ultipro.com/PAR1038PCIGL/JobBoard/6a66e02d-11b7-4e70-974a-bbff974fd3d6
+Pathfinder International,https://recruiting.ultipro.com/PAT1012PATH/JobBoard/39cd1fd5-010e-4cba-b70e-a30ea3163220,https://recruiting.ultipro.com/PAT1012PATH/JobBoard/39cd1fd5-010e-4cba-b70e-a30ea3163220
+Planned Parenthood North Central States,https://recruiting.ultipro.com/PLA1010PLANN/JobBoard/87959a5b-c910-41ff-90b8-da23644409c6,https://recruiting.ultipro.com/PLA1010PLANN/JobBoard/87959a5b-c910-41ff-90b8-da23644409c6
+PM Hotel Group,https://recruiting.ultipro.com/POL1006/JobBoard/c0e3f015-388f-2bf6-e3ac-af081fcad685,https://recruiting.ultipro.com/POL1006/JobBoard/c0e3f015-388f-2bf6-e3ac-af081fcad685
+Premier Orthopaedics,https://recruiting.ultipro.com/COR1016COREI/JobBoard/6f95c5a6-575e-44db-9bf9-a129157b227e,https://recruiting.ultipro.com/COR1016COREI/JobBoard/6f95c5a6-575e-44db-9bf9-a129157b227e
+Public Health Management Corporation,https://recruiting.ultipro.com/PUB1002/JobBoard/c8784846-358b-1bec-45e9-f994af5fccee,https://recruiting.ultipro.com/PUB1002/JobBoard/c8784846-358b-1bec-45e9-f994af5fccee
+Rainforest Alliance,https://recruiting.ultipro.com/RAI1015FORES/JobBoard/7a1c3d86-f0fa-4e0e-a501-dcfedd4f7d8c,https://recruiting.ultipro.com/RAI1015FORES/JobBoard/7a1c3d86-f0fa-4e0e-a501-dcfedd4f7d8c
 RealTruck,https://recruiting.ultipro.com/TRU1016TRKH/JobBoard/8457004c-183a-4d47-967d-c7961234886e,https://recruiting.ultipro.com/TRU1016TRKH/JobBoard/8457004c-183a-4d47-967d-c7961234886e
+Refresco,https://recruiting.ultipro.com/REF1001RBUS/JobBoard/9dc59b6d-6dab-454e-883b-4c8c6d36d52d,https://recruiting.ultipro.com/REF1001RBUS/JobBoard/9dc59b6d-6dab-454e-883b-4c8c6d36d52d
+Roman Catholic Archdiocese of Washington,https://recruiting.ultipro.com/ARC1012ARCHW/JobBoard/a6c08282-64df-408a-a35b-24830a852469,https://recruiting.ultipro.com/ARC1012ARCHW/JobBoard/a6c08282-64df-408a-a35b-24830a852469
+Rosecrance Health Network,https://recruiting.ultipro.com/ROS1002RHN/JobBoard/389ddb2f-d29b-4181-966c-d25f81a974db,https://recruiting.ultipro.com/ROS1002RHN/JobBoard/389ddb2f-d29b-4181-966c-d25f81a974db
+Rosina Food Products,https://recruiting.ultipro.com/ROS1006RFPI/JobBoard/38b27aba-e0d7-40a6-b47b-71044b4f2aa6,https://recruiting.ultipro.com/ROS1006RFPI/JobBoard/38b27aba-e0d7-40a6-b47b-71044b4f2aa6
 Royal College,https://recruiting.ultipro.ca/ROY5000RCPS/JobBoard/9a9d6241-e23f-47c0-80f3-e43a148972a0,https://recruiting.ultipro.ca/ROY5000RCPS/JobBoard/9a9d6241-e23f-47c0-80f3-e43a148972a0
+Rubicon,https://recruiting.ultipro.com/RUB1004RUGH/JobBoard/b65b7a3c-d3fb-4185-85d4-ac59fac2f527,https://recruiting.ultipro.com/RUB1004RUGH/JobBoard/b65b7a3c-d3fb-4185-85d4-ac59fac2f527
+Safety National,https://recruiting.ultipro.com/SAF1003SNCC/JobBoard/eb5e6dcc-5a67-4833-b31e-f54b97ea0c3a,https://recruiting.ultipro.com/SAF1003SNCC/JobBoard/eb5e6dcc-5a67-4833-b31e-f54b97ea0c3a
 Save the Children,https://recruiting.ultipro.com/SAV1002STCF/JobBoard/7d92e82b-af74-464d-859b-c5b8cba6e92e,https://recruiting.ultipro.com/SAV1002STCF/JobBoard/7d92e82b-af74-464d-859b-c5b8cba6e92e
+Self Regional Healthcare,https://recruiting.ultipro.com/GRE1050GNHP/JobBoard/2b67ecb4-00fb-4863-931a-7bf0ebcb493a,https://recruiting.ultipro.com/GRE1050GNHP/JobBoard/2b67ecb4-00fb-4863-931a-7bf0ebcb493a
+Service Employees International Union,https://recruiting.ultipro.com/SER1005SEIU/JobBoard/e131b2ae-a5ce-4fb1-a93c-84c36a485721,https://recruiting.ultipro.com/SER1005SEIU/JobBoard/e131b2ae-a5ce-4fb1-a93c-84c36a485721
+Sound Transit,https://recruiting.ultipro.com/SOU1036SOUND/JobBoard/dcc5dbea-875e-4cd1-bfd2-8e046cecc54f,https://recruiting.ultipro.com/SOU1036SOUND/JobBoard/dcc5dbea-875e-4cd1-bfd2-8e046cecc54f
 Sportsman's Guide,https://recruiting.ultipro.com/WIN1014WINDQ/JobBoard/08eb8299-5b26-4208-adb7-897aa42c6959,https://recruiting.ultipro.com/WIN1014WINDQ/JobBoard/08eb8299-5b26-4208-adb7-897aa42c6959
+Summit Orthopedics,https://recruiting.ultipro.com/SUM1008SUMOR/JobBoard/a8eac62e-c51f-41ad-acc8-a69c75cad4cc,https://recruiting.ultipro.com/SUM1008SUMOR/JobBoard/a8eac62e-c51f-41ad-acc8-a69c75cad4cc
 Surgery Partners,https://recruiting.ultipro.com/SUR1004SRGY/JobBoard/aa616d8f-f2a8-46c2-8f8e-1ca56e162ffd,https://recruiting.ultipro.com/SUR1004SRGY/JobBoard/aa616d8f-f2a8-46c2-8f8e-1ca56e162ffd
+Swisher,https://recruiting.ultipro.com/SWI1007SWSH/JobBoard/2d5ce14b-91ed-42c0-aaad-b48985350a8e,https://recruiting.ultipro.com/SWI1007SWSH/JobBoard/2d5ce14b-91ed-42c0-aaad-b48985350a8e
+TechnoServe,https://recruiting.ultipro.com/TEC1006TESER/JobBoard/18180d88-ced0-4361-bd09-d5eef66dab24,https://recruiting.ultipro.com/TEC1006TESER/JobBoard/18180d88-ced0-4361-bd09-d5eef66dab24
+Toshiba America Business Solutions,https://recruiting.ultipro.com/TOS1002TABS/JobBoard/4e00f0f0-e066-43c0-9b38-8d30cafa7582,https://recruiting.ultipro.com/TOS1002TABS/JobBoard/4e00f0f0-e066-43c0-9b38-8d30cafa7582
+Tri Counties Bank,https://recruiting.ultipro.com/TRI1013/JobBoard/4245b871-01e9-d361-c591-d813261dcc18,https://recruiting.ultipro.com/TRI1013/JobBoard/4245b871-01e9-d361-c591-d813261dcc18
+TridentCare,https://recruiting.ultipro.com/SYM1000/JobBoard/95b2381b-66d2-45ce-b4ee-1e0f131d98a5,https://recruiting.ultipro.com/SYM1000/JobBoard/95b2381b-66d2-45ce-b4ee-1e0f131d98a5
+U.S. Institute of Peace,https://recruiting.ultipro.com/UNI1083USIOP/JobBoard/14900d11-c546-42ff-ab52-7bbbfa78cb97,https://recruiting.ultipro.com/UNI1083USIOP/JobBoard/14900d11-c546-42ff-ab52-7bbbfa78cb97
+UJA-Federation of New York,https://recruiting.ultipro.com/UNI1075UJAF/JobBoard/6fb253e7-0e57-4901-91f6-0fa69833c3be,https://recruiting.ultipro.com/UNI1075UJAF/JobBoard/6fb253e7-0e57-4901-91f6-0fa69833c3be
 United Nations Foundation,https://recruiting.ultipro.com/UNI1076UNFI/JobBoard/86df2700-c124-49b9-b096-7cacea55e9dd,https://recruiting.ultipro.com/UNI1076UNFI/JobBoard/86df2700-c124-49b9-b096-7cacea55e9dd
+Upland Software,https://recruiting.ultipro.com/UPL1000USI/JobBoard/c34cd0cf-aee3-47f1-bc4b-530112a37fed,https://recruiting.ultipro.com/UPL1000USI/JobBoard/c34cd0cf-aee3-47f1-bc4b-530112a37fed
+Upstate Caring Partners,https://recruiting.ultipro.com/UNI1017UCPGU/JobBoard/16bcd1b6-cb77-444f-aa82-c7eb0539a32e,https://recruiting.ultipro.com/UNI1017UCPGU/JobBoard/16bcd1b6-cb77-444f-aa82-c7eb0539a32e
 Upstate Niagara Cooperative,https://recruiting.ultipro.com/ups1000upnc/JobBoard/8278ab32-7638-486b-a889-8265d76f85da,https://recruiting.ultipro.com/ups1000upnc/JobBoard/8278ab32-7638-486b-a889-8265d76f85da
+US Fertility,https://recruiting.ultipro.com/SGF1000SGFS/JobBoard/8daa09e3-0c07-4497-8d06-48273e07968f,https://recruiting.ultipro.com/SGF1000SGFS/JobBoard/8daa09e3-0c07-4497-8d06-48273e07968f
+USAble Life,https://recruiting.ultipro.com/USA1002USAL/JobBoard/003df104-d0d0-4233-8068-07ba35aacc79,https://recruiting.ultipro.com/USA1002USAL/JobBoard/003df104-d0d0-4233-8068-07ba35aacc79
+Welltower,https://recruiting.ultipro.com/WEL1008WLLT/JobBoard/30969ce4-3b7e-40a6-b86c-34d3616fe0ed,https://recruiting.ultipro.com/WEL1008WLLT/JobBoard/30969ce4-3b7e-40a6-b86c-34d3616fe0ed
+Wyckoff Heights Medical Center,https://recruiting.ultipro.com/WYC1000WHMC/JobBoard/5e6bf310-55e9-45dd-8252-85e4c670f433,https://recruiting.ultipro.com/WYC1000WHMC/JobBoard/5e6bf310-55e9-45dd-8252-85e4c670f433
+Yaskawa Drives & Motion,https://recruiting.ultipro.com/YAS1000YAAMI/JobBoard/8a2317d2-a61e-4259-a857-722d164a211c,https://recruiting.ultipro.com/YAS1000YAAMI/JobBoard/8a2317d2-a61e-4259-a857-722d164a211c

--- a/tests/test_ukg_contracts.py
+++ b/tests/test_ukg_contracts.py
@@ -28,5 +28,5 @@ def test_ukg_has_direct_employer_dedup_priority() -> None:
 def test_ukg_seed_catalogue_is_provider_only() -> None:
     rows = Path("ats-companies/ukg.csv").read_text().splitlines()
 
-    assert len(rows) == 20
+    assert len(rows) == 108
     assert all("ultipro." in row for row in rows[1:])


### PR DESCRIPTION
## Summary
- add 88 direct-employer UKG Pro boards
- keep the change isolated to the UKG provider and its catalogue-size contract
- use one public board per UKG tenant to avoid alternate-board duplication

## Live validation
- 8,841 current jobs across all 88 boards
- 8,841 unique UKG opportunity IDs and 8,841 unique URLs
- 8,841 descriptions and 8,841 locations
- regional split from UKG country codes: 8,508 US, 188 other North America, 35 Europe, 27 Asia, 83 unknown
- same-name Alchemy and Rubicon feeds were probed against existing ATS entries; zero exact title/location overlap, and Alchemy is labeled `Alchemy Global Solutions`

## Tests
- `PYTHONPATH=src uv run --extra test --with-requirements pipeline/requirements.txt pytest -q tests/test_ukg.py tests/test_ukg_contracts.py tests/test_resolve.py`
- 83 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added 88 validated UKG Pro direct-employer boards and updated the UKG catalogue contract to the new size. Uses one public board per tenant to avoid alternate-board duplication.

- **New Features**
  - Expanded `ats-companies/ukg.csv`; total rows now 108.
  - Updated `tests/test_ukg_contracts.py` to expect 108 rows and keep provider-only seed.

<sup>Written for commit b393978fc8dd37bfb9d13356bc59c72874b559fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds 88 validated direct-employer UKG Pro boards and updates the UKG catalogue-size contract from 20 to 108 rows.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The added catalogue entries conform to the UKG URL and tenant parsing contracts, and the accompanying contract test accurately reflects the new catalogue size.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The general-contract-validation-proof confirms that the auditable log records the exact pytest command, the working directory used for the run, the complete pytest output, and an exit code of 0.
- The log artifact is accessible via a reviewer URL, allowing inspectors to review the command, the working directory, and the full pytest output.

<a href="https://app.greptile.com/trex/runs/16098832/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ats-companies/ukg.csv | Adds 88 uniquely identified UKG employer boards using the existing canonical name, slug, and URL schema. |
| tests/test_ukg_contracts.py | Updates the expected UKG catalogue row count to match the expanded seed file while retaining the provider-only assertion. |

<sub>Reviews (1): Last reviewed commit: ["Update UKG catalogue contract"](https://github.com/kalil0321/ats-scrapers/commit/b393978fc8dd37bfb9d13356bc59c72874b559fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47735555)</sub>

<!-- /greptile_comment -->