### PR TITLE
feat(successfactors): support legacy XML feeds

### DIFF
--- a/ats-companies/successfactors.csv
+++ b/ats-companies/successfactors.csv
@@ -1273,3 +1273,34 @@ EssilorLuxottica,essilorluxottica,https://careers.essilorluxottica.com
 Jerónimo Martins,jeronimomartins,https://careers.jeronimomartins.com
 AmRest,amrest,https://careers.amrest.eu
 Vodafone,vodafone,https://opportunities.vodafone.com
+International Criminal Court,1657261P,https://career5.successfactors.eu/career?company=1657261P
+University of Lausanne,universitdP,https://career5.successfactors.eu/career?company=universitdP
+Austrian Post,oepag,https://career5.successfactors.eu/career?company=oepag
+Al-Futtaim,C0001144036P,https://career5.successfactors.eu/career?company=C0001144036P
+Amkor Technology,amkor,https://career8.successfactors.com/career?company=amkor
+Moody's,MoodysProd,https://career8.successfactors.com/career?company=MoodysProd
+Freeman,freemanP1,https://career8.successfactors.com/career?company=freemanP1
+Janus Henderson,Janus,https://career8.successfactors.com/career?company=Janus
+LATAM Airlines,lan,https://career8.successfactors.com/career?company=lan
+Queensland Fire Department,datacombusP,https://career10.successfactors.com/career?company=datacombusP
+Royal Caribbean Group,royalcarib,https://career4.successfactors.com/career?company=royalcarib
+Johns Hopkins Health System,SFHUP,https://career4.successfactors.com/career?company=SFHUP
+Huntsville Utilities,huntsvilleP,https://career4.successfactors.com/career?company=huntsvilleP
+Western Financial Group,wfg,https://career4.successfactors.com/career?company=wfg
+Village of Schaumburg,Schaumburg,https://career4.successfactors.com/career?company=Schaumburg
+Vistance Networks,ArrisP,https://career4.successfactors.com/career?company=ArrisP
+Watco,zWatco,https://career4.successfactors.com/career?company=zWatco
+Brevard County,brevardcou,https://career8.successfactors.com/career?company=brevardcou
+SPX FLOW,spxflowP,https://career8.successfactors.com/career?company=spxflowP
+Gainesville Regional Utilities,gainesvill,https://career8.successfactors.com/career?company=gainesvill
+Englewood Health,englewoodh,https://career8.successfactors.com/career?company=englewoodh
+Volkswagen Group China,volkswag09,https://career15.sapsf.cn/career?company=volkswag09
+Xi'an Jiaotong-Liverpool University,xjtlu,https://career15.sapsf.cn/career?company=xjtlu
+Duke Kunshan University,dukekunsha,https://career15.sapsf.cn/career?company=dukekunsha
+DRÄXLMAIER China,draexlmaie,https://career15.sapsf.cn/career?company=draexlmaie
+Hager Group,HagerGroup,https://career012.successfactors.eu/career?company=HagerGroup
+Mohammed VI Polytechnic University,ump,https://career2.successfactors.eu/career?company=ump
+VFS Global,vfsglobalsP,https://career2.successfactors.eu/career?company=vfsglobalsP
+New Development Bank,newdevelop,https://career15.sapsf.cn/career?company=newdevelop
+National Agriculture Development,133723,https://133723.jobs2web.com
+TIM Brasil,timbrasil,https://timbrasil.jobs2web.com

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -399,6 +399,9 @@ CONFIGS: dict[str, dict[str, Any]] = {
     "successfactors": {
         "scraper": SuccessFactorsScraper,
         "slug": _successfactors_slug,
+        "kwargs": lambda r: {
+            "company_name": (r.get("name") or "").strip() or None,
+        },
         "csv": "ats-companies/successfactors.csv",
         "output": "successfactors/jobs.csv",
     },

--- a/src/ats_scrapers/scrapers/successfactors.py
+++ b/src/ats_scrapers/scrapers/successfactors.py
@@ -2,20 +2,21 @@
 
 Used by Procter & Gamble, Pfizer, Daimler, Schindler, and many others.
 
-SuccessFactors Recruiting Marketing instances expose a public RSS 2.0 feed
-at the canonical (typo-included, undocumented but stable) path:
+SuccessFactors exposes two credential-free public job feeds:
 
-    GET https://{recruiting-marketing-host}/sitemal.xml
+* Recruiting Marketing sites expose RSS 2.0 at the canonical
+  (typo-included, undocumented but stable) path:
 
-Yes, the path is ``sitemal.xml`` (one ``p`` short of ``sitemap``) — that's
-SAP's actual URL. Each ``<item>`` carries the job title (with location often
-appended in parens), an HTML-escaped ``description``, ``link``, and
-``pubDate``. The Google Merchant namespace adds ``g:id``, ``g:location``,
-etc. on some tenants.
+      GET https://{recruiting-marketing-host}/sitemal.xml
 
