### PR TITLE
Fix Oracle tenant IDs and add one validated employer

### DIFF
--- a/ats-companies/oracle.csv
+++ b/ats-companies/oracle.csv
@@ -1044,3 +1044,4 @@ Fortive,ejta,https://ejta.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/si
 SCV Water,fa-epmn-saasfaprod1,https://fa-epmn-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/SCVWaterCareers
 Hermès,fa-eoic-saasfaprod1,https://fa-eoic-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
 Mapei,fa-elhu-saasfaprod1,https://fa-elhu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+NMIMS,fa-elxu-saasfaprod1/cx_3013,https://fa-elxu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3013

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -399,6 +399,10 @@ CONFIGS: dict[str, dict[str, Any]] = {
     "oracle": {
         "scraper": OracleScraper,
         "slug": _oracle_slug,
+        "kwargs": lambda r: {
+            "company_name": (r.get("name") or "").strip() or None,
+        },
+        "dedupe_by_ats_id": True,
         "csv": "ats-companies/oracle.csv",
         "output": "oracle/jobs.csv",
     },
@@ -1091,6 +1095,16 @@ def _description_keys(job: Job) -> list[tuple[str, str]]:
     return keys
 
 
+def _job_dedupe_key(
+    job: Job,
+    config: dict[str, Any],
+) -> tuple[str, str]:
+    ats_id = job.ats_id or ""
+    if config.get("dedupe_by_ats_id"):
+        return "", ats_id
+    return job.company, ats_id
+
+
 def _row_description_keys(row: dict[str, str]) -> list[tuple[str, str]]:
     keys: list[tuple[str, str]] = []
     company = (row.get("company") or "").strip()
@@ -1450,7 +1464,7 @@ async def run(ats: str, concurrency: int, max_tenants: int | None, timeout: floa
                         "error": 0,
                     }
                     for job in jobs:
-                        key = (job.company, job.ats_id)
+                        key = _job_dedupe_key(job, cfg)
                         if key in seen_keys:
                             continue
                         seen_keys.add(key)

--- a/src/ats_scrapers/scrapers/oracle.py
+++ b/src/ats_scrapers/scrapers/oracle.py
@@ -112,6 +112,23 @@ class OracleScraper(BaseScraper):
 
     default_headers: ClassVar[dict[str, str]] = {"Accept": "application/json"}
 
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        company_name: str | None = None,
+        timeout: float = 30.0,
+        include_descriptions: bool = True,
+        proxy: str | None = None,
+    ) -> None:
+        super().__init__(
+            company_slug,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        self.company_name = company_name
+
     def get_description(self, job: Job) -> str | None:
         if job.description:
             return job.description
@@ -151,24 +168,22 @@ class OracleScraper(BaseScraper):
                 if job.ats_id and job.ats_id not in seen:
                     seen.add(job.ats_id)
                     all_jobs.append(job)
-            if total is None or total <= len(items):
-                return all_jobs
-
-            # Paginate the rest. Use `len(items)` as the actual page size
-            # (Oracle may return less than the requested limit on the first
-            # page, e.g. 198 instead of 200).
-            page_size = max(len(items), 1)
-            offsets = list(range(page_size, total, page_size))
-            for offset in offsets:
-                payload = await self._fetch_page(fetch, api, site, offset=offset)
-                page_items, _ = _unwrap(payload)
-                if not page_items:
-                    break
-                for it in page_items:
-                    job = self._parse_job(it, base, site)
-                    if job.ats_id and job.ats_id not in seen:
-                        seen.add(job.ats_id)
-                        all_jobs.append(job)
+            if total is not None and total > len(items):
+                # Paginate the rest. Use `len(items)` as the actual page size
+                # (Oracle may return less than the requested limit on the first
+                # page, e.g. 198 instead of 200).
+                page_size = max(len(items), 1)
+                offsets = list(range(page_size, total, page_size))
+                for offset in offsets:
+                    payload = await self._fetch_page(fetch, api, site, offset=offset)
+                    page_items, _ = _unwrap(payload)
+                    if not page_items:
+                        break
+                    for it in page_items:
+                        job = self._parse_job(it, base, site)
+                        if job.ats_id and job.ats_id not in seen:
+                            seen.add(job.ats_id)
+                            all_jobs.append(job)
 
             if self.include_descriptions and all_jobs:
                 sem = asyncio.Semaphore(DETAIL_CONCURRENCY)
@@ -191,14 +206,15 @@ class OracleScraper(BaseScraper):
     ) -> None:
         # Best-effort: detail failures keep the listing-derived row
         # (CompanyNotFoundError subclasses ScraperError).
