### PR TITLE
Preserve case-sensitive Lever tenant slugs

### DIFF
--- a/ats-companies/lever.csv
+++ b/ats-companies/lever.csv
@@ -2,7 +2,7 @@ name,slug,url
 #paid,hashtagpaid,https://jobs.lever.co/hashtagpaid
 100MS,100ms,https://jobs.lever.co/100ms
 15Five,15five,https://jobs.lever.co/15five
-1840 & Company,1840&company,https://jobs.lever.co/1840&Company
+1840 & Company,1840&Company,https://jobs.lever.co/1840&Company
 1inch,1inch,https://jobs.lever.co/1inch
 21st Century Home Health Services Inc.,21hhs,https://jobs.lever.co/21hhs
 2brains,2brains,https://jobs.lever.co/2brains
@@ -12,7 +12,7 @@ name,slug,url
 3E,3eco,https://jobs.lever.co/3eco
 3Pillar,3pillarglobal,https://jobs.lever.co/3pillarglobal
 4Front Ventures,4front,https://jobs.lever.co/4front
-4SIGHT Supply Chain,4sightsupplychain,https://jobs.lever.co/4SIGHTSupplyChain
+4SIGHT Supply Chain,4SIGHTSupplyChain,https://jobs.lever.co/4SIGHTSupplyChain
 90 Seconds,90seconds,https://jobs.lever.co/90seconds
 @hotel,tripscout,https://jobs.lever.co/tripscout
 AIFund,AIFund,https://jobs.lever.co/AIFund
@@ -505,7 +505,7 @@ Extreme Networks,extremenetworks,https://jobs.lever.co/extremenetworks
 Eyeline,Eyeline,https://jobs.lever.co/Eyeline
 Factor,factor,https://jobs.lever.co/factor
 Fair Trade Real Estate,FairTradeRealEstate,https://jobs.lever.co/FairTradeRealEstate
-Fairmat,fairmat,https://jobs.lever.co/Fairmat
+Fairmat,Fairmat,https://jobs.lever.co/Fairmat
 Fam,fampay,https://jobs.lever.co/fampay
 Fanatee,fanatee,https://jobs.lever.co/fanatee
 Farfetch,farfetch,https://jobs.lever.co/farfetch
@@ -680,7 +680,7 @@ Humaans,humaans,https://jobs.lever.co/humaans
 Hunger Free America,hungerfreeamerica,https://jobs.lever.co/hungerfreeamerica
 HUSH,hush,https://jobs.lever.co/hush
 Hypebeast,hypebeast,https://jobs.lever.co/hypebeast
-iCodde,icodde,https://jobs.lever.co/iCodde
+iCodde,iCodde,https://jobs.lever.co/iCodde
 Ideas United,ideasunited,https://jobs.lever.co/ideasunited
 IDMWORKS,idmworks,https://jobs.lever.co/idmworks
 IDT,idt,https://jobs.lever.co/idt
@@ -1779,7 +1779,7 @@ Evident ID,evidentid,https://jobs.lever.co/evidentid
 ezCater,ezcater,https://jobs.lever.co/ezcater
 Falcon.io,falcon,https://jobs.lever.co/falcon
 Fantasy,fantasy,https://jobs.lever.co/fantasy
-Farcast,farcast,https://jobs.lever.co/Farcast
+Farcast,Farcast,https://jobs.lever.co/Farcast
 Felix Construction,felix-construction,https://jobs.lever.co/felix-construction
 FEVO,fevo,https://jobs.lever.co/fevo
 Field Fastener,fieldfastener,https://jobs.lever.co/fieldfastener
@@ -1796,11 +1796,11 @@ Fundrise,fundrise,https://jobs.lever.co/fundrise
 Gamma,gamma,https://jobs.lever.co/gamma
 Collaborative Strategies,getcollaborative,https://jobs.lever.co/getcollaborative
 Five Star Solutions,getfivestar,https://jobs.lever.co/getfivestar
-Flare Therapeutics,flaretherapeutics,https://jobs.lever.co/FlareTherapeutics
-Flat.mx,flat.mx,https://jobs.lever.co/Flat.mx
-Fliff,fliff,https://jobs.lever.co/Fliff
+Flare Therapeutics,FlareTherapeutics,https://jobs.lever.co/FlareTherapeutics
+Flat.mx,Flat.mx,https://jobs.lever.co/Flat.mx
+Fliff,Fliff,https://jobs.lever.co/Fliff
 Flux Mobility,flux-mobility,https://jobs.lever.co/flux-mobility
-Flytographer,flytographer,https://jobs.lever.co/Flytographer
+Flytographer,Flytographer,https://jobs.lever.co/Flytographer
 Giving Home Health Care,givinghhc,https://jobs.lever.co/givinghhc
 Global Strategy Group,globalstrategygroup,https://jobs.lever.co/globalstrategygroup
 Good Eggs,goodeggs,https://jobs.lever.co/goodeggs
@@ -1839,14 +1839,14 @@ INFINIT,infinit,https://jobs.lever.co/infinit
 Infobase,infobase,https://jobs.lever.co/infobase
 Innodata,innodata,https://jobs.lever.co/innodata
 Innophos,innophos,https://jobs.lever.co/innophos
