### PR TITLE
Expand Darwinbox with 12 validated employers

### DIFF
--- a/ats-companies/darwinbox.csv
+++ b/ats-companies/darwinbox.csv
@@ -25,11 +25,15 @@ Aragen Life Sciences,aragen,https://aragen.darwinbox.in/ms/candidate/careers
 Arvind,arvind,https://arvind.darwinbox.in/ms/candidate/careers
 Ather Energy,atherenergy,https://atherenergy.darwinbox.in/ms/candidate/careers
 AU Small Finance Bank,autalenthub,https://autalenthub.darwinbox.in/ms/candidate/careers
+Avaada Group,myavaada,https://myavaada.darwinbox.in/ms/candidate/careers
 AXIS Clinicals Limited,axisclinicals,https://axisclinicals.darwinbox.in/ms/candidate/careers
+Baazi Games,baazigames,https://baazigames.darwinbox.in/ms/candidate/careers
 Bajaj Electricals,bel.com,https://bel.darwinbox.com/ms/candidate/careers
 Bajaj Finserv Direct,hrisbdirect,https://hrisbdirect.darwinbox.in/ms/candidate/careers
 Bank BTPN,btpn.com,https://btpn.darwinbox.com/ms/candidate/careers
+Bank of the Philippine Islands (BPI),rhea.com,https://rhea.darwinbox.com/ms/candidate/careers
 Bharti Airtel Foundation,bhartifoundation,https://bhartifoundation.darwinbox.in/ms/candidate/careers
+Blibli,blibli.com,https://blibli.darwinbox.com/ms/candidate/careers
 Botree Software (HRMS Botree),hrmsbotree,https://hrmsbotree.darwinbox.in/ms/candidate/careers
 Brigade Group,brigadegroup,https://brigadegroup.darwinbox.in/ms/candidate/careers
 BSA,bsa.com,https://bsa.darwinbox.com/ms/candidate/careers
@@ -58,13 +62,16 @@ Glenmark,glenmark,https://glenmark.darwinbox.in/ms/candidate/careers
 Glenmark | Spring,glenmarkspring.com,https://glenmarkspring.darwinbox.com/ms/candidate/careers
 Great Learning,greatlearning,https://greatlearning.darwinbox.in/ms/candidate/careers
 GYS,gys.com,https://gys.darwinbox.com/ms/candidate/careers
+HCA Healthcare India,hcahr,https://hcahr.darwinbox.in/ms/candidate/careers
 Hetero,hetero,https://hetero.darwinbox.in/ms/candidate/careers
 HL Mando India,hrmsmandoindia,https://hrmsmandoindia.darwinbox.in/ms/candidate/careers
 HMS Vanguard Sdn Bhd,healthmetrics.com,https://healthmetrics.darwinbox.com/ms/candidate/careers
 HOH / HFS,hoh,https://hoh.darwinbox.in/ms/candidate/careers
+Home Credit Philippines,hcconnect.com,https://hcconnect.darwinbox.com/ms/candidate/careers
 Homevista Decor & Furnishings Private Limited,homelane,https://homelane.darwinbox.in/ms/candidate/careers
 Honasa Consumer (Mamaearth),honasa,https://honasa.darwinbox.in/ms/candidate/careers
 HT Group,htmediagroup,https://htmediagroup.darwinbox.in/ms/candidate/careers
+Invesco Mutual Fund,iiamihrms,https://iiamihrms.darwinbox.in/ms/candidate/careers
 iQuanti,iquanti,https://iquanti.darwinbox.in/ms/candidate/careers
 ITC Hotels,itchotels,https://itchotels.darwinbox.in/ms/candidate/careers
 JSW (My JSW),myjsw,https://myjsw.darwinbox.in/ms/candidate/careers
@@ -82,11 +89,13 @@ Licious,licious,https://licious.darwinbox.in/ms/candidate/careers
 Linfox International Group,linfoxasiahrms.com,https://linfoxasiahrms.darwinbox.com/ms/candidate/careers
 Lionbridge Technologies,lionbridge.com,https://lionbridge.darwinbox.com/ms/candidate/careers
 Mahindra Logistics,nectar,https://nectar.darwinbox.in/ms/candidate/careers
