### PR TITLE
feat(successfactors): add 24 validated legacy tenants

### DIFF
--- a/ats-companies/successfactors.csv
+++ b/ats-companies/successfactors.csv
@@ -628,7 +628,6 @@ the University of Cincinnati,jobs,https://jobs.uc.edu
 Voith,jobs,https://jobs.voith.com
 Work for the City of Vancouver — Do your best work here,jobs,https://jobs.vancouver.ca
 water-link,jobs,https://jobs.water-link.be
-Customer Service Jobs at Foundever®,jobs,https://jobs.sitel.com
 Careers and Job Opportunities,jobs,https://jobs.vistaprint.com
 Tetra Pak,jobs,https://jobs.tetrapak.com
 Trabaja en Volaris,jobs,https://jobs.volaris.com
@@ -1092,7 +1091,6 @@ Jobs at Bourns,bournsinc,https://jobs.bourns.com
 Careers | BT Group Plc,britisht01P1,https://jobs.bt.com
 BWB,berlinerwa,https://jobs.bwb.de
 Canadalife,thegreatweP2,https://jobs.canadalife.com
-Capgemini Careers,jobs,https://jobs.capgemini.com
 Jobs at Cargill,cargill,https://jobs.cargill.com
 Central Bedfordshire Council Jobs,centralbed,https://jobs.centralbedfordshire.gov.uk
 Careers at City Edge Developments,cityedgede,https://jobs.cityedgedevelopments.com
@@ -1302,5 +1300,29 @@ Hager Group,HagerGroup,https://career012.successfactors.eu/career?company=HagerG
 Mohammed VI Polytechnic University,ump,https://career2.successfactors.eu/career?company=ump
 VFS Global,vfsglobalsP,https://career2.successfactors.eu/career?company=vfsglobalsP
 New Development Bank,newdevelop,https://career15.sapsf.cn/career?company=newdevelop
+Ahold Delhaize USA,ADPROD,https://career2.successfactors.eu/career?company=ADPROD
+Wipro,wiprolimitP2,https://career55.sapsf.eu/career?company=wiprolimitP2
+Deloitte India,deloittesh,https://career44.sapsf.com/career?company=deloittesh
+Capgemini,capgemitecP3,https://career5.successfactors.eu/career?company=capgemitecP3
+HSBC,hsbcholdin,https://career2.successfactors.eu/career?company=hsbcholdin
+Atlas Copco Group,atlascopcoP,https://career5.successfactors.eu/career?company=atlascopcoP
+Dycom Industries,dycomindus,https://career41.sapsf.com/career?company=dycomindus
+Serco,SercoGroup,https://career2.successfactors.eu/career?company=SercoGroup
+Pandora,pandoraas,https://career2.successfactors.eu/career?company=pandoraas
+State of Indiana,indianaoff,https://career8.successfactors.com/career?company=indianaoff
+Under Armour,ua,https://career8.successfactors.com/career?company=ua
+Boehringer Ingelheim,BoehringerPRD,https://career5.successfactors.eu/career?company=BoehringerPRD
+Sobeys,Sobeys,https://career4.successfactors.com/career?company=Sobeys
+Ericsson,Ericsson,https://career2.successfactors.eu/career?company=Ericsson
+Foundever,SitelPROD,https://career4.successfactors.com/career?company=SitelPROD
+Owens Corning,OwensCorning,https://career8.successfactors.com/career?company=OwensCorning
+Kerry,kerryluxemP,https://career5.successfactors.eu/career?company=kerryluxemP
+TELUS,TelusP,https://career17.sapsf.com/career?company=TelusP
+Charles River Laboratories,charlesrivP,https://career4.successfactors.com/career?company=charlesrivP
+CPKC,CPR,https://career4.successfactors.com/career?company=CPR
+BCD Travel,bcdtravels,https://career2.successfactors.eu/career?company=bcdtravels
+Percassi,percassire,https://career55.sapsf.eu/career?company=percassire
+Hospital Israelita Albert Einstein,C0001240283P,https://career8.successfactors.com/career?company=C0001240283P
+Dynatrace,dynatracel,https://career41.sapsf.com/career?company=dynatracel
 National Agriculture Development,133723,https://133723.jobs2web.com
 TIM Brasil,timbrasil,https://timbrasil.jobs2web.com

--- a/docs/DISCOVERY_RULES.md
+++ b/docs/DISCOVERY_RULES.md
@@ -235,12 +235,18 @@ Validation:
 
 Validation:
 
