### PR TITLE
Expand SmartRecruiters tenant coverage

### DIFF
--- a/ats-companies/smartrecruiters.csv
+++ b/ats-companies/smartrecruiters.csv
@@ -2643,3 +2643,106 @@ Zinkworks,zinkworks,https://careers.smartrecruiters.com/zinkworks
 Zoic Studios,zoicstudios,https://careers.smartrecruiters.com/zoicstudios
 Zuum,zuum,https://careers.smartrecruiters.com/zuum
 Zycron,zycron,https://careers.smartrecruiters.com/zycron
+A.T.U Auto-Teile-Unger,ATUAuto-Teile-Unger,https://careers.smartrecruiters.com/ATUAuto-Teile-Unger
+Abramson Labor Group,AbramsonLaborGroup,https://careers.smartrecruiters.com/AbramsonLaborGroup
+Accesa,ACCESA,https://careers.smartrecruiters.com/ACCESA
+Ace & Tate,AceTate,https://careers.smartrecruiters.com/AceTate
+ACT-ON,ACT-ON,https://careers.smartrecruiters.com/ACT-ON
+AFCA,AFCA,https://careers.smartrecruiters.com/AFCA
+AIR Communities,AIRCommunities,https://careers.smartrecruiters.com/AIRCommunities
+ALPADIA Language Schools SA,AlpadiaLanguageSchoolsSA,https://careers.smartrecruiters.com/AlpadiaLanguageSchoolsSA
+Ardentis,Ardentis1,https://careers.smartrecruiters.com/Ardentis1
+Arvida,Arvida,https://careers.smartrecruiters.com/Arvida
+ASICS,ASICS,https://careers.smartrecruiters.com/ASICS
+ATEXIS,ATEXIS,https://careers.smartrecruiters.com/ATEXIS
+ATLAS,ATLAS4,https://careers.smartrecruiters.com/ATLAS4
+Canadian Bank Note Company,CanadianBankNoteCompany,https://careers.smartrecruiters.com/CanadianBankNoteCompany
+Care Partners,CarePartners1,https://careers.smartrecruiters.com/CarePartners1
+carsales,carsales,https://careers.smartrecruiters.com/carsales
+CEDA,CEDA1,https://careers.smartrecruiters.com/CEDA1
+Chandos,Chandos,https://careers.smartrecruiters.com/Chandos
+Christ's Church of the Valley,ChristsChurchOfTheValley,https://careers.smartrecruiters.com/ChristsChurchOfTheValley
+Circle Logistics,CircleLogistics1,https://careers.smartrecruiters.com/CircleLogistics1
+City and County Healthcare Group Ltd,CityCountyHealthcareGroupLtd,https://careers.smartrecruiters.com/CityCountyHealthcareGroupLtd
+Clifford Chance,CliffordChance,https://careers.smartrecruiters.com/CliffordChance
+Clinique Saint-Jean - Kliniek Sint-Jan,CliniqueSaint-Jean,https://careers.smartrecruiters.com/CliniqueSaint-Jean
+Colisée France,ColiseeFrance,https://careers.smartrecruiters.com/ColiseeFrance
+"Crown Innovations, Inc.",CrownInnovationsInc,https://careers.smartrecruiters.com/CrownInnovationsInc
+Crystal Clear Building Services,CrystalClearBuildingServices,https://careers.smartrecruiters.com/CrystalClearBuildingServices
+Deciphera Pharmaceuticals,DecipheraPharmaceuticals1,https://careers.smartrecruiters.com/DecipheraPharmaceuticals1
+Deloitte Netherlands,deloittenetherlands,https://careers.smartrecruiters.com/deloittenetherlands
+Devexperts,Devexperts,https://careers.smartrecruiters.com/Devexperts
+ERIC BOMPARD,ERICBOMPARD,https://careers.smartrecruiters.com/ERICBOMPARD
+Etihad Airways,EtihadAirways5,https://careers.smartrecruiters.com/EtihadAirways5
+Eurofiber,Eurofiber1,https://careers.smartrecruiters.com/Eurofiber1
+Facility Performance Consulting Limited,FacilityPerformanceConsultingLimited,https://careers.smartrecruiters.com/FacilityPerformanceConsultingLimited
+fischer Group,FischerGroup,https://careers.smartrecruiters.com/FischerGroup
+Frette,Frette,https://careers.smartrecruiters.com/Frette
+Generix Group,GenerixGroup,https://careers.smartrecruiters.com/GenerixGroup
+Grupo Mariposa,GrupoMariposa1,https://careers.smartrecruiters.com/GrupoMariposa1
+Harley Therapy,HarleyTherapy,https://careers.smartrecruiters.com/HarleyTherapy
+Haufe Group,HaufeGroup,https://careers.smartrecruiters.com/HaufeGroup
+Healthcare Australia,HealthcareAustralia1,https://careers.smartrecruiters.com/HealthcareAustralia1
+"Houston Engineering, Inc.",HoustonEngineeringInc,https://careers.smartrecruiters.com/HoustonEngineeringInc
+InPost,InPost,https://careers.smartrecruiters.com/InPost
+Integrated Dermatology,IntegratedDermatology,https://careers.smartrecruiters.com/IntegratedDermatology
+Jitterbit,Jitterbit,https://careers.smartrecruiters.com/Jitterbit
+JYSK Baltics,JYSKBaltics,https://careers.smartrecruiters.com/JYSKBaltics
+King and Moffatt,KingAndMoffatt,https://careers.smartrecruiters.com/KingAndMoffatt
+Kronospan,Kronospan,https://careers.smartrecruiters.com/Kronospan
+Labelium,Labelium,https://careers.smartrecruiters.com/Labelium
+LACROIX,LACROIX1,https://careers.smartrecruiters.com/LACROIX1
+LivCor LLC,LivCorLLC1,https://careers.smartrecruiters.com/LivCorLLC1
+"Lucid Hearing Holding Company, LLC",LucidHearingHoldingCompanyLLC,https://careers.smartrecruiters.com/LucidHearingHoldingCompanyLLC
+LVMH,LVMH2,https://careers.smartrecruiters.com/LVMH2
+McArthurGlen UK Ltd,McArthurGlenUKLtd1,https://careers.smartrecruiters.com/McArthurGlenUKLtd1
+Mission Critical Group,MissionCriticalGroup,https://careers.smartrecruiters.com/MissionCriticalGroup
+MUFG Investor Services,MUFGInvestorServices,https://careers.smartrecruiters.com/MUFGInvestorServices
+naturéO,natureO,https://careers.smartrecruiters.com/natureO
+NETZSCH Group,NETZSCHGroup,https://careers.smartrecruiters.com/NETZSCHGroup
+NEXTON,NEXTON,https://careers.smartrecruiters.com/NEXTON
+North40 Outfitters,North40Outfitters,https://careers.smartrecruiters.com/North40Outfitters
+OceanaGold,OceanaGold,https://careers.smartrecruiters.com/OceanaGold
+Oterra,Oterra1,https://careers.smartrecruiters.com/Oterra1
+Outpost VFX,OutpostVFX,https://careers.smartrecruiters.com/OutpostVFX
+Pact Group,PactGroup,https://careers.smartrecruiters.com/PactGroup
+Petit Bateau,PetitBateau,https://careers.smartrecruiters.com/PetitBateau
+PortmanDentex,PortmanDentex,https://careers.smartrecruiters.com/PortmanDentex
+Precoat Metals,PrecoatMetals,https://careers.smartrecruiters.com/PrecoatMetals
+ProMedia Group,ProMediaGroup,https://careers.smartrecruiters.com/ProMediaGroup
+Red Wing Shoe Company,RedWingShoeCompany,https://careers.smartrecruiters.com/RedWingShoeCompany
+Rituals,Rituals1,https://careers.smartrecruiters.com/Rituals1
+ROCO,ROCO1,https://careers.smartrecruiters.com/ROCO1
+RTE,RTE1,https://careers.smartrecruiters.com/RTE1
+Septeo,Septeo,https://careers.smartrecruiters.com/Septeo
+Silvaco,Silvaco1,https://careers.smartrecruiters.com/Silvaco1
+Silverchain,Silverchain,https://careers.smartrecruiters.com/Silverchain
+SISLEY,SISLEY,https://careers.smartrecruiters.com/SISLEY
+SMAC,SMAC1,https://careers.smartrecruiters.com/SMAC1
+SMCP,SMCP,https://careers.smartrecruiters.com/SMCP
+Stanford Medicine Children's Health,StanfordMedicineChildrensHealth,https://careers.smartrecruiters.com/StanfordMedicineChildrensHealth
+Strukton Nederland,StruktonNederland,https://careers.smartrecruiters.com/StruktonNederland
+Summerset,Summerset1,https://careers.smartrecruiters.com/Summerset1
+SWARCO,SWARCO,https://careers.smartrecruiters.com/SWARCO
+Sysco GB,SyscoGB,https://careers.smartrecruiters.com/SyscoGB
+Teach Me Personnel LLC,TeachMePersonnelLLC,https://careers.smartrecruiters.com/TeachMePersonnelLLC
+Techland S.A.,TechlandSA,https://careers.smartrecruiters.com/TechlandSA
+Tessenderlo Group,TessenderloGroup,https://careers.smartrecruiters.com/TessenderloGroup
+The Yiros Shop,TheYirosShop,https://careers.smartrecruiters.com/TheYirosShop
+"Truck Centers, Inc.",TruckCentersInc,https://careers.smartrecruiters.com/TruckCentersInc
+UAP Inc.,UAPInc,https://careers.smartrecruiters.com/UAPInc
+UFF,UFF1,https://careers.smartrecruiters.com/UFF1
+Unit4,Unit44,https://careers.smartrecruiters.com/Unit44
+United Franchise Group,UnitedFranchiseGroup,https://careers.smartrecruiters.com/UnitedFranchiseGroup
+Universidad del Valle de Guatemala,UniversidadDelValleDeGuatemala,https://careers.smartrecruiters.com/UniversidadDelValleDeGuatemala
+Vattenfall,Vattenfall,https://careers.smartrecruiters.com/Vattenfall
+Vetoquinol,Vetoquinol,https://careers.smartrecruiters.com/Vetoquinol
+Villa Group,VillaGroup,https://careers.smartrecruiters.com/VillaGroup
+Village Green,VillageGreen1,https://careers.smartrecruiters.com/VillageGreen1
+Vosker,Vosker,https://careers.smartrecruiters.com/Vosker
+Walmart,Walmart30,https://careers.smartrecruiters.com/Walmart30
+WCG International Consultants Ltd.,WCGInternationalConsultantsLtd,https://careers.smartrecruiters.com/WCGInternationalConsultantsLtd
+"Wellmark, Inc.",WellmarkInc,https://careers.smartrecruiters.com/WellmarkInc
+Werner & Mertz GmbH,WernerMertzGmbH,https://careers.smartrecruiters.com/WernerMertzGmbH
+Whakarongorau Aotearoa,WhakarongorauAotearoa1,https://careers.smartrecruiters.com/WhakarongorauAotearoa1
+Williams Racing,WilliamsRacing,https://careers.smartrecruiters.com/WilliamsRacing