-Insight M,insightm,https://jobs.lever.co/InsightM
-Institute for Public Health Innovation,iphi,https://jobs.lever.co/IPHI
+Insight M,InsightM,https://jobs.lever.co/InsightM
+Institute for Public Health Innovation,IPHI,https://jobs.lever.co/IPHI
 Integra Beauty,integrabeauty,https://jobs.lever.co/integrabeauty
 Integrators services a.s.,integrators.cz,https://jobs.lever.co/integrators.cz
-Interior Marketing Group,interiormarketinggroup,https://jobs.lever.co/InteriorMarketingGroup
+Interior Marketing Group,InteriorMarketingGroup,https://jobs.lever.co/InteriorMarketingGroup
 Intrepid College Prep Schools,intrepidcollegeprep,https://jobs.lever.co/intrepidcollegeprep
 Invo Healthcare - Family of Companies,invohealthcare,https://jobs.lever.co/invohealthcare
-Ionic Partners,ionicpartners,https://jobs.lever.co/Ionicpartners
+Ionic Partners,Ionicpartners,https://jobs.lever.co/Ionicpartners
 Ironflow AI,ironflow,https://jobs.lever.co/ironflow
 Iru,iru,https://jobs.lever.co/iru
 Issuu,issuu,https://jobs.lever.co/issuu
@@ -1882,8 +1882,8 @@ Ledger,ledger,https://jobs.lever.co/ledger
 Lever Demo 2,leverdemo,https://jobs.lever.co/leverdemo
 Lever Education,leverdemo50000,https://jobs.lever.co/leverdemo50000
 Lexeo Therapeutics,lexeotx,https://jobs.lever.co/lexeotx
-Liberatii,liberatii,https://jobs.lever.co/Liberatii
-Lillio (formerly HiMama),lillio,https://jobs.lever.co/Lillio
+Liberatii,Liberatii,https://jobs.lever.co/Liberatii
+Lillio (formerly HiMama),Lillio,https://jobs.lever.co/Lillio
 LinkedIn Partner Sandbox - RSC testing,linkedin,https://jobs.lever.co/linkedin
 Link Rehab and Wellness,linkrehabwellness,https://jobs.lever.co/linkrehabwellness
 "Little Sprouts, LLC",littlesprouts,https://jobs.lever.co/littlesprouts
@@ -1895,7 +1895,7 @@ Rainmaker Technology Corporation,make-rain,https://jobs.lever.co/make-rain
 Makpar,makpar,https://jobs.lever.co/makpar
 Malbon,malbongolf,https://jobs.lever.co/malbongolf
 Mammoth Biosciences,mammothbiosci,https://jobs.lever.co/mammothbiosci
-MantaNetwork,mantanetwork,https://jobs.lever.co/MantaNetwork
+MantaNetwork,MantaNetwork,https://jobs.lever.co/MantaNetwork
 Maquette Virtuelle,maquettevirtuelle,https://jobs.lever.co/maquettevirtuelle
 Marquette Associates,marquetteassociates,https://jobs.lever.co/marquetteassociates
 Marshall Reddick Real Estate,marshallreddick,https://jobs.lever.co/marshallreddick
@@ -1927,8 +1927,8 @@ Ubiquity Retirement and Savings (dba Decimal Inc),myubiquity,https://jobs.lever.
 Nango,nango,https://jobs.lever.co/nango
 NAVISITE - Part of Accenture,navisite,https://jobs.lever.co/navisite
 Nelnet Community Engagement,nce,https://jobs.lever.co/nce
-New Jersey Innovation Authority,njstateofficeofinnovation,https://jobs.lever.co/NJStateOfficeofInnovation
-nexos.ai,nexos,https://jobs.lever.co/Nexos
+New Jersey Innovation Authority,NJStateOfficeofInnovation,https://jobs.lever.co/NJStateOfficeofInnovation
+nexos.ai,Nexos,https://jobs.lever.co/Nexos
 NFX,nfx,https://jobs.lever.co/nfx
 Nimbus,nimbus,https://jobs.lever.co/nimbus
 NOBULL,nobullproject,https://jobs.lever.co/nobullproject
@@ -1944,7 +1944,7 @@ O'Donnell/Snider Construction,odonnellsnider,https://jobs.lever.co/odonnellsnide
 Okendo,okendo,https://jobs.lever.co/okendo
 Oktopost,oktopost,https://jobs.lever.co/oktopost
 Oliver Wyman Labs,oliverwyman,https://jobs.lever.co/oliverwyman
-Onehouse,onehouse,https://jobs.lever.co/Onehouse
+Onehouse,Onehouse,https://jobs.lever.co/Onehouse
 Oomnitza,oomnitza,https://jobs.lever.co/oomnitza
 Optimus SBR,optimussbr,https://jobs.lever.co/optimussbr
 OPYS,opys,https://jobs.lever.co/opys
@@ -1957,7 +1957,7 @@ OTI Lumionics Inc.,otilumionics,https://jobs.lever.co/otilumionics
 OU Education Services,ou-education-services,https://jobs.lever.co/ou-education-services
 OutcomesAI,outcomesai,https://jobs.lever.co/outcomesai
 Overcast,overcast,https://jobs.lever.co/overcast
-Overclock Labs,akashnetwork,https://jobs.lever.co/AkashNetwork
+Overclock Labs,AkashNetwork,https://jobs.lever.co/AkashNetwork
 Overmind,overmind,https://jobs.lever.co/overmind
 Paradigm Health,paradigm-health,https://jobs.lever.co/paradigm-health
 Paramedic Services of Illinois,paramedicservices,https://jobs.lever.co/paramedicservices