-1. Validate the exact host from the CSV.
-2. Fetch `https://{host}/sitemal.xml`.
-3. Require HTTP 200.
-4. Parse XML/RSS successfully.
-5. Require at least one `<item>` or live job entry.
-6. Reject stage, QA, sandbox, and test hosts even when they return XML.
+1. Identify whether the row is a Recruiting Marketing host or a legacy
+   Recruiting Management URL with a `company` query parameter.
+2. For Recruiting Marketing, fetch `https://{host}/sitemal.xml`, parse RSS,
+   and require at least one `<item>`.
+3. For legacy Recruiting Management, call `/career` with the exact `company`
+   ID, `career_ns=job_listing_summary`, and `resultType=XML`.
+4. Require HTTP 200, a `<Job-Listing>` root, and at least one `<Job>` with a
+   non-empty `ReqId`, `JobTitle`, and real `Job-Description`.
+5. Deduplicate legacy rows by the stable `company` ID and remove superseded
+   empty Recruiting Marketing feeds for the same employer.
+6. Reject login-only responses, generic career shells, stage, QA, sandbox,
+   and test tenants even when they return HTTP 200.
 
 ### Recruitee
 

--- a/src/ats_scrapers/scrapers/successfactors.py
+++ b/src/ats_scrapers/scrapers/successfactors.py
@@ -180,6 +180,7 @@ class SuccessFactorsScraper(BaseScraper):
         parsed_feed = urlparse(feed_url)
         feed_host = parsed_feed.hostname or ""
         company = self.company_name or company_id
+        day_first_dates = _legacy_dates_are_day_first(root)
         jobs: list[Job] = []
         seen: set[str] = set()
         for item in root.findall("./Job"):
@@ -224,7 +225,8 @@ class SuccessFactorsScraper(BaseScraper):
                     requisition_id=requisition_id,
                     description=description,
                     posted_at=_parse_legacy_date(
-                        item.findtext("Posted-Date")
+                        item.findtext("Posted-Date"),
+                        day_first=day_first_dates,
                     ),
                     fetched_at=datetime.now(UTC),
                 )
@@ -425,10 +427,33 @@ def _parse_pubdate(value: object) -> datetime | None:
         return None
 
 
-def _parse_legacy_date(value: object) -> datetime | None:
+def _legacy_dates_are_day_first(root: ET.Element) -> bool:
+    day_first_votes = 0
+    month_first_votes = 0
+    for value in root.iterfind("./Job/Posted-Date"):
+        parts = (value.text or "").strip().split("/")
+        if len(parts) != 3:
+            continue
+        try:
+            first, second = int(parts[0]), int(parts[1])
+        except ValueError:
+            continue
+        if first > 12 >= second:
+            day_first_votes += 1
+        elif second > 12 >= first:
+            month_first_votes += 1
+    return day_first_votes > month_first_votes
+
+
+def _parse_legacy_date(
+    value: object,
+    *,
+    day_first: bool = False,
+) -> datetime | None:
     if not isinstance(value, str) or not value.strip():
         return None
-    for date_format in ("%m/%d/%Y", "%Y-%m-%d"):
+    slash_format = "%d/%m/%Y" if day_first else "%m/%d/%Y"
+    for date_format in (slash_format, "%Y-%m-%d"):
         try:
             return datetime.strptime(value.strip(), date_format).replace(
                 tzinfo=UTC

--- a/tests/test_successfactors.py
+++ b/tests/test_successfactors.py
@@ -157,6 +157,8 @@ def test_legacy_catalog_urls_use_production_hosts() -> None:
             (
                 ".successfactors.com",
                 ".successfactors.eu",
+                ".sapsf.com",
+                ".sapsf.eu",
                 ".sapsf.cn",
             )
         )
@@ -292,6 +294,48 @@ def test_legacy_feed_ignores_invalid_posted_date(httpx_mock) -> None:
     )
     jobs = SuccessFactorsScraper(LEGACY_CAREER_URL).fetch()
     assert jobs[0].posted_at is None
+
+
+def test_legacy_feed_infers_day_first_dates(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=LEGACY_FEED_URL,
+        text=_legacy_feed([
+            _legacy_item(
+                requisition_id="day-first-signal",
+                posted_date="27/07/2026",
+            ),
+            _legacy_item(
+                requisition_id="ambiguous",
+                posted_date="08/07/2026",
+            ),
+        ]),
+    )
+    jobs = SuccessFactorsScraper(LEGACY_CAREER_URL).fetch()
+    assert [job.posted_at.isoformat() for job in jobs if job.posted_at] == [
+        "2026-07-27T00:00:00+00:00",
+        "2026-07-08T00:00:00+00:00",
+    ]
+
+
+def test_legacy_feed_keeps_month_first_dates(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=LEGACY_FEED_URL,
+        text=_legacy_feed([
+            _legacy_item(
+                requisition_id="month-first-signal",
+                posted_date="07/27/2026",
+            ),
+            _legacy_item(
+                requisition_id="ambiguous",
+                posted_date="07/08/2026",
+            ),
+        ]),
+    )
+    jobs = SuccessFactorsScraper(LEGACY_CAREER_URL).fetch()
+    assert [job.posted_at.isoformat() for job in jobs if job.posted_at] == [
+        "2026-07-27T00:00:00+00:00",
+        "2026-07-08T00:00:00+00:00",
+    ]
 
 
 def test_legacy_feed_removes_invalid_empty_name_elements(httpx_mock) -> None:


