### PR TITLE
Add validated Oracle employer wave

### DIFF
--- a/ats-companies/oracle.csv
+++ b/ats-companies/oracle.csv
@@ -1081,3 +1081,200 @@ Solstice Advanced Materials,ibzdjb/solstice,https://ibzdjb.fa.ocs.oraclecloud.co
 South Lanarkshire Council,fa-euuc-saasfaprod1/cx_1,https://fa-euuc-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1
 Staples,fa-exhh-saasfaprod1/staplesinc,https://fa-exhh-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/StaplesInc
 UNITEC,fa-ewts-saasfaprod1/unitec,https://fa-ewts-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/es/sites/unitec
+ACCO Engineered Systems,ekkt/cx_4,https://ekkt.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_4
+Action for Children,fa-evrg-saasfaprod1/cx_3,https://fa-evrg-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_3
+ADGM,fa-eukk-saasfaprod1/cx_1,https://fa-eukk-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Agri Foods,ibanqy/cx_1,https://ibanqy.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+AirAsia India,fa-eron-saasfaprod1/cx_2001,https://fa-eron-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2001
+Ajman University,iabeey/cx_2001,https://iabeey.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2001
+Al Tamimi & Company,fa-eoob-saasfaprod1/cx,https://fa-eoob-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx
+Alithya,effx/alithyacareerscarrieres,https://effx.fa.ca2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/alithyacareerscarrieres
+Alkermes,hbap/cx_1,https://hbap.fa.us1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Allegheny College,alleghenycollege-ibwwjb/cx_2,https://alleghenycollege-ibwwjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2
+Americold Global,fa-ewwt-saasfaprod1/cx_6001,https://fa-ewwt-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_6001
+Amico,iaefup/cx_1,https://iaefup.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Apps Associates,ebdt/cx_9003,https://ebdt.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_9003
+APRA,ejkm/cx_1,https://ejkm.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+ARaymond,hdex/cx_1,https://hdex.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Archrock,edva/cx_1,https://edva.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Argano,fa-eyau-saasfaprod1/cx_1,https://fa-eyau-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+AtlantiCare,ibywjb/cx_1,https://ibywjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Avient,fa-eqzh-saasfaprod1/cx_1,https://fa-eqzh-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+AzerConnect,fa-emfh-saasfaprod1/cx_1007,https://fa-emfh-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1007
+Bahri,fa-eqhm-saasfaprod1/cx_2,https://fa-eqhm-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2
+Baltimore County Public Schools,bcps-ibohjb/cx_1,https://bcps-ibohjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Bank Street College of Education,fa-emlm-saasfaprod1/cx,https://fa-emlm-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx
+Baylor,ejof/cx,https://ejof.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx
+BBB,fa-euha-saasfaprod1/cx_1,https://fa-euha-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+BC Pensions,fa-exby-saasfaprod1/cx_1013,https://fa-exby-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1013
+Benoy,edte/cx_1,https://edte.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Blue Cross Blue Shield of Michigan,ejko/cx_2,https://ejko.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2
+bolttech,fa-eqnk-saasfaprod1/cx_6001,https://fa-eqnk-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_6001
+Boston Beer,hcrb/cx,https://hcrb.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx
+BOT,fa-exfj-saasfaprod1/cx_1,https://fa-exfj-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Brinker International,fa-etjg-saasfaprod1/rsc,https://fa-etjg-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/rsc
+CADRail,fa-eygk-saasfaprod1/cadrail,https://fa-eygk-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cadrail
+Capitol View Transitional Care Center,fa-etnv-saasfaprod1/capitol-view-transitional-care-center,https://fa-etnv-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/capitol-view-transitional-care-center
+Careers At Butler,fa-exer-saasfaprod1/cx_1001,https://fa-exer-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+Careers at Heathrow,encd/cx_6005,https://encd.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_6005
+Cargolux Luxembourg Pilots,cargolux-iajigs/cargoluxpilots,https://cargolux-iajigs.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cargoluxpilots
+CarolinaEast,enpu/cx_1001,https://enpu.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+CCASH,fa-ewdf-saasfaprod1/cx_1001,https://fa-ewdf-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+Centra Health,ejid/cx_1001,https://ejid.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+Centre for Addiction and Mental Health (CAMH),iaemup/camh,https://iaemup.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/camh
+Cheniere Energy,hcgi/cx_2,https://hcgi.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2
+Cherokee Nation Businesses Corporate,ejvp/cx_1001,https://ejvp.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+City of Knoxville Government,ibbyqy/cx_4,https://ibbyqy.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_4
+Coherent Corp. US,hcwp/cx_2004,https://hcwp.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2004
+Convergint,iaaxhs/cx_1001,https://iaaxhs.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+Costain Group,iahime/costain,https://iahime.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/costain
+Cummins,fa-espx-saasfaprod1/cx_1007,https://fa-espx-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1007
+D360 Bank,fa-erqw-saasfaprod1/d360bankcareerpage,https://fa-erqw-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/d360bankcareerpage
+daa,fa-etol-saasfaprod1/cx_1,https://fa-etol-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Dallas County,fa-etvc-saasfaprod1/cx_1001,https://fa-etvc-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+Definity,hdks/careers-definity,https://hdks.fa.ca2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/careers-definity
+Department of Internal Affairs,fa-eqqg-saasfaprod1/cx_1001,https://fa-eqqg-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+DEQ,eybw/virginia-deq-careers,https://eybw.fa.us8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/virginia-deq-careers
+Dexa Group,fa-esfy-saasfaprod1/dexa-group-en,https://fa-esfy-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/dexa-group-en
+Dubai Holding,esbe/cx_1001,https://esbe.fa.em8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+Dürr Group,fa-eurk-saasfaprod1/cx_2,https://fa-eurk-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2
+East Sussex County Council,fa-euru-saasfaprod1/cx_1,https://fa-euru-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+EF / Hult,fa-evad-saasfaprod1/ef,https://fa-evad-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/ef
+EKFC,iacsey/cx_1,https://iacsey.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+ELCA Global,iaaras/cx_3,https://iaaras.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_3
+EP | Central Casting,eoko/cx_1001,https://eoko.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+EPE,ibrvjb/cx_1,https://ibrvjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+ESM Vacancies,ebuz/cx,https://ebuz.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx
+Etihad Rail,etihadrail-iaalbv/cx_1,https://etihadrail-iaalbv.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+ETSU,fa-evyu-saasfaprod1/cx_1,https://fa-evyu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Events DC,fa-etlq-saasfaprod1/cx_1,https://fa-etlq-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Farm Credit,eozs/cx_28,https://eozs.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_28
+Farm Credit,eozs/cx_8,https://eozs.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_8
+FDLC,fa-evcm-saasfaprod1/cx_1,https://fa-evcm-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+FHH,fa-emmq-saasfaprod1/fhhcareers,https://fa-emmq-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/fhhcareers
+First Hawaiian Bank,ibfhqy/fhbcareers,https://ibfhqy.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/fhbcareers
+First Solar (US),fa-esbv-saasfaprod1/cx_2001,https://fa-esbv-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2001
+FirstEnergy,fa-etjd-saasfaprod1/firstenergycareers,https://fa-etjd-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/firstenergycareers
+Flagler,fa-ewbi-saasfaprod1/cx_1,https://fa-ewbi-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Flagler,fa-ewbi-saasfaprod1/cx_4,https://fa-ewbi-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_4
+Florida Blue,fa-etum-saasfaprod1/floridablue,https://fa-etum-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/floridablue
+Franciscan Missionaries of Our Lady Health System,eqtm/cx_3001,https://eqtm.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_3001
+FUJIFILM Business Innovation,hcjq/cx_1,https://hcjq.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+FUJIFILM Business Innovation,hcjq/cx_13,https://hcjq.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_13
+FUJIFILM Business Innovation,hcjq/cx_21,https://hcjq.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_21
+Fujitsu,edzt/cx_1,https://edzt.fa.em4.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+GEDU,geduglobal-iabmbn/gedu,https://geduglobal-iabmbn.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/gedu
+Golden State Lumber,ibjzqy/cx_1,https://ibjzqy.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Goldman Sachs,hdpc/cx_3001,https://hdpc.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_3001
+Good Samaritan,fa-exgl-saasfaprod1/joinourteam,https://fa-exgl-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/joinourteam
+Government of New Brunswick,emgi/cx_3001,https://emgi.fa.ca3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_3001
+GPI,gpi-iacriz/cx_1,https://gpi-iacriz.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Great Canadian Entertainment,elvk/cx_1001,https://elvk.fa.ca3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+Green Climate Fund,iaayou/cx_1001,https://iaayou.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+Groupama,eocd/cx_1001,https://eocd.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+Grupo Werthein,egky/cx_6001,https://egky.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_6001
+Harford County Public Schools,fa-exea-saasfaprod1/cx_1001,https://fa-exea-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+Havells,iabgcp/cx_1,https://iabgcp.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Hayat National Hospital,iaasbk/cx_1,https://iaasbk.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Hilltop Holdings,ejlu/hilltopholdingsalljobs,https://ejlu.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/hilltopholdingsalljobs
+Historic Environment Scotland,ekov/cx_2001,https://ekov.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2001
+Houston ISD,houstonisd-ibffqy/cx_1,https://houstonisd-ibffqy.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+HS2,egif/cx_1001,https://egif.fa.em1.ukg.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+Hudson Advisors,fa-exvv-saasfaprod1/hudson,https://fa-exvv-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/hudson
+IKS Health,eiyi/cx_3001,https://eiyi.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_3001
+Imdaad,ekkz/cx_5001,https://ekkz.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_5001
+ITC Holdings,edqo/cx_3001,https://edqo.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_3001
+Jubilant Corporate,fa-exph-saasfaprod1/jubilant,https://fa-exph-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/jubilant
+Kerakoll,iaaemj/cx_1001,https://iaaemj.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+Kirey,iabigs/kirey-career-site,https://iabigs.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/kirey-career-site
+Klépierre,fa-ewfm-saasfaprod1/klepierre,https://fa-ewfm-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/klepierre
+Lambeth New,effe/cx_1001,https://effe.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+LCS,eexs/alljobs,https://eexs.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/alljobs
+LHC,erzb/cx_1,https://erzb.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Malomatia,fa-eyhb-saasfaprod1/cx_1,https://fa-eyhb-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+MAREK,eixy/cx_2002,https://eixy.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2002
+Mayo Clinic,fa-euwp-saasfaprod1/mayo-us,https://fa-euwp-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/mayo-us
+MCERT,fa-evjy-saasfaprod1/cx_1,https://fa-evjy-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Messiah University,messiah-ibvrjb/cx_2,https://messiah-ibvrjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2
+Moravian University,ibtsjb/cx_2,https://ibtsjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2
+Mr Price Group,fa-etyi-saasfaprod1/mrpricegroupcareers,https://fa-etyi-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/mrpricegroupcareers
+National Heritage Academies,fa-eotc-saasfaprod1/specialeducation,https://fa-eotc-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/specialeducation
+Nayara,fa-escq-saasfaprod1/cx_1001,https://fa-escq-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+New LHRC,evqk/cx_2001,https://evqk.fa.us8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2001
+New LHRC,evqk/cx_3001,https://evqk.fa.us8.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_3001
+Newham Council,elyq/cx,https://elyq.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx
+NexOps,iaarey/cx_1001,https://iaarey.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+NMC,eiby/cx_1001,https://eiby.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+NMDC,fa-evft-saasfaprod1/nmdccareers,https://fa-evft-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/nmdccareers
+NMIMS,fa-elxu-saasfaprod1/cx_2001,https://fa-elxu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2001
+NMIMS,fa-elxu-saasfaprod1/cx_2005,https://fa-elxu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2005
+NMIMS,fa-elxu-saasfaprod1/cx_4001,https://fa-elxu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_4001
+Northbay,erou/cx_1,https://erou.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Notified,eclz/cx_3001,https://eclz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_3001
+Nottingham City Council,eism/ncc,https://eism.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/ncc
+OKC,fa-etyr-saasfaprod1/cx_2,https://fa-etyr-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2
+Olathe Public Schools,fa-ewbu-saasfaprod1/cx_1,https://fa-ewbu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Omega Healthcare,fa-equm-saasfaprod1/cx_2001,https://fa-equm-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2001
+Parker,elje/cx,https://elje.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx
+PETRONAS,epuc/cx_4,https://epuc.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_4
+PMMA,ibdyqy/cx_1,https://ibdyqy.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Port of Dover,iagxme/cx_1,https://iagxme.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Port of Townsville,iaaonf/cx_1,https://iaaonf.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Presbyterian Medical Services,echs/cx,https://echs.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx
+Providence,evac/cx_2,https://evac.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2
+Pulse,ejgl/uowpulse,https://ejgl.fa.ap1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/uowpulse
+QIA,fa-esgr-saasfaprod1/cx_1,https://fa-esgr-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Quad,ebud/cx_1,https://ebud.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+R+L Carriers,erhk/cx_7,https://erhk.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_7
+Raley's,fa-epss-saasfaprod1/cx_1,https://fa-epss-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Ralliant,ibwujb/cx_1001,https://ibwujb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+Riverside,eqay/cx_1,https://eqay.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Safaricom,egjd/cx,https://egjd.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx
+SAFE,fa-esiu-saasfaprod1/cx_1001,https://fa-esiu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+SAFE,fa-esiu-saasfaprod1/cx_2001,https://fa-esiu-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2001
+Saint Michael's College,stmichaels-ibukjb/cx_2,https://stmichaels-ibukjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2
+Sally Beauty Holdings,eigx/cx_13,https://eigx.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_13
+Sally Beauty Holdings,eigx/cx_9,https://eigx.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_9
+Samsonite,ekkf/cx,https://ekkf.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx
+Savencia,eoct/cx_2005,https://eoct.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2005
+Scottish Government Recruitment,fa-evxn-saasfaukgovprod1/cx_1001,https://fa-evxn-saasfaukgovprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+SHEIN,fa-exjq-saasfaprod1/shein,https://fa-exjq-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/shein
+Sidra Medicine,fa-epxn-saasfaprod1/sidra-career-site,https://fa-epxn-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/sidra-career-site
+Sleep Country,eklv/cx_1001,https://eklv.fa.ca3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+SMA,fa-exow-saasfaprod1/cx_1,https://fa-exow-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Socomec,iahxgs/cx_1001,https://iahxgs.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+Sodiaal,fa-epmr-saasfaprod1/cx_1,https://fa-epmr-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+SOH,fa-evmb-saasfaprod1/cx_1,https://fa-evmb-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+St. Peter's Health,fa-eqec-saasfaprod1/cx_2,https://fa-eqec-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2
+Stamford Health,fa-ewfb-saasfaprod1/gemsnursing,https://fa-ewfb-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/gemsnursing
+Staples Retail,fa-exhh-saasfaprod1/staplesretail,https://fa-exhh-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/staplesretail
+Stirling Council,fa-etrw-saasfaprod1/cx_1,https://fa-etrw-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Structure Tone,fa-exrr-saasfaprod1/structuretoneus,https://fa-exrr-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/structuretoneus
+Suffolk Jobs Direct,eoce/cx_1004,https://eoce.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1004
+Summit Companies,fa-exxm-saasfaprod1/cx_3,https://fa-exxm-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_3
+Talento Dos Pinos,fa-enfw-saasfaprod1/cx_4001,https://fa-enfw-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_4001
+Tao Group Hospitality,fa-euyb-saasfaprod1/cx_1001,https://fa-euyb-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+Telenet,ebza/cx_1001,https://ebza.fa.em2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+Telstra Health,iaaktz/cx_2,https://iaaktz.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2
+The City of Red Deer,fa-eyjj-saasfaprod1/cx_1,https://fa-eyjj-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Thurston County,fa-etsa-saasfaprod1/cx_1,https://fa-etsa-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+TriNet,fa-etgw-saasfaprod1/cx_1,https://fa-etgw-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+TrueBlue,ehnn/cx_1001,https://ehnn.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+Tulane,tulane-ibqejb/cx_2,https://tulane-ibqejb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2
+UBL,ublcloud-iaanbv/ubl-careers,https://ublcloud-iaanbv.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/ubl-careers
+UK SBS,fa-evzn-saasfaukgovprod1/uksbs-careers,https://fa-evzn-saasfaukgovprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/uksbs-careers
+UL Solutions,fa-eups-saasfaprod1/cx_1,https://fa-eups-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Universidad Simón Bolívar,fa-ewdp-saasfaprod1/portal-usb,https://fa-ewdp-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/portal-usb
+University of Birmingham,edzz/cx_6004,https://edzz.fa.em3.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_6004
+University of South Florida,fa-ewkd-saasfaprod1/cx_1,https://fa-ewkd-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+University of Tulsa,utulsa-ibvjjb/cx_1,https://utulsa-ibvjjb.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+USGI,usgi-iacoiz/cx_1,https://usgi-iacoiz.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Varun Beverages Limited (VBL),rjcorphcm-iacbiz/cx_4,https://rjcorphcm-iacbiz.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_4
+Veikkaus Oy,fa-exdl-saasfaprod1/cx_2,https://fa-exdl-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2
+Victoria University,fa-ercy-saasfaprod1/cx_2001,https://fa-ercy-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_2001
+Wayne County,emqz/cx_1,https://emqz.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1
+Weber County,fa-etrb-saasfaprod1/cx_3001,https://fa-etrb-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_3001
+WEPA,hdra/cx_1001,https://hdra.fa.em5.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001
+Westfield,fa-exdv-saasfaprod1/careers,https://fa-exdv-saasfaprod1.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/careers
+Worthington Steel,cbdt/cx_3001,https://cbdt.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_3001
+WSIB,wsib-iaepup/cx_1001,https://wsib-iaepup.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/cx_1001