@@ -2000,7 +2000,7 @@ Proxima,proxima,https://jobs.lever.co/proxima
 Blood,pslove-pte,https://jobs.lever.co/pslove-pte
 Pyka,pyka,https://jobs.lever.co/pyka
 Q Bio,qbio,https://jobs.lever.co/qbio
-Qover,qover,https://jobs.lever.co/Qover
+Qover,Qover,https://jobs.lever.co/Qover
 Quandri,quandri,https://jobs.lever.co/quandri
 Quilted Health,quilted-health,https://jobs.lever.co/quilted-health
 Quiq,quiq,https://jobs.lever.co/quiq
@@ -2009,7 +2009,7 @@ Quokka,quokka,https://jobs.lever.co/quokka
 Range Energy,rangeenergy,https://jobs.lever.co/rangeenergy
 RapidDeploy,rapiddeploy,https://jobs.lever.co/rapiddeploy
 Rapid Micro Biosystems,rapidmicrobio,https://jobs.lever.co/rapidmicrobio
-Rapt Studio,raptstudio,https://jobs.lever.co/RaptStudio
+Rapt Studio,RaptStudio,https://jobs.lever.co/RaptStudio
 RAVL,ravl_io,https://jobs.lever.co/ravl_io
 rbanw,rbanw,https://jobs.lever.co/rbanw
 RECESS,recess,https://jobs.lever.co/recess
@@ -2026,7 +2026,7 @@ Rupa Health,rupa,https://jobs.lever.co/rupa
 Safran.AI,safran-ai,https://jobs.lever.co/safran-ai
 Saga,saga-xyz,https://jobs.lever.co/saga-xyz
 Sapling - Partner,sapling,https://jobs.lever.co/sapling
-Sauce,sauce,https://jobs.lever.co/Sauce
+Sauce,Sauce,https://jobs.lever.co/Sauce
 Scott Logic,scottlogic,https://jobs.lever.co/scottlogic
 Seattle Art Museum,seattleartmuseum,https://jobs.lever.co/seattleartmuseum
 Sequel Med Tech,sequel-med-tech,https://jobs.lever.co/sequel-med-tech
@@ -2041,19 +2041,19 @@ Actriv,actriv,https://jobs.lever.co/actriv
 Ad Hoc Labs,adhoclabs,https://jobs.lever.co/adhoclabs
 Advanced Agrilytics,advancedagrilytics,https://jobs.lever.co/advancedagrilytics
 AE,ae-2,https://jobs.lever.co/ae-2
-AFAR,afarmedia,https://jobs.lever.co/AfarMedia
-Agerpoint,agerpoint,https://jobs.lever.co/Agerpoint
+AFAR,AfarMedia,https://jobs.lever.co/AfarMedia
+Agerpoint,Agerpoint,https://jobs.lever.co/Agerpoint
 Aicrete,aicrete,https://jobs.lever.co/aicrete
 Aizon,aizon,https://jobs.lever.co/aizon
 All Ears Veterinary,allears-vet,https://jobs.lever.co/allears-vet
 Allworknow,allworknow,https://jobs.lever.co/allworknow
 Altarum,altarum,https://jobs.lever.co/altarum
-Altoida,altoida,https://jobs.lever.co/Altoida
+Altoida,Altoida,https://jobs.lever.co/Altoida
 Ambergroup,ambergroup,https://jobs.lever.co/ambergroup
 Ambi Robotics,ambirobotics,https://jobs.lever.co/ambirobotics
 Ampeco Ltd,ampeco-global,https://jobs.lever.co/ampeco-global
 AmSty,amsty,https://jobs.lever.co/amsty
-AntiCapital,anticapital,https://jobs.lever.co/AntiCapital
+AntiCapital,AntiCapital,https://jobs.lever.co/AntiCapital
 Sila,silasg,https://jobs.lever.co/silasg
 DNAM Brands,silhouette,https://jobs.lever.co/silhouette
 SimonMed Imaging,simonmed,https://jobs.lever.co/simonmed
@@ -2117,7 +2117,7 @@ True Zero Technologies,truezerotech,https://jobs.lever.co/truezerotech
 Tusker,tusker,https://jobs.lever.co/tusker
 UATX,uaustin,https://jobs.lever.co/uaustin
 Uberflip,uberflip,https://jobs.lever.co/uberflip
-Ubiminds,ubiminds,https://jobs.lever.co/Ubiminds
+Ubiminds,Ubiminds,https://jobs.lever.co/Ubiminds
 UCSF,ucsf,https://jobs.lever.co/ucsf
 Ullico,ullico,https://jobs.lever.co/ullico
 UQUAL,uqual,https://jobs.lever.co/uqual
@@ -2126,7 +2126,7 @@ Vail Systems Inc.,vailsys,https://jobs.lever.co/vailsys
 Valarian Technologies Limited,valarian,https://jobs.lever.co/valarian
 VALPEO,valpeo.com,https://jobs.lever.co/valpeo.com
 Veda Tech Labs,vedatechlabs,https://jobs.lever.co/vedatechlabs
-VeeFriends,veefriends,https://jobs.lever.co/VeeFriends
+VeeFriends,VeeFriends,https://jobs.lever.co/VeeFriends
 Veeva Systems,veeva,https://jobs.lever.co/veeva
 Velo3D,velo3d,https://jobs.lever.co/velo3d
 Venus Aerospace,venusaero,https://jobs.lever.co/venusaero