### PR DESCRIPTION
## What changed

- add 24 live SuccessFactors legacy Recruiting Management tenants
- replace the superseded Capgemini and Foundever Recruiting Marketing rows
- infer DD/MM versus MM/DD dates from unambiguous dates across each legacy feed
- document the legacy XML discovery and validation rules

## Discovery funnel

- 718 public urlscan observations across supported SuccessFactors domains
- 234 company IDs absent from the catalog
- 147 company IDs returned non-empty legacy XML feeds
- 24 tenants passed the final identity, quality, and published-overlap checks

## Live validation

- 32,408 current jobs
- 32,408 unique global IDs; 0 duplicate IDs
- 32,264 jobs with descriptions (99.56%)
- 28,065 descriptions contain at least 100 characters
- 11,880 jobs expose posting dates; 11,366 are within 365 days
- 0 future-dated jobs after the date-orientation fix
- 0 generic login/password-reset titles
- 0 company-name mismatches

The selected jobs have zero exact normalized title + description fingerprint
matches in the current 290,728-row published SuccessFactors snapshot. The
removed Capgemini Recruiting Marketing feed currently contributes one row and
the removed Foundever feed contributes none, so the expected net dataset gain
is approximately 32,407 rows on the next pipeline run.

## Checks

- `uv run --extra test pytest -q` — 1,684 passed, 2 skipped, 31 deselected
- focused SuccessFactors and pipeline guard tests — 59 passed
- `uv run ruff check .`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 24 validated legacy SuccessFactors Recruiting Management tenants and replaces superseded Capgemini and Foundever Recruiting Marketing rows with stable legacy feeds. Improves date parsing by inferring DD/MM vs MM/DD per tenant; expect ~32k net new jobs on the next run.

- **New Features**
  - Added 24 legacy tenants to `ats-companies/successfactors.csv`; switched Capgemini to `capgemitecP3` and Foundever to `SitelPROD`.
  - Legacy date parser infers DD/MM vs MM/DD from unambiguous `Posted-Date` samples per feed.
  - Accept `.sapsf.com` and `.sapsf.eu` production hosts.
  - Documented legacy XML discovery, validation, and deduplication rules.

- **Bug Fixes**
  - Eliminates future-dated postings by applying per-feed date orientation.

<sup>Written for commit 5f1cc83e2339fd4d732277ef3989ea3c02a5bd64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds 24 validated legacy SuccessFactors tenants and replaces two superseded Recruiting Marketing entries.
- Infers a feed-wide day-first or month-first orientation from unambiguous legacy posting dates.
- Expands production-host validation to include `.sapsf.com` and `.sapsf.eu`.
- Documents legacy tenant discovery and validation requirements.
- Adds focused tests for both date orientations.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code-triggered failures identified.

The new tenant URL forms route through the existing legacy feed path, and the date-orientation logic consistently applies the inferred format while preserving ISO parsing and invalid-date handling.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The successfactors-live-validation.py harness was generated to derive changed catalog rows, perform real HTTP requests, invoke the runtime parser, and record status, message, counts, date samples, and errors.
- The end-to-end live validation was executed using the harness to exercise the catalog changes against the live service.
- The before-state log captures the base runtime, showing 24 HTTP 200 OK responses, 0 parsed jobs, and 24 parser errors.
- The after-state log captures the head runtime after changes, showing 23 HTTP 200 OK non-empty feeds, 7,657 parsed/unique jobs, 2,880 posting dates, and 0 future dates.

<a href="https://app.greptile.com/trex/runs/16161018/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/ats_scrapers/scrapers/successfactors.py | Adds feed-wide legacy date-orientation inference while retaining ISO-date parsing and existing job normalization. |
| ats-companies/successfactors.csv | Adds 24 legacy tenant URLs and replaces the superseded Capgemini and Foundever Recruiting Marketing rows. |
| tests/test_successfactors.py | Extends production-host validation and covers day-first and month-first legacy date inference. |
| docs/DISCOVERY_RULES.md | Documents distinct discovery and validation procedures for Recruiting Marketing and legacy Recruiting Management feeds. |

<sub>Reviews (1): Last reviewed commit: ["Expand SuccessFactors legacy coverage"](https://github.com/kalil0321/ats-scrapers/commit/5f1cc83e2339fd4d732277ef3989ea3c02a5bd64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47852305)</sub>

<!-- /greptile_comment -->