+Marks & Spencer Reliance India,mandsmyhr,https://mandsmyhr.darwinbox.in/ms/candidate/careers
 MatchMove,matchmove.com,https://matchmove.darwinbox.com/ms/candidate/careers
 Maxicare Healthcare (Philippines),onehrad.com,https://onehrad.darwinbox.com/ms/candidate/careers
 Mayapada Hospital Group,mayapadahospital.com,https://mayapadahospital.darwinbox.com/ms/candidate/careers
 MHealth,mhealth.com,https://mhealth.darwinbox.com/ms/candidate/careers
 MobiKwik,mobikwik,https://mobikwik.darwinbox.in/ms/candidate/careers
+mPokket,mpokket,https://mpokket.darwinbox.in/ms/candidate/careers
 Modinity Group,modinity.com,https://modinity.darwinbox.com/ms/candidate/careers
 MOL,molit,https://molit.darwinbox.in/ms/candidate/careers
 Moneyview,moneyview,https://moneyview.darwinbox.in/ms/candidate/careers
@@ -109,6 +118,7 @@ Pluang,pluanghrms.com,https://pluanghrms.darwinbox.com/ms/candidate/careers
 Polycab,polycab,https://polycab.darwinbox.in/ms/candidate/careers
 Porter,porter,https://porter.darwinbox.in/ms/candidate/careers
 PT. Nippon Indosari Corpindo Tbk.,hrsr.com,https://hrsr.darwinbox.com/ms/candidate/careers
+Punjab National Bank International,merapnbil.com,https://merapnbil.darwinbox.com/ms/candidate/careers
 Quick Heal Technologies Ltd,lifecycleqhtl,https://lifecycleqhtl.darwinbox.in/ms/candidate/careers
 QX Global Group,qxhrms.com,https://qxhrms.darwinbox.com/ms/candidate/careers
 RateGain,rategain.com,https://rategain.darwinbox.com/ms/candidate/careers
@@ -123,6 +133,7 @@ Singland,singland.com,https://singland.darwinbox.com/ms/candidate/careers
 Singlife,singlife.com,https://singlife.darwinbox.com/ms/candidate/careers
 SMC Group,mysmcdbx,https://mysmcdbx.darwinbox.in/ms/candidate/careers
 SMN Group,protelindo.com,https://protelindo.darwinbox.com/ms/candidate/careers
+Sonata Software,sonataone,https://sonataone.darwinbox.in/ms/candidate/careers
 Spark Minda Group,sparkminda-hris,https://sparkminda-hris.darwinbox.in/ms/candidate/careers
 Spinzone,spinzone,https://spinzone.darwinbox.in/ms/candidate/careers
 SPML Infra,spml,https://spml.darwinbox.in/ms/candidate/careers
@@ -142,6 +153,7 @@ UEM Sunrise,uemsunrise.com,https://uemsunrise.darwinbox.com/ms/candidate/careers
 Unacademy,unacademy,https://unacademy.darwinbox.in/ms/candidate/careers
 Upstox,upstox,https://upstox.darwinbox.in/ms/candidate/careers
 Vedanta,vhr,https://vhr.darwinbox.in/ms/candidate/careers
+Virtual Staffing Solutions,atlas.com,https://atlas.darwinbox.com/ms/candidate/careers
 Visteon,visteon-panorama.com,https://visteon-panorama.darwinbox.com/ms/candidate/careers
 Vivriti Capital,vivriti,https://vivriti.darwinbox.in/ms/candidate/careers
 Y-Axis,y-axis,https://y-axis.darwinbox.in/ms/candidate/careers

--- a/ats-companies/pinpoint.csv
+++ b/ats-companies/pinpoint.csv
@@ -385,7 +385,6 @@ V.Group,vgroup,https://vgroup.pinpointhq.com
 Vaiie,vaiie,https://vaiie.pinpointhq.com
 Vena Solutions,vena,https://vena.pinpointhq.com
 Veriforce,alcumus,https://alcumus.pinpointhq.com