@@ -2140,9 +2140,9 @@ Vohra Physicians,vohra,https://jobs.lever.co/vohra
 Vrify Trial,vrify,https://jobs.lever.co/vrify
 VTG,vtg,https://jobs.lever.co/vtg
 Wavicle Data Solutions,wavicledata,https://jobs.lever.co/wavicledata
-Wayground (formerly Quizizz),wayground,https://jobs.lever.co/Wayground
+Wayground (formerly Quizizz),Wayground,https://jobs.lever.co/Wayground
 Welo Global,weloglobal,https://jobs.lever.co/weloglobal
-WeSalute,wesalute,https://jobs.lever.co/WeSalute
+WeSalute,WeSalute,https://jobs.lever.co/WeSalute
 Western Aircraft,westair,https://jobs.lever.co/westair
 Westminster-Canterbury of the Blue Ridge,wc-br,https://jobs.lever.co/wc-br
 Monster Tree Service,whymonster,https://jobs.lever.co/whymonster
@@ -2154,11 +2154,11 @@ Worldscape Technology Inc.,worldscape-technology,https://jobs.lever.co/worldscap
 XTB Trial,xtb,https://jobs.lever.co/xtb
 Yonex USA,yonexusa,https://jobs.lever.co/yonexusa
 Z1 Tech,z1tech,https://jobs.lever.co/z1tech
-Zadara,zadara,https://jobs.lever.co/Zadara
+Zadara,Zadara,https://jobs.lever.co/Zadara
 Zambezi,zambezi,https://jobs.lever.co/zambezi
 Zazzle,zazzle,https://jobs.lever.co/zazzle
 Zeiss,zeiss,https://jobs.lever.co/zeiss
-Zeller,zeller,https://jobs.lever.co/Zeller
+Zeller,Zeller,https://jobs.lever.co/Zeller
 Zilliz,zilliz,https://jobs.lever.co/zilliz
 Zingtree,zingtree,https://jobs.lever.co/zingtree
 Zinier Trial,zinier,https://jobs.lever.co/zinier
@@ -2175,7 +2175,7 @@ Avenues Recovery,avenuesrecovery,https://jobs.lever.co/avenuesrecovery
 AVIA,aviahealth,https://jobs.lever.co/aviahealth
 Balbix,balbix,https://jobs.lever.co/balbix
 base | flowa,base-flowa,https://jobs.lever.co/base-flowa
-Beem,beemenergy,https://jobs.lever.co/BeemEnergy
+Beem,BeemEnergy,https://jobs.lever.co/BeemEnergy
 Bekk,bekk,https://jobs.lever.co/bekk
 Bellese,bellese,https://jobs.lever.co/bellese
 Belong,belong,https://jobs.lever.co/belong
@@ -2187,17 +2187,17 @@ BLEN,blencorp,https://jobs.lever.co/blencorp
 Blue Coding,bluecoding,https://jobs.lever.co/bluecoding
 "BrainStorm, Inc.",brainstorminc,https://jobs.lever.co/brainstorminc
 Branch,branch.gg,https://jobs.lever.co/branch.gg
-Breakwater Technology,breakwatertech,https://jobs.lever.co/BreakwaterTech
+Breakwater Technology,BreakwaterTech,https://jobs.lever.co/BreakwaterTech
 Brooklyn Investment Group,bkln,https://jobs.lever.co/bkln
 Brotherhood Crusade,brotherhoodcrusade,https://jobs.lever.co/brotherhoodcrusade
-Burro,burro,https://jobs.lever.co/Burro
+Burro,Burro,https://jobs.lever.co/Burro
 Cheerz,cheerz,https://jobs.lever.co/cheerz
 ClickTime,clicktime,https://jobs.lever.co/clicktime
 "CopilotKit, Inc.",copilotkit,https://jobs.lever.co/copilotkit
 dermalogica,dermalogica,https://jobs.lever.co/dermalogica
 Designetics,designetics,https://jobs.lever.co/designetics
 Dimension,getdimension,https://jobs.lever.co/getdimension
-Dioxycle,dioxycle,https://jobs.lever.co/Dioxycle
+Dioxycle,Dioxycle,https://jobs.lever.co/Dioxycle
 Distru,distru,https://jobs.lever.co/distru
 Doonails,doonails,https://jobs.lever.co/doonails
 DoubleDown Interactive,doubledown,https://jobs.lever.co/doubledown
@@ -2205,32 +2205,32 @@ Draslovka,draslovka,https://jobs.lever.co/draslovka
 Easy Agile,easyagile,https://jobs.lever.co/easyagile
 Edera,edera,https://jobs.lever.co/edera
 EDR,edr,https://jobs.lever.co/edr
-Electrified Thermal,electrifiedthermalsolutions,https://jobs.lever.co/ElectrifiedThermalSolutions
+Electrified Thermal,ElectrifiedThermalSolutions,https://jobs.lever.co/ElectrifiedThermalSolutions
 Eliyan,eliyan,https://jobs.lever.co/eliyan
 Ellevation,ellevationeducation,https://jobs.lever.co/ellevationeducation
 Elroy Air,elroyair,https://jobs.lever.co/elroyair
 Empirico,empiricotx,https://jobs.lever.co/empiricotx
 Encore Renewable Energy,encore-renewable-energy,https://jobs.lever.co/encore-renewable-energy