### PR DESCRIPTION
## Summary
- add 103 verified SmartRecruiters employers
- expand direct-employer coverage across Europe, North America, Australia/New Zealand, Latin America, Africa, and Asia
- keep one catalog-only PR for the SmartRecruiters provider

## Live validation
- extracted 2,010 unique company tokens from 5,766 recent Internet Archive CDX observations
- live-probed all 1,239 catalog-missing tokens against the official public postings API
- rejected empty, stale-heavy, sandbox, job-board, staffing-feed, confidential, and test-style tenants
- fully scraped the 103 selected employers: 11,996 current jobs
- all 11,996 IDs are absent from the published SmartRecruiters dataset; 0 internal or cross-company duplicate IDs
- 11,996/11,996 have locations and dates; 11,083 are within 365 days; 0 future dates
- sampled one detail per tenant: 103/103 returned a real description over 100 characters and a real apply URL

## Tests
- `uv run pytest -q` (1684 passed, 2 skipped, 31 deselected)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 103 verified SmartRecruiters employers to expand direct-employer coverage across Europe, North America, ANZ, Latin America, Africa, and Asia. This adds 11,996 current jobs with valid locations/dates and no ID collisions.

- **New Features**
  - Updated `ats-companies/smartrecruiters.csv` with 103 live-validated tenants.
  - Excluded sandbox, job-board, staffing, confidential, and test tenants to keep data clean.

<sup>Written for commit 6dddaadf863e4c3e4ac1e2a983c65f9a1c1076e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