-Virtual Staffing Solutions,virtualstaffing,https://virtualstaffing.pinpointhq.com
 Vital Bio,vitalbio,https://vitalbio.pinpointhq.com
 W.E. O'Neil Construction,weoneil,https://weoneil.pinpointhq.com
 Wanstor,wanstor,https://wanstor.pinpointhq.com

--- a/ats-companies/workable.csv
+++ b/ats-companies/workable.csv
@@ -3783,7 +3783,6 @@ Virgin,virgin,https://apply.workable.com/virgin
 Virtasant,virtasant,https://apply.workable.com/virtasant
 Virtual Assist,virtual-assist,https://apply.workable.com/virtual-assist
 Virtual Staff 365,virtual-staff-365,https://apply.workable.com/virtual-staff-365
-Careers at VirtualStaffing.com,virtualstaffing,https://apply.workable.com/virtualstaffing
 VirtueStaff,virtuestaff,https://apply.workable.com/virtuestaff
 VirtuHire,virtuhire,https://apply.workable.com/virtuhire
 Virtusa Polaris,virtusa-polaris,https://apply.workable.com/virtusa-polaris

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -580,6 +580,9 @@ CONFIGS: dict[str, dict[str, Any]] = {
     "darwinbox": {
         "scraper": DarwinboxScraper,
         "slug": lambda r: _slug_col(r) or (r.get("name") or "").strip() or None,
+        "kwargs": lambda r: {
+            "company_name": (r.get("name") or "").strip() or None,
+        },
         "csv": "ats-companies/darwinbox.csv",
         "output": "darwinbox/jobs.csv",
     },

--- a/src/ats_scrapers/scrapers/darwinbox.py
+++ b/src/ats_scrapers/scrapers/darwinbox.py
@@ -57,31 +57,57 @@ _TYPE_MAP: dict[str, EmploymentType] = {
     "seasonal": "TEMPORARY",
 }
 _COUNTRY_METADATA = {
+    "argentina": ("AR", "South America"),
     "australia": ("AU", "Oceania"),
+    "austria": ("AT", "Europe"),
     "bahrain": ("BH", "Asia"),
     "bangladesh": ("BD", "Asia"),
+    "belgium": ("BE", "Europe"),
+    "brazil": ("BR", "South America"),
     "cambodia": ("KH", "Asia"),
+    "canada": ("CA", "North America"),
+    "chile": ("CL", "South America"),
     "china": ("CN", "Asia"),
+    "colombia": ("CO", "South America"),
+    "czech republic": ("CZ", "Europe"),
+    "denmark": ("DK", "Europe"),
+    "finland": ("FI", "Europe"),
+    "france": ("FR", "Europe"),
+    "germany": ("DE", "Europe"),
     "hong kong": ("HK", "Asia"),
     "india": ("IN", "Asia"),
     "indonesia": ("ID", "Asia"),
+    "ireland": ("IE", "Europe"),
+    "italy": ("IT", "Europe"),
     "japan": ("JP", "Asia"),
     "kuwait": ("KW", "Asia"),
     "malaysia": ("MY", "Asia"),
+    "mexico": ("MX", "North America"),
     "myanmar": ("MM", "Asia"),
     "nepal": ("NP", "Asia"),
+    "netherlands": ("NL", "Europe"),
     "new zealand": ("NZ", "Oceania"),
+    "norway": ("NO", "Europe"),
     "oman": ("OM", "Asia"),
     "pakistan": ("PK", "Asia"),
     "philippines": ("PH", "Asia"),
+    "poland": ("PL", "Europe"),
+    "portugal": ("PT", "Europe"),
     "qatar": ("QA", "Asia"),
     "saudi arabia": ("SA", "Asia"),
     "singapore": ("SG", "Asia"),
+    "south africa": ("ZA", "Africa"),
     "south korea": ("KR", "Asia"),
+    "spain": ("ES", "Europe"),
     "sri lanka": ("LK", "Asia"),
+    "sweden": ("SE", "Europe"),
+    "switzerland": ("CH", "Europe"),
     "taiwan": ("TW", "Asia"),
     "thailand": ("TH", "Asia"),
     "united arab emirates": ("AE", "Asia"),
+    "united kingdom": ("GB", "Europe"),
+    "united states": ("US", "North America"),
+    "united states of america": ("US", "North America"),
     "vietnam": ("VN", "Asia"),
 }
 
@@ -103,6 +129,27 @@ class DarwinboxScraper(BaseScraper):
         "Content-Type": "application/json",
         "X-Requested-With": "XMLHttpRequest",
     }
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        include_descriptions: bool = True,
+        proxy: str | None = None,
+        company_name: str | None = None,
+    ) -> None:
+        super().__init__(
+            company_slug,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        self.company_name = (
+            company_name.strip()
+            if isinstance(company_name, str) and company_name.strip()
+            else None
+        )
 
     async def afetch(self) -> list[Job]:
         tenant, tld = self._resolve_tenant()
@@ -247,7 +294,7 @@ class DarwinboxScraper(BaseScraper):
         return Job(
             url=HttpUrl(f"{base_url}/ms/candidate/careers/{ats_id}"),
             title=title,
-            company=tenant,
+            company=self.company_name or tenant,
             ats_type=ATSType.DARWINBOX,
             ats_id=ats_id,
             location=_format_location(item),

--- a/tests/test_darwinbox.py
+++ b/tests/test_darwinbox.py
@@ -145,6 +145,15 @@ def test_parses_current_alljobs_payload(fake_httpcloak) -> None:
     assert calls[0]["timeout"] == 30_000
 
 
+def test_uses_catalog_company_name(fake_httpcloak) -> None:
+    responses, _calls = fake_httpcloak
+    responses.append(FakeResponse(payload([listing()])))
+
+    [result] = DarwinboxScraper("airtel", company_name="Airtel").fetch()
+
+    assert result.company == "Airtel"
+
+
 def test_com_tenant_uses_com_host(fake_httpcloak) -> None:
     responses, calls = fake_httpcloak
     responses.append(FakeResponse(payload([])))
@@ -208,6 +217,31 @@ def test_preserves_zero_experience_and_normalizes_country_and_naive_time(
     assert result.experience == 0
     assert result.posted_at is not None
     assert result.posted_at.tzinfo is UTC
+
+
+@pytest.mark.parametrize(
+    ("country", "country_iso", "region"),
+    [
+        ("Canada", "CA", "North America"),
+        ("United Kingdom", "GB", "Europe"),
+        ("United States", "US", "North America"),
+    ],
+)
+def test_normalizes_global_countries(
+    fake_httpcloak,
+    country: str,
+    country_iso: str,
+    region: str,
+) -> None:
+    responses, _calls = fake_httpcloak
+    item = listing()
+    item["country"] = country
+    responses.append(FakeResponse(payload([item])))
+
+    [result] = DarwinboxScraper("airtel").fetch()
+
+    assert result.country_iso == country_iso
+    assert result.region == region
 
 
 def test_skips_rows_missing_identity(fake_httpcloak) -> None:

--- a/tests/test_run_pipeline_guards.py
+++ b/tests/test_run_pipeline_guards.py
@@ -169,6 +169,9 @@ def test_provider_slug_normalizers_match_current_company_csv_shape() -> None:
     }
     assert runner.CONFIGS["darwinbox"]["scraper"] is runner.DarwinboxScraper
     assert runner.CONFIGS["darwinbox"]["slug"](darwinbox_row) == "pwc.com"
+    assert runner.CONFIGS["darwinbox"]["kwargs"](darwinbox_row) == {
+        "company_name": "PwC Asia"
+    }
     assert runner.CONFIGS["darwinbox"]["output"] == "darwinbox/jobs.csv"
 
     moka_row = {


### PR DESCRIPTION
## Summary
- add 12 credential-free Darwinbox tenants validated against the live `alljobs` API
- pass catalog company names into `DarwinboxScraper` instead of emitting tenant slugs
- normalize major European, North American, South American, and African country labels
- remove two dead Virtual Staffing Solutions feeds after confirming Pinpoint and Workable both return zero jobs

## Live validation
- 897 live jobs across 12 employers
- 897 unique global IDs; 0 cross-tenant duplicates
- 877 Asia, 15 North America, 5 Europe
- 868/897 jobs include descriptions (96.8%)
- 888/897 jobs were posted within the last 365 days (99.0%)
- 0 unknown country codes and 0 incorrect company names

Rejected during discovery: empty/login-only tenants, opaque identities, MoEngage because its Darwinbox feed only exposed stale 2022-2023 jobs, Greenko because most jobs were old/incomplete, and Winjit because only 1/4 jobs had descriptions.

## Tests
- `uv run --extra test pytest -q tests/test_darwinbox.py tests/test_run_pipeline_guards.py` (50 passed)
- `uv run --extra test pytest -q` (1657 passed, 2 skipped, 29 deselected)
- `uv run ruff check .`
- live API validation of all 12 added tenants

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand Darwinbox coverage with 12 validated employers. Improve data quality by using catalog company names and broader country normalization; remove two dead Virtual Staffing Solutions feeds.

- **New Features**
  - Added 12 credential-free Darwinbox tenants validated via live `alljobs` API.
  - Expanded country normalization across Europe, North America, South America, and Africa.

- **Refactors**
  - `DarwinboxScraper` now accepts `company_name`; `run_pipeline.py` passes catalog names to override tenant slugs in output.
  - Removed `Virtual Staffing Solutions` from `pinpoint.csv` and `workable.csv` after confirming zero jobs.
  - Added tests for company name override and global country mapping.

<sup>Written for commit 32fc44fbf39161f88c95f82807b3bf826367d2bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Expands Darwinbox coverage and improves normalized employer and country metadata.
- Adds 12 validated Darwinbox tenants and removes two inactive Virtual Staffing Solutions feeds.
- Passes canonical catalog company names into Darwinbox job records.
- Adds country and region mappings for Europe, the Americas, and Africa.
- Extends tests for company-name propagation, country normalization, and pipeline configuration.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete correctness or security defects identified.

The constructor remains compatible with BaseScraper and existing callers, catalog names flow through established runner conventions, and the added country mappings conform to the shared schema and sibling adapters.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the metrics harness validate\_darwinbox\_live.py to run the code-execution proof-of-work for the pull request.
- Captured the darwinbox-live-pipeline.log, which records the exact command, working directory, exit code, progress, and final live totals.
- Saved the darwinbox-live-metrics.json, which contains reproducible full catalog and added-tenant metrics.
- Compared before/after captures against HEAD using the same live rows, showing 897 added-scope mismatches in the prior behavior and 0 mismatches relative to HEAD.

<a href="https://app.greptile.com/trex/runs/16154501/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/ats_scrapers/scrapers/darwinbox.py | Adds an optional company-name override and valid canonical country mappings while preserving the complete BaseScraper constructor contract. |
| scripts/run_pipeline.py | Supplies canonical catalog names to DarwinboxScraper consistently with established multi-tenant scraper configurations. |
| ats-companies/darwinbox.csv | Adds 12 Darwinbox tenants with populated, distinct names, slugs, and careers URLs. |
| ats-companies/pinpoint.csv | Removes the inactive Virtual Staffing Solutions Pinpoint tenant. |
| ats-companies/workable.csv | Removes the inactive Virtual Staffing Solutions Workable tenant. |
| tests/test_darwinbox.py | Covers catalog company-name propagation and representative global country normalization. |
| tests/test_run_pipeline_guards.py | Verifies Darwinbox pipeline configuration passes the catalog company name. |

<sub>Reviews (1): Last reviewed commit: ["Expand Darwinbox coverage with validated..."](https://github.com/kalil0321/ats-scrapers/commit/32fc44fbf39161f88c95f82807b3bf826367d2bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47840511)</sub>

<!-- /greptile_comment -->