### PR DESCRIPTION
## Summary
- add 197 production Oracle Fusion career sites discovered from Common Crawl
- exclude dev/test/demo surfaces, unnamed portals, low-net aliases, and duplicate site mirrors
- keep one provider-specific PR; no scraper or credential changes

## Live validation
- current `OracleScraper`: 197/197 sites successful, 0 failures
- 29,730 reported rows; 29,469 exact unique `ats_id`s after cross-site dedupe
- 29,469/29,469 have title, location, and posted date
- immutable publication audit at selection time: 28,920 selected jobs, 64 existing, 28,856 exact net-new
- approximate selected regional yield: 20,137 US, 2,204 Europe, 4,539 Asia

## Checks
- `env -u SSL_CERT_FILE uv run --extra all pytest -q tests/test_scrapers_extra.py -k oracle tests/test_run_pipeline_guards.py` (7 passed)
- `git diff --check`
- CSV URLs and slugs are unique against current `main` and within the wave

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 197 validated Oracle Fusion employer career sites to `ats-companies/oracle.csv`. Expands coverage with 28,856 net-new jobs; no scraper or credential changes.

- **New Features**
  - 197 production sites from Common Crawl; dev/test/demo, unnamed portals, and mirrors excluded.
  - Validation: 197/197 successful; 29,469 unique `ats_id`s; all records have title, location, and posted date.
  - Publication audit: 28,920 selected jobs (64 existing, 28,856 net-new); regional yield ~20,137 US, 2,204 Europe, 4,539 Asia.
  - Checks: tests pass (7); URLs and slugs unique vs `main` and within the wave.

<sup>Written for commit 552059e3342f135af3a85ba470b515514fbd8da6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

