### PR TITLE
Allow pipelines to write into a separate publication root

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -7,7 +7,8 @@ Used by ``full_pipeline.sh`` for ATSes that don't have a legacy
 Reads ``ats-companies/{ats}.csv`` (the canonical tenant list — single
 source of truth, columns ``name,url``), scrapes each tenant via the
 appropriate ats-scrapers scraper class, dedupes, and writes a flat
-``data/{ats}/jobs.csv``.
+``{repo}/{ats}/jobs.csv`` by default. Set ``ATS_SCRAPERS_JOBS_ROOT`` (or
+the legacy ``JOBHIVE_JOBS_ROOT``) to write into a separate publication tree.
 
 Usage:
     python scripts/run_pipeline.py cornerstone
@@ -908,6 +909,14 @@ def _eightfold_kwargs(row: dict[str, Any]) -> dict[str, Any]:
 
 DATA_ROOT = Path(__file__).resolve().parent.parent  # → repo root
 
+
+def _jobs_output_root() -> Path:
+    configured = os.environ.get("ATS_SCRAPERS_JOBS_ROOT") or os.environ.get(
+        "JOBHIVE_JOBS_ROOT"
+    )
+    return Path(configured).expanduser() if configured else DATA_ROOT
+
+
 JOB_CSV_FIELDS = [
     "url", "title", "company", "ats_type", "ats_id", "location",
     "country_iso", "region", "language", "lat", "lon",
@@ -1414,7 +1423,8 @@ async def run(ats: str, concurrency: int, max_tenants: int | None, timeout: floa
     description_delay = float(cfg.get("description_delay_seconds", 0))
     counts = {"success": 0, "not_found": 0, "error": 0, "jobs": 0}
 
-    output_path = DATA_ROOT / cfg["output"]
+    jobs_output_root = _jobs_output_root()
+    output_path = jobs_output_root / cfg["output"]
     output_path.parent.mkdir(parents=True, exist_ok=True)
     if cfg.get("publish_previous_while_running"):
         tmp_output_path = output_path.with_name(
@@ -1425,7 +1435,9 @@ async def run(ats: str, concurrency: int, max_tenants: int | None, timeout: floa
     uses_streaming = bool(cfg.get("singleton") and hasattr(cfg["scraper"], "fetch_stream"))
     cache_cap = cfg.get("skip_description_cache_if_max_len_lte")
     persistent_path_rel = cfg.get("description_cache_path")
-    persistent_path = (DATA_ROOT / persistent_path_rel) if persistent_path_rel else None
+    persistent_path = (
+        jobs_output_root / persistent_path_rel if persistent_path_rel else None
+    )
     cache_compress = bool(cfg.get("description_cache_compress"))
     if isinstance(cache_cap, int) and _descriptions_look_capped(output_path, cache_cap):
         print(

--- a/tests/test_run_pipeline_guards.py
+++ b/tests/test_run_pipeline_guards.py
@@ -12,6 +12,30 @@ from ats_scrapers.exceptions import CompanyNotFoundError
 from ats_scrapers.models import ATSType, Job
 
 
+def test_jobs_output_root_defaults_to_repository_root(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("ATS_SCRAPERS_JOBS_ROOT", raising=False)
+    monkeypatch.delenv("JOBHIVE_JOBS_ROOT", raising=False)
+    monkeypatch.setattr(runner, "DATA_ROOT", tmp_path)
+
+    assert runner._jobs_output_root() == tmp_path
+
+
+def test_jobs_output_root_supports_current_and_legacy_environment_names(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    legacy_root = tmp_path / "legacy"
+    current_root = tmp_path / "current"
+    monkeypatch.setenv("JOBHIVE_JOBS_ROOT", str(legacy_root))
+
+    assert runner._jobs_output_root() == legacy_root
+
+    monkeypatch.setenv("ATS_SCRAPERS_JOBS_ROOT", str(current_root))
+
+    assert runner._jobs_output_root() == current_root
+
+
 def test_job_to_row_preserves_structured_location_metadata() -> None:
     row = runner._job_to_row(
         Job(


### PR DESCRIPTION
## Summary
- add an optional `ATS_SCRAPERS_JOBS_ROOT` output root for provider CSVs and persistent description caches
- keep compatibility with the production `JOBHIVE_JOBS_ROOT` environment name
- preserve the repository root as the default for local runs

## Why
Production still publishes from the legacy `data/jobs` tree. This lets a current-main sidecar run validated providers directly into that tree without replacing the legacy checkout or publisher.

## Validation
- `uv run --extra test pytest -q tests/test_run_pipeline_guards.py` (30 passed)
- `uv run --extra dev ruff check scripts/run_pipeline.py tests/test_run_pipeline_guards.py`
- `git diff --check`

The local full suite was also attempted after installing `pipeline/requirements.txt`, but this machine's HTTP transport environment caused repository-wide mock interception failures unrelated to this two-file change; CI is the clean full-suite check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows pipelines to publish provider CSVs and description caches to a separate output root. Local runs still write to the repo root by default.

- **New Features**
  - Added `runner._jobs_output_root()` to resolve the output root from `ATS_SCRAPERS_JOBS_ROOT`, falling back to legacy `JOBHIVE_JOBS_ROOT`, else the repo root.
  - Output paths for `jobs.csv` and the persistent description cache now derive from this root.
  - Tests cover default behavior and env var precedence.

<sup>Written for commit 6ba3fdde666e1e458195ad97eb3f0f3ce7a0df44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change lets operators choose where generated job CSVs and persistent description caches are published, while retaining the repository root as the default and accepting the legacy environment variable. The concurrent publication path was exercised: two runs for the same ATS with separate output roots resolve separate CSV and cache paths, but the second run is skipped because the lock is shared by ATS name alone.

**Merge safety: not safe to merge.** A publication destination can silently miss its refresh while an independent destination is processing the same ATS.

<h3>Confidence Score: 3/5</h3>

The change is not safe to merge because independent publication roots cannot refresh concurrently for the same ATS.

The reproduced concurrent-run behavior shows that a normal multi-destination deployment can exit successfully without producing its expected refreshed data.

**Files Needing Attention:** scripts/run_pipeline.py needs the lock key to incorporate the selected publication root as well as the ATS.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a finding-proof for the posted P1 finding and attached supporting artifacts, including a Python harness and two run logs.
- T-Rex produced a second finding-proof for another posted P1 finding; no artifacts were attached.
- T-Rex performed a general-contract-validation proof that documents the ATS roots-lock logic, authored the repro harness, and captured baseline and concurrent-run logs as evidence.

<a href="https://app.greptile.com/trex/runs/16511516/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `scripts/run_pipeline.py`, line 940 ([link](https://github.com/kalil0321/ats-scrapers/blob/6ba3fdde666e1e458195ad97eb3f0f3ce7a0df44/scripts/run_pipeline.py#L940)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Lock ignores publication root**

   The new `ATS_SCRAPERS_JOBS_ROOT` setting makes the output CSV and description cache independent per publication tree, but the lock file is still keyed only by `ats`. A run for the same ATS targeting a separate publication root therefore sees the other root's lock and exits successfully without scraping. Its publication tree is left stale even though it does not share output or cache files with the active run. Include a canonicalized output-root identifier in the lock key so independent publication trees can run concurrently.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Evidence from the check](https://app.greptile.com/trex/artifacts/f5d99863-9dd7-4a4e-9216-9eaa9c3c340f)**

   - Authored harness imports the production root and lock helpers, holds one ATS lock under root A, and starts a contender under root B; it captures whether the contender is skipped, proving the tested path.

   **[Command output from the check](https://app.greptile.com/trex/artifacts/e425b97d-fe2e-4ec6-a0f3-e0c3a6b43ff6)**

   - Executed baseline command from \`/home/user/repo\` shows a single process acquired the production ATS lock and resolved its root-A output and cache paths, establishing the comparison.

   **[Command output from the check](https://app.greptile.com/trex/artifacts/6da515d9-3acf-4317-b540-8ff25d582cc8)**

   - Executed concurrent command from \`/home/user/repo\` shows root A and root B output/cache paths differ but the root-B contender prints the production skip message and has \`second\_acquired=False\`, proving the finding.

   <a href="https://app.greptile.com/trex/runs/16511516/artifacts?artifact=f5d99863-9dd7-4a4e-9216-9eaa9c3c340f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: scripts/run_pipeline.py
   Line: 940

   Comment:
   **Lock ignores publication root**

   The new `ATS_SCRAPERS_JOBS_ROOT` setting makes the output CSV and description cache independent per publication tree, but the lock file is still keyed only by `ats`. A run for the same ATS targeting a separate publication root therefore sees the other root's lock and exits successfully without scraping. Its publication tree is left stale even though it does not share output or cache files with the active run. Include a canonicalized output-root identifier in the lock key so independent publication trees can run concurrently.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **ATS-only pipeline lock skips independent publication roots**

   - **Bug**
     - When one pipeline process holds the lock for an ATS under one `ATS_SCRAPERS_JOBS_ROOT`, a concurrent process for the same ATS under another root skips. The reproduction showed distinct root, `jobs.csv`, and derived cache paths but `second_acquired=False` and the production skip message.
   - **Cause**
     - `_pipeline_lock(ats)` builds its lock filename using only `ats`, omitting the configured publication root.
   - **Fix**
     - Scope the lock key by a canonicalized jobs-output root plus ATS (for example, a stable hash of `str(_jobs_output_root().resolve())` and `ats`), while retaining ATS-only serialization only if it is explicitly required for shared resources outside that root.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/run_pipeline.py:940
**Lock ignores publication root**

The new `ATS_SCRAPERS_JOBS_ROOT` setting makes the output CSV and description cache independent per publication tree, but the lock file is still keyed only by `ats`. A run for the same ATS targeting a separate publication root therefore sees the other root's lock and exits successfully without scraping. Its publication tree is left stale even though it does not share output or cache files with the active run. Include a canonicalized output-root identifier in the lock key so independent publication trees can run concurrently.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Allow separate pipeline output root"](https://github.com/kalil0321/ats-scrapers/commit/6ba3fdde666e1e458195ad97eb3f0f3ce7a0df44) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48553712)</sub>

<!-- /greptile_comment -->