-Energy Vault,energyvault,https://jobs.lever.co/EnergyVault
+Energy Vault,EnergyVault,https://jobs.lever.co/EnergyVault
 Engine Ventures,engine-ventures,https://jobs.lever.co/engine-ventures
-Espresso,espresso,https://jobs.lever.co/Espresso
+Espresso,Espresso,https://jobs.lever.co/Espresso
 Eternal,eternal,https://jobs.lever.co/eternal
 EV Realty,evrealty-us,https://jobs.lever.co/evrealty-us
 Evergreen Strategy Group,evergreenstrategygroup,https://jobs.lever.co/evergreenstrategygroup
 Exploding Kittens,explodingkittens,https://jobs.lever.co/explodingkittens
 "Galatea Bio, Inc.",galatea,https://jobs.lever.co/galatea
-Gantri,gantri,https://jobs.lever.co/Gantri
+Gantri,Gantri,https://jobs.lever.co/Gantri
 Glue,gluegroups,https://jobs.lever.co/gluegroups
 Gobrightside,gobrightside,https://jobs.lever.co/gobrightside
 Circuit,getcircuit,https://jobs.lever.co/getcircuit
 goFluent,gofluent,https://jobs.lever.co/gofluent
 GR0,gr0,https://jobs.lever.co/gr0
 Graviticsspace,graviticsspace,https://jobs.lever.co/graviticsspace
-Gurobi Optimization,gurobioptimization,https://jobs.lever.co/GurobiOptimization
+Gurobi Optimization,GurobiOptimization,https://jobs.lever.co/GurobiOptimization
 Gursey,gursey,https://jobs.lever.co/gursey
 Harmony,harmony,https://jobs.lever.co/harmony
 Havenpark Communities,havenparkcommunities,https://jobs.lever.co/havenparkcommunities
-HDVI,hdvi,https://jobs.lever.co/HDVI
+HDVI,HDVI,https://jobs.lever.co/HDVI
 Healthmark Group Trial,healthmark-group,https://jobs.lever.co/healthmark-group
 Heetch,heetch,https://jobs.lever.co/heetch
 Hellotickets,hellotickets,https://jobs.lever.co/hellotickets
@@ -2238,36 +2238,36 @@ Hero Cosmetics,herocosmetics,https://jobs.lever.co/herocosmetics
 Hgen,hgen,https://jobs.lever.co/hgen
 Highbar Physical Therapy,highbarhealth,https://jobs.lever.co/highbarhealth
 Highland Electric Fleets,highlandfleets-2,https://jobs.lever.co/highlandfleets-2
-Highlight,highlight,https://jobs.lever.co/Highlight
+Highlight,Highlight,https://jobs.lever.co/Highlight
 HiHello,hihello,https://jobs.lever.co/hihello
 Hiring Our Heroes,hiringourheroes,https://jobs.lever.co/hiringourheroes
-Hively,hively,https://jobs.lever.co/Hively
-HowGood,howgood,https://jobs.lever.co/HowGood
+Hively,Hively,https://jobs.lever.co/Hively
+HowGood,HowGood,https://jobs.lever.co/HowGood
 Humata,humata,https://jobs.lever.co/humata
-"Hydrow, Inc.",hydrow,https://jobs.lever.co/Hydrow
+"Hydrow, Inc.",Hydrow,https://jobs.lever.co/Hydrow
 Center For Humane Technology,humanetech,https://jobs.lever.co/humanetech
-CesiumAstro,cesiumastro,https://jobs.lever.co/CesiumAstro
-Chamber of Progress,chamberofprogress,https://jobs.lever.co/ChamberofProgress
+CesiumAstro,CesiumAstro,https://jobs.lever.co/CesiumAstro
+Chamber of Progress,ChamberofProgress,https://jobs.lever.co/ChamberofProgress
 ChannelApe,channelape,https://jobs.lever.co/channelape
 Chargezoom,chargezoom,https://jobs.lever.co/chargezoom
-ChefRobotics,chefrobotics,https://jobs.lever.co/ChefRobotics
+ChefRobotics,ChefRobotics,https://jobs.lever.co/ChefRobotics
 Church at the Park,churchatthepark,https://jobs.lever.co/churchatthepark
 CITCON USA LLC,citcon,https://jobs.lever.co/citcon
-Civitta,civitta,https://jobs.lever.co/Civitta
+Civitta,Civitta,https://jobs.lever.co/Civitta
 ClearEdge,clearedge,https://jobs.lever.co/clearedge
-Clearer.io,clearer,https://jobs.lever.co/Clearer
-Clozd,clozd,https://jobs.lever.co/Clozd
+Clearer.io,Clearer,https://jobs.lever.co/Clearer
+Clozd,Clozd,https://jobs.lever.co/Clozd
 CNM LLP,cnmllp,https://jobs.lever.co/cnmllp
 co:collective,cocollective,https://jobs.lever.co/cocollective
 Cobaltrobotics,cobaltrobotics,https://jobs.lever.co/cobaltrobotics
