### PR TITLE
Expand Greenhouse tenant coverage

### DIFF
--- a/ats-companies/greenhouse.csv
+++ b/ats-companies/greenhouse.csv
@@ -6018,3 +6018,15 @@ Yuvo Health,yuvohealthllc,https://job-boards.greenhouse.io/yuvohealthllc
 Zafin,zafinlabsamericasinc,https://job-boards.greenhouse.io/zafinlabsamericasinc
 Zaviant,zaviant,https://job-boards.greenhouse.io/zaviant
 Zest AI,zestai,https://job-boards.greenhouse.io/zestai
+Acadian Asset Management,acadianassetmanagementllc,https://job-boards.greenhouse.io/acadianassetmanagementllc
+ACT Group,testendouble,https://job-boards.greenhouse.io/testendouble
+Aircall,aircallioinc,https://job-boards.greenhouse.io/aircallioinc
+BTG Pactual LA,btgpactualla,https://job-boards.greenhouse.io/btgpactualla
+CD Baby,cdbabyjobs,https://job-boards.greenhouse.io/cdbabyjobs
+Coinbase,coinbase,https://job-boards.greenhouse.io/coinbase
+Eltropy,eltropyinc,https://job-boards.greenhouse.io/eltropyinc
+International Business University (Outside Canada),ibuglobal,https://job-boards.greenhouse.io/ibuglobal
+Lendz Financial,lendzfinancial,https://job-boards.greenhouse.io/lendzfinancial
+Materiom,materiom,https://job-boards.greenhouse.io/materiom
+Wizeline,wizeline,https://job-boards.greenhouse.io/wizeline
+Wolt - Hebrew,woltisrael,https://job-boards.greenhouse.io/woltisrael


### PR DESCRIPTION
## Summary
- add 12 verified Greenhouse boards
- include US, Europe, Israel, India, Latin America, and Canada-facing employers
- keep one catalog-only PR for the Greenhouse provider

## Live validation
- checked 31,185 latest Common Crawl URLs, 2,318 recent urlscan observations, and an additional historical crawl page
- live-probed every catalog-missing board token against the public Greenhouse API
- rejected dead/empty boards, private/internal boards, stale contractor pools, training programs, and malformed tokens
- selected boards return 372 jobs; all 372 IDs are absent from the published Greenhouse dataset
- 372/372 have descriptions over 100 characters, locations, and dates
- 337/372 dates are within 365 days; 0 future dates and 0 duplicate IDs

## Tests
- `uv run pytest -q` (1684 passed, 2 skipped, 31 deselected)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added 12 verified Greenhouse job boards to `ats-companies/greenhouse.csv` to expand global coverage and surface 372 previously missing jobs.

- **New Features**
  - Coverage spans US, Europe, Israel, India, LATAM, and Canada-facing orgs; examples: Coinbase, Aircall, Wizeline, Wolt Israel.
  - Verified via 31,185 Common Crawl URLs, 2,318 urlscan observations, and live Greenhouse API; excluded dead/private/stale boards.
  - 372 new postings with valid descriptions, locations, and dates; 337 within 365 days; no duplicates or future dates.
  - Tests pass: 1684 passed, 2 skipped.

<sup>Written for commit cd5bbbc6cea1d92dfe9cd7fc5461687d156f9a2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