-There is also a server-side XML feed at ``career{N}.successfactors.com/career?company={ID}&...``
-that requires a tenant-specific ``company`` ID and picklist filters — we
-prefer the simpler RSS path here. Pass the recruiting-marketing host as
+* Legacy Recruiting Management sites expose ``Job-Listing`` XML:
+
+      GET https://career{N}.successfactors.com/career
+          ?company={ID}
+          &career_ns=job_listing_summary
+          &resultType=XML
+
+Pass either a recruiting-marketing host or a public legacy career URL as
 ``company_slug``.
 """
 
@@ -26,7 +27,7 @@ import re
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
 from typing import TYPE_CHECKING, ClassVar
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 from xml.etree import ElementTree as ET
 
 from ats_scrapers.exceptions import ScraperError
@@ -37,6 +38,8 @@ if TYPE_CHECKING:
     pass
 
 _TAG_RE = re.compile(r"<[^>]+>")
+_TEMPLATE_TOKEN_RE = re.compile(r"\[\[([^\[\]]+)\]\]")
+_INVALID_EMPTY_ELEMENT_RE = re.compile(r"<>\s*[^<]*?</>")
 # Job titles are often `"Title (City, State, Country)"` — extract location
 # from the trailing parens when no other source is available.
 _TITLE_LOCATION_RE = re.compile(r"^(?P<title>.+?)\s*\((?P<loc>[^()]+)\)\s*$")
@@ -68,10 +71,10 @@ _EMPLOYMENT_TYPE_PATTERNS = {
 
 @ScraperRegistry.register(ATSType.SUCCESSFACTORS)
 class SuccessFactorsScraper(BaseScraper):
-    """SAP SuccessFactors scraper. ``company_slug`` is the recruiting-marketing
-    host (e.g. ``"job.schindler.com"`` → ``https://job.schindler.com/sitemal.xml``).
+    """SAP SuccessFactors Recruiting Marketing and legacy XML scraper.
 
-    Bare slugs are also accepted (``"schindler"`` → assumes ``job.schindler.com``).
+    ``company_slug`` may be a recruiting-marketing host or a legacy public
+    career URL containing the tenant's ``company`` query parameter.
     """
 
     ats = ATSType.SUCCESSFACTORS
@@ -81,27 +84,156 @@ class SuccessFactorsScraper(BaseScraper):
         "Accept": "application/rss+xml, application/xml, text/xml",
     }
 
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        company_name: str | None = None,
+        timeout: float = 30.0,
+        include_descriptions: bool = True,
+        proxy: str | None = None,
+    ) -> None:
+        super().__init__(
+            company_slug,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        self.company_name = company_name
+
     async def afetch(self) -> list[Job]:
-        feed_url = self._resolve_feed_url()
+        feed_url, legacy_company_id = self._resolve_feed_target()
         async with self.make_fetcher() as fetch:
             xml_text = await fetch.get_text(feed_url)
+        if legacy_company_id is not None:
+            return self._parse_legacy_feed(
+                xml_text,
+                feed_url=feed_url,
+                company_id=legacy_company_id,
+            )
         return self._parse_feed(xml_text)
+
+    def _resolve_feed_target(self) -> tuple[str, str | None]:
+        parsed = urlparse(self.company_slug)
+        query = parse_qs(parsed.query)
+        company_values = query.get("company")
+        if (
+            parsed.scheme in {"http", "https"}
+            and parsed.hostname
+            and _is_legacy_host(parsed.hostname)
+            and company_values
+            and company_values[0].strip()
+        ):
+            company_id = company_values[0].strip()
+            legacy_query = {
+                "company": company_id,
+                "career_ns": "job_listing_summary",
+                "resultType": "XML",
+            }
+            locale_values = query.get("rcm_site_locale")
+            if locale_values and locale_values[0].strip():
+                legacy_query["rcm_site_locale"] = locale_values[0].strip()
+            feed_url = urlunparse(
+                (
+                    "https",
+                    parsed.hostname,
+                    "/career",
+                    "",
+                    urlencode(legacy_query),
+                    "",
+                )
+            )
+            return feed_url, company_id
+        return self._resolve_feed_url(), None
 
     def _resolve_feed_url(self) -> str:
         slug = self.company_slug
         if slug.startswith(("http://", "https://")):
-            base = slug.rstrip("/")
+            parsed = urlparse(slug)
+            base = urlunparse((parsed.scheme, parsed.netloc, parsed.path, "", "", ""))
+            base = base.rstrip("/")
         elif "." in slug:
-            # Bare host like "job.schindler.com"
             base = f"https://{slug}"
         else:
-            # Bare slug — guess `job.{slug}.com`
             base = f"https://job.{slug}.com"
         return f"{base}/sitemal.xml"
 
+    def _parse_legacy_feed(
+        self,
+        xml_text: str,
+        *,
+        feed_url: str,
+        company_id: str,
+    ) -> list[Job]:
+        try:
+            root = _parse_xml(xml_text)
+        except ET.ParseError as exc:
+            raise ScraperError(
+                f"SuccessFactors returned malformed XML: {exc}"
+            ) from exc
+        if root.tag != "Job-Listing":
+            raise ScraperError(
+                f"SuccessFactors returned non-job-listing XML for "
+                f"{self.company_slug} (root <{root.tag}>)"
+            )
+
+        parsed_feed = urlparse(feed_url)
+        feed_host = parsed_feed.hostname or ""
+        company = self.company_name or company_id
+        jobs: list[Job] = []
+        seen: set[str] = set()
+        for item in root.findall("./Job"):
+            requisition_id = _first_text(item.findtext("ReqId"))
+            title = _first_text(item.findtext("JobTitle"))
+            if not requisition_id or not title or requisition_id in seen:
+                continue
+            seen.add(requisition_id)
+            job_url = urlunparse(
+                (
+                    "https",
+                    feed_host,
+                    "/sfcareer/jobreqcareer",
+                    "",
+                    urlencode(
+                        {"jobId": requisition_id, "company": company_id}
+                    ),
+                    "",
+                )
+            )
+            description = None
+            if self.include_descriptions:
+                replacements = {
+                    child.tag: value
+                    for child in item
+                    if (value := _first_text(child.text))
+                }
+                replacements["id"] = requisition_id
+                description = _clean_description(
+                    _render_template(
+                        item.findtext("Job-Description"),
+                        replacements,
+                    )
+                )
+            jobs.append(
+                Job(
+                    url=job_url,
+                    title=html.unescape(title),
+                    company=company,
+                    ats_type=ATSType.SUCCESSFACTORS,
+                    ats_id=f"{company_id}:{requisition_id}",
+                    requisition_id=requisition_id,
+                    description=description,
+                    posted_at=_parse_legacy_date(
+                        item.findtext("Posted-Date")
+                    ),
+                    fetched_at=datetime.now(UTC),
+                )
+            )
+        return jobs
+
     def _parse_feed(self, xml_text: str) -> list[Job]:
         try:
-            root = ET.fromstring(xml_text)
+            root = _parse_xml(xml_text)
         except ET.ParseError as exc:
             raise ScraperError(
                 f"SuccessFactors returned malformed XML: {exc}"
@@ -240,6 +372,41 @@ def _first_text(value: object) -> str | None:
     return None
 
 
+def _is_legacy_host(host: str) -> bool:
+    normalized = host.lower().rstrip(".")
+    return normalized.endswith(
+        (
+            ".successfactors.com",
+            ".successfactors.eu",
+            ".sapsf.com",
+            ".sapsf.eu",
+            ".sapsf.cn",
+        )
+    )
+
+
+def _parse_xml(xml_text: str) -> ET.Element:
+    try:
+        return ET.fromstring(xml_text)
+    except ET.ParseError:
+        sanitized = _INVALID_EMPTY_ELEMENT_RE.sub("", xml_text)
+        if sanitized == xml_text:
+            raise
+        return ET.fromstring(sanitized)
+
+
+def _render_template(
+    value: object,
+    replacements: dict[str, str],
+) -> object:
+    if not isinstance(value, str):
+        return value
+    return _TEMPLATE_TOKEN_RE.sub(
+        lambda match: replacements.get(match.group(1), ""),
+        value,
+    )
+
+
 def _clean_description(value: object) -> str | None:
     if not isinstance(value, str) or not value.strip():
         return None
@@ -256,3 +423,16 @@ def _parse_pubdate(value: object) -> datetime | None:
         return parsedate_to_datetime(value)
     except (TypeError, ValueError):
         return None
+
+
+def _parse_legacy_date(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    for date_format in ("%m/%d/%Y", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(value.strip(), date_format).replace(
+                tzinfo=UTC
+            )
+        except ValueError:
+            continue
+    return None

--- a/tests/test_successfactors.py
+++ b/tests/test_successfactors.py
@@ -1,10 +1,14 @@
 """Tests for the SAP SuccessFactors scraper.
 
-The scraper fetches the public RSS 2.0 feed at ``{host}/sitemal.xml``.
-These tests pin XML parsing, title/location splitting, dedup, and retry.
+The scraper fetches public RSS 2.0 and legacy Recruiting Management XML feeds.
+These tests pin URL resolution, XML parsing, field extraction, and retry.
 """
 
 from __future__ import annotations
+
+import csv
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
@@ -16,6 +20,11 @@ from ats_scrapers.scrapers import ScraperRegistry, SuccessFactorsScraper
 # conftest.py — the shared fetch layer replaced per-scraper retry constants.
 
 FEED_URL = "https://job.acme.com/sitemal.xml"
+LEGACY_CAREER_URL = "https://career8.successfactors.com/career?company=amkor"
+LEGACY_FEED_URL = (
+    "https://career8.successfactors.com/career"
+    "?company=amkor&career_ns=job_listing_summary&resultType=XML"
+)
 
 
 def _rss(items: list[str], company: str = "Acme") -> str:
@@ -47,6 +56,30 @@ def _item(
 </item>"""
 
 
+def _legacy_feed(items: list[str]) -> str:
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<Job-Listing>
+{''.join(items)}
+</Job-Listing>"""
+
+
+def _legacy_item(
+    *,
+    title: str = "Account Manager",
+    requisition_id: str = "29023",
+    description: str = "<![CDATA[<p>Manage customer accounts.</p>]]>",
+    filters: str = "",
+    posted_date: str = "",
+) -> str:
+    return f"""<Job>
+<JobTitle>{title}</JobTitle>
+<Job-Description>{description}</Job-Description>
+<ReqId>{requisition_id}</ReqId>
+<Posted-Date>{posted_date}</Posted-Date>
+{filters}
+</Job>"""
+
+
 # --- Registry ---------------------------------------------------------------
 
 
@@ -70,6 +103,74 @@ def test_full_url_accepted() -> None:
 def test_bare_slug_assumes_job_dot_slug_dot_com() -> None:
     s = SuccessFactorsScraper("acme")
     assert s._resolve_feed_url() == "https://job.acme.com/sitemal.xml"
+
+
+def test_legacy_url_resolves_xml_feed() -> None:
+    scraper = SuccessFactorsScraper(LEGACY_CAREER_URL)
+    assert scraper._resolve_feed_target() == (LEGACY_FEED_URL, "amkor")
+
+
+def test_legacy_url_preserves_locale() -> None:
+    scraper = SuccessFactorsScraper(
+        f"{LEGACY_CAREER_URL}&rcm_site_locale=de_DE&career_ns=job_listing"
+    )
+    assert scraper._resolve_feed_target() == (
+        f"{LEGACY_FEED_URL}&rcm_site_locale=de_DE",
+        "amkor",
+    )
+
+
+def test_china_legacy_host_resolves_xml_feed() -> None:
+    scraper = SuccessFactorsScraper(
+        "https://career15.sapsf.cn/career?company=volkswag09"
+    )
+    assert scraper._resolve_feed_target() == (
+        "https://career15.sapsf.cn/career"
+        "?company=volkswag09&career_ns=job_listing_summary&resultType=XML",
+        "volkswag09",
+    )
+
+
+def test_legacy_url_discards_userinfo_and_port() -> None:
+    scraper = SuccessFactorsScraper(
+        "https://ignored@career8.successfactors.com:8443/career?company=amkor"
+    )
+    assert scraper._resolve_feed_target() == (LEGACY_FEED_URL, "amkor")
+
+
+def test_successfactors_catalog_urls_are_unique() -> None:
+    catalog = Path("ats-companies/successfactors.csv")
+    with catalog.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    urls = [row["url"].rstrip("/") for row in rows]
+    assert len(urls) == len(set(urls))
+
+
+def test_legacy_catalog_urls_use_production_hosts() -> None:
+    catalog = Path("ats-companies/successfactors.csv")
+    with catalog.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    legacy_rows = [
+        row
+        for row in rows
+        if (urlparse(row["url"]).hostname or "").endswith(
+            (
+                ".successfactors.com",
+                ".successfactors.eu",
+                ".sapsf.cn",
+            )
+        )
+    ]
+    assert legacy_rows
+    for row in legacy_rows:
+        parsed = urlparse(row["url"])
+        assert parsed.scheme == "https"
+        assert parsed.path == "/career"
+        assert len(parse_qs(parsed.query).get("company", [])) == 1
+        assert not any(
+            marker in (parsed.hostname or "")
+            for marker in ("preview", "salesdemo", "stage")
+        )
 
 
 # --- Happy path -------------------------------------------------------------
@@ -113,6 +214,95 @@ def test_skips_item_without_link(httpx_mock) -> None:
 <link></link>
 </item>"""]))
     assert SuccessFactorsScraper("job.acme.com").fetch() == []
+
+
+def test_parses_legacy_xml_feed(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=LEGACY_FEED_URL,
+        text=_legacy_feed([
+            _legacy_item(
+                title="R&amp;D Manager",
+                posted_date="07/26/2026",
+                description=(
+                    "<![CDATA[<p>Manage [[id]] in [[filter2]] "
+                    "for [[missing]].</p>]]>"
+                ),
+                filters="<filter2>Paris</filter2>",
+            )
+        ]),
+    )
+    jobs = SuccessFactorsScraper(
+        LEGACY_CAREER_URL,
+        company_name="Amkor Technology",
+    ).fetch()
+    assert len(jobs) == 1
+    job = jobs[0]
+    assert job.ats_id == "amkor:29023"
+    assert job.requisition_id == "29023"
+    assert job.title == "R&D Manager"
+    assert job.company == "Amkor Technology"
+    assert job.description == "Manage 29023 in Paris for ."
+    assert job.posted_at is not None
+    assert job.posted_at.isoformat() == "2026-07-26T00:00:00+00:00"
+    assert str(job.url) == (
+        "https://career8.successfactors.com/sfcareer/jobreqcareer"
+        "?jobId=29023&company=amkor"
+    )
+
+
+def test_legacy_feed_uses_company_id_as_fallback_name(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=LEGACY_FEED_URL,
+        text=_legacy_feed([_legacy_item()]),
+    )
+    jobs = SuccessFactorsScraper(LEGACY_CAREER_URL).fetch()
+    assert jobs[0].company == "amkor"
+
+
+def test_legacy_feed_dedupes_and_skips_incomplete_jobs(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=LEGACY_FEED_URL,
+        text=_legacy_feed([
+            _legacy_item(),
+            _legacy_item(title="Duplicate"),
+            "<Job><JobTitle>No requisition</JobTitle></Job>",
+            "<Job><ReqId>123</ReqId></Job>",
+        ]),
+    )
+    jobs = SuccessFactorsScraper(LEGACY_CAREER_URL).fetch()
+    assert [job.title for job in jobs] == ["Account Manager"]
+
+
+def test_legacy_feed_can_omit_descriptions(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=LEGACY_FEED_URL,
+        text=_legacy_feed([_legacy_item()]),
+    )
+    jobs = SuccessFactorsScraper(
+        LEGACY_CAREER_URL,
+        include_descriptions=False,
+    ).fetch()
+    assert jobs[0].description is None
+
+
+def test_legacy_feed_ignores_invalid_posted_date(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=LEGACY_FEED_URL,
+        text=_legacy_feed([_legacy_item(posted_date="not-a-date")]),
+    )
+    jobs = SuccessFactorsScraper(LEGACY_CAREER_URL).fetch()
+    assert jobs[0].posted_at is None
+
+
+def test_legacy_feed_removes_invalid_empty_name_elements(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=LEGACY_FEED_URL,
+        text=_legacy_feed([
+            _legacy_item().replace("</Job>", "<>250</></Job>")
+        ]),
+    )
+    jobs = SuccessFactorsScraper(LEGACY_CAREER_URL).fetch()
+    assert [job.ats_id for job in jobs] == ["amkor:29023"]
 
 
 # --- Title / location extraction --------------------------------------------
@@ -193,3 +383,9 @@ def test_html_response_treated_as_non_rss(httpx_mock) -> None:
     httpx_mock.add_response(url=FEED_URL, text="<html><body>nope</body></html>")
     with pytest.raises(ScraperError, match="non-RSS"):
         SuccessFactorsScraper("job.acme.com").fetch()
+
+
+def test_non_job_listing_legacy_xml_raises_clean_error(httpx_mock) -> None:
+    httpx_mock.add_response(url=LEGACY_FEED_URL, text="<rss></rss>")
+    with pytest.raises(ScraperError, match="non-job-listing"):
+        SuccessFactorsScraper(LEGACY_CAREER_URL).fetch()


### PR DESCRIPTION
## Summary

- support the credential-free SuccessFactors Recruiting Management `Job-Listing` XML feed alongside the existing RMK RSS feed
- add 31 live production sources across the US, Europe, China/APAC, Canada, Latin America, Africa, and global employers
- preserve tenant identity in legacy job IDs, render description template fields, recover the narrow malformed-empty-tag variant seen in production, and parse available posting dates
- pass catalog company names through the pipeline for legacy feeds

## Live validation

- 31/31 sources returned non-empty real jobs
- 3,623 current jobs
- 0 exact title+description matches against the current 290,728-job SuccessFactors dataset
- 0 exact duplicates across the accepted new sources
- one sampled canonical job URL per source returned HTTP 200/302
- branded redirects for Royal Caribbean and Vistance were separately followed through to HTTP 200

Employer/tenant coverage buckets (legacy XML does not consistently expose a structured location field):

- US: 1,631
- China: 640
- Europe: 108
- Canada: 46
- Asia: 247
- Asia-Pacific: 152
- Global employers: 743
- Latin America: 5
- Africa: 51

Cross-provider duplicate checks excluded Whirlpool (68/68 titles already in Eightfold) and TJX (2/2 already in Phenom). Branded RMK duplicates for SAP, BASF, Schwarz, NetApp, BNSF, State of Florida, and others were also rejected.

## Tests

- `pytest -q`: 1,653 passed, 2 skipped, 29 deselected
- `pytest -q tests/test_successfactors.py tests/test_run_pipeline_guards.py`: 57 passed
- `ruff check src/ats_scrapers/scrapers/successfactors.py scripts/run_pipeline.py tests/test_successfactors.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for legacy SuccessFactors Recruiting Management `Job-Listing` XML feeds alongside the existing RMK RSS, enabling 31 new production sources. Also passes company names from the catalog into the scraper for clearer job metadata.

- **New Features**
  - Support legacy career URLs (`careerN.successfactors.com/.eu/.cn`) and build canonical job links with `jobId` + tenant `company`.
  - Parse description template fields, map posted dates, and keep tenant identity in `ats_id` (e.g., `company:ReqId`).
  - Improve XML robustness: recover malformed empty tags and skip duplicate/incomplete jobs.
  - Add 31 live sources to the SuccessFactors catalog and update the pipeline to pass `company_name` to the scraper.

<sup>Written for commit 4543af1ec52a3c9cade592ce9078eb1fad6d0213. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds support for legacy SuccessFactors `Job-Listing` XML feeds.
- Resolves legacy tenant feed URLs and parses job identifiers, descriptions, template fields, and posting dates.
- Passes catalog company names into the SuccessFactors scraper.
- Adds 31 legacy-feed tenant sources and corresponding parser and pipeline tests.

<h3>Confidence Score: 3/5</h3>

The URL-resolution integration should be fixed before merging so the public generic scraper API can reach the newly supported legacy feeds.

Direct scraper and pipeline use can process legacy feeds, but callers using the repository's URL-based entry point receive an unsupported-URL error for the same newly recognized SuccessFactors hosts.

**Files Needing Attention:** src/ats_scrapers/scrapers/successfactors.py and src/ats_scrapers/resolve.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I reproduced that the legacy SuccessFactors URL bypasses the URL resolution path in the offline public API harness, with resolve\_careers\_url() returning None.
- On PR HEAD, direct scraper resolution produced a valid legacy XML target but failed to construct the scraper because get\_scraper\_for\_url() raised a ScraperError.
- After changes, the legacy live feed validation succeeded, returning 25 parsed jobs and HTTP 200 for the canonical URL.
- A focused supplied-date test passed, confirming correct handling of posted dates.

<a href="https://app.greptile.com/trex/runs/16124880/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/ats_scrapers/scrapers/successfactors.py | Adds the legacy XML fetch and parsing path, but the newly accepted URL shape is not integrated with generic URL resolution. |
| scripts/run_pipeline.py | Passes normalized catalog company names to SuccessFactors scraper instances. |
| ats-companies/successfactors.csv | Adds 31 legacy and related SuccessFactors production sources. |
| tests/test_successfactors.py | Covers legacy feed resolution and parsing extensively, but does not exercise the public `get_scraper_for_url()` path for a legacy URL. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/ats_scrapers/scrapers/successfactors.py:116-123
**Legacy URLs bypass URL resolution**

When a caller passes a newly supported `career*.successfactors.*` or `career*.sapsf.*` URL to `get_scraper_for_url()`, the resolver has no matching SuccessFactors pattern and raises `ScraperError` before this legacy-feed path can run, leaving the public URL-based API unable to use the new support.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(successfactors): support legacy XML..."](https://github.com/kalil0321/ats-scrapers/commit/4543af1ec52a3c9cade592ce9078eb1fad6d0213) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47783670)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->