### PR TITLE
Expand Beisen coverage and restore locations

### DIFF
--- a/ats-companies/beisen.csv
+++ b/ats-companies/beisen.csv
@@ -215,3 +215,8 @@ POP MART,popmart,https://popmart.zhiye.com
 北京宇信科技集团股份有限公司,yusys-campus,https://yusys-campus.zhiye.com
 中迅农科,zhxcn,https://zhxcn.zhiye.com
 中元汇吉,zybio,https://zybio.zhiye.com
+高松电子,degson,https://degson.zhiye.com
+深圳市尚水智能股份有限公司,ss-smartech,https://ss-smartech.zhiye.com
+新芯股份,whxmc,https://whxmc.zhiye.com
+伊之密,yizumi,https://yizumi.zhiye.com
+臻格生物,zgbiotech,https://zgbiotech.zhiye.com

--- a/src/ats_scrapers/scrapers/beisen.py
+++ b/src/ats_scrapers/scrapers/beisen.py
@@ -187,8 +187,8 @@ class BeisenScraper(BaseScraper):
             "DisplayFields": [
                 "Category",
                 "Description",
-                "Location",
-                "Department",
+                "LocId",
+                "Org",
                 "Salary",
             ],
         }
@@ -269,7 +269,8 @@ class BeisenScraper(BaseScraper):
             region="Asia" if self.country_iso in {"CN", "HK", "MO", "TW"} else None,
             description=description,
             salary_summary=_clean_text(item.get("Salary")),
-            department=_clean_text(item.get("Category")),
+            department=_clean_text(item.get("Org"))
+            or _clean_text(item.get("Category")),
             posted_at=_parse_date(item.get("ChangeDate"))
             or _parse_date(item.get("PostDate")),
             fetched_at=datetime.now(UTC),

--- a/tests/test_beisen.py
+++ b/tests/test_beisen.py
@@ -93,7 +93,7 @@ def test_parses_nested_config_and_current_listing(httpx_mock) -> None:
     assert result.region == "Asia"
     assert result.description == "构建可靠平台。\n\n三年以上经验。\n熟悉 Python。"
     assert result.salary_summary == "20-30K"
-    assert result.department == "社会招聘"
+    assert result.department == "研发中心"
     assert result.posted_at is not None and result.posted_at.tzinfo is UTC
     assert result.fetched_at.tzinfo is UTC
     assert str(result.url) == "https://fixturecorp.zhiye.com/portal/jobs/123"
@@ -121,6 +121,17 @@ def test_uses_catalog_company_name(httpx_mock) -> None:
     assert result.company == "Fixture Corporation"
 
 
+def test_department_falls_back_to_recruitment_category(httpx_mock) -> None:
+    add_register(httpx_mock)
+    item = listing()
+    item["Org"] = ""
+    httpx_mock.add_response(url=SEARCH_URL, json=payload([item]))
+
+    [result] = BeisenScraper("fixturecorp").fetch()
+
+    assert result.department == "社会招聘"
+
+
 def test_include_descriptions_false_omits_embedded_content(httpx_mock) -> None:
     add_register(httpx_mock)
     httpx_mock.add_response(url=SEARCH_URL, json=payload([listing()]))
@@ -144,8 +155,8 @@ def test_request_body_matches_public_api(httpx_mock) -> None:
         "DisplayFields": [
             "Category",
             "Description",
-            "Location",
-            "Department",
+            "LocId",
+            "Org",
             "Salary",
         ],
         "Category": ["1"],


### PR DESCRIPTION
## Summary

- request Beisen's live `LocId` and `Org` display fields instead of unsupported `Location` and `Department`
- publish the structured `Org` as department, falling back to recruitment category
- add 5 live Beisen employers with zero overlap against the current published slice

## Discovery and deduplication

- Common Crawl surfaced 242 Beisen subdomains across recent snapshots
- 191 were absent from both `main` and the prior probe set
- 122 current-generation tenants returned 13,618 live jobs
- compared all candidate IDs against the current 181,106-row Beisen parquet
- rejected every full or partial alias feed: 13,255 overlapping IDs
- retained only 5 tenants with zero current ID overlap and zero title+description fingerprint overlap

## Retained jobs

- 335 jobs and 335 unique IDs
- 0 duplicate IDs
- 0 current published ID overlap
- 0 current published title+description overlap
- 335 descriptions; 323 substantial descriptions
- 335 structured locations
- 335 organizational departments
- 333 dated; 149 dated within 365 days; 0 future-dated

## Location fix

The current 181,106-row Beisen snapshot has 0 populated locations because the list request asks for `Location`. A live 1,000-job comparison on `jobtaikang.zhiye.com` returned:

- `Location`: 0/1,000 populated locations
- `LocId`: 1,000/1,000 populated `LocNames`

## Validation

- focused tests: 48 passed
- full suite: 1,695 passed, 2 skipped, 31 deselected
- Ruff: clean
- CSV: 221 rows, unique slugs and URLs
- `git diff --check`: clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Beisen job locations by switching to `LocId`/`Org` and mapping `Org` to department with a fallback to recruitment category. Adds five live employers with zero overlap with current published jobs.

- **Bug Fixes**
  - Request `LocId` and `Org` instead of unsupported `Location` and `Department`.
  - Set department from `Org`, falling back to `Category` when `Org` is empty.

- **New Features**
  - Added employers: `degson`, `ss-smartech`, `whxmc`, `yizumi`, `zgbiotech`.
  - Publishes 335 unique jobs from these tenants with 0 ID and content overlap.

<sup>Written for commit bb6b80a322d76554949662802fc220406b8b4779. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates Beisen scraping coverage and field normalization.
- Requests `LocId` and `Org` display fields from the current Beisen API.
- Maps `Org` to the normalized department field with recruitment category as a fallback.
- Adds five Beisen tenants and tests the updated request and parsing behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete correctness or security issues identified.

The revised request fields align with the parser’s expected response fields, department fallback behavior is covered, and the added tenant rows follow the existing catalog format.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated that after the changes, the process exited with code 0, API responses stayed HTTP 200 with 1,000 and 773 results, and the structured sample now includes location 北京市·朝阳区, Org-derived department 人寿总公司, and raw\_org\_present: true, showing that the new fields did not break parsing.

<a href="https://app.greptile.com/trex/runs/16461123/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/ats_scrapers/scrapers/beisen.py | Replaces unsupported display fields with live Beisen fields and publishes `Org` as department with a category fallback; no actionable defect identified. |
| tests/test_beisen.py | Updates request and department expectations and adds explicit coverage for the category fallback. |
| ats-companies/beisen.csv | Adds five valid, uniquely slugged Beisen tenant records using the existing CSV schema. |

<sub>Reviews (1): Last reviewed commit: ["Expand Beisen coverage and restore locat..."](https://github.com/kalil0321/ats-scrapers/commit/bb6b80a322d76554949662802fc220406b8b4779) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48458830)</sub>

<!-- /greptile_comment -->