-Cofactr,cofactr,https://jobs.lever.co/Cofactr
-Collectly,collectlyinc,https://jobs.lever.co/CollectlyInc
-CommunityBoost,communityboost,https://jobs.lever.co/CommunityBoost
+Cofactr,Cofactr,https://jobs.lever.co/Cofactr
+Collectly,CollectlyInc,https://jobs.lever.co/CollectlyInc
+CommunityBoost,CommunityBoost,https://jobs.lever.co/CommunityBoost
 Component Repair Technologies,componentrepairtechnologies,https://jobs.lever.co/componentrepairtechnologies
 confluera,confluera,https://jobs.lever.co/confluera
 Connext Network,connext-network,https://jobs.lever.co/connext-network
 "Constellation Technologies, Inc",cti-md,https://jobs.lever.co/cti-md
-ContactOut,contactout,https://jobs.lever.co/ContactOut
+ContactOut,ContactOut,https://jobs.lever.co/ContactOut
 Copia Automation,copia,https://jobs.lever.co/copia
 Craftwater,craftwater,https://jobs.lever.co/craftwater
 Crossing Minds Recruiting,crossing-minds,https://jobs.lever.co/crossing-minds
@@ -2276,24 +2276,24 @@ Cubegroup,cubegroup,https://jobs.lever.co/cubegroup
 Curio Research,curio.gg,https://jobs.lever.co/curio.gg
 iyzico,iyzico,https://jobs.lever.co/iyzico
 Katten Muchin Rosenman LLP,katten,https://jobs.lever.co/katten
-Ketch,ketch,https://jobs.lever.co/Ketch
+Ketch,Ketch,https://jobs.lever.co/Ketch
 Kitman Labs,kitmanlabs,https://jobs.lever.co/kitmanlabs
 Lincoln Institute of Land Policy,lincolninst,https://jobs.lever.co/lincolninst
 Lovepop,lovepop,https://jobs.lever.co/lovepop
 Loyal,loyalhealth,https://jobs.lever.co/loyalhealth
-Lumary,lumary,https://jobs.lever.co/Lumary
+Lumary,Lumary,https://jobs.lever.co/Lumary
 Luminary Labs,luminary-labs,https://jobs.lever.co/luminary-labs
 LumiQ,lumiq-learn,https://jobs.lever.co/lumiq-learn
 LUUM,luumlash,https://jobs.lever.co/luumlash
-Lyra Collective,lyracollective,https://jobs.lever.co/LyraCollective
+Lyra Collective,LyraCollective,https://jobs.lever.co/LyraCollective
 Lyrebird Health,lyrebirdhealth,https://jobs.lever.co/lyrebirdhealth
 Markham LLC,markham,https://jobs.lever.co/markham
-Mast Reforestation,mastreforestation,https://jobs.lever.co/MastReforestation
-Matters,matters,https://jobs.lever.co/Matters
+Mast Reforestation,MastReforestation,https://jobs.lever.co/MastReforestation
+Matters,Matters,https://jobs.lever.co/Matters
 Maureen Joy Charter School,joycharter,https://jobs.lever.co/joycharter
 McChrystal Group,mcchrystalgroup,https://jobs.lever.co/mcchrystalgroup
 MedCare Pediatric,medcarepediatric,https://jobs.lever.co/medcarepediatric
-Mediafly,mediafly,https://jobs.lever.co/Mediafly
+Mediafly,Mediafly,https://jobs.lever.co/Mediafly
 Medical Outsourcing Solutions,medical-outsourcing-solutions,https://jobs.lever.co/medical-outsourcing-solutions
 MedRhythms,medrhythms,https://jobs.lever.co/medrhythms
 Metawealth,metawealth,https://jobs.lever.co/metawealth
@@ -2301,16 +2301,16 @@ Milo,milocredit,https://jobs.lever.co/milocredit
 MIRAI FOODS AG,mirai-foods,https://jobs.lever.co/mirai-foods
 Mirastar FCU,mirastarfcu,https://jobs.lever.co/mirastarfcu
 Mission Graduates,missiongraduates,https://jobs.lever.co/missiongraduates
-MO,mostudio,https://jobs.lever.co/MOstudio
+MO,MOstudio,https://jobs.lever.co/MOstudio
 MobileAction,mobile-action,https://jobs.lever.co/mobile-action
-Modern Intelligence,modernintelligence,https://jobs.lever.co/ModernIntelligence
+Modern Intelligence,ModernIntelligence,https://jobs.lever.co/ModernIntelligence
 Modern Life,modernlife,https://jobs.lever.co/modernlife
 Molten Industries,moltenindustries,https://jobs.lever.co/moltenindustries
 Moneytree,moneytree,https://jobs.lever.co/moneytree
 Monterey Technologies Inc,mti-inc,https://jobs.lever.co/mti-inc
 Motif,motifsystems,https://jobs.lever.co/motifsystems
 NOBODY,nobody,https://jobs.lever.co/nobody
-Nomagic,nomagic,https://jobs.lever.co/Nomagic
+Nomagic,Nomagic,https://jobs.lever.co/Nomagic
 Nova,ioconnectservices.com,https://jobs.lever.co/ioconnectservices.com
 Owlet,owletcare,https://jobs.lever.co/owletcare
 Payactiv,payactiv,https://jobs.lever.co/payactiv
@@ -2318,16 +2318,16 @@ Pison,pison,https://jobs.lever.co/pison
 Planned Parenthood Keystone,ppkeystone,https://jobs.lever.co/ppkeystone
 Planned Parenthood South Atlantic,ppsat,https://jobs.lever.co/ppsat
 PlayVS,playvs,https://jobs.lever.co/playvs
