### PR TITLE
Add Paylocity scraper and 48 validated employers

### DIFF
--- a/ats-companies/paylocity.csv
+++ b/ats-companies/paylocity.csv
@@ -1,0 +1,49 @@
+name,slug,url
+Abby's Catering,8e0feae7-e42f-437e-97b1-53b917185eed,https://recruiting.paylocity.com/Recruiting/Jobs/All/8e0feae7-e42f-437e-97b1-53b917185eed
+"AEMI Holdings, LLC",463a34eb-52cc-4f6e-9325-a8e93ccaf1a3,https://recruiting.paylocity.com/Recruiting/Jobs/All/463a34eb-52cc-4f6e-9325-a8e93ccaf1a3
+Agile Physical Therapy Inc,970f9403-7f14-43e6-b53a-bf685b347556,https://recruiting.paylocity.com/Recruiting/Jobs/All/970f9403-7f14-43e6-b53a-bf685b347556
+Amethod Public Schools (AMPS),c4af0b69-eaa7-4097-bcf4-577830528c7b,https://recruiting.paylocity.com/Recruiting/Jobs/All/c4af0b69-eaa7-4097-bcf4-577830528c7b
+Applied Medical Technology Inc.,5242621e-5e01-4dcc-bc9b-6fd69c204f97,https://recruiting.paylocity.com/Recruiting/Jobs/All/5242621e-5e01-4dcc-bc9b-6fd69c204f97
+Bitzer Scroll Inc,3005d498-4c76-4bc1-a1ba-e4527dfae067,https://recruiting.paylocity.com/Recruiting/Jobs/All/3005d498-4c76-4bc1-a1ba-e4527dfae067
+Complete Billing Services,36bb0c23-b03b-40ad-9c23-c7772124bdd6,https://recruiting.paylocity.com/Recruiting/Jobs/All/36bb0c23-b03b-40ad-9c23-c7772124bdd6
+Coopersburg Kenworth,b39f30b7-6c8b-4c9a-8dd6-2c1fbb7b4d49,https://recruiting.paylocity.com/Recruiting/Jobs/All/b39f30b7-6c8b-4c9a-8dd6-2c1fbb7b4d49
+Division-D,8a645a8f-9e72-4889-9889-02e545fbb039,https://recruiting.paylocity.com/Recruiting/Jobs/All/8a645a8f-9e72-4889-9889-02e545fbb039
+EL T MEXICAN INC,5a5040a4-c890-413f-a682-c60889b0e85c,https://recruiting.paylocity.com/Recruiting/Jobs/All/5a5040a4-c890-413f-a682-c60889b0e85c
+Elizabethtown College,cb493a4a-af9e-4be5-a440-94dd402867b4,https://recruiting.paylocity.com/Recruiting/Jobs/All/cb493a4a-af9e-4be5-a440-94dd402867b4
+Evansville Marine Service,697d9806-9944-4bd6-b51b-d2a5eee54259,https://recruiting.paylocity.com/Recruiting/Jobs/All/697d9806-9944-4bd6-b51b-d2a5eee54259
+Forsman Farms,c47e27a2-5dd2-408a-9ef0-c799cbdd5796,https://recruiting.paylocity.com/Recruiting/Jobs/All/c47e27a2-5dd2-408a-9ef0-c799cbdd5796
+Fulcrum,2710144d-adf2-428c-b626-ff90e87589e5,https://recruiting.paylocity.com/Recruiting/Jobs/All/2710144d-adf2-428c-b626-ff90e87589e5
+Goodwill Industries of the Southern Piedmont,0fc5696d-c267-4a7f-86f3-ded7b45e3145,https://recruiting.paylocity.com/Recruiting/Jobs/All/0fc5696d-c267-4a7f-86f3-ded7b45e3145
+GROWTH OPERATORS ADVISORY SERVICES LLC,5c926302-b0e4-4fab-98fd-4ddc8f5a4ae1,https://recruiting.paylocity.com/Recruiting/Jobs/All/5c926302-b0e4-4fab-98fd-4ddc8f5a4ae1
+HEALTHY KIDS PROGRAMS,3a22f29d-a4e6-4369-b6ad-91be22993148,https://recruiting.paylocity.com/Recruiting/Jobs/All/3a22f29d-a4e6-4369-b6ad-91be22993148
+HYDE PARK SCHOOLS,f8de6551-7140-413b-82d4-ef7b095b7aa2,https://recruiting.paylocity.com/Recruiting/Jobs/All/f8de6551-7140-413b-82d4-ef7b095b7aa2
+Invariant LLC,de88db6e-5da5-4d0e-a5fb-fe81b271eedf,https://recruiting.paylocity.com/Recruiting/Jobs/All/de88db6e-5da5-4d0e-a5fb-fe81b271eedf
+Jack in the Box - J & F AND SONS LLC,1b9c4c79-1ba2-412d-a2d9-fbac04b50565,https://recruiting.paylocity.com/Recruiting/Jobs/All/1b9c4c79-1ba2-412d-a2d9-fbac04b50565
+KSA Integration,51d6efc9-51e2-4bdd-8da2-1d4fb6c6258a,https://recruiting.paylocity.com/Recruiting/Jobs/All/51d6efc9-51e2-4bdd-8da2-1d4fb6c6258a
+Lactalis American Group Inc,6197b9db-7396-41d1-9bab-a64d738c1d73,https://recruiting.paylocity.com/Recruiting/Jobs/All/6197b9db-7396-41d1-9bab-a64d738c1d73
+Legacy Technologies LLC,0257995d-8779-4557-9bcc-ef50d4a7da60,https://recruiting.paylocity.com/Recruiting/Jobs/All/0257995d-8779-4557-9bcc-ef50d4a7da60
+Levin Papantonio Law Firm,746d92ef-9e4e-4025-b456-59e2f91e1e14,https://recruiting.paylocity.com/Recruiting/Jobs/All/746d92ef-9e4e-4025-b456-59e2f91e1e14
+"Lion Real Estate Group, LLC",4d7e80e3-8d85-4e3d-a4c8-43a3017a3210,https://recruiting.paylocity.com/Recruiting/Jobs/All/4d7e80e3-8d85-4e3d-a4c8-43a3017a3210
+Little Sunshine's Playhouse,273074a3-6ae3-4be1-b8da-31fcc05c9700,https://recruiting.paylocity.com/Recruiting/Jobs/All/273074a3-6ae3-4be1-b8da-31fcc05c9700
+Little Sunshine's Playhouse,54ad3e5a-0067-41f0-8e4a-5682db409439,https://recruiting.paylocity.com/Recruiting/Jobs/All/54ad3e5a-0067-41f0-8e4a-5682db409439
+Little Sunshine's Playhouse,e064434e-4f47-4fde-b7c3-48f6edfc31c0,https://recruiting.paylocity.com/Recruiting/Jobs/All/e064434e-4f47-4fde-b7c3-48f6edfc31c0
+"Longview, an Ithacare Community",a8184ff4-448a-4c7f-a4d0-9eda39e04750,https://recruiting.paylocity.com/Recruiting/Jobs/All/a8184ff4-448a-4c7f-a4d0-9eda39e04750
+Louisiana Cat,ff517f63-c379-48fb-acc8-8d66e8d5b076,https://recruiting.paylocity.com/Recruiting/Jobs/All/ff517f63-c379-48fb-acc8-8d66e8d5b076
+Managed Work Services,0c7d1250-1d8c-4347-9baf-a219806e0468,https://recruiting.paylocity.com/Recruiting/Jobs/All/0c7d1250-1d8c-4347-9baf-a219806e0468
+MetalTek International,25d9c4a6-9bf1-4859-a269-f9dbd4cabb2d,https://recruiting.paylocity.com/Recruiting/Jobs/All/25d9c4a6-9bf1-4859-a269-f9dbd4cabb2d
+Our Community Our Kids,3f467bf5-2d13-4c22-a1db-bfd1ccee305f,https://recruiting.paylocity.com/Recruiting/Jobs/All/3f467bf5-2d13-4c22-a1db-bfd1ccee305f
+Pennsylvania Medical Society,ad52e45c-2502-4b38-a16c-a1158c7793e4,https://recruiting.paylocity.com/Recruiting/Jobs/All/ad52e45c-2502-4b38-a16c-a1158c7793e4
+People Incorporated,10021f25-b058-426e-ad07-ed08850c3ccb,https://recruiting.paylocity.com/Recruiting/Jobs/All/10021f25-b058-426e-ad07-ed08850c3ccb
+Plainfield Park District,db797b94-5705-423a-8730-e5af84c8be20,https://recruiting.paylocity.com/Recruiting/Jobs/All/db797b94-5705-423a-8730-e5af84c8be20
+PMM - America's Technology Molder,84b39507-3eae-4571-9994-b35b21cce035,https://recruiting.paylocity.com/Recruiting/Jobs/All/84b39507-3eae-4571-9994-b35b21cce035
+Positive Impact Health Centers INC,76b9b616-bb54-4de9-9ae2-fd1f7eb3e2b2,https://recruiting.paylocity.com/Recruiting/Jobs/All/76b9b616-bb54-4de9-9ae2-fd1f7eb3e2b2
+Public Service Credit Union,bf02703f-8670-42a4-8066-78dab04099a3,https://recruiting.paylocity.com/Recruiting/Jobs/All/bf02703f-8670-42a4-8066-78dab04099a3
+Ram Restaurant & Brewery - Puyallup,9f57867f-f703-47bc-b933-66194c068331,https://recruiting.paylocity.com/Recruiting/Jobs/All/9f57867f-f703-47bc-b933-66194c068331
+Rooted Hospitality Group,417fef0c-8eb5-46a1-88b3-a19ceefd912d,https://recruiting.paylocity.com/Recruiting/Jobs/All/417fef0c-8eb5-46a1-88b3-a19ceefd912d
+St Charles Borromeo Catholic Church Kansas City,b181f77f-0432-453f-b229-869d786bb46c,https://recruiting.paylocity.com/Recruiting/Jobs/All/b181f77f-0432-453f-b229-869d786bb46c
+St Peter - Geneva,3b967847-942e-4ea9-a2b1-055e2605afd1,https://recruiting.paylocity.com/Recruiting/Jobs/All/3b967847-942e-4ea9-a2b1-055e2605afd1
+"Summer Consultants, Inc.",c40c6ed3-8a5c-4dfe-a576-42a4ee778071,https://recruiting.paylocity.com/Recruiting/Jobs/All/c40c6ed3-8a5c-4dfe-a576-42a4ee778071
+TCH RGV,b80c3a01-6ecd-46d0-b474-22448c48e612,https://recruiting.paylocity.com/Recruiting/Jobs/All/b80c3a01-6ecd-46d0-b474-22448c48e612
+US Neuro LLC,5185d630-7b08-4a17-b664-4c81d3030393,https://recruiting.paylocity.com/Recruiting/Jobs/All/5185d630-7b08-4a17-b664-4c81d3030393
+Virtual Service Operations,1b11cd7d-eb07-44d5-8c7c-8e953bafa909,https://recruiting.paylocity.com/Recruiting/Jobs/All/1b11cd7d-eb07-44d5-8c7c-8e953bafa909
+Weigel Broadcasting Co,e583bee1-43b8-46fb-af01-cf1cac431f59,https://recruiting.paylocity.com/Recruiting/Jobs/All/e583bee1-43b8-46fb-af01-cf1cac431f59