-        if not job.ats_id or job.description:
+        source_id = _oracle_source_id(job)
+        if not source_id or job.description:
             return
         async with sem:
             try:
                 response = await fetch.request(
                     "GET",
                     detail_url,
-                    params={"finder": f"ById;Id={job.ats_id}", "onlyData": "true"},
+                    params={"finder": f"ById;Id={source_id}", "onlyData": "true"},
                 )
             except ScraperError:
                 return
@@ -247,8 +263,10 @@ class OracleScraper(BaseScraper):
         return await fetch.get_json(api, params=params)
 
     def _parse_job(self, item: dict[str, Any], base: str, site: str) -> Job:
-        ats_id = str(item.get("Id") or item.get("RequisitionNumber") or "")
-        company = urlparse(base).hostname or self.company_slug
+        source_id = str(item.get("Id") or item.get("RequisitionNumber") or "")
+        host = urlparse(base).hostname or self.company_slug
+        ats_id = f"{host.casefold()}:{source_id}" if source_id else ""
+        company = self.company_name or host
         title = item.get("Title") or "Untitled"
 
         # Description from the listing's ``ShortDescriptionStr`` when
@@ -312,7 +330,7 @@ class OracleScraper(BaseScraper):
             else None
         )
 
-        raw: dict[str, Any] = {}
+        raw: dict[str, Any] = {"oracle_id": source_id} if source_id else {}
         for k in ("Category", "JobFamily", "JobFamilyName",
                   "JobFunction", "JobFunctionCode", "WorkLocation",
                   "WorkerType", "WorkerCategory", "WorkplaceTypeCode",
@@ -325,7 +343,7 @@ class OracleScraper(BaseScraper):
 
         return Job(
             url=item.get("ExternalURL")
-            or f"{base}/?keyword=&mode=jobs&lang=en&site_number={site}#{ats_id}",
+            or f"{base}/?keyword=&mode=jobs&lang=en&site_number={site}#{source_id}",
             title=title,
             company=company,
             ats_type=ATSType.ORACLE,
@@ -342,6 +360,16 @@ class OracleScraper(BaseScraper):
             fetched_at=datetime.now(UTC),
             raw=raw or None,
         )
+
+
+def _oracle_source_id(job: Job) -> str | None:
+    if job.raw:
+        raw_id = job.raw.get("oracle_id")
+        if raw_id is not None and str(raw_id).strip():
+            return str(raw_id).strip()
+    if not job.ats_id:
+        return None
+    return job.ats_id.rsplit(":", 1)[-1].strip() or None
 
 
 def _unwrap(payload: dict[str, Any]) -> tuple[list[dict[str, Any]], int | None]:

--- a/tests/test_run_pipeline_guards.py
+++ b/tests/test_run_pipeline_guards.py
@@ -34,6 +34,28 @@ def test_job_to_row_preserves_structured_location_metadata() -> None:
     assert row["lon"] == 100.5018
 
 
+def test_oracle_dedupes_same_tenant_job_across_named_sites() -> None:
+    first = Job(
+        url="https://oracle.example/sites/english/jobs/1",
+        title="Engineer",
+        company="Named English Site",
+        ats_type=ATSType.ORACLE,
+        ats_id="tenant.oraclecloud.com:1",
+    )
+    second = first.model_copy(
+        update={
+            "url": "https://oracle.example/sites/french/jobs/1",
+            "company": "Named French Site",
+        }
+    )
+
+    oracle_config = runner.CONFIGS["oracle"]
+    assert runner._job_dedupe_key(first, oracle_config) == (
+        runner._job_dedupe_key(second, oracle_config)
+    )
+    assert runner._job_dedupe_key(first, {}) != runner._job_dedupe_key(second, {})
+
+
 def test_provider_slug_normalizers_match_current_company_csv_shape() -> None:
     sf_row = {
         "name": "Ace1950",
@@ -63,6 +85,10 @@ def test_provider_slug_normalizers_match_current_company_csv_shape() -> None:
         runner._oracle_slug(oracle_row)
         == "https://eiqg.fa.us2.oraclecloud.com?site_number=CX_1"
     )
+    assert runner.CONFIGS["oracle"]["kwargs"](oracle_row) == {
+        "company_name": "ABM US"
+    }
+    assert runner.CONFIGS["oracle"]["dedupe_by_ats_id"] is True
 
     cornerstone_row = {
         "name": "AAK",

--- a/tests/test_scrapers_extra.py
+++ b/tests/test_scrapers_extra.py
@@ -520,9 +520,86 @@ def test_oracle_with_default_site(httpx_mock) -> None:
             }]
         },
     )
