### PR TITLE
Expand Oracle tenant coverage

### DIFF
--- a/ats-companies/oracle.csv
+++ b/ats-companies/oracle.csv
@@ -1045,3 +1045,39 @@ SCV Water,fa-epmn-saasfaprod1,https://fa-epmn-saasfaprod1.fa.ocs.oraclecloud.com
 Hermès,fa-eoic-saasfaprod1,https://fa-eoic-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
 Mapei,fa-elhu-saasfaprod1,https://fa-elhu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
 NMIMS,fa-elxu-saasfaprod1/cx_3013,https://fa-elxu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3013
+A49,emit/a49,https://emit.fa.ca3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1004
+Albertsons Companies,eofd/cx,https://eofd.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX
+Alithya,alithya,https://careers.alithya.com/hcmUI/CandidateExperience/en/sites/AlithyaCareersCarrieres
+Amneal India,hcfa/amneal-india,https://hcfa.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/AmnealIndiaCareers
+An Post,fa-ewnd-saasfaprod1,https://fa-ewnd-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+Avient,fa-eqzh-saasfaprod1,https://fa-eqzh-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/Avient
+Baptist Health Care,fa-etrr-saasfaprod1,https://fa-etrr-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_6001
+BNY,eofe/cx_1001,https://eofe.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+CHA,fa-ewik-saasfaprod1,https://fa-ewik-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Champlain College,champlain-ibumjb,https://champlain-ibumjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Cherokee Federal,ibtcjb/careers,https://ibtcjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/careers
+Chicago Park District,fa-esjf-saasfaprod1,https://fa-esjf-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Davie,fa-ewde-saasfaprod1,https://fa-ewde-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+ELCA,iaaras/cx_4,https://iaaras.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_4
+Gaston County Schools,eobs/cx_1001,https://eobs.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Goldman Sachs Lateral Hiring,hdpc/lateralhiring,https://hdpc.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/LateralHiring
+Gruppo BCC Iccrea,fa-exnq-saasfaprod1,https://fa-exnq-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Hard Rock Hotel & Casino Tulsa,ejvp/cx_6001,https://ejvp.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_6001
+Henner,henner,https://talents.henner.com/hcmUI/CandidateExperience/fr/sites/CX_5
+Hilton,efet/cx_1009,https://efet.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1009
+IOM,fa-evlj-saasfaprod1/cx_1,https://fa-evlj-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+KIK Consumer Products,edwa/cx_2,https://edwa.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Lutech,edsv/cx_1001,https://edsv.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Mahou San Miguel,fa-exox-saasfaprod1,https://fa-exox-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001
+Meezan Bank,fa-ewvh-saasfaprod1,https://fa-ewvh-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3002
+Mission Support & Test Services,ewij/cx_2,https://ewij.fa.us8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+NOV,egay/cx_2001,https://egay.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2001
+OPEX,cbcz/cx_1,https://cbcz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Penske,fa-euyk-saasfaprod1/penske,https://fa-euyk-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/PenskeCareers
+RAKBANK,iacqey/cx_1,https://iacqey.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Sandhill Cove,eexs/cx_9003,https://eexs.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_9003
+Schroders,ekbq/cx_2,https://ekbq.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2
+Solstice Advanced Materials,ibzdjb/solstice,https://ibzdjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/SolsticeAdvancedMaterials
+South Lanarkshire Council,fa-euuc-saasfaprod1/cx_1,https://fa-euuc-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
+Staples,fa-exhh-saasfaprod1/staplesinc,https://fa-exhh-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/StaplesInc
+UNITEC,fa-ewts-saasfaprod1/unitec,https://fa-ewts-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/es/sites/unitec


### PR DESCRIPTION
## Summary
- add 36 verified Oracle CandidateExperience sites
- cover US, Europe, Canada, India, Mexico, Pakistan, and UAE employers
- keep one catalog-only PR for the Oracle provider

## Live validation
- discovered from 1,198 recent public urlscan observations
- probed 74 catalog-missing host/site identities against the public `recruitingCEJobRequisitions` API
- rejected test/dev, empty, blocked, ambiguous, and duplicate aliases
- selected sites returned 19,094 current jobs; estimated 10,192 are net-new versus the published Oracle snapshot
- 18,928/19,094 dated jobs are within 365 days; 0 future-dated
- sampled 2 detail records per site: 72/72 returned real descriptions (970-9,693 characters)

## Tests
- `uv run ruff check src/ats_scrapers/scrapers/oracle.py scripts/run_pipeline.py tests/test_scrapers_extra.py tests/test_run_pipeline_guards.py`
- `uv run pytest -q` (1684 passed, 2 skipped, 31 deselected)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 36 verified Oracle `CandidateExperience` tenants to `ats-companies/oracle.csv`, expanding coverage across the US, Europe, Canada, India, Mexico, Pakistan, and the UAE. Catalog-only update for the Oracle provider; sites were validated via the public `recruitingCEJobRequisitions` API and are expected to surface ~10k net-new jobs.

<sup>Written for commit 18f3b356ab21f610eb6a11a9b85b03737b5ce699. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