--- a/pipeline/publisher.py
+++ b/pipeline/publisher.py
@@ -540,7 +540,7 @@ ATS_DEDUP_PRIORITY: dict[str, int] = {
     "darwinbox": 1, "dayforce": 1,
     "greenhouse": 1, "gupy": 1, "icims": 1, "jazzhr": 1, "join_com": 1, "jobvite": 1,
     "lever": 1,
-    "moka": 1, "oracle": 1, "pageup": 1, "personio": 1, "phenom": 1, "pinpoint": 1,
+    "moka": 1, "oracle": 1, "pageup": 1, "paylocity": 1, "personio": 1, "phenom": 1, "pinpoint": 1,
     "recruitee": 1,
     "recruiterbox": 1, "rippling": 1, "smartrecruiters": 1,
     "successfactors": 1, "taleo": 1, "teamtailor": 1, "ukg": 1, "workable": 1,

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -74,6 +74,7 @@ from ats_scrapers.scrapers import (
     MokaScraper,
     OracleScraper,
     PageUpScraper,
+    PaylocityScraper,
     PersonioScraper,
     PhenomScraper,
     PinpointScraper,
@@ -533,6 +534,17 @@ CONFIGS: dict[str, dict[str, Any]] = {
         "csv": "ats-companies/pageup.csv",
         "output": "pageup/jobs.csv",
         "fail_closed_on_any_error": True,
+        "fail_closed_on_empty": True,
+    },
+    "paylocity": {
+        "scraper": PaylocityScraper,
+        "slug": lambda r: _slug_col(r) or (r.get("url") or "").strip() or None,
+        "kwargs": lambda r: {"company_name": (r.get("name") or "").strip()},
+        "csv": "ats-companies/paylocity.csv",
+        "output": "paylocity/jobs.csv",
+        "max_concurrency": 1,
+        "fail_closed_on_any_error": True,
+        "fail_closed_on_not_found": True,
         "fail_closed_on_empty": True,
     },
     "recruitee": {
@@ -1275,6 +1287,15 @@ def _job_to_row(job: Job) -> dict[str, Any]:
     }
 
 
+def _bounded_concurrency(cfg: dict[str, Any], requested: int) -> int:
+    if requested < 1:
+        raise ValueError("concurrency must be at least 1")
+    configured = cfg.get("max_concurrency")
+    if isinstance(configured, int) and configured > 0:
+        return min(requested, configured)
+    return requested
+
+
 async def _run_scraper(
     scraper_cls,
     slug,
@@ -1302,6 +1323,7 @@ async def _run_scraper(
 
 async def run(ats: str, concurrency: int, max_tenants: int | None, timeout: float) -> int:
     cfg = CONFIGS[ats]
+    concurrency = _bounded_concurrency(cfg, concurrency)
     configured_max_concurrency = cfg.get("max_concurrency")
     if isinstance(configured_max_concurrency, int):
         concurrency = min(concurrency, max(1, configured_max_concurrency))

--- a/src/ats_scrapers/models.py
+++ b/src/ats_scrapers/models.py
@@ -53,6 +53,7 @@ class ATSType(StrEnum):
     MOKA = "moka"
     ORACLE = "oracle"
     PAGEUP = "pageup"
+    PAYLOCITY = "paylocity"
     PERSONIO = "personio"
     PHENOM = "phenom"
     PINPOINT = "pinpoint"

--- a/src/ats_scrapers/resolve.py
+++ b/src/ats_scrapers/resolve.py
@@ -174,6 +174,19 @@ def resolve_careers_url(url: str) -> ResolvedCareersUrl | None:
             )
         return None
 
+    if host == "recruiting.paylocity.com":
+        segments = [segment for segment in parsed.path.split("/") if segment]
+        if (
+            len(segments) == 4
+            and [segment.casefold() for segment in segments[:3]]
+            == ["recruiting", "jobs", "all"]
+            and _UUID_RE.fullmatch(segments[3])
+            and not parsed.query
+            and not parsed.fragment
+        ):
+            return ResolvedCareersUrl(ATSType.PAYLOCITY, segments[3].lower())
+        return None
+
     # join.com/companies/{slug}
     if host == "join.com":
         segments = [s for s in parsed.path.split("/") if s]

--- a/src/ats_scrapers/scrapers/__init__.py
+++ b/src/ats_scrapers/scrapers/__init__.py
@@ -47,6 +47,7 @@ from ats_scrapers.scrapers.meta import MetaScraper
 from ats_scrapers.scrapers.moka import MokaScraper
 from ats_scrapers.scrapers.oracle import OracleScraper
 from ats_scrapers.scrapers.pageup import PageUpScraper
+from ats_scrapers.scrapers.paylocity import PaylocityScraper
 from ats_scrapers.scrapers.personio import PersonioScraper
 from ats_scrapers.scrapers.phenom import PhenomScraper
 from ats_scrapers.scrapers.pinpoint import PinpointScraper
@@ -113,6 +114,7 @@ __all__ = [
     "MokaScraper",
     "OracleScraper",
     "PageUpScraper",
+    "PaylocityScraper",
     "PersonioScraper",
     "PhenomScraper",
     "PinpointScraper",

--- a/src/ats_scrapers/scrapers/paylocity.py
+++ b/src/ats_scrapers/scrapers/paylocity.py
@@ -1,0 +1,539 @@
+"""Paylocity public recruiting scraper."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import html
+import json
+import logging
+import re
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, ClassVar
+from urllib.parse import urlparse
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType, EmploymentType, Job, SalaryPeriod
+from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from bs4 import BeautifulSoup
+
+    from ats_scrapers.fetch import Fetcher
+
+BASE_URL = "https://recruiting.paylocity.com"
+DETAIL_CONCURRENCY = 2
+_PAGE_DATA_RE = re.compile(r"\bwindow\.pageData\s*=\s*")
+_EMPLOYMENT_TYPE_MAP: dict[str, EmploymentType] = {
+    "FULL_TIME": "FULL_TIME",
+    "FULLTIME": "FULL_TIME",
+    "PART_TIME": "PART_TIME",
+    "PARTTIME": "PART_TIME",
+    "CONTRACT": "CONTRACT",
+    "CONTRACTOR": "CONTRACT",
+    "TEMPORARY": "TEMPORARY",
+    "SEASONAL": "TEMPORARY",
+    "INTERN": "INTERN",
+    "INTERNSHIP": "INTERN",
+}
+_SALARY_PERIOD_MAP: dict[str, SalaryPeriod] = {
+    "HOUR": "HOUR",
+    "HOURLY": "HOUR",
+    "DAY": "DAY",
+    "DAILY": "DAY",
+    "WEEK": "WEEK",
+    "WEEKLY": "WEEK",
+    "MONTH": "MONTH",
+    "MONTHLY": "MONTH",
+    "YEAR": "YEAR",
+    "YEARLY": "YEAR",
+    "ANNUAL": "YEAR",
+    "ANNUALLY": "YEAR",
+}
+_COUNTRY_CODES = {
+    "CAN": "CA",
+    "CANADA": "CA",
+    "MEX": "MX",
+    "MEXICO": "MX",
+    "UNITED STATES": "US",
+    "UNITED STATES OF AMERICA": "US",
+    "USA": "US",
+}
+logger = logging.getLogger(__name__)
+
+
+@ScraperRegistry.register(ATSType.PAYLOCITY)
+class PaylocityScraper(BaseScraper):
+    """Scrape one public Paylocity external-job module."""
+
+    ats = ATSType.PAYLOCITY
+    default_headers: ClassVar[dict[str, str]] = {
+        "Accept": "text/html,application/xhtml+xml",
+        "User-Agent": "Mozilla/5.0",
+    }
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        include_descriptions: bool = True,
+        proxy: str | None = None,
+        company_name: str | None = None,
+    ) -> None:
+        super().__init__(
+            company_slug,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        self.board_id = _normalize_board_id(company_slug)
+        self.company_name = (
+            company_name.strip()
+            if isinstance(company_name, str) and company_name.strip()
+            else None
+        )
+        self.listing_url = (
+            f"{BASE_URL}/Recruiting/Jobs/All/{self.board_id}"
+        )
+
+    async def afetch(self) -> list[Job]:
+        async with self.make_fetcher() as fetch:
+            listing_html = await fetch.get_text(self.listing_url)
+            payload = _extract_page_data(listing_html)
+            jobs = self._parse_listing(payload)
+            if not self.include_descriptions or not jobs:
+                return jobs
+
+            semaphore = asyncio.Semaphore(DETAIL_CONCURRENCY)
+            enriched = await asyncio.gather(
+                *(self._enrich_detail(fetch, semaphore, job) for job in jobs)
+            )
+
+        completed = [job for job in enriched if job is not None]
+        if jobs and not completed:
+            raise ScraperError(
+                f"Paylocity ({self.board_id}) lost every listed job "
+                "during detail validation"
+            )
+        return completed
+
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+        copy = job.model_copy(deep=True)
+
+        async def run() -> str | None:
+            async with self.make_fetcher() as fetch:
+                semaphore = asyncio.Semaphore(1)
+                enriched = await self._enrich_detail(
+                    fetch,
+                    semaphore,
+                    copy,
+                )
+            return enriched.description if enriched is not None else None
+
+        return self._run_sync(run())
+
+    def _parse_listing(self, payload: dict[str, Any]) -> list[Job]:
+        rows = payload.get("Jobs")
+        if not isinstance(rows, list):
+            raise ScraperError(
+                f"Paylocity ({self.board_id}) omitted the Jobs list"
+            )
+        module_title = _string(payload.get("ModuleTitle"))
+        module_id = _string(payload.get("ModuleId"))
+        fallback_company = self.company_name or (
+            module_title
+            if module_title
+            and module_title.casefold() not in {
+                "career opportunities",
+                "employment opportunities",
+                "job opportunities",
+            }
+            else self.board_id
+        )
+
+        jobs: list[Job] = []
+        seen_ids: set[int] = set()
+        for index, row in enumerate(rows):
+            if not isinstance(row, dict):
+                raise ScraperError(
+                    f"Paylocity listing row {index} was not an object"
+                )
+            is_internal = row.get("IsInternal")
+            if not isinstance(is_internal, bool):
+                raise ScraperError(
+                    f"Paylocity row {index} omitted the external-job flag"
+                )
+            if is_internal:
+                continue
+
+            job_id = _job_id(row.get("JobId"))
+            if job_id in seen_ids:
+                raise ScraperError(
+                    f"Paylocity returned duplicate job id {job_id}"
+                )
+            seen_ids.add(job_id)
+            title = _required_string(row, "JobTitle")
+            location_data = row.get("JobLocation")
+            location = _listing_location(
+                location_data,
+                _string(row.get("LocationName")),
+            )
+            explicit_remote = row.get("IsRemote")
+            is_remote = (
+                explicit_remote
+                if isinstance(explicit_remote, bool)
+                else (
+                    True
+                    if location and "remote" in location.casefold()
+                    else None
+                )
+            )
+            raw = {
+                key: value
+                for key, value in {
+                    "board_id": self.board_id,
+                    "module_id": module_id,
+                    "module_title": module_title,
+                    "location_id": (
+                        location_data.get("LocationId")
+                        if isinstance(location_data, dict)
+                        else None
+                    ),
+                    "indeed_remote_type": row.get("IndeedRemoteType"),
+                }.items()
+                if value not in (None, "")
+            }
+
+            jobs.append(Job(
+                url=f"{BASE_URL}/Recruiting/Jobs/Details/{job_id}",
+                title=title,
+                company=fallback_company,
+                ats_type=ATSType.PAYLOCITY,
+                ats_id=f"{self.board_id}:{job_id}",
+                location=location,
+                country_iso=_listing_country(location_data),
+                is_remote=is_remote,
+                department=_string(row.get("HiringDepartment")),
+                posted_at=_parse_date(row.get("PublishedDate")),
+                fetched_at=datetime.now(tz=UTC),
+                requisition_id=str(job_id),
+                apply_url=f"{BASE_URL}/Recruiting/Jobs/Apply/{job_id}",
+                raw=raw or None,
+            ))
+        return jobs
+
+    async def _enrich_detail(
+        self,
+        fetch: Fetcher,
+        semaphore: asyncio.Semaphore,
+        job: Job,
+    ) -> Job | None:
+        try:
+            async with semaphore:
+                response = await fetch.request(
+                    "GET",
+                    str(job.url),
+                    handled={404, 410},
+                )
+        except ScraperError as exc:
+            logger.warning(
+                "Retaining Paylocity job %s without detail metadata after "
+                "detail failure: %s",
+                job.ats_id,
+                exc,
+            )
+            return job
+        if response.status_code in {404, 410}:
+            return None
+        _apply_detail(job, response.text)
+        return job
+
+
+def _normalize_board_id(value: str) -> str:
+    raw = value.strip().rstrip("/")
+    if not raw:
+        raise ValueError("Paylocity board id cannot be empty")
+    if raw.startswith(("http://", "https://")):
+        parsed = urlparse(raw)
+        try:
+            port = parsed.port
+        except ValueError as exc:
+            raise ValueError("Invalid Paylocity URL port") from exc
+        segments = [segment for segment in parsed.path.split("/") if segment]
+        if (
+            parsed.scheme != "https"
+            or parsed.hostname != "recruiting.paylocity.com"
+            or parsed.username is not None
+            or parsed.password is not None
+            or port not in {None, 443}
+            or parsed.query
+            or parsed.fragment
+            or len(segments) != 4
+            or [segment.casefold() for segment in segments[:3]]
+            != ["recruiting", "jobs", "all"]
+        ):
+            raise ValueError(
+                "Paylocity URL must be an https recruiting job-list URL"
+            )
+        raw = segments[3]
+    try:
+        return str(uuid.UUID(raw))
+    except ValueError as exc:
+        raise ValueError(f"Invalid Paylocity board id: {value!r}") from exc
+
+
+def _extract_page_data(html_text: str) -> dict[str, Any]:
+    matches = list(_PAGE_DATA_RE.finditer(html_text))
+    if len(matches) != 1:
+        raise ScraperError(
+            "Paylocity listing must contain exactly one window.pageData payload"
+        )
+    start = matches[0].end()
+    try:
+        payload, consumed = json.JSONDecoder().raw_decode(html_text[start:])
+    except json.JSONDecodeError as exc:
+        raise ScraperError(
+            f"Paylocity listing pageData was not valid JSON: {exc}"
+        ) from exc
+    if not html_text[start + consumed :].lstrip().startswith(";"):
+        raise ScraperError("Paylocity listing pageData was not terminated")
+    if not isinstance(payload, dict):
+        raise ScraperError("Paylocity listing pageData was not an object")
+    return payload
+
+
+def _apply_detail(job: Job, html_text: str) -> None:
+    posting = _find_job_posting(html_text)
+    if posting is None:
+        description = _find_legacy_description(html_text)
+        if description is None:
+            raise ScraperError(
+                f"Paylocity detail page for {job.ats_id} omitted job content"
+            )
+        job.description = description
+        return
+    description = posting.get("description")
+    if not isinstance(description, str) or not description.strip():
+        raise ScraperError(
+            f"Paylocity detail page for {job.ats_id} omitted a description"
+        )
+    job.description = description.strip()
+
+    title = _string(posting.get("title"))
+    if title:
+        job.title = title
+    organization = posting.get("hiringOrganization")
+    if isinstance(organization, dict):
+        company = _string(organization.get("name"))
+        if company:
+            job.company = company
+    posted_at = _parse_date(posting.get("datePosted"))
+    if posted_at is not None:
+        job.posted_at = posted_at
+    employment_type = _employment_type(posting.get("employmentType"))
+    if employment_type is not None:
+        job.employment_type = employment_type
+    if _is_remote(posting.get("jobLocationType")):
+        job.is_remote = True
+
+    location, country_iso = _jsonld_location(posting.get("jobLocation"))
+    if location:
+        job.location = location
+    if country_iso:
+        job.country_iso = country_iso
+    _apply_salary(job, posting.get("baseSalary"))
+
+
+def _find_job_posting(html_text: str) -> dict[str, Any] | None:
+    soup = _parse_html(html_text)
+    for script in soup.select('script[type="application/ld+json"]'):
+        raw = script.string or script.get_text()
+        if not raw:
+            continue
+        with contextlib.suppress(json.JSONDecodeError):
+            payload = json.loads(raw)
+            for item in _jsonld_items(payload):
+                item_type = item.get("@type")
+                types = item_type if isinstance(item_type, list) else [item_type]
+                if "JobPosting" in types:
+                    return item
+    return None
+
+
+def _find_legacy_description(html_text: str) -> str | None:
+    soup = _parse_html(html_text)
+    sections: list[str] = []
+    for header in soup.select(".job-preview-details .job-listing-header"):
+        label = header.get_text(" ", strip=True)
+        body = header.find_next_sibling("div")
+        if not label or body is None or not body.get_text(" ", strip=True):
+            continue
+        content = body.decode_contents().strip()
+        if content:
+            sections.append(f"<p>{html.escape(label)}</p>{content}")
+    return "".join(sections) or None
+
+
+def _parse_html(html_text: str) -> BeautifulSoup:
+    try:
+        from bs4 import BeautifulSoup
+    except ImportError as exc:
+        raise ScraperError(
+            "Paylocity scraper requires beautifulsoup4; "
+            "install `ats-scrapers[scrapers]`"
+        ) from exc
+    return BeautifulSoup(html_text, "html.parser")
+
+
+def _jsonld_items(value: object) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, dict)]
+    if not isinstance(value, dict):
+        return []
+    graph = value.get("@graph")
+    if isinstance(graph, list):
+        return [item for item in graph if isinstance(item, dict)]
+    return [value]
+
+
+def _listing_location(value: object, fallback: str | None) -> str | None:
+    if not isinstance(value, dict):
+        return fallback
+    parts = [
+        _string(value.get("City")) or _string(value.get("Metro")),
+        _string(value.get("State")),
+        _country_code(value.get("Country")),
+    ]
+    joined = ", ".join(dict.fromkeys(part for part in parts if part))
+    return joined or fallback
+
+
+def _listing_country(value: object) -> str | None:
+    if not isinstance(value, dict):
+        return None
+    return _country_code(value.get("Country"))
+
+
+def _jsonld_location(value: object) -> tuple[str | None, str | None]:
+    candidates = value if isinstance(value, list) else [value]
+    locations: list[str] = []
+    country_iso: str | None = None
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            continue
+        address = candidate.get("address")
+        if not isinstance(address, dict):
+            continue
+        country = _country_code(address.get("addressCountry"))
+        parts = [
+            _string(address.get("addressLocality")),
+            _string(address.get("addressRegion")),
+            country,
+        ]
+        location = ", ".join(dict.fromkeys(part for part in parts if part))
+        if location and location not in locations:
+            locations.append(location)
+        country_iso = country_iso or country
+    return "; ".join(locations) or None, country_iso
+
+
+def _country_code(value: object) -> str | None:
+    if isinstance(value, dict):
+        value = value.get("name")
+    text = _string(value)
+    if not text:
+        return None
+    upper = text.upper()
+    if len(upper) == 2 and upper.isalpha():
+        return upper
+    return _COUNTRY_CODES.get(upper)
+
+
+def _employment_type(value: object) -> EmploymentType | None:
+    values = value if isinstance(value, list) else [value]
+    for item in values:
+        if not isinstance(item, str):
+            continue
+        normalized = re.sub(r"[^A-Z0-9]+", "_", item.upper()).strip("_")
+        if mapped := _EMPLOYMENT_TYPE_MAP.get(normalized):
+            return mapped
+    return None
+
+
+def _is_remote(value: object) -> bool:
+    values = value if isinstance(value, list) else [value]
+    return any(
+        isinstance(item, str)
+        and item.strip().upper() in {"REMOTE", "TELECOMMUTE"}
+        for item in values
+    )
+
+
+def _apply_salary(job: Job, value: object) -> None:
+    if not isinstance(value, dict):
+        return
+    salary_value = value.get("value")
+    if not isinstance(salary_value, dict):
+        return
+    minimum = _to_float(
+        salary_value.get("minValue") or salary_value.get("value")
+    )
+    maximum = _to_float(
+        salary_value.get("maxValue") or salary_value.get("value")
+    )
+    currency = _string(value.get("currency"))
+    unit = _string(salary_value.get("unitText"))
+    if minimum is not None:
+        job.salary_min = minimum
+    if maximum is not None:
+        job.salary_max = maximum
+    if currency and len(currency) == 3:
+        job.salary_currency = currency.upper()
+    if unit and (period := _SALARY_PERIOD_MAP.get(unit.upper())):
+        job.salary_period = period
+
+
+def _parse_date(value: object) -> datetime | None:
+    text = _string(value)
+    if not text:
+        return None
+    with contextlib.suppress(ValueError):
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+    return None
+
+
+def _to_float(value: object) -> float | None:
+    if value in (None, ""):
+        return None
+    with contextlib.suppress(TypeError, ValueError):
+        return float(value)  # type: ignore[arg-type]
+    return None
+
+
+def _job_id(value: object) -> int:
+    if isinstance(value, bool):
+        raise ScraperError("Paylocity job id cannot be boolean")
+    with contextlib.suppress(TypeError, ValueError):
+        parsed = int(value)  # type: ignore[arg-type]
+        if parsed > 0 and str(parsed) == str(value).strip():
+            return parsed
+    raise ScraperError(f"Invalid Paylocity job id: {value!r}")
+
+
+def _required_string(item: dict[str, Any], key: str) -> str:
+    value = _string(item.get(key))
+    if not value:
+        raise ScraperError(f"Paylocity row omitted {key}")
+    return value
+
+
+def _string(value: object) -> str | None:
+    if not isinstance(value, (str, int)) or isinstance(value, bool):
+        return None
+    text = str(value).strip()
+    return text or None

--- a/src/ats_scrapers/scrapers/paylocity.py
+++ b/src/ats_scrapers/scrapers/paylocity.py
@@ -249,7 +249,15 @@ class PaylocityScraper(BaseScraper):
             return job
         if response.status_code in {404, 410}:
             return None
-        _apply_detail(job, response.text)
+        try:
+            _apply_detail(job, response.text)
+        except ScraperError as exc:
+            logger.warning(
+                "Retaining Paylocity job %s without detail metadata after "
+                "detail parsing failure: %s",
+                job.ats_id,
+                exc,
+            )
         return job
 
 

--- a/tests/e2e/test_live_paylocity.py
+++ b/tests/e2e/test_live_paylocity.py
@@ -1,0 +1,46 @@
+"""Live smoke test for Paylocity."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+from ats_scrapers.scrapers.paylocity import PaylocityScraper
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.skipif(
+        not os.getenv("ATS_SCRAPERS_LIVE_E2E"),
+        reason="set ATS_SCRAPERS_LIVE_E2E=1 to hit real Paylocity endpoints",
+    ),
+]
+
+
+async def test_live_paylocity_smoke() -> None:
+    async with asyncio.timeout(90):
+        jobs = await PaylocityScraper(
+            "273074a3-6ae3-4be1-b8da-31fcc05c9700",
+            company_name="Little Sunshine's Playhouse",
+        ).afetch()
+
+    assert jobs
+    assert len({job.ats_id for job in jobs}) == len(jobs)
+    assert all(job.title.strip() for job in jobs)
+    assert all(job.description for job in jobs)
+    assert all(
+        "recruiting.paylocity.com/Recruiting/Jobs/Details/" in str(job.url)
+        for job in jobs
+    )
+
+
+async def test_live_paylocity_legacy_detail_template() -> None:
+    async with asyncio.timeout(90):
+        jobs = await PaylocityScraper(
+            "b39f30b7-6c8b-4c9a-8dd6-2c1fbb7b4d49",
+            company_name="Coopersburg Kenworth",
+        ).afetch()
+
+    assert jobs
+    assert all(job.description for job in jobs)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -19,7 +19,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # Multi-tenant ATS systems
         "adp", "ashby", "avature", "beisen", "beisen_legacy", "cornerstone",
         "darwinbox", "dayforce", "eightfold", "gem", "greenhouse", "gupy",
-        "icims", "join_com", "jobvite", "lever", "mercor", "moka", "oracle", "pageup",
+        "icims", "join_com", "jobvite", "lever", "mercor", "moka", "oracle", "pageup", "paylocity",
         "personio", "phenom",
         "pinpoint", "recruiterbox", "rippling", "smartrecruiters",
         "successfactors", "ukg", "workable", "workday",

--- a/tests/test_paylocity.py
+++ b/tests/test_paylocity.py
@@ -158,15 +158,33 @@ def test_hydrates_legacy_detail_sections_without_json_ld(httpx_mock) -> None:
     )
 
 
-def test_detail_without_supported_content_fails_closed(httpx_mock) -> None:
-    httpx_mock.add_response(url=LISTING_URL, text=_listing([_row(4363000)]))
+def test_malformed_detail_retains_listing_and_adjacent_job_enriches(
+    httpx_mock,
+) -> None:
+    httpx_mock.add_response(
+        url=LISTING_URL,
+        text=_listing([
+            _row(4363000),
+            _row(4363001, title="Designer"),
+        ]),
+    )
     httpx_mock.add_response(
         url="https://recruiting.paylocity.com/Recruiting/Jobs/Details/4363000",
         text="<html><div class='job-preview-details'></div></html>",
     )
+    httpx_mock.add_response(
+        url="https://recruiting.paylocity.com/Recruiting/Jobs/Details/4363001",
+        text=_detail(title="Product Designer"),
+    )
 
-    with pytest.raises(ScraperError, match="omitted job content"):
-        PaylocityScraper(BOARD_ID, company_name="Acme").fetch()
+    jobs = PaylocityScraper(BOARD_ID, company_name="Acme").fetch()
+
+    assert len(jobs) == 2
+    assert jobs[0].company == "Acme"
+    assert jobs[0].description is None
+    assert jobs[0].location == "Houston, TX, US"
+    assert jobs[1].title == "Product Designer"
+    assert jobs[1].description == "<p>Build reliable systems.</p>"
 
 
 def test_include_descriptions_false_skips_detail(httpx_mock) -> None:

--- a/tests/test_paylocity.py
+++ b/tests/test_paylocity.py
@@ -1,0 +1,278 @@
+"""Tests for the Paylocity public recruiting scraper."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType
+from ats_scrapers.scrapers.paylocity import (
+    PaylocityScraper,
+    _extract_page_data,
+    _normalize_board_id,
+)
+
+BOARD_ID = "8e0feae7-e42f-437e-97b1-53b917185eed"
+LISTING_URL = (
+    "https://recruiting.paylocity.com/Recruiting/Jobs/All/" + BOARD_ID
+)
+
+
+def _row(
+    job_id: int,
+    *,
+    title: str = "Platform Engineer",
+    internal: bool = False,
+) -> dict[str, object]:
+    return {
+        "JobId": job_id,
+        "JobTitle": title,
+        "LocationName": "HQ",
+        "PublishedDate": "2026-07-24T14:16:35-05:00",
+        "IsInternal": internal,
+        "HiringDepartment": "Engineering",
+        "JobLocation": {
+            "LocationId": 10,
+            "City": "Houston",
+            "State": "TX",
+            "Country": "USA",
+        },
+        "IsRemote": False,
+        "IndeedRemoteType": 2,
+    }
+
+
+def _listing(rows: list[dict[str, object]]) -> str:
+    payload = {
+        "Jobs": rows,
+        "ModuleId": "19907",
+        "ModuleTitle": "Career Opportunities",
+    }
+    return (
+        "<html><script>window.pageData = "
+        + json.dumps(payload)
+        + ";</script></html>"
+    )
+
+
+def _detail(
+    *,
+    title: str = "Platform Engineer",
+    company: str = "Acme Corp",
+) -> str:
+    posting = {
+        "@context": "https://schema.org",
+        "@type": "JobPosting",
+        "title": title,
+        "datePosted": "2026-07-24T19:19:35-05:00",
+        "hiringOrganization": {
+            "@type": "Organization",
+            "name": company,
+        },
+        "description": "<p>Build reliable systems.</p>",
+        "employmentType": "FULL_TIME",
+        "jobLocation": {
+            "@type": "Place",
+            "address": {
+                "@type": "PostalAddress",
+                "addressLocality": "Austin",
+                "addressRegion": "TX",
+                "addressCountry": "US",
+            },
+        },
+        "baseSalary": {
+            "@type": "MonetaryAmount",
+            "currency": "USD",
+            "value": {
+                "@type": "QuantitativeValue",
+                "minValue": 100000,
+                "maxValue": 130000,
+                "unitText": "YEAR",
+            },
+        },
+    }
+    return (
+        '<html><script type="application/ld+json">'
+        + json.dumps(posting)
+        + "</script></html>"
+    )
+
+
+def _legacy_detail() -> str:
+    return """
+    <html>
+      <div class="job-preview-details">
+        <div class="job-listing-header">Description</div>
+        <div><p>Repair heavy trucks.</p></div>
+        <div class="job-listing-header">Requirements</div>
+        <div><ul><li>Diesel experience</li></ul></div>
+      </div>
+    </html>
+    """
+
+
+def test_fetches_external_jobs_and_hydrates_details(httpx_mock) -> None:
+    httpx_mock.add_response(url=LISTING_URL, text=_listing([
+        _row(4363000),
+        _row(4363001, title="Internal Role", internal=True),
+    ]))
+    httpx_mock.add_response(
+        url="https://recruiting.paylocity.com/Recruiting/Jobs/Details/4363000",
+        text=_detail(),
+    )
+
+    jobs = PaylocityScraper(BOARD_ID, company_name="Acme").fetch()
+
+    assert len(jobs) == 1
+    job = jobs[0]
+    assert job.ats_type is ATSType.PAYLOCITY
+    assert job.ats_id == f"{BOARD_ID}:4363000"
+    assert job.company == "Acme Corp"
+    assert job.description == "<p>Build reliable systems.</p>"
+    assert job.location == "Austin, TX, US"
+    assert job.country_iso == "US"
+    assert job.department == "Engineering"
+    assert job.employment_type == "FULL_TIME"
+    assert job.salary_min == 100000
+    assert job.salary_max == 130000
+    assert job.salary_currency == "USD"
+    assert job.salary_period == "YEAR"
+    assert str(job.apply_url).endswith("/Recruiting/Jobs/Apply/4363000")
+
+
+def test_hydrates_legacy_detail_sections_without_json_ld(httpx_mock) -> None:
+    httpx_mock.add_response(url=LISTING_URL, text=_listing([_row(4363000)]))
+    httpx_mock.add_response(
+        url="https://recruiting.paylocity.com/Recruiting/Jobs/Details/4363000",
+        text=_legacy_detail(),
+    )
+
+    jobs = PaylocityScraper(BOARD_ID, company_name="Acme").fetch()
+
+    assert len(jobs) == 1
+    assert jobs[0].description == (
+        "<p>Description</p><p>Repair heavy trucks.</p>"
+        "<p>Requirements</p><ul><li>Diesel experience</li></ul>"
+    )
+
+
+def test_detail_without_supported_content_fails_closed(httpx_mock) -> None:
+    httpx_mock.add_response(url=LISTING_URL, text=_listing([_row(4363000)]))
+    httpx_mock.add_response(
+        url="https://recruiting.paylocity.com/Recruiting/Jobs/Details/4363000",
+        text="<html><div class='job-preview-details'></div></html>",
+    )
+
+    with pytest.raises(ScraperError, match="omitted job content"):
+        PaylocityScraper(BOARD_ID, company_name="Acme").fetch()
+
+
+def test_include_descriptions_false_skips_detail(httpx_mock) -> None:
+    httpx_mock.add_response(url=LISTING_URL, text=_listing([_row(4363000)]))
+
+    jobs = PaylocityScraper(
+        BOARD_ID,
+        include_descriptions=False,
+        company_name="Acme",
+    ).fetch()
+
+    assert len(jobs) == 1
+    assert jobs[0].description is None
+    assert jobs[0].location == "Houston, TX, US"
+
+
+def test_closed_job_between_listing_and_detail_is_dropped(httpx_mock) -> None:
+    httpx_mock.add_response(url=LISTING_URL, text=_listing([
+        _row(4363000),
+        _row(4363001, title="Designer"),
+    ]))
+    httpx_mock.add_response(
+        url="https://recruiting.paylocity.com/Recruiting/Jobs/Details/4363000",
+        text=_detail(),
+    )
+    httpx_mock.add_response(
+        url="https://recruiting.paylocity.com/Recruiting/Jobs/Details/4363001",
+        status_code=404,
+    )
+
+    jobs = PaylocityScraper(BOARD_ID).fetch()
+
+    assert [job.requisition_id for job in jobs] == ["4363000"]
+
+
+def test_transient_detail_failure_retains_listing(httpx_mock) -> None:
+    httpx_mock.add_response(url=LISTING_URL, text=_listing([_row(4363000)]))
+    for _ in range(3):
+        httpx_mock.add_response(
+            url=(
+                "https://recruiting.paylocity.com/Recruiting/Jobs/Details/"
+                "4363000"
+            ),
+            status_code=500,
+        )
+
+    jobs = PaylocityScraper(BOARD_ID, company_name="Acme").fetch()
+
+    assert len(jobs) == 1
+    assert jobs[0].company == "Acme"
+    assert jobs[0].description is None
+
+
+def test_duplicate_external_job_ids_fail_closed(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=LISTING_URL,
+        text=_listing([_row(4363000), _row(4363000)]),
+    )
+
+    with pytest.raises(ScraperError, match="duplicate job id"):
+        PaylocityScraper(BOARD_ID, include_descriptions=False).fetch()
+
+
+@pytest.mark.parametrize(
+    "html_text",
+    [
+        "<html></html>",
+        "<script>window.pageData = nope;</script>",
+        '<script>window.pageData = {"Jobs":[]}</script>',
+        (
+            '<script>window.pageData = {"Jobs":[]};</script>'
+            '<script>window.pageData = {"Jobs":[]};</script>'
+        ),
+    ],
+)
+def test_malformed_page_data_fails_closed(html_text: str) -> None:
+    with pytest.raises(ScraperError):
+        _extract_page_data(html_text)
+
+
+def test_listing_requires_explicit_external_flag(httpx_mock) -> None:
+    row = _row(4363000)
+    row.pop("IsInternal")
+    httpx_mock.add_response(url=LISTING_URL, text=_listing([row]))
+
+    with pytest.raises(ScraperError, match="external-job flag"):
+        PaylocityScraper(BOARD_ID, include_descriptions=False).fetch()
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "not-a-uuid",
+        "https://evil.example/Recruiting/Jobs/All/" + BOARD_ID,
+        "http://recruiting.paylocity.com/Recruiting/Jobs/All/" + BOARD_ID,
+        (
+            "https://recruiting.paylocity.com/Recruiting/Jobs/Details/"
+            "4363000"
+        ),
+        LISTING_URL + "?internal=true",
+    ],
+)
+def test_rejects_untrusted_board_identifiers(value: str) -> None:
+    with pytest.raises(ValueError):
+        _normalize_board_id(value)
+
+
+def test_normalizes_trusted_listing_url() -> None:
+    assert _normalize_board_id(LISTING_URL) == BOARD_ID

--- a/tests/test_paylocity_contracts.py
+++ b/tests/test_paylocity_contracts.py
@@ -1,0 +1,48 @@
+"""Pipeline contracts for Paylocity."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from ats_scrapers.scrapers.paylocity import PaylocityScraper
+from pipeline.publisher import ATS_DEDUP_PRIORITY
+from scripts.run_pipeline import CONFIGS, _bounded_concurrency
+
+
+def test_paylocity_pipeline_contract() -> None:
+    config = CONFIGS["paylocity"]
+
+    assert config["scraper"] is PaylocityScraper
+    assert config["csv"] == "ats-companies/paylocity.csv"
+    assert config["output"] == "paylocity/jobs.csv"
+    assert config["max_concurrency"] == 1
+    assert config["fail_closed_on_any_error"] is True
+    assert config["fail_closed_on_not_found"] is True
+    assert config["fail_closed_on_empty"] is True
+    assert config["kwargs"]({"name": "Acme"}) == {"company_name": "Acme"}
+
+
+def test_provider_concurrency_cap_is_enforced() -> None:
+    assert _bounded_concurrency(CONFIGS["paylocity"], 8) == 1
+    assert _bounded_concurrency({}, 8) == 8
+
+
+def test_paylocity_has_direct_employer_dedup_priority() -> None:
+    assert ATS_DEDUP_PRIORITY["paylocity"] == ATS_DEDUP_PRIORITY["workday"]
+
+
+def test_paylocity_seed_catalogue_is_validated_provider_only() -> None:
+    with Path("ats-companies/paylocity.csv").open(newline="") as handle:
+        rows = list(csv.DictReader(handle))
+
+    assert len(rows) == 48
+    assert len({row["slug"] for row in rows}) == len(rows)
+    assert all(
+        row["url"]
+        == (
+            "https://recruiting.paylocity.com/Recruiting/Jobs/All/"
+            + row["slug"]
+        )
+        for row in rows
+    )

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -18,6 +18,7 @@ from ats_scrapers.scrapers import (
     JobviteScraper,
     MokaScraper,
     PageUpScraper,
+    PaylocityScraper,
     UKGProScraper,
     WorkdayScraper,
 )
@@ -57,6 +58,12 @@ RESOLVES = [
         ATSType.UKG,
         "https://recruiting2.ultipro.com/HEN1009HPCC/JobBoard/"
         "b27ab828-18a9-4f10-8ee1-8259de6c9e73",
+    ),
+    (
+        "https://recruiting.paylocity.com/Recruiting/Jobs/All/"
+        "8e0feae7-e42f-437e-97b1-53b917185eed",
+        ATSType.PAYLOCITY,
+        "8e0feae7-e42f-437e-97b1-53b917185eed",
     ),
     ("https://join.com/companies/acme", ATSType.JOIN_COM, "acme"),
     (
@@ -167,6 +174,7 @@ def test_icims_nonstandard_prefix_keeps_full_url() -> None:
         "https://bad_slug.zhiye.com/social/jobs",
         "https://recruiting.ultipro.com/bad-tenant/JobBoard/"
         "11111111-2222-3333-4444-555555555555",
+        "https://recruiting.paylocity.com/Recruiting/Jobs/Details/4363000",
         "https://jobs.dayforcehcm.com/en-CA/mayfair/"
         "CANDIDATEPORTAL/search",
         f"https://{'a' * 64}.zhiye.com/social/jobs",
@@ -212,6 +220,13 @@ def test_get_scraper_for_url_builds_scraper() -> None:
             "9a9d6241-e23f-47c0-80f3-e43a148972a0"
         ),
         UKGProScraper,
+    )
+    assert isinstance(
+        get_scraper_for_url(
+            "https://recruiting.paylocity.com/Recruiting/Jobs/All/"
+            "8e0feae7-e42f-437e-97b1-53b917185eed"
+        ),
+        PaylocityScraper,
     )
     assert isinstance(
         get_scraper_for_url(


### PR DESCRIPTION
## Summary
- add a credential-free scraper for public Paylocity recruiting boards
- support modern JSON-LD and legacy HTML detail templates
- register URL resolution, pipeline execution, direct-employer dedup priority, and live E2E coverage
- add 48 live-validated employer boards

## Validation
- `uv run pytest -q`: 1,677 passed, 2 skipped, 31 deselected
- `ATS_SCRAPERS_LIVE_E2E=1 uv run pytest -q -m live tests/e2e/test_live_paylocity.py`: 2 passed
- live catalogue probe: 48/48 non-empty boards, 1,250 jobs, 1,250 unique IDs, 0 cross-tenant duplicate IDs
- geography: 1,248 US, 2 unknown
- `uv run ruff check ...`: passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a credential‑free scraper for public Paylocity recruiting boards and seed 48 validated employers. Registers `paylocity` across resolve, pipeline, and dedup with JSON‑LD and legacy HTML detail parsing and live E2E coverage.

- **New Features**
  - Added `PaylocityScraper` with JSON‑LD and legacy HTML detail parsing.
  - Added URL resolution for `recruiting.paylocity.com/Recruiting/Jobs/All/{uuid}`.
  - Added pipeline config for `paylocity` with `max_concurrency: 1`, fail‑closed flags, and bounded concurrency handling.
  - Set direct‑employer dedup priority for `paylocity`.
  - Seeded 48 validated employer boards and added unit, contract, and live E2E tests.

- **Bug Fixes**
  - Retain listings when detail parsing fails and drop 404/410 jobs, preventing board aborts and allowing per‑job graceful fallback.

<sup>Written for commit 9e3f896a63985604f1131347e4c6eba2fcbabe33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Paylocity as a supported ATS across scraping, URL resolution, publishing, and pipeline execution.
- Implements listing parsing plus modern JSON-LD and legacy HTML detail enrichment.
- Registers 48 Paylocity employer boards and direct-employer deduplication priority.
- Adds unit, contract, resolver, and live end-to-end coverage.

<h3>Confidence Score: 3/5</h3>

The detail-enrichment failure boundary should be fixed before merging because one unsupported Paylocity detail page can block the entire provider refresh.

_apply_detail can raise outside the per-job exception handler, and asyncio.gather propagates that error into a pipeline configuration that fails the complete Paylocity run on any tenant error.

**Files Needing Attention:** src/ats_scrapers/scrapers/paylocity.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The focused Paylocity board enrichment test reproduced an abort caused by an unsupported detail response, with a ScraperError propagated through the detail path and the board exited before any listing was returned.
- The live end-to-end Paylocity test run completed successfully, showing two tests passing in 31.60 seconds and exit status 0.

<a href="https://app.greptile.com/trex/runs/16152187/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/ats_scrapers/scrapers/paylocity.py | Adds the Paylocity adapter, but an unsupported detail response aborts the entire tenant rather than degrading only that job. |
| scripts/run_pipeline.py | Registers Paylocity with serialized tenant execution and strict fail-closed publication guards. |
| src/ats_scrapers/resolve.py | Resolves canonical Paylocity board URLs to validated lowercase board UUIDs. |
| src/ats_scrapers/models.py | Adds Paylocity to the public ATS type enumeration. |
| pipeline/publisher.py | Gives Paylocity the same cross-ATS deduplication priority as direct employer sources. |
| ats-companies/paylocity.csv | Adds 48 canonical Paylocity employer board identifiers and URLs. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/ats_scrapers/scrapers/paylocity.py:252-253
**Detail parsing aborts tenant scrape**

When a successful detail response lacks recognized JobPosting JSON-LD and legacy description markup, `_apply_detail` raises outside the per-job exception handler, causing `asyncio.gather` to abort the board and the fail-closed pipeline to reject the entire Paylocity refresh instead of retaining the valid listing-only job.

```suggestion
        try:
            _apply_detail(job, response.text)
        except ScraperError as exc:
            logger.warning(
                "Retaining Paylocity job %s without detail metadata after "
                "detail parsing failure: %s",
                job.ats_id,
                exc,
            )
        return job
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add Paylocity scraper and validated empl..."](https://github.com/kalil0321/ats-scrapers/commit/02e8a5a8a698b7fa012b3d7f9673ae07674824b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47836237)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->