-    jobs = OracleScraper(base).fetch()
+    jobs = OracleScraper(
+        base,
+        company_name="Oracle Test Tenant",
+        include_descriptions=False,
+    ).fetch()
     assert jobs[0].title == "DBA"
     assert jobs[0].location == "Redwood Shores"
+    assert jobs[0].company == "Oracle Test Tenant"
+    assert jobs[0].ats_id == "eeho.fa.us2.oraclecloud.com:001"
+    assert jobs[0].global_id == "oracle:eeho.fa.us2.oraclecloud.com:001"
+    assert jobs[0].raw is not None
+    assert jobs[0].raw["oracle_id"] == "001"
+
+
+def test_oracle_scopes_job_ids_to_tenant_not_site() -> None:
+    item = {"Id": "1071", "Title": "Finance Manager"}
+    acme = OracleScraper(
+        "https://acme.fa.em2.oraclecloud.com",
+        include_descriptions=False,
+    )
+    other = OracleScraper(
+        "https://other.fa.em2.oraclecloud.com",
+        include_descriptions=False,
+    )
+
+    acme_english = acme._parse_job(
+        item,
+        "https://acme.fa.em2.oraclecloud.com",
+        "CX_1",
+    )
+    acme_french = acme._parse_job(
+        item,
+        "https://acme.fa.em2.oraclecloud.com",
+        "CX_2",
+    )
+    other_job = other._parse_job(
+        item,
+        "https://other.fa.em2.oraclecloud.com",
+        "CX_1",
+    )
+
+    assert acme_english.ats_id == acme_french.ats_id
+    assert acme_english.ats_id != other_job.ats_id
+
+
+def test_oracle_enriches_single_page_job_with_raw_source_id(httpx_mock) -> None:
+    base = "https://eeho.fa.us2.oraclecloud.com"
+    listing_api = (
+        f"{base}/hcmRestApi/resources/latest/recruitingCEJobRequisitions"
+    )
+    detail_api = (
+        f"{base}/hcmRestApi/resources/latest/"
+        "recruitingCEJobRequisitionDetails"
+    )
+    httpx_mock.add_response(
+        url=(
+            f"{listing_api}?onlyData=true"
+            f"&finder=findReqs%3BsiteNumber%3DCX_1%2Climit%3D200%2Coffset%3D0"
+            f"&expand=requisitionList"
+        ),
+        json={
+            "items": [{
+                "TotalJobsCount": 1,
+                "requisitionList": [{"Id": "001", "Title": "DBA"}],
+            }]
+        },
+    )
+    httpx_mock.add_response(
+        url=f"{detail_api}?finder=ById%3BId%3D001&onlyData=true",
+        json={
+            "items": [{
+                "ExternalDescriptionStr": "<p>Maintain databases.</p>",
+                "ExternalResponsibilitiesStr": "<p>Ship backups.</p>",
+            }]
+        },
+    )
+
+    [job] = OracleScraper(base).fetch()
+
+    assert job.description == "Maintain databases.\n\nShip backups."
 
 
 def test_oracle_extracts_site_number_from_query(httpx_mock) -> None:


### PR DESCRIPTION
## Summary
- scope Oracle `ats_id` values by tenant host while preserving the raw Oracle ID for detail requests
- pass canonical CSV company names into Oracle jobs and dedupe alternate sites by the scoped ATS ID
- fix description enrichment for single-page Oracle boards
- add NMIMS, the only description-complete non-duplicate board retained from this discovery wave