-PocketHealth,pockethealth,https://jobs.lever.co/PocketHealth
+PocketHealth,PocketHealth,https://jobs.lever.co/PocketHealth
 Portoro,portoro,https://jobs.lever.co/portoro
 Premier Truck Group,premiertruck,https://jobs.lever.co/premiertruck
-Pretto,pretto,https://jobs.lever.co/Pretto
+Pretto,Pretto,https://jobs.lever.co/Pretto
 Primate Labs Inc.,primatelabs,https://jobs.lever.co/primatelabs
 Prime Electric,primee,https://jobs.lever.co/primee
 Prime Fiber,primefiber,https://jobs.lever.co/primefiber
-Probius,probiusdx,https://jobs.lever.co/ProbiusDx
+Probius,ProbiusDx,https://jobs.lever.co/ProbiusDx
 Product Ventures,productventures,https://jobs.lever.co/productventures
-Progressive Physician Associates,ppa,https://jobs.lever.co/PPA
+Progressive Physician Associates,PPA,https://jobs.lever.co/PPA
 Project Kitty Hawk,projectkittyhawk,https://jobs.lever.co/projectkittyhawk
 Promesa Academy,promesaacademy,https://jobs.lever.co/promesaacademy
 Prominent Edge LLC,prominentedge,https://jobs.lever.co/prominentedge
@@ -2345,15 +2345,15 @@ Relay Robotics,relayrobotics.com,https://jobs.lever.co/relayrobotics.com
 Remedyproductstudio,remedyproductstudio,https://jobs.lever.co/remedyproductstudio
 Resiliencelab,resiliencelab,https://jobs.lever.co/resiliencelab
 Richards Services,richards-services,https://jobs.lever.co/richards-services
-Riptide Technology,riptidetech,https://jobs.lever.co/RiptideTech
+Riptide Technology,RiptideTech,https://jobs.lever.co/RiptideTech
 Riverdale Country School,riverdale,https://jobs.lever.co/riverdale
 Rocket Partners,rocketpartners,https://jobs.lever.co/rocketpartners
 Roofstacks,roofstacks,https://jobs.lever.co/roofstacks
-RouteThis,routethis,https://jobs.lever.co/RouteThis
+RouteThis,RouteThis,https://jobs.lever.co/RouteThis
 Ruby Play,rubyplay,https://jobs.lever.co/rubyplay
 Rylo,rylo,https://jobs.lever.co/rylo
 sbz,sbz,https://jobs.lever.co/sbz
-Scale Microgrid Solutions,scalemicrogridsolutions,https://jobs.lever.co/ScaleMicrogridSolutions
+Scale Microgrid Solutions,ScaleMicrogridSolutions,https://jobs.lever.co/ScaleMicrogridSolutions
 Schedule Engine,scheduleengine,https://jobs.lever.co/scheduleengine
 Scoperecruiting,scoperecruiting,https://jobs.lever.co/scoperecruiting
 Seedify Fund,seedify-fund,https://jobs.lever.co/seedify-fund
@@ -2364,7 +2364,7 @@ Skip,skipscooters,https://jobs.lever.co/skipscooters
 Skyral Group,skyralio,https://jobs.lever.co/skyralio
 "Skyward IT Solutions, LLC",skywarditsolutions,https://jobs.lever.co/skywarditsolutions
 Slangai,slangai,https://jobs.lever.co/slangai
-Smile.io,smile.io,https://jobs.lever.co/Smile.io
+Smile.io,Smile.io,https://jobs.lever.co/Smile.io
 SOLFL,solfl,https://jobs.lever.co/solfl
 Solutions Journalism Network,solutionsjournalism,https://jobs.lever.co/solutionsjournalism
 Sonrai Security,sonrai-security,https://jobs.lever.co/sonrai-security
@@ -2372,25 +2372,25 @@ Spruce Street Compliance,sprucestreetcomp,https://jobs.lever.co/sprucestreetcomp
 Squire Patton Boggs,squirepb,https://jobs.lever.co/squirepb
 Stackblitz,stackblitz,https://jobs.lever.co/stackblitz
 StarCompliance,starcompliance,https://jobs.lever.co/starcompliance
-Storygrounds,storygrounds,https://jobs.lever.co/Storygrounds
+Storygrounds,Storygrounds,https://jobs.lever.co/Storygrounds
 Studion,gostudion,https://jobs.lever.co/gostudion
-Swiftly,swiftlysystems,https://jobs.lever.co/SwiftlySystems
+Swiftly,SwiftlySystems,https://jobs.lever.co/SwiftlySystems
 Tech Nation,technation,https://jobs.lever.co/technation
 Technexus,technexus,https://jobs.lever.co/technexus
-Terraformation,terraformation,https://jobs.lever.co/Terraformation
+Terraformation,Terraformation,https://jobs.lever.co/Terraformation
 The Upright Project,uprightproject,https://jobs.lever.co/uprightproject
 "Therma-Tron-X, Inc.",ttxinc,https://jobs.lever.co/ttxinc
 Titan Electric,titanelectric-ga,https://jobs.lever.co/titanelectric-ga
 Tonsser,tonsser,https://jobs.lever.co/tonsser
-Topl,topl,https://jobs.lever.co/Topl
+Topl,Topl,https://jobs.lever.co/Topl
 Tribe Payments,tribe-payments,https://jobs.lever.co/tribe-payments
