### PR TITLE
Add 35 validated iCIMS portals

### DIFF
--- a/ats-companies/icims.csv
+++ b/ats-companies/icims.csv
@@ -2054,3 +2054,38 @@ zenimax,zenimax,https://careers-zenimax.icims.com
 zs,zs,https://careers-zs.icims.com
 Council of Industry,zumtobel,https://careers-zumtobel.icims.com
 רשימת משרות,https://hebrewcareers-pepsico.icims.com,https://hebrewcareers-pepsico.icims.com
+Allied Universal,https://adminstartup-aus.icims.com,https://adminstartup-aus.icims.com
+Allied Universal,https://aujscareers-aus.icims.com,https://aujscareers-aus.icims.com
+Allied Universal,https://startup-aus.icims.com,https://startup-aus.icims.com
+Amivero,https://careers-amivero.icims.com,https://careers-amivero.icims.com
+Aptean,https://emea-aptean.icims.com,https://emea-aptean.icims.com
+Ascension Recruitment,https://ascensionjobs1-ascension.icims.com,https://ascensionjobs1-ascension.icims.com
+BCI Capital,https://external-bcicapital.icims.com,https://external-bcicapital.icims.com
+By Light HQ,https://jobs-bylight.icims.com,https://jobs-bylight.icims.com
+"Core Spaces, LLC",https://hiddencareers-corespaces.icims.com,https://hiddencareers-corespaces.icims.com
+Fox Pest Control,https://fox-rollins.icims.com,https://fox-rollins.icims.com
+"H-E-B, L.P.",https://career-joevsmartshop.icims.com,https://career-joevsmartshop.icims.com
+"H-E-B, L.P.",https://pharmacist-heb.icims.com,https://pharmacist-heb.icims.com
+HireRight,https://careersintl-hireright1.icims.com,https://careersintl-hireright1.icims.com
+IBEX Global,https://phcareers-ibex.icims.com,https://phcareers-ibex.icims.com
+Intelligent Waves LLC,https://apply-intelligentwaves.icims.com,https://apply-intelligentwaves.icims.com
+ITT Inc.,https://careersen-itt-inc.icims.com,https://careersen-itt-inc.icims.com
+MAG Aerospace,https://priority-magaero.icims.com,https://priority-magaero.icims.com
+Mammoet,https://int-nl-mammoet.icims.com,https://int-nl-mammoet.icims.com
+MarketSource,https://applyatmarketsource-msc.icims.com,https://applyatmarketsource-msc.icims.com
+MaxLinear,https://careersintl-maxlinear.icims.com,https://careersintl-maxlinear.icims.com
+Menarini Group,https://careers-menarinigroup.icims.com,https://careers-menarinigroup.icims.com
+OE Federal Credit Union,https://careers-oefederal.icims.com,https://careers-oefederal.icims.com
+Quanta Services,https://careers2-quanta.icims.com,https://careers2-quanta.icims.com
+Shure Incorporated,https://careersus-shure.icims.com,https://careersus-shure.icims.com
+Stagwell Global LLC,https://careers-assemblyglobalmena.icims.com,https://careers-assemblyglobalmena.icims.com
+Sunrise Senior Living,https://uscareers-sunriseseniorliving.icims.com,https://uscareers-sunriseseniorliving.icims.com
+TEKsystems,https://careersca-teksystems.icims.com,https://careersca-teksystems.icims.com
+Teleperformance,https://careerseng-teleperformance.icims.com,https://careerseng-teleperformance.icims.com
+Teleperformance,https://careersfre-teleperformance.icims.com,https://careersfre-teleperformance.icims.com
+Teleperformance,https://careersph-teleperformance.icims.com,https://careersph-teleperformance.icims.com
+Teleperformance,https://careersuk-teleperformance.icims.com,https://careersuk-teleperformance.icims.com
+Teleperformance,https://careersus-teleperformance.icims.com,https://careersus-teleperformance.icims.com
+The CSL Group Inc,https://careers-cslships.icims.com,https://careers-cslships.icims.com
+Therapy Management Corporation,https://careers-therapymgmt.icims.com,https://careers-therapymgmt.icims.com
+WOOD Consulting Services,https://jobs-woodcons.icims.com,https://jobs-woodcons.icims.com


### PR DESCRIPTION
## Summary
- add 35 credential-free, company-specific iCIMS listing portals
- current scraper returned 6,432 live jobs with zero intra-wave duplicate fingerprints
- estimate 6,363 net-new jobs after comparison with the published iCIMS parquet and 49 related live sibling portals

## Coverage
- observed locations: 4,461 US, 513 Asia core, 135 Europe, 158 Africa, 24 Canada, 8 Latin America, 6 Oceania, 1 Middle East, 1,126 unclassified
- largest validated additions: Ascension (2,918), Teleperformance English (719), Quanta (701), and Therapy Management Corporation (617)

## Discovery and validation
- paginated 7,391 public URLScan records, reduced them to 111 hosts absent from main, and required a non-empty response through the current iCIMS parser
- ran all 51 live candidates through full scraper pagination
- compared against 119,755 published iCIMS rows plus 8,916 current jobs from 49 related portals
- excluded login/internal/test/stale portals and high-overlap siblings; also removed two otherwise-live portals to eliminate all five intra-wave duplicate fingerprints
- confirmed unique CSV URLs and slugs

## Tests
- `uv run pytest -q tests/test_icims.py tests/test_run_pipeline_guards.py` (49 passed)
- `uv run pytest -q` (1,684 passed, 2 skipped)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 35 validated, credential-free iCIMS company portals to expand coverage and surface ~6.3k net-new jobs with no duplicate fingerprints. Updates `ats-companies/icims.csv` only.

- **New Features**
  - Added 35 portals with unique CSV URLs and slugs; validated via parser and full pagination.
  - Results: 6,432 live jobs; ~6,363 net-new after dedupe against published iCIMS data and 49 sibling portals; zero intra-wave dupes.
  - Largest sources: Ascension (2,918), Teleperformance English (719), Quanta (701), Therapy Management Corporation (617).

<sup>Written for commit 8b731b0ff63e1675a3e4fa964e13b9f155dc6684. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