## Discovery audit
- Common Crawl produced 97 clean Oracle site candidates; 47 were live with 9,630 board-job rows
- probed all 57 existing Oracle boards on matching tenant hosts and compared exact raw-ID sets
- only 6 apparent incremental jobs remained; 4 belonged to duplicate Penske/Staples alternate sites
- rejected Imdaad's one incremental job because its detail endpoint yielded no usable description
- retained NMIMS: 1 live job, 1 unique ID, 1 unique URL, 1 description, correct company label

## Validation
- live-probed two unrelated tenants sharing raw Oracle ID `1071`; scoped IDs/global IDs are now distinct
- 1,532 tests passed, 2 skipped, 29 live tests deselected
- repository-wide Ruff passed
- the local all-module collection additionally requires `polars`; CI runs with the complete dependency set

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes Oracle job IDs by tenant host to prevent cross-tenant collisions and dedupe duplicates across named sites. Fixes Oracle description enrichment and adds the validated NMIMS tenant.

- **New Features**
  - Scope Oracle `ats_id` to `<host>:<id>` and update `global_id` to `oracle:<host>:<id>`.
  - Pass CSV `company_name` into `OracleScraper` for canonical company labels.
  - Add NMIMS to `ats-companies/oracle.csv`.

- **Bug Fixes**
  - Use the raw Oracle ID for detail requests to fix single-page board enrichment.
  - Dedupe Oracle jobs across the same tenant’s sites via `dedupe_by_ats_id` in the pipeline.
  - Only paginate when `total > first-page-size` to avoid empty extra requests.

<sup>Written for commit f0ad8f7e14a351d60b719c8660e9ce6abea3fafe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR revises Oracle job identity and enrichment behavior.
- Scopes Oracle ATS IDs by tenant host while preserving raw IDs for detail calls.
- Propagates CSV company names and deduplicates alternate Oracle sites by scoped ATS ID.
- Ensures single-page boards still receive description enrichment.
- Adds the validated NMIMS Oracle board and corresponding regression coverage.

<h3>Confidence Score: 3/5</h3>

The Oracle attribution race should be fixed before merging because identical runs can publish a shared requisition under different company labels.

ATS-ID-only deduplication is performed inside concurrently executing tenant tasks after each site assigns its own CSV company name, so the first task to claim a shared host-scoped ID determines the published attribution.

**Files Needing Attention:** scripts/run_pipeline.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The nondeterministic Oracle attribution was reproduced by running the asynchronous Oracle pipeline with two mocked same-host tenants that returned identical ATS IDs under distinct CSV company names.
- When Beta finished first, deduplication published one row attributed to Beta Company.
- When Alpha finished first, the otherwise identical run published one row attributed to Alpha Company.
- Validated identity and detail behavior across pre-change and post-change implementations using the focused live harness, and verified HTTP 200 responses with sanitized fields.

<a href="https://app.greptile.com/trex/runs/16104765/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/ats_scrapers/scrapers/oracle.py | Adds canonical company names, host-scoped IDs, raw-ID preservation, and single-page detail enrichment; these changes are internally consistent. |
| scripts/run_pipeline.py | Adds Oracle-specific ATS-ID deduplication, but concurrent alternate-site processing can make the retained company attribution nondeterministic. |
| ats-companies/oracle.csv | Adds the NMIMS Oracle tenant using the expected canonical tenant-list shape. |
| tests/test_run_pipeline_guards.py | Covers Oracle configuration and cross-site deduplication but does not exercise deterministic attribution when duplicate sites have different names. |
| tests/test_scrapers_extra.py | Adds focused coverage for scoped IDs, raw source IDs, canonical company labels, and single-page description enrichment. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/run_pipeline.py:404
**Nondeterministic Oracle company attribution**

When two Oracle site rows on the same host expose the same requisition under different CSV company names, ATS-ID-only deduplication retains whichever concurrent tenant task finishes first, causing the published company label to vary across otherwise identical runs.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Scope Oracle job IDs by tenant and add N..."](https://github.com/kalil0321/ats-scrapers/commit/f0ad8f7e14a351d60b719c8660e9ce6abea3fafe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47745854)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->