-Trilogy Federal,trilogyfederal,https://jobs.lever.co/TrilogyFederal
+Trilogy Federal,TrilogyFederal,https://jobs.lever.co/TrilogyFederal
 Trinity Hunt Partners,trinityhunt,https://jobs.lever.co/trinityhunt
 TXI,txidigital,https://jobs.lever.co/txidigital
 Universal Electronics Inc.,uei,https://jobs.lever.co/uei
 Unlikely,unlikely,https://jobs.lever.co/unlikely
 Unstructuredtechnologies,unstructuredtechnologies,https://jobs.lever.co/unstructuredtechnologies
-UpMetrics,upmetrics,https://jobs.lever.co/UpMetrics
+UpMetrics,UpMetrics,https://jobs.lever.co/UpMetrics
 Velocity Global,velocityglobal,https://jobs.lever.co/velocityglobal
 Venteur,venteur,https://jobs.lever.co/venteur
 Verkor,verkor,https://jobs.lever.co/verkor
@@ -2398,3 +2398,6 @@ Viome Life Sciences,viome,https://jobs.lever.co/viome
 WisdomTree,wisdomtree,https://jobs.lever.co/wisdomtree
 Wisdomtree UK,wisdomtree-2,https://jobs.lever.co/wisdomtree-2
 "WRA, Inc.",wra-ca,https://jobs.lever.co/wra-ca
+Mindy Support,mindy,https://jobs.lever.co/mindy
+OpenPayd,OpenPayd,https://jobs.lever.co/OpenPayd
+TrainSweatEat,trainsweateat,https://jobs.lever.co/trainsweateat

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -32,7 +32,7 @@ import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, unquote, urlparse
 
 from ats_scrapers.exceptions import CompanyNotFoundError
 from ats_scrapers.models import Job
@@ -225,13 +225,13 @@ def _workable_slug(row: dict[str, Any]) -> str | None:
 
 
 def _lever_slug(row: dict[str, Any]) -> str | None:
-    if (slug := _slug_col(row)):
-        return slug.lower()
     url = (row.get("url") or "").strip()
     if url.startswith("http"):
         m = re.match(r"https?://jobs\.lever\.co/([^/?#]+)", url, re.IGNORECASE)
         if m:
-            return m.group(1).lower()
+            return unquote(m.group(1))
+    if (slug := _slug_col(row)):
+        return slug
     name = (row.get("name") or "").strip()
     return name or None
 

--- a/tests/test_run_pipeline_guards.py
+++ b/tests/test_run_pipeline_guards.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import csv
+from pathlib import Path
+from urllib.parse import unquote, urlparse
 
 import pytest
 
@@ -148,9 +150,36 @@ def test_provider_slug_normalizers_match_current_company_csv_shape() -> None:
         runner._oracle_slug(oracle_row)
         == "https://eiqg.fa.us2.oraclecloud.com?site_number=CX_1"
     )
+
+    lever_row = {
+        "name": "OpenPayd",
+        "slug": "openpayd",
+        "url": "https://jobs.lever.co/OpenPayd",
+    }
+    assert runner._lever_slug(lever_row) == "OpenPayd"
+
+    lever_slug_only_row = {
+        "name": "OpenPayd",
+        "slug": "OpenPayd",
+        "url": "",
+    }
+    assert runner._lever_slug(lever_slug_only_row) == "OpenPayd"
     assert runner.CONFIGS["oracle"]["kwargs"](oracle_row) == {
         "company_name": "ABM US"
     }
+
+
+def test_lever_catalog_slugs_preserve_canonical_url_case() -> None:
+    with Path("ats-companies/lever.csv").open(newline="") as handle:
+        rows = list(csv.DictReader(handle))
+
+    mismatches = []
+    for row in rows:
+        canonical = unquote(urlparse(row["url"]).path.strip("/").split("/", 1)[0])
+        if row["slug"] != canonical:
+            mismatches.append((row["slug"], canonical, row["url"]))
+
+    assert mismatches == []
     assert runner.CONFIGS["oracle"]["dedupe_by_ats_id"] is True
 
     cornerstone_row = {


### PR DESCRIPTION
## Summary
- preserve canonical Lever URL-path casing in both runtime normalization and every published catalog slug
- add three credential-free boards: OpenPayd, TrainSweatEat, and Mindy Support
- recover 2,435 currently missed jobs from 157 existing case-sensitive tenants, plus 34 jobs from the new tenants

## Validation
- found 163 catalog rows whose canonical URL path differs from the old lowercase runtime slug
- live-probed both forms for every row: 157 exact-case endpoints returned 2,435 jobs; all 157 lowercase forms returned zero jobs
- corrected all 80 catalog rows whose published `slug` differed from the canonical URL path; a repository test now enforces zero mismatches
- validated 2,469 unique Lever IDs with zero overlap against the published Lever parquet
- observed locations: 1,385 US, 329 Europe, 289 Asia core, 212 Africa, 136 Latin America, 47 Canada, 25 Oceania, 18 Middle East, 28 unknown
- ran Aprio, Yassir, CesiumAstro, OpenPayd, TrainSweatEat, and Mindy Support through the updated normalizer and current scraper; all returned non-empty structured jobs

## Review feedback
- addressed and resolved the Codex P1 about public `find_company()` slugs by updating every affected CSV slug

## Tests
- `uv run pytest -q tests/test_lever.py tests/test_run_pipeline_guards.py tests/test_find_company.py` (41 passed)
- `uv run pytest -q` (1,685 passed, 2 skipped)