### PR TITLE
Add Talentio ATS provider (4,917 net-new jobs)

### DIFF
--- a/ats-companies/talentio.csv
+++ b/ats-companies/talentio.csv
@@ -1,0 +1,634 @@
+name,url
+株式会社10X,https://open.talentio.com/r/1/c/10x/homes/3786
+株式会社トゥエンティーフォーセブン,https://open.talentio.com/r/1/c/247group/homes/4539
+3Hメディソリューション株式会社,https://open.talentio.com/r/1/c/3h-ms/homes/3586
+株式会社5Minutes,https://open.talentio.com/r/1/c/5min/homes/4666
+62Complex株式会社,https://open.talentio.com/r/1/c/62complex/homes/3928
+株式会社9E,https://open.talentio.com/r/1/c/9e-hs/homes/4207
+株式会社better,https://open.talentio.com/r/1/c/_better_requisitions_01/homes/2826
+株式会社A2Z,https://open.talentio.com/r/1/c/a2z/homes/4799
+株式会社A＆Cコンサルティング,https://open.talentio.com/r/1/c/aandcjapan/homes/4442
+株式会社アクリア,https://open.talentio.com/r/1/c/accrea/homes/4141
+株式会社ACES,https://open.talentio.com/r/1/c/aces/homes/2662
+アクトインディ株式会社,https://open.talentio.com/r/1/c/actindi/homes/4058
+Activaid株式会社,https://open.talentio.com/r/1/c/activaid/homes/1896
+株式会社アダル,https://open.talentio.com/r/1/c/adal_careers/homes/4149
+株式会社ＡＤＤＩＸ,https://open.talentio.com/r/1/c/addix/homes/1767
+アグリコネクト株式会社,https://open.talentio.com/r/1/c/agri-connect/homes/1036
+株式会社アイディオット,https://open.talentio.com/r/1/c/aidiot/homes/3925
+株式会社アイディス,https://open.talentio.com/r/1/c/aidis/homes/4171
+株式会社アイディス,https://open.talentio.com/r/1/c/aidis/homes/4198
+株式会社アイディス,https://open.talentio.com/r/1/c/aidis/homes/4758
+株式会社AirX,https://open.talentio.com/r/1/c/airx/homes/1662
+アイザック株式会社,https://open.talentio.com/r/1/c/aisaac/homes/3970
+Alche株式会社,https://open.talentio.com/r/1/c/alche/homes/4317
+アリババ株式会社,https://open.talentio.com/r/1/c/alibaba/homes/2985
+株式会社ALiNKインターネット,https://open.talentio.com/r/1/c/alink/homes/4614
+株式会社alma,https://open.talentio.com/r/1/c/alma-inc/homes/1663
+SAMURAI FINANCIAL HOLDINGS株式会社,https://open.talentio.com/r/1/c/alternabank/homes/4057
+株式会社Amazia,https://open.talentio.com/r/1/c/amazia/homes/2502
+アメリエフ株式会社,https://open.talentio.com/r/1/c/amelieff/homes/4090
+アニマルメディカルセンター,https://open.talentio.com/r/1/c/ams-jyui/homes/1645
+アンカーテクノロジーズ株式会社,https://open.talentio.com/r/1/c/anchor-u/homes/4042
+株式会社AND PARTNERS,https://open.talentio.com/r/1/c/and-partners/homes/4567
+Aniwo株式会社,https://open.talentio.com/r/1/c/aniwo-career/homes/1666
+Ann株式会社,https://open.talentio.com/r/1/c/ann-inc/homes/4428
+株式会社くふうウェディング,https://open.talentio.com/r/1/c/anymarry/homes/4443
+あおい在宅クリニック,https://open.talentio.com/r/1/c/aoi-zaitaku-clinic/homes/4572
+あおい在宅クリニック,https://open.talentio.com/r/1/c/aoi-zaitaku-clinic/homes/4577
+蒼株式会社,https://open.talentio.com/r/1/c/aoiinc/homes/4454
+株式会社アプトポッド,https://open.talentio.com/r/1/c/aptpod/homes/3629
+株式会社ARCH,https://open.talentio.com/r/1/c/arch-social/homes/4475
+株式会社ARCH,https://open.talentio.com/r/1/c/arch-social/homes/4707
+株式会社アーキタイプ,https://open.talentio.com/r/1/c/archetyp/homes/2388
+株式会社ARCRA,https://open.talentio.com/r/1/c/arcra/homes/4467
+株式会社AREXY,https://open.talentio.com/r/1/c/arexy/homes/4118
+株式会社アリストル,https://open.talentio.com/r/1/c/aristol/homes/4530
+株式会社アリストル,https://open.talentio.com/r/1/c/aristol/homes/4531
+株式会社アリストル,https://open.talentio.com/r/1/c/aristol/homes/4532
+株式会社アロバ,https://open.talentio.com/r/1/c/aroba/homes/4553
+アルサーガパートナーズ株式会社,https://open.talentio.com/r/1/c/arsaga/homes/2668
+アートシステム株式会社,https://open.talentio.com/r/1/c/art-system/homes/2130
+アストロラボ株式会社,https://open.talentio.com/r/1/c/astrolab/homes/4256
+株式会社アトラエ,https://open.talentio.com/r/1/c/atrae/homes/4050
+awoo株式会社,https://open.talentio.com/r/1/c/awoo/homes/4001
+株式会社 BACKSTAGE,https://open.talentio.com/r/1/c/backstage/homes/4186
+株式会社BANKEY,https://open.talentio.com/r/1/c/bankey/homes/4520
+ベース株式会社,https://open.talentio.com/r/1/c/basenet_200plus_ai/homes/4589
+BBIX株式会社,https://open.talentio.com/r/1/c/bbix/homes/4610
+株式会社ビーブリッジ,https://open.talentio.com/r/1/c/bebridge/homes/4158
+株式会社BEC,https://open.talentio.com/r/1/c/bec-inc/homes/1816
+株式会社Belong,https://open.talentio.com/r/1/c/belong/homes/3908
+ビートレンド株式会社,https://open.talentio.com/r/1/c/betrend/homes/3902
+株式会社BFM,https://open.talentio.com/r/1/c/bfm/homes/4576
+BASE株式会社,https://open.talentio.com/r/1/c/binc/homes/4380
+株式会社ビットアルゴ取引所東京,https://open.talentio.com/r/1/c/bitargx/homes/1804
+株式会社BlasTrain,https://open.talentio.com/r/1/c/blastrain/homes/3253
+株式会社ボーダレスシティ,https://open.talentio.com/r/1/c/blcity/homes/4173
+BlueFarm株式会社,https://open.talentio.com/r/1/c/blue-farm/homes/4402
+株式会社Boatrip,https://open.talentio.com/r/1/c/boatrip-recruit/homes/1897
+NPO法人ボーダレスファウンデーション,https://open.talentio.com/r/1/c/borderless/homes/4603
+株式会社ブレイブ・ワーク,https://open.talentio.com/r/1/c/bravework/homes/4283
+ブリッジコンサルティンググループ株式会社,https://open.talentio.com/r/1/c/bridge-group/homes/4781
+ビーサイズ株式会社,https://open.talentio.com/r/1/c/bsize/homes/3870
+株式会社シー・コネクト,https://open.talentio.com/r/1/c/c-connect/homes/1077
+キャディ株式会社,https://open.talentio.com/r/1/c/caddi-jp-recruit/homes/4257
+キャディ株式会社,https://open.talentio.com/r/1/c/caddi-jp-recruit/homes/4493
+キャディ株式会社,https://open.talentio.com/r/1/c/caddi-jp-recruit/homes/4761
+株式会社ケアクル,https://open.talentio.com/r/1/c/carecle/homes/1799
+株式会社キャリオット,https://open.talentio.com/r/1/c/cariot-recruit/homes/4431
+株式会社Catallaxy,https://open.talentio.com/r/1/c/catallaxy/homes/2947
+株式会社キャッチボール,https://open.talentio.com/r/1/c/catch-ball/homes/2196
+C Channel株式会社,https://open.talentio.com/r/1/c/cchan/homes/3781
+株式会社centerwave,https://open.talentio.com/r/1/c/centerwave/homes/4750
+チェックイン株式会社,https://open.talentio.com/r/1/c/checkinn/homes/2688
+株式会社ケミカン,https://open.talentio.com/r/1/c/chemican/homes/4559
+株式会社チカク,https://open.talentio.com/r/1/c/chikaku/homes/2323
+株式会社ちょびリッチ,https://open.talentio.com/r/1/c/chobirich-saiyou/homes/2042
+シスルナテクノロジーズ株式会社,https://open.talentio.com/r/1/c/cislunartech/homes/4271
+Clase Azul Asia株式会社,https://open.talentio.com/r/1/c/claseazul/homes/4275
+CLINIC TEN,https://open.talentio.com/r/1/c/clinicten/homes/4769
+株式会社クラウドネイティブ,https://open.talentio.com/r/1/c/cloudnative/homes/1901
+株式会社コードタクト,https://open.talentio.com/r/1/c/codetakt/homes/2629
+コインスペース株式会社,https://open.talentio.com/r/1/c/coinspace/homes/1962
+コミューン株式会社,https://open.talentio.com/r/1/c/commune/homes/4404
+コミューン株式会社,https://open.talentio.com/r/1/c/commune/homes/4473
+株式会社コズレ,https://open.talentio.com/r/1/c/cozre/homes/4000
+クラフトマン株式会社,https://open.talentio.com/r/1/c/craftsman/homes/1589
+株式会社Crepe,https://open.talentio.com/r/1/c/crepeinc/homes/4480
+Creyon Japan合同会社,https://open.talentio.com/r/1/c/creyon/homes/4676
+クルーズ株式会社,https://open.talentio.com/r/1/c/crooz/homes/1556
+株式会社Crossdoor,https://open.talentio.com/r/1/c/crossdoor/homes/3866
+クロスログ株式会社,https://open.talentio.com/r/1/c/crosslog/homes/4248
+ファンズ株式会社,https://open.talentio.com/r/1/c/crowdport_entry/homes/3643
+株式会社クラウンデータ,https://open.talentio.com/r/1/c/crowndata/homes/3649
+株式会社pafin,https://open.talentio.com/r/1/c/cryptact/homes/2045
+株式会社Cubec,https://open.talentio.com/r/1/c/cubec-jp/homes/4221
+株式会社CuboRex,https://open.talentio.com/r/1/c/cuborex_recruit/homes/4119
+DADAN株式会社,https://open.talentio.com/r/1/c/dadan/homes/4668
+株式会社データフォーシーズ,https://open.talentio.com/r/1/c/data4cs/homes/3784
+株式会社データ・エージェンシー,https://open.talentio.com/r/1/c/dataagency/homes/3963
+株式会社DECENCIA,https://open.talentio.com/r/1/c/decencia/homes/1009
+株式会社Decentier,https://open.talentio.com/r/1/c/decentier/homes/4157
+株式会社ディープインパクト,https://open.talentio.com/r/1/c/deepimpact/homes/4188
+DeFactory株式会社,https://open.talentio.com/r/1/c/defactory/homes/4121
+株式会社デリズマート,https://open.talentio.com/r/1/c/delizmart/homes/3924
+株式会社DentaLight,https://open.talentio.com/r/1/c/dentalight/homes/1033
+株式会社デプロイゲート,https://open.talentio.com/r/1/c/deploygate/homes/1626
+株式会社デプロイネイチャー,https://open.talentio.com/r/1/c/deploynature/homes/2702
+株式会社DigiMan,https://open.talentio.com/r/1/c/digi-man/homes/4634
+株式会社DigitalArchi,https://open.talentio.com/r/1/c/digital-archi/homes/4512
+株式会社ディッカー,https://open.talentio.com/r/1/c/dikker/homes/1578
+株式会社ディマージシェア,https://open.talentio.com/r/1/c/dimage/homes/3701
+フューチャーセキュアウェイブ株式会社,https://open.talentio.com/r/1/c/dit-recruit/homes/1075
+フューチャーセキュアウェイブ株式会社,https://open.talentio.com/r/1/c/dit-recruit/homes/4258
+フューチャーセキュアウェイブ株式会社,https://open.talentio.com/r/1/c/dit-recruit/homes/4787
+株式会社電通マクロミルインサイト,https://open.talentio.com/r/1/c/dmi_recruit/homes/3052
+株式会社電通マクロミルインサイト,https://open.talentio.com/r/1/c/dmi_recruit/homes/3053
+株式会社リード,https://open.talentio.com/r/1/c/doctorbelee/homes/1793
+ダブルビーゼット株式会社,https://open.talentio.com/r/1/c/doublebz/homes/4401
+株式会社douzo,https://open.talentio.com/r/1/c/douzo/homes/4328
+[中途採用] 株式会社ドリコム,https://open.talentio.com/r/1/c/drecom/homes/3387
+株式会社DROBE,https://open.talentio.com/r/1/c/drobe/homes/2501
+ダイナミックプラス株式会社,https://open.talentio.com/r/1/c/dynamic-plus/homes/4315
+ダイナミックプラス株式会社,https://open.talentio.com/r/1/c/dynamic-plus/homes/4362
+ダイナミックプラス株式会社,https://open.talentio.com/r/1/c/dynamic-plus/homes/4363
+ダイナミックプラス株式会社,https://open.talentio.com/r/1/c/dynamic-plus/homes/4365
+ダイナミックプラス株式会社,https://open.talentio.com/r/1/c/dynamic-plus/homes/4767
+株式会社ダイナトレック,https://open.talentio.com/r/1/c/dynatrek/homes/1885
+イーサポートリンク株式会社,https://open.talentio.com/r/1/c/e-supportlink/homes/1638
+株式会社ジャパンチケットホールディングス,https://open.talentio.com/r/1/c/ebisol_recruit/homes/2600
+ecbo株式会社,https://open.talentio.com/r/1/c/ecbo/homes/1794
+株式会社Edulead,https://open.talentio.com/r/1/c/edulead/homes/3017
+イレブンナイン株式会社,https://open.talentio.com/r/1/c/elevennines/homes/1613
+株式会社エルブズ,https://open.talentio.com/r/1/c/elvez/homes/1627
+emol株式会社,https://open.talentio.com/r/1/c/emol/homes/1846
+eMotion Fleet株式会社,https://open.talentio.com/r/1/c/emotion-fleet/homes/4620
+株式会社ENIAQ,https://open.talentio.com/r/1/c/eniaq/homes/4568
+GMOエンペイ株式会社,https://open.talentio.com/r/1/c/enpay/homes/4067
+株式会社Ｅストアー,https://open.talentio.com/r/1/c/estore/homes/593
+エシカル・スピリッツ株式会社,https://open.talentio.com/r/1/c/ethicalspirits/homes/4061
+株式会社エクサウィザーズ,https://open.talentio.com/r/1/c/exwzd/homes/4039
+Fairy Devices株式会社,https://open.talentio.com/r/1/c/fairydevices/homes/4010
+医療法人社団柏木記念会,https://open.talentio.com/r/1/c/famil-s-group/homes/4508
+株式会社ファームノート,https://open.talentio.com/r/1/c/farmnote-holdings/homes/2913
+株式会社フィスコ仮想通貨取引所,https://open.talentio.com/r/1/c/fcce/homes/2250
+株式会社フィスコ仮想通貨取引所,https://open.talentio.com/r/1/c/fcce/homes/2251
+株式会社フィードフォース,https://open.talentio.com/r/1/c/feedforce/homes/2971
+株式会社FERMENT,https://open.talentio.com/r/1/c/ferment_inc/homes/4770
+株式会社Feynma Technology,https://open.talentio.com/r/1/c/feynma/homes/4683
+株式会社フィジオ,https://open.talentio.com/r/1/c/figeo/homes/3406
+株式会社FIKA,https://open.talentio.com/r/1/c/fika/homes/2343
+株式会社フレアリンク,https://open.talentio.com/r/1/c/flairlink/homes/4616
+株式会社フレイムハーツ,https://open.talentio.com/r/1/c/flamehearts/homes/3209
+株式会社フレイムハーツ,https://open.talentio.com/r/1/c/flamehearts/homes/3951
+株式会社フレイムハーツ,https://open.talentio.com/r/1/c/flamehearts/homes/4015
+株式会社flaro,https://open.talentio.com/r/1/c/flaro/homes/4556
+株式会社FLIGHTS,https://open.talentio.com/r/1/c/flights/homes/1842
+Fracta Leap株式会社,https://open.talentio.com/r/1/c/fracta-leap/homes/3905
+株式会社フリークアウト・ホールディングス,https://open.talentio.com/r/1/c/freakout/homes/3202
+株式会社フリークアウト・ホールディングス,https://open.talentio.com/r/1/c/freakout/homes/4562
+株式会社フリークアウト・ホールディングス,https://open.talentio.com/r/1/c/freakout/homes/4564
+株式会社フリークアウト・ホールディングス,https://open.talentio.com/r/1/c/freakout/homes/4565
+株式会社フリークアウト・ホールディングス,https://open.talentio.com/r/1/c/freakout/homes/4566
+株式会社フリークアウト・ホールディングス,https://open.talentio.com/r/1/c/freakout/homes/4697
+株式会社フリークアウト・ホールディングス,https://open.talentio.com/r/1/c/freakout/homes/4768
+Frich株式会社,https://open.talentio.com/r/1/c/frich/homes/4108
+株式会社FrienDoggy,https://open.talentio.com/r/1/c/friendoggy/homes/4792
+医療法人社団富岳会,https://open.talentio.com/r/1/c/fugakukai/homes/4763
+株式会社FUNDINNO,https://open.talentio.com/r/1/c/fundinno/homes/4718
+フューチャー株式会社,https://open.talentio.com/r/1/c/future/homes/3520
+株式会社フューチャースタンダード,https://open.talentio.com/r/1/c/futurestandard/homes/1028
+Gatebox株式会社,https://open.talentio.com/r/1/c/gateboxlab/homes/1633
+Gate Japan株式会社,https://open.talentio.com/r/1/c/gatejapan.com/homes/2581
+株式会社GENDA,https://open.talentio.com/r/1/c/genda/homes/4356
+株式会社ゼネラルパートナーズ,https://open.talentio.com/r/1/c/generalpartners/homes/3246
+株式会社ゼネラルパートナーズ,https://open.talentio.com/r/1/c/generalpartners/homes/3248
+トレーダム株式会社,https://open.talentio.com/r/1/c/gfit-careers/homes/4252
+トレーダム株式会社,https://open.talentio.com/r/1/c/gfit-careers/homes/4436
+ギグベース株式会社,https://open.talentio.com/r/1/c/gigbase/homes/3998
+株式会社銀河エージェンシー,https://open.talentio.com/r/1/c/ginga/homes/4447
+グローバル・ソリューションズ・コンサルティング株式会社,https://open.talentio.com/r/1/c/global-solution/homes/4439
+互恵デベロップアーク株式会社,https://open.talentio.com/r/1/c/gokei-d/homes/4630
+株式会社グッドラックスリー,https://open.talentio.com/r/1/c/goodluck3/homes/1598
+株式会社GRA,https://open.talentio.com/r/1/c/gra-inc/homes/3898
+GRANDS株式会社,https://open.talentio.com/r/1/c/grands-pets/homes/4793
+Gran Manibus,https://open.talentio.com/r/1/c/granmanibus/homes/4359
+株式会社GRAPES,https://open.talentio.com/r/1/c/grapes/homes/3859
+グリーエンターテインメント株式会社,https://open.talentio.com/r/1/c/gree-entertainment_recruit/homes/3090
+株式会社GRI,https://open.talentio.com/r/1/c/gri-jp/homes/4541
+株式会社グリモア,https://open.talentio.com/r/1/c/grimoire/homes/1775
+グローリング株式会社,https://open.talentio.com/r/1/c/growring/homes/4398
+株式会社GROWTH IMT,https://open.talentio.com/r/1/c/growth-imt-mirai/homes/4448
+株式会社Habbit,https://open.talentio.com/r/1/c/habbit/homes/2646
+株式会社Habbit,https://open.talentio.com/r/1/c/habbit/homes/2683
+株式会社Habiny,https://open.talentio.com/r/1/c/habiny/homes/4477
+株式会社ハッカズーク,https://open.talentio.com/r/1/c/hackazouk/homes/4419
+株式会社hacomono,https://open.talentio.com/r/1/c/hacomono/homes/4140
+株式会社ペイルド,https://open.talentio.com/r/1/c/handii/homes/2724
+ハンディ株式会社,https://open.talentio.com/r/1/c/handy-school/homes/4282
+ヘルスケアテクノロジーズ株式会社,https://open.talentio.com/r/1/c/healthcare-tech/homes/4626
+ヘルスケアテクノロジーズ株式会社,https://open.talentio.com/r/1/c/healthcare-tech/homes/4627
+ヘルスケアテクノロジーズ株式会社,https://open.talentio.com/r/1/c/healthcare-tech/homes/4628
+ヘルスケアテクノロジーズ株式会社,https://open.talentio.com/r/1/c/healthcare-tech/homes/4629
+株式会社ヒューリズム,https://open.talentio.com/r/1/c/heurithm/homes/4452
+株式会社HIROBA,https://open.talentio.com/r/1/c/hiroba/homes/4028
+株式会社Hokanグループ,https://open.talentio.com/r/1/c/hokan/homes/3936
+株式会社Hokanグループ,https://open.talentio.com/r/1/c/hokan/homes/3987
+株式会社Hokanグループ,https://open.talentio.com/r/1/c/hokan/homes/4263
+株式会社Nature Innovation Group,https://open.talentio.com/r/1/c/i-kasa/homes/4126
+ICI株式会社,https://open.talentio.com/r/1/c/ici-inc/homes/2056
+株式会社いえらぶGROUP,https://open.talentio.com/r/1/c/ielove-group/homes/4088
+株式会社アイ・グリッド・ソリューションズ,https://open.talentio.com/r/1/c/igrid/homes/2505
+イジゲングループ株式会社,https://open.talentio.com/r/1/c/ijgn_careers/homes/2096
+株式会社IKOL,https://open.talentio.com/r/1/c/ikol-int/homes/4288
+株式会社Inazma,https://open.talentio.com/r/1/c/inazma/homes/4260
+Increments株式会社,https://open.talentio.com/r/1/c/increments/homes/1574
+インキュベイトファンド株式会社,https://open.talentio.com/r/1/c/incubatefund_recruit/homes/2649
+株式会社インディゲンス,https://open.talentio.com/r/1/c/indigens/homes/3973
+株式会社インフキュリオン,https://open.talentio.com/r/1/c/infcurion/homes/3395
+株式会社Insity,https://open.talentio.com/r/1/c/insity/homes/2321
+フューチャーインスペース株式会社,https://open.talentio.com/r/1/c/inspace/homes/3024
+インタラクティブ株式会社,https://open.talentio.com/r/1/c/inta/homes/3999
+株式会社IRIS,https://open.talentio.com/r/1/c/iris/homes/1593
+株式会社アイスタイル,https://open.talentio.com/r/1/c/istyle_career/homes/4344
+JAMU株式会社,https://open.talentio.com/r/1/c/jamuinc/homes/3917
+Japan Digital Design 株式会社,https://open.talentio.com/r/1/c/japan-d2/homes/2004
+ジャパンシステム株式会社,https://open.talentio.com/r/1/c/japan-systems/homes/3884
+ジャパンシステム株式会社,https://open.talentio.com/r/1/c/japan-systems/homes/3886
+ジャパンシステム株式会社,https://open.talentio.com/r/1/c/japan-systems/homes/4091
+JCCコンサルティング株式会社,https://open.talentio.com/r/1/c/japancloud/homes/3295
+JCCコンサルティング株式会社,https://open.talentio.com/r/1/c/japancloud/homes/3296
+JCCコンサルティング株式会社,https://open.talentio.com/r/1/c/japancloud/homes/3299
+JCCコンサルティング株式会社,https://open.talentio.com/r/1/c/japancloud/homes/3995
+JCCコンサルティング株式会社,https://open.talentio.com/r/1/c/japancloud/homes/4310
+株式会社ジャンティサービス,https://open.talentio.com/r/1/c/jaunty-services_recruit_joblist/homes/4788
+ジクー株式会社,https://open.talentio.com/r/1/c/jicoo/homes/3959
+jinjer株式会社,https://open.talentio.com/r/1/c/jinjer/homes/4753
+株式会社経営承継支援,https://open.talentio.com/r/1/c/jms-support/homes/2430
+ジョイズ株式会社,https://open.talentio.com/r/1/c/joyz/homes/2229
+日本トライスタイル株式会社,https://open.talentio.com/r/1/c/jpn-ts/homes/4561
+株式会社SPeak,https://open.talentio.com/r/1/c/jportbyspeak/homes/4292
+ENEOS Xplora株式会社,https://open.talentio.com/r/1/c/jxgr/homes/4240
+株式会社JX通信社,https://open.talentio.com/r/1/c/jxpress/homes/3376
+一般社団法人　患者目線,https://open.talentio.com/r/1/c/k-mesen/homes/4137
+ケイスリー株式会社,https://open.talentio.com/r/1/c/k-three/homes/4142
+株式会社KABU＆ほけんパートナーズ,https://open.talentio.com/r/1/c/kabu-hp/homes/4651
+株式会社角川クラフト,https://open.talentio.com/r/1/c/kadokawa-craft/homes/4756
+株式会社カイラススタイル,https://open.talentio.com/r/1/c/kailashstyle/homes/4021
+株式会社KaKa Creation,https://open.talentio.com/r/1/c/kakacreation/homes/4615
+株式会社カカオピッコマ,https://open.talentio.com/r/1/c/kakaopiccoma/homes/2676
+株式会社関東エース　佐野営業所,https://open.talentio.com/r/1/c/kantoace-sano/homes/1809
+株式会社建設人事部,https://open.talentio.com/r/1/c/kensetsu-hr/homes/4730
+HITOWAグループ,https://open.talentio.com/r/1/c/kids-connect/homes/4580
+株式会社ナレッジセンス,https://open.talentio.com/r/1/c/knowledgesense/homes/4303
+株式会社神戸デジタル・ラボ,https://open.talentio.com/r/1/c/kobedigitallabo/homes/3091
+株式会社くふうカンパニー,https://open.talentio.com/r/1/c/kufu/homes/3849
+株式会社くふうカンパニーホールディングス,https://open.talentio.com/r/1/c/kufu-company/homes/4232
+株式会社くふうカンパニーホールディングス,https://open.talentio.com/r/1/c/kufu-company/homes/4622
+株式会社KURASERU,https://open.talentio.com/r/1/c/kuraseru/homes/2007
+有限会社草川工作所,https://open.talentio.com/r/1/c/kusakawakousakusho/homes/4209
+株式会社L is B,https://open.talentio.com/r/1/c/l-is-b/homes/3964
+株式会社LayerX,https://open.talentio.com/r/1/c/layerx/homes/3589
+株式会社LayerX,https://open.talentio.com/r/1/c/layerx/homes/4116
+株式会社LayerX,https://open.talentio.com/r/1/c/layerx/homes/4117
+リードインクス株式会社,https://open.talentio.com/r/1/c/leadinx/homes/4103
+株式会社LexxPluss,https://open.talentio.com/r/1/c/lexxpluss/homes/1863
+株式会社LexxPluss,https://open.talentio.com/r/1/c/lexxpluss/homes/4624
+株式会社リンクバル,https://open.talentio.com/r/1/c/linkbal/homes/4181
+株式会社リンクバル,https://open.talentio.com/r/1/c/linkbal/homes/4208
+LiNKX株式会社,https://open.talentio.com/r/1/c/linkx-dev/homes/4155
+Linne株式会社,https://open.talentio.com/r/1/c/linne/homes/1553
+株式会社LITALICO,https://open.talentio.com/r/1/c/litalico-inc/homes/2411
+株式会社LiveSmart,https://open.talentio.com/r/1/c/livesmart/homes/2324
+株式会社Looper,https://open.talentio.com/r/1/c/looper/homes/4
+株式会社LOWBAL,https://open.talentio.com/r/1/c/lowbal/homes/4665
+Loycus株式会社,https://open.talentio.com/r/1/c/loycus/homes/4418
+株式会社Life Style Innovation,https://open.talentio.com/r/1/c/lsi-inc/homes/4661
+株式会社エイビット,https://open.talentio.com/r/1/c/m-abit/homes/4272
+エムスリー株式会社,https://open.talentio.com/r/1/c/m3/homes/3719
+エムスリー株式会社,https://open.talentio.com/r/1/c/m3/homes/4354
+エムスリー株式会社,https://open.talentio.com/r/1/c/m3/homes/4517
+エムスリー株式会社,https://open.talentio.com/r/1/c/m3/homes/4524
+エムスリー,https://open.talentio.com/r/1/c/m3-inc/homes/3729
+エムスリー,https://open.talentio.com/r/1/c/m3-inc/homes/3730
+エムスリーキャリア株式会社,https://open.talentio.com/r/1/c/m3career/homes/2467
+エムスリーキャリア株式会社,https://open.talentio.com/r/1/c/m3career/homes/2669
+エムスリーデジタルコミュニケーションズ株式会社,https://open.talentio.com/r/1/c/m3dc/homes/3519
+エムスリーマーケティング株式会社,https://open.talentio.com/r/1/c/m3marketing/homes/3411
+エムスリーマーケティング株式会社,https://open.talentio.com/r/1/c/m3marketing/homes/3890
+エムスリーマーケティング株式会社,https://open.talentio.com/r/1/c/m3marketing/homes/4330
+エムスリーソリューションズ株式会社,https://open.talentio.com/r/1/c/m3sol/homes/4086
+株式会社M&Aバリューエンジニアリング,https://open.talentio.com/r/1/c/ma-ve/homes/4465
+株式会社MACオフィス,https://open.talentio.com/r/1/c/mac-office/homes/2319
+株式会社マテリアルゲート,https://open.talentio.com/r/1/c/materialgate/homes/4397
+マテリアルグループ株式会社,https://open.talentio.com/r/1/c/materialpr/homes/3211
+Matlantis株式会社,https://open.talentio.com/r/1/c/matlantis/homes/4495
+Matlantis株式会社,https://open.talentio.com/r/1/c/matlantis/homes/4504
+Matlantis株式会社,https://open.talentio.com/r/1/c/matlantis/homes/4506
+株式会社松尾研究所,https://open.talentio.com/r/1/c/matsuo-institute/homes/4144
+株式会社マックスプロデュース,https://open.talentio.com/r/1/c/max-produce/homes/4563
+株式会社MAZIN,https://open.talentio.com/r/1/c/mazintech/homes/4605
+MCデジタル・リアルティ株式会社,https://open.talentio.com/r/1/c/mc-digitalrealty/homes/4128
+メビックス株式会社,https://open.talentio.com/r/1/c/mebix/homes/2924
+メビックス株式会社,https://open.talentio.com/r/1/c/mebix/homes/2926
+株式会社メカノクロス,https://open.talentio.com/r/1/c/mechanocross/homes/4385
+株式会社メドエックス,https://open.talentio.com/r/1/c/med-x/homes/4654
+株式会社メドレー,https://open.talentio.com/r/1/c/medley/homes/3673
+メドメイン株式会社,https://open.talentio.com/r/1/c/medmain/homes/3686
+メドメイン株式会社,https://open.talentio.com/r/1/c/medmain/homes/3703
+メドテリア株式会社,https://open.talentio.com/r/1/c/medteria/homes/4509
+株式会社メンテモ,https://open.talentio.com/r/1/c/mentemo/homes/2639
+株式会社ミツバファクトリー,https://open.talentio.com/r/1/c/mf/homes/1887
+株式会社マイクロ・シー・エー・デー,https://open.talentio.com/r/1/c/microcad/homes/2672
+株式会社ミライヘ,https://open.talentio.com/r/1/c/miraieagent/homes/3887
+ミライウェブ株式会社,https://open.talentio.com/r/1/c/miraiweb/homes/4381
+MITI Laboratory,https://open.talentio.com/r/1/c/mitilab/homes/3943
+桃太郎セールス株式会社,https://open.talentio.com/r/1/c/mmtr-sales/homes/4253
+モビルス株式会社,https://open.talentio.com/r/1/c/mobilus/homes/2498
+モビルス株式会社,https://open.talentio.com/r/1/c/mobilus/homes/4165
+モビルス株式会社,https://open.talentio.com/r/1/c/mobilus/homes/4445
+モデラート株式会社,https://open.talentio.com/r/1/c/moderato/homes/4220
+マネックスグループ株式会社,https://open.talentio.com/r/1/c/monex/homes/2366
+株式会社モノリスソフト,https://open.talentio.com/r/1/c/monolithsoft/homes/2930
+株式会社MONSTER DIVE,https://open.talentio.com/r/1/c/monster-dive/homes/4387
+株式会社モルフォ,https://open.talentio.com/r/1/c/morphoinc/homes/3630
+モベンシス株式会社,https://open.talentio.com/r/1/c/movensys/homes/4663
+株式会社MUGENUP,https://open.talentio.com/r/1/c/mugenup/homes/2686
+株式会社MUGENUP,https://open.talentio.com/r/1/c/mugenup/homes/4437
+MUSE Inc.,https://open.talentio.com/r/1/c/muse/homes/4049
+MUSE Inc.,https://open.talentio.com/r/1/c/muse/homes/4544
+株式会社LESS PLUS DESIGN,https://open.talentio.com/r/1/c/mw-tokyo.com/homes/4671
+株式会社マイベスト,https://open.talentio.com/r/1/c/my-best/homes/4200
+株式会社N8tive Works,https://open.talentio.com/r/1/c/n8tive-works/homes/2689
+株式会社ネイチャーズウェイ,https://open.talentio.com/r/1/c/naturesway/homes/3635
+株式会社ネイチャーズウェイ,https://open.talentio.com/r/1/c/naturesway/homes/3636
+N.Avenue株式会社,https://open.talentio.com/r/1/c/navenue/homes/2722
+株式会社Nbase,https://open.talentio.com/r/1/c/nbase/homes/4440
+エヌ・シー・ジャパン株式会社,https://open.talentio.com/r/1/c/ncjapan/homes/4636
+株式会社NEIGHBOR,https://open.talentio.com/r/1/c/neighbor_careers/homes/4080
+ノイエス株式会社,https://open.talentio.com/r/1/c/neues/homes/3074
+株式会社New C's,https://open.talentio.com/r/1/c/new-cs/homes/4535
+株式会社NeXT STAR,https://open.talentio.com/r/1/c/next-star/homes/4302
+ニフティ株式会社,https://open.talentio.com/r/1/c/nifty/homes/4640
+ニフティ株式会社,https://open.talentio.com/r/1/c/nifty/homes/4643
+ニフティ株式会社,https://open.talentio.com/r/1/c/nifty/homes/4645
+ニフティ株式会社,https://open.talentio.com/r/1/c/nifty/homes/4647
+ニフティ株式会社,https://open.talentio.com/r/1/c/nifty/homes/4648
+ニフティ株式会社,https://open.talentio.com/r/1/c/nifty/homes/4649
+ニフティ株式会社,https://open.talentio.com/r/1/c/nifty/homes/4650
+株式会社ninoya,https://open.talentio.com/r/1/c/ninoya/homes/2960
+株式会社Drawing,https://open.talentio.com/r/1/c/nipponia_kosa/homes/4494
+学校法人角川ドワンゴ学園,https://open.talentio.com/r/1/c/nnn-ac/homes/2546
+学校法人角川ドワンゴ学園,https://open.talentio.com/r/1/c/nnn-ac/homes/2554
+学校法人角川ドワンゴ学園,https://open.talentio.com/r/1/c/nnn-ac/homes/2555
+学校法人角川ドワンゴ学園,https://open.talentio.com/r/1/c/nnn-ac/homes/2556
+学校法人角川ドワンゴ学園,https://open.talentio.com/r/1/c/nnn-ac/homes/2563
+学校法人角川ドワンゴ学園,https://open.talentio.com/r/1/c/nnn-ac/homes/2572
+学校法人角川ドワンゴ学園,https://open.talentio.com/r/1/c/nnn-ac/homes/2576
+学校法人角川ドワンゴ学園,https://open.talentio.com/r/1/c/nnn-ac/homes/2577
+学校法人角川ドワンゴ学園,https://open.talentio.com/r/1/c/nnn-ac/homes/2578
+学校法人角川ドワンゴ学園,https://open.talentio.com/r/1/c/nnn-ac/homes/3875
+学校法人角川ドワンゴ学園,https://open.talentio.com/r/1/c/nnn-ac/homes/3988
+学校法人角川ドワンゴ学園,https://open.talentio.com/r/1/c/nnn-ac/homes/3989
+学校法人角川ドワンゴ学園,https://open.talentio.com/r/1/c/nnn-ac/homes/3991
+学校法人角川ドワンゴ学園,https://open.talentio.com/r/1/c/nnn-ac/homes/4427
+ノイン株式会社,https://open.talentio.com/r/1/c/noin/homes/2807
+NOT A HOTEL MANAGEMENT株式会社,https://open.talentio.com/r/1/c/notahotelm/homes/3907
+株式会社New Space Intelligence,https://open.talentio.com/r/1/c/nsi-recruit/homes/4715
+株式会社くふう住まい,https://open.talentio.com/r/1/c/o-uccino/homes/4018
+株式会社OASIZ,https://open.talentio.com/r/1/c/oasiz/homes/4596
+ワンファイナンシャル株式会社,https://open.talentio.com/r/1/c/ofco/homes/1783
+OGUNI株式会社,https://open.talentio.com/r/1/c/ogunirecruit/homes/1555
+株式会社オハコ,https://open.talentio.com/r/1/c/ohako-inc/homes/1573
+株式会社オオツカ,https://open.talentio.com/r/1/c/ohtsuka/homes/1658
+株式会社おいしい健康,https://open.talentio.com/r/1/c/oishi-kenko/homes/3084
+Oishii Farm株式会社,https://open.talentio.com/r/1/c/oishii_farm/homes/4510
+オイシックス株式会社,https://open.talentio.com/r/1/c/oisix2016/homes/1977
+株式会社Ollo,https://open.talentio.com/r/1/c/ollo/homes/4782
+株式会社One StepS,https://open.talentio.com/r/1/c/onesteps/homes/4476
+株式会社Onion,https://open.talentio.com/r/1/c/onion/homes/2207
+株式会社Onion,https://open.talentio.com/r/1/c/onion/homes/2208
+株式会社オプティム,https://open.talentio.com/r/1/c/optim/homes/4774
+OptQC株式会社,https://open.talentio.com/r/1/c/optqc.job-board/homes/4802
+OptQC株式会社,https://open.talentio.com/r/1/c/optqc.job-board/homes/4803
+株式会社オレンジ,https://open.talentio.com/r/1/c/orange0/homes/4378
+オーガニックグループ株式会社,https://open.talentio.com/r/1/c/organic-gr/homes/4345
+オーガニックグループ株式会社,https://open.talentio.com/r/1/c/organic-gr/homes/4695
+オーガニックグループ株式会社,https://open.talentio.com/r/1/c/organic-gr/homes/4776
+株式会社オリゾ,https://open.talentio.com/r/1/c/orizo/homes/4235
+orosy株式会社,https://open.talentio.com/r/1/c/orosy.recruiting/homes/2167
+orosy株式会社,https://open.talentio.com/r/1/c/orosy.recruiting/homes/4151
+マイクロポート・オーソペディックス・ジャパン株式会社,https://open.talentio.com/r/1/c/ortho-microport/homes/2043
+株式会社オトバンク,https://open.talentio.com/r/1/c/otobank/homes/1894
+株式会社オトバンク,https://open.talentio.com/r/1/c/otobank/homes/4164
+株式会社overflow,https://open.talentio.com/r/1/c/overflow/homes/3677
+株式会社Pale Blue,https://open.talentio.com/r/1/c/pale-blue/homes/2329
+株式会社パネイル,https://open.talentio.com/r/1/c/panair/homes/2246
+park&port株式会社,https://open.talentio.com/r/1/c/parknport/homes/810
+株式会社PECOFREE,https://open.talentio.com/r/1/c/pecofree/homes/2948
+perzik株式会社,https://open.talentio.com/r/1/c/perzik/homes/4309
+ペットゴー株式会社,https://open.talentio.com/r/1/c/petgo/homes/1841
+株式会社PhoneAppli,https://open.talentio.com/r/1/c/phoneappli/homes/1682
+株式会社pHydrogen,https://open.talentio.com/r/1/c/phydrogen/homes/4586
+株式会社Pictoria,https://open.talentio.com/r/1/c/pictoria/homes/4065
+パイン株式会社,https://open.talentio.com/r/1/c/pineshine/homes/4095
+株式会社ポケットペア,https://open.talentio.com/r/1/c/pocketpair/homes/2647
+ポノス株式会社,https://open.talentio.com/r/1/c/ponos/homes/3208
+株式会社Preferred Networks,https://open.talentio.com/r/1/c/preferred/homes/4290
+株式会社Preferred Networks,https://open.talentio.com/r/1/c/preferred/homes/4291
+株式会社Preferred Networks,https://open.talentio.com/r/1/c/preferred/homes/4293
+株式会社Preferred Networks,https://open.talentio.com/r/1/c/preferred/homes/4294
+株式会社Preferred Networks,https://open.talentio.com/r/1/c/preferred/homes/4296
+株式会社Preferred Networks,https://open.talentio.com/r/1/c/preferred/homes/4297
+株式会社Preferred Networks,https://open.talentio.com/r/1/c/preferred/homes/4298
+株式会社Preferred Networks,https://open.talentio.com/r/1/c/preferred/homes/4299
+株式会社Preferred Networks,https://open.talentio.com/r/1/c/preferred/homes/4306
+株式会社Preferred Networks,https://open.talentio.com/r/1/c/preferred/homes/4307
+株式会社Preferred Networks,https://open.talentio.com/r/1/c/preferred/homes/4325
+株式会社Preferred Networks,https://open.talentio.com/r/1/c/preferred/homes/4334
+株式会社Preferred Networks,https://open.talentio.com/r/1/c/preferred/homes/4551
+株式会社Preferred Networks,https://open.talentio.com/r/1/c/preferred/homes/4558
+株式会社Preferred Networks,https://open.talentio.com/r/1/c/preferred/homes/4595
+株式会社Preferred Networks,https://open.talentio.com/r/1/c/preferred/homes/4618
+株式会社Preferred Networks,https://open.talentio.com/r/1/c/preferred/homes/4619
+株式会社Preferred Networks,https://open.talentio.com/r/1/c/preferred/homes/4655
+株式会社Preferred Networks,https://open.talentio.com/r/1/c/preferred/homes/4678
+株式会社Preferred Networks,https://open.talentio.com/r/1/c/preferred/homes/4679
+株式会社Preferred Networks,https://open.talentio.com/r/1/c/preferred/homes/4684
+PreMed株式会社,https://open.talentio.com/r/1/c/premed_recruit/homes/4245
+PreMed株式会社,https://open.talentio.com/r/1/c/premed_recruit/homes/4513
+株式会社プレジデント社,https://open.talentio.com/r/1/c/president-inc/homes/4216
+株式会社ピー・アール・オー,https://open.talentio.com/r/1/c/pro-japan/homes/2360
+株式会社プロジェクト・モード,https://open.talentio.com/r/1/c/projectmode/homes/2018
+プロ事務オフィス,https://open.talentio.com/r/1/c/projimuoffice/homes/4764
+株式会社プロスタファウンデーション,https://open.talentio.com/r/1/c/prosta/homes/4176
+株式会社プロトコーポレーション,https://open.talentio.com/r/1/c/proto-g/homes/3688
+株式会社プロトコーポレーション,https://open.talentio.com/r/1/c/proto-g/homes/3698
+株式会社プロトコーポレーション,https://open.talentio.com/r/1/c/proto-g/homes/4388
+株式会社プロキシワークス,https://open.talentio.com/r/1/c/proxyworks/homes/1689
+QFPAYJAPAN株式会社,https://open.talentio.com/r/1/c/qfpj/homes/1772
+株式会社Quesqu,https://open.talentio.com/r/1/c/quesqu/homes/2164
+クイックゲット株式会社,https://open.talentio.com/r/1/c/quickget/homes/2655
+クイックゲット株式会社,https://open.talentio.com/r/1/c/quickget/homes/3707
+株式会社クオカード,https://open.talentio.com/r/1/c/quo-digital/homes/4327
+株式会社クオトミー,https://open.talentio.com/r/1/c/quotomy/homes/4420
+レイド株式会社,https://open.talentio.com/r/1/c/rayd/homes/4337
+株式会社リアルミー,https://open.talentio.com/r/1/c/realme/homes/1784
+[中途採用] 株式会社リアークスファインド,https://open.talentio.com/r/1/c/rearx-find/homes/4741
+株式会社レアゾン・ホールディングス,https://open.talentio.com/r/1/c/reazon/homes/2816
+株式会社レアゾン・ホールディングス,https://open.talentio.com/r/1/c/reazon/homes/2817
+株式会社レアゾン・ホールディングス,https://open.talentio.com/r/1/c/reazon/homes/2819
+株式会社レアゾン・ホールディングス,https://open.talentio.com/r/1/c/reazon/homes/2820
+株式会社レアゾン・ホールディングス,https://open.talentio.com/r/1/c/reazon/homes/3881
+株式会社レアゾン・ホールディングス,https://open.talentio.com/r/1/c/reazon/homes/4732
+株式会社ミナカラ,https://open.talentio.com/r/1/c/recruit_minacolor/homes/1038
+株式会社STANDARD,https://open.talentio.com/r/1/c/recruit_standard/homes/4163
+レンティオ株式会社,https://open.talentio.com/r/1/c/rentio/homes/1884
+RePath株式会社,https://open.talentio.com/r/1/c/repath/homes/4653
+株式会社Resilire,https://open.talentio.com/r/1/c/resilire/homes/4617
+株式会社レボルト,https://open.talentio.com/r/1/c/revoltjapan/homes/4716
+株式会社Rise,https://open.talentio.com/r/1/c/rise-inc/homes/4789
+リバーフィールド株式会社,https://open.talentio.com/r/1/c/riverfieldinc/homes/1631
+株式会社route-D,https://open.talentio.com/r/1/c/route-d/homes/4533
+株式会社route-D,https://open.talentio.com/r/1/c/route-d/homes/4538
+ランウェイ・エージェンシー株式会社,https://open.talentio.com/r/1/c/runwayagency/homes/4414
+ランウェイ・エージェンシー株式会社,https://open.talentio.com/r/1/c/runwayagency/homes/4458
+株式会社LALALA Plus,https://open.talentio.com/r/1/c/ryugaku-centres/homes/1855
+株式会社流通研究所,https://open.talentio.com/r/1/c/ryutsu-kenkyusho/homes/4632
+株式会社SACCSY,https://open.talentio.com/r/1/c/saccsy/homes/815
+セーフィー株式会社,https://open.talentio.com/r/1/c/safie/homes/3663
+株式会社佐賀古湯キャンプ,https://open.talentio.com/r/1/c/sagafuruyucamp/homes/1856
+さくらインターナショナルクリニック,https://open.talentio.com/r/1/c/sakura-inter/homes/4734
+株式会社Sapeet,https://open.talentio.com/r/1/c/sapeet/homes/4557
+株式会社SARAH,https://open.talentio.com/r/1/c/sarah30/homes/2362
+株式会社SAZO,https://open.talentio.com/r/1/c/sazo/homes/4371
+株式会社SAZO,https://open.talentio.com/r/1/c/sazo/homes/4712
+SB OAI Japan合同会社,https://open.talentio.com/r/1/c/sb-oai/homes/4709
+SB Intuitions株式会社,https://open.talentio.com/r/1/c/sbintuitions/homes/4413
+SB Intuitions株式会社,https://open.talentio.com/r/1/c/sbintuitions/homes/4644
+株式会社Scalar,https://open.talentio.com/r/1/c/scalar-labs/homes/4360
+株式会社SCOグループ,https://open.talentio.com/r/1/c/scogr/homes/4474
+株式会社シニアジョブ,https://open.talentio.com/r/1/c/senior-job/homes/4219
+株式会社サーバーワークス,https://open.talentio.com/r/1/c/serverworks/homes/1569
+株式会社セブンデックス,https://open.talentio.com/r/1/c/sevendex/homes/4150
+SHARE株式会社,https://open.talentio.com/r/1/c/share-yap/homes/1688
+社会福祉法人新栄会,https://open.talentio.com/r/1/c/shineikai/homes/4593
+新庄自動車株式会社,https://open.talentio.com/r/1/c/shinjyo-motors/homes/4034
+塩野香料株式会社,https://open.talentio.com/r/1/c/shiono-koryo/homes/4675
+塩野香料株式会社,https://open.talentio.com/r/1/c/shiono-koryo/homes/4680
+ショップフォース株式会社,https://open.talentio.com/r/1/c/shopforce/homes/1672
+株式会社Sider,https://open.talentio.com/r/1/c/sider/homes/1959
+シグマ株式会社,https://open.talentio.com/r/1/c/sigmakcojp/homes/4417
+しくみ製作所株式会社,https://open.talentio.com/r/1/c/sikmi/homes/2102
+株式会社総合教育研究所,https://open.talentio.com/r/1/c/skklic/homes/4599
+株式会社エス・エム・エスサポートサービス,https://open.talentio.com/r/1/c/sms-s-s/homes/4346
+株式会社エス・エム・エス,https://open.talentio.com/r/1/c/smsc/homes/3762
+株式会社エス・エム・エス,https://open.talentio.com/r/1/c/smsc/homes/3764
+株式会社エス・エム・エス,https://open.talentio.com/r/1/c/smsc/homes/3768
+株式会社エス・エム・エス,https://open.talentio.com/r/1/c/smsc/homes/3769
+株式会社エス・エム・エス,https://open.talentio.com/r/1/c/smsc/homes/3770
+株式会社エス・エム・エス,https://open.talentio.com/r/1/c/smsc/homes/3771
+株式会社エス・エム・エス,https://open.talentio.com/r/1/c/smsc/homes/3772
+株式会社エス・エム・エス,https://open.talentio.com/r/1/c/smsc/homes/3774
+株式会社エス・エム・エス,https://open.talentio.com/r/1/c/smsc/homes/3775
+株式会社エス・エム・エス,https://open.talentio.com/r/1/c/smsc/homes/4047
+株式会社エス・エム・エス,https://open.talentio.com/r/1/c/smsc/homes/4074
+株式会社エス・エム・エス,https://open.talentio.com/r/1/c/smsc/homes/4262
+株式会社エス・エム・エス,https://open.talentio.com/r/1/c/smsc/homes/4625
+株式会社エス・エム・エス,https://open.talentio.com/r/1/c/smsc/homes/4685
+株式会社エス・エム・エス,https://open.talentio.com/r/1/c/smsc/homes/4686
+株式会社ソーシャルPLUS,https://open.talentio.com/r/1/c/socialplus/homes/3972
+株式会社SODA,https://open.talentio.com/r/1/c/soda-inc.jp/homes/4691
+株式会社SODA,https://open.talentio.com/r/1/c/soda-inc.jp/homes/4791
+SOICO株式会社,https://open.talentio.com/r/1/c/soico/homes/4070
+株式会社ソラコム,https://open.talentio.com/r/1/c/soracom/homes/2341
+株式会社souco,https://open.talentio.com/r/1/c/souco/homes/3896
+株式会社スペイシー,https://open.talentio.com/r/1/c/spacee/homes/3109
+株式会社Sparty,https://open.talentio.com/r/1/c/sparty/homes/3778
+sportsbull,https://open.talentio.com/r/1/c/sportsbull/homes/3170
+デジタルエクスペリエンス株式会社,https://open.talentio.com/r/1/c/sprasia/homes/4192
+デジタルエクスペリエンス株式会社,https://open.talentio.com/r/1/c/sprasia/homes/4193
+株式会社Srush,https://open.talentio.com/r/1/c/srush/homes/4255
+株式会社Staple,https://open.talentio.com/r/1/c/staple_inc/homes/3990
+株式会社Staple,https://open.talentio.com/r/1/c/staple_inc/homes/4285
+株式会社Staple,https://open.talentio.com/r/1/c/staple_inc/homes/4719
+株式会社Staple,https://open.talentio.com/r/1/c/staple_inc/homes/4720
+株式会社Staple,https://open.talentio.com/r/1/c/staple_inc/homes/4722
+株式会社Staple,https://open.talentio.com/r/1/c/staple_inc/homes/4723
+株式会社Staple,https://open.talentio.com/r/1/c/staple_inc/homes/4727
+株式会社Staple,https://open.talentio.com/r/1/c/staple_inc/homes/4731
+スターフェスティバル株式会社,https://open.talentio.com/r/1/c/starfestival/homes/3308
+株式会社Stayway,https://open.talentio.com/r/1/c/stayway/homes/4105
+ステップ・アラウンド株式会社,https://open.talentio.com/r/1/c/step-around/homes/3883
+株式会社Strobo,https://open.talentio.com/r/1/c/strobo/homes/1785
+株式会社スタジオレックス,https://open.talentio.com/r/1/c/studiorex/homes/3599
+スタディプラス株式会社,https://open.talentio.com/r/1/c/studyplus_recruit/homes/2768
+スタディプラス株式会社,https://open.talentio.com/r/1/c/studyplus_recruit/homes/2769
+SUGAR株式会社,https://open.talentio.com/r/1/c/sugar/homes/1646
+株式会社くふう住まいコンサルティング,https://open.talentio.com/r/1/c/sumai-c.kufu/homes/4677
+株式会社サンウェル,https://open.talentio.com/r/1/c/sunwells/homes/2052
+株式会社SUPWAT,https://open.talentio.com/r/1/c/supwat/homes/3861
+株式会社すららネット,https://open.talentio.com/r/1/c/surala/homes/3699
+SyntheticGestalt株式会社,https://open.talentio.com/r/1/c/syntheticgestalt/homes/3906
+Tabist株式会社,https://open.talentio.com/r/1/c/tabist/homes/4353
+株式会社Takram,https://open.talentio.com/r/1/c/takram/homes/2127
+talentbook株式会社,https://open.talentio.com/r/1/c/talentbook/homes/2041
+株式会社タレンティオ,https://recruit.talentio.co.jp/r/1/c/talentio/homes/1
+トークノート株式会社,https://open.talentio.com/r/1/c/talknote/homes/1557
+株式会社たなか銘産,https://open.talentio.com/r/1/c/tanaka-meisan/homes/4501
+Tane FZCO,https://open.talentio.com/r/1/c/tanelabs/homes/4667
+株式会社タノム,https://open.talentio.com/r/1/c/tanomu/homes/2141
+チームラボ,https://open.talentio.com/r/1/c/teamlab/homes/4227
+チームラボ,https://open.talentio.com/r/1/c/teamlab/homes/4635
+株式会社テクニカルクリーン,https://open.talentio.com/r/1/c/technicalclean/homes/4453
+株式会社TechTalk,https://open.talentio.com/r/1/c/techtalk/homes/4585
+株式会社テリロジー,https://open.talentio.com/r/1/c/terilogy/homes/4689
+株式会社Terrain,https://open.talentio.com/r/1/c/terrain-projects/homes/4146
+株式会社Terrain,https://open.talentio.com/r/1/c/terrain-projects/homes/4238
+株式会社Melon,https://open.talentio.com/r/1/c/the-melon_recruit/homes/4340
+株式会社たのしいミュージアム,https://open.talentio.com/r/1/c/tmuseum/homes/4433
+株式会社当直連携基盤,https://open.talentio.com/r/1/c/tochoku/homes/4736
+TOHO Global株式会社,https://open.talentio.com/r/1/c/toho-global/homes/4570
+TopoLogic株式会社,https://open.talentio.com/r/1/c/topologic/homes/3912
+株式会社トリアナ,https://open.talentio.com/r/1/c/triana/homes/4122
+医療法人　光彩会,https://open.talentio.com/r/1/c/tsuda-ganka/homes/4411
+株式会社tsumug,https://open.talentio.com/r/1/c/tsumug/homes/1791
+株式会社テレビ東京コミュニケーションズ,https://open.talentio.com/r/1/c/txcom/homes/4355
+株式会社キャリアデザインセンター,https://open.talentio.com/r/1/c/type/homes/4554
+株式会社ユープラス,https://open.talentio.com/r/1/c/u-plus/homes/2648
+株式会社うるる,https://open.talentio.com/r/1/c/uluru/homes/3205
+株式会社UMIAILE,https://open.talentio.com/r/1/c/umiaile/homes/4537
+UMITRON PTE. LTD.,https://open.talentio.com/r/1/c/umitron/homes/3603
+UMITRON PTE. LTD.,https://open.talentio.com/r/1/c/umitron/homes/3604
+川口水産株式会社,https://open.talentio.com/r/1/c/unagiya/homes/4187
+Unipos株式会社,https://open.talentio.com/r/1/c/unipos/homes/4487
+株式会社アップストリーム,https://open.talentio.com/r/1/c/up-stream/homes/4113
+UPWARD株式会社,https://open.talentio.com/r/1/c/upward/homes/3682
+株式会社ユートニック,https://open.talentio.com/r/1/c/utoniq/homes/3878
+宇都宮工業株式会社,https://open.talentio.com/r/1/c/utsunomiya-kogyo_recruit/homes/4700
+株式会社ウーオ,https://open.talentio.com/r/1/c/uuuo/homes/3903
+ユカイ工学株式会社,https://open.talentio.com/r/1/c/ux-xu/homes/4472
+VALANCE株式会社,https://open.talentio.com/r/1/c/valance/homes/4682
+株式会社バリューナップ,https://open.talentio.com/r/1/c/valuenap/homes/4106
+税理士法人ベリーベスト,https://open.talentio.com/r/1/c/vbest-tax/homes/1647
+株式会社LAMILA,https://open.talentio.com/r/1/c/videostep/homes/4204
+株式会社ビューン,https://open.talentio.com/r/1/c/viewn/homes/2635
+株式会社バーチャルキャスト,https://open.talentio.com/r/1/c/virtualcast/homes/1796
+Vistex Japan合同会社,https://open.talentio.com/r/1/c/vistexjapan/homes/4174
+株式会社ユリーカ,https://open.talentio.com/r/1/c/vivaeureka/homes/3132
+わいわいメディカル株式会社,https://open.talentio.com/r/1/c/waiwaimedi/homes/4672
+株式会社ホワイト・ベアーファミリー,https://open.talentio.com/r/1/c/wbf-holdings/homes/1637
+株式会社weare,https://open.talentio.com/r/1/c/weare/homes/4710
+株式会社ウェルヴィーナス,https://open.talentio.com/r/1/c/wellvenus/homes/2621
+株式会社ウェルヴィーナス,https://open.talentio.com/r/1/c/wellvenus/homes/2622
+株式会社ホワイトプラス,https://open.talentio.com/r/1/c/wh-plus/homes/2585
+ワンダープラネット株式会社,https://open.talentio.com/r/1/c/wonderplanet/homes/3385
+ワンダープラネット株式会社,https://open.talentio.com/r/1/c/wonderplanet/homes/3386
+ワンダープラネット株式会社,https://open.talentio.com/r/1/c/wonderplanet/homes/3679
+株式会社ワークハピネス,https://open.talentio.com/r/1/c/workhappiness/homes/2656
+株式会社ワークサイド,https://open.talentio.com/r/1/c/workside/homes/1851
+Wovn Technologies株式会社,https://open.talentio.com/r/1/c/wovnio/homes/3693
+Wovn Technologies株式会社,https://open.talentio.com/r/1/c/wovnio/homes/3695
+Wovn Technologies株式会社,https://open.talentio.com/r/1/c/wovnio/homes/3696
+株式会社サイカ,https://open.talentio.com/r/1/c/xica/homes/3491
+株式会社キメラ,https://open.talentio.com/r/1/c/ximera/homes/1979
+山川国際特許事務所,https://open.talentio.com/r/1/c/yamakawa-ipo/homes/4704
+株式会社ヤプリ,https://open.talentio.com/r/1/c/yappli/homes/3493
+株式会社ヤプリ,https://open.talentio.com/r/1/c/yappli/homes/3494
+フューチャーアーティザン株式会社,https://open.talentio.com/r/1/c/ydc-corporation/homes/2959
+株式会社ヤッホーブルーイング,https://open.talentio.com/r/1/c/yohobrewing/homes/3516
+株式会社ヤッホーブルーイング,https://open.talentio.com/r/1/c/yohobrewing/homes/4639
+ユアマイスター株式会社,https://open.talentio.com/r/1/c/yourmystar/homes/3502
+株式会社 YumiCoreBody,https://open.talentio.com/r/1/c/yumicorebody/homes/2059
+ZaPASS JAPAN 株式会社,https://open.talentio.com/r/1/c/zapass/homes/4391
+ZAZA株式会社,https://open.talentio.com/r/1/c/zaza/homes/4205
+学校法人日本財団ドワンゴ学園,https://open.talentio.com/r/1/c/zen-univ/homes/4500
+株式会社ZENKIGEN,https://open.talentio.com/r/1/c/zenkigen/homes/2197
+株式会社ZENKIGEN,https://open.talentio.com/r/1/c/zenkigen/homes/2198
+株式会社ZenTech,https://open.talentio.com/r/1/c/zentech/homes/4434
+株式会社ZERO COLOR,https://open.talentio.com/r/1/c/zero-color/homes/4744
+ゼロスペック株式会社,https://open.talentio.com/r/1/c/zero-spec/homes/3900
+株式会社ザイナス,https://open.talentio.com/r/1/c/zynas/homes/2732
+株式会社ザイナス,https://open.talentio.com/r/1/c/zynas/homes/3087
+株式会社ザイナス,https://open.talentio.com/r/1/c/zynas/homes/4082

--- a/docs/provider-description-matrix.md
+++ b/docs/provider-description-matrix.md
@@ -1,6 +1,6 @@
 # Provider Description Matrix
 
-This table covers the 52 providers listed below.
+This table covers the 53 providers listed below.
 `API/feed` means the data comes from a machine-readable endpoint such as JSON,
 XML, RSS, GraphQL, or a markdown endpoint. `HTML` means the scraper parses a
 page/rendered page rather than a structured job payload.
@@ -48,6 +48,7 @@ page/rendered page rather than a structured job payload.
 | `softgarden` | Yes | No | API/feed | API/feed |
 | `successfactors` | Yes | No | API/feed (RSS/XML) | API/feed (RSS/XML) |
 | `taleo` | Yes | Yes | HTML | HTML |
+| `talentio` | Yes | Yes | HTML bootstrap | HTML (JSON-LD) |
 | `teamtailor` | Yes | No | API/feed (RSS/XML) | API/feed (RSS/XML) |
 | `tesla` | Yes | Yes | API/feed / browser | API/feed |
 | `thehub` | Yes | No | API/feed | API/feed |

--- a/pipeline/publisher.py
+++ b/pipeline/publisher.py
@@ -543,7 +543,7 @@ ATS_DEDUP_PRIORITY: dict[str, int] = {
     "moka": 1, "oracle": 1, "pageup": 1, "paycom": 1, "paylocity": 1, "personio": 1, "phenom": 1, "pinpoint": 1,
     "recruitee": 1,
     "recruiterbox": 1, "rippling": 1, "smartrecruiters": 1, "softgarden": 1,
-    "successfactors": 1, "taleo": 1, "teamtailor": 1, "ukg": 1, "workable": 1,
+    "successfactors": 1, "taleo": 1, "talentio": 1, "teamtailor": 1, "ukg": 1, "workable": 1,
     "workday": 1,
     # Big-tech bespoke careers — also priority 1 (single-tenant, canonical)
     "amazon": 1, "apple": 1, "bytedance": 1, "google": 1, "meta": 1,

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -92,6 +92,7 @@ from ats_scrapers.scrapers import (
     SmartRecruitersScraper,
     SoftgardenScraper,
     SuccessFactorsScraper,
+    TalentioScraper,
     TaleoScraper,
     TeamtailorScraper,
     TeslaScraper,
@@ -459,6 +460,20 @@ CONFIGS: dict[str, dict[str, Any]] = {
         ),
         "csv": "ats-companies/taleo.csv",
         "output": "taleo/jobs.csv",
+    },
+    "talentio": {
+        "scraper": TalentioScraper,
+        "slug": lambda r: (r.get("url") or "").strip() or None,
+        "kwargs": lambda r: {
+            "company_name": (r.get("name") or "").strip() or None,
+        },
+        "csv": "ats-companies/talentio.csv",
+        "output": "talentio/jobs.csv",
+        "dedupe_by_ats_id": True,
+        "max_concurrency": 2,
+        "tenant_delay_seconds": 0.25,
+        "fail_closed_on_empty": True,
+        "fail_closed_on_any_error": True,
     },
     "oracle": {
         "scraper": OracleScraper,

--- a/src/ats_scrapers/models.py
+++ b/src/ats_scrapers/models.py
@@ -66,6 +66,7 @@ class ATSType(StrEnum):
     SMARTRECRUITERS = "smartrecruiters"
     SOFTGARDEN = "softgarden"
     SUCCESSFACTORS = "successfactors"
+    TALENTIO = "talentio"
     UKG = "ukg"
     WORKABLE = "workable"
     WORKDAY = "workday"

--- a/src/ats_scrapers/resolve.py
+++ b/src/ats_scrapers/resolve.py
@@ -145,6 +145,20 @@ def resolve_careers_url(url: str) -> ResolvedCareersUrl | None:
             return ResolvedCareersUrl(ATSType.HRMOS, segments[1])
         return None
 
+    if host in {"open.talentio.com", "recruit.talentio.co.jp"}:
+        if parsed.query or parsed.fragment:
+            return None
+        match = re.fullmatch(
+            r"/r/1/c/[A-Za-z0-9._-]+/homes/[1-9]\d*/?",
+            parsed.path,
+        )
+        if match:
+            return ResolvedCareersUrl(
+                ATSType.TALENTIO,
+                parsed._replace(path=parsed.path.rstrip("/")).geturl(),
+            )
+        return None
+
     if host.endswith(".keka.com"):
         tenant = host.removesuffix(".keka.com")
         segments = [segment for segment in parsed.path.split("/") if segment]

--- a/src/ats_scrapers/scrapers/__init__.py
+++ b/src/ats_scrapers/scrapers/__init__.py
@@ -64,6 +64,7 @@ from ats_scrapers.scrapers.seek import SeekScraper
 from ats_scrapers.scrapers.smartrecruiters import SmartRecruitersScraper
 from ats_scrapers.scrapers.softgarden import SoftgardenScraper
 from ats_scrapers.scrapers.successfactors import SuccessFactorsScraper
+from ats_scrapers.scrapers.talentio import TalentioScraper
 from ats_scrapers.scrapers.taleo import TaleoScraper
 from ats_scrapers.scrapers.teamtailor import TeamtailorScraper
 from ats_scrapers.scrapers.tesla import TeslaScraper
@@ -137,6 +138,7 @@ __all__ = [
     "SmartRecruitersScraper",
     "SoftgardenScraper",
     "SuccessFactorsScraper",
+    "TalentioScraper",
     "TaleoScraper",
     "TeamtailorScraper",
     "TeslaScraper",

--- a/src/ats_scrapers/scrapers/talentio.py
+++ b/src/ats_scrapers/scrapers/talentio.py
@@ -1,0 +1,684 @@
+"""Talentio public careers scraper.
+
+Talentio employer portals expose active jobs in server-rendered React props:
+
+    GET https://open.talentio.com/r/1/c/{namespace}/homes/{home_id}
+
+Each active detail page includes schema.org ``JobPosting`` JSON-LD with the
+full description, location, publication date, employment type, and salary:
+
+    GET https://open.talentio.com/r/1/c/{namespace}/pages/{page_id}
+
+No account, API key, browser, or JavaScript rendering is required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from datetime import UTC, datetime
+from html import escape, unescape
+from typing import TYPE_CHECKING, Any, ClassVar
+from urllib.parse import ParseResult, urlparse
+
+from bs4 import BeautifulSoup
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType, Job
+from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from ats_scrapers.fetch import Fetcher
+
+_ALLOWED_HOSTS = frozenset({"open.talentio.com", "recruit.talentio.co.jp"})
+_HOME_PATH_RE = re.compile(r"^/r/1/c/([A-Za-z0-9._-]+)/homes/([1-9]\d*)$")
+_PAGE_PATH_RE = re.compile(r"^/r/1/c/([A-Za-z0-9._-]+)/pages/([1-9]\d*)$")
+_DETAIL_CONCURRENCY = 3
+_DETAIL_HANDLED = frozenset({404, 410})
+_EMPLOYMENT_TYPE_MAP = {
+    "FULL_TIME": "FULL_TIME",
+    "PART_TIME": "PART_TIME",
+    "CONTRACTOR": "CONTRACT",
+    "CONTRACT": "CONTRACT",
+    "TEMPORARY": "TEMPORARY",
+    "INTERN": "INTERN",
+    "正社員": "FULL_TIME",
+    "パート": "PART_TIME",
+    "アルバイト": "PART_TIME",
+    "契約社員": "CONTRACT",
+    "業務委託": "CONTRACT",
+    "派遣社員": "TEMPORARY",
+    "インターン": "INTERN",
+}
+_SALARY_PERIOD_MAP = {
+    "HOUR": "HOUR",
+    "DAY": "DAY",
+    "WEEK": "WEEK",
+    "MONTH": "MONTH",
+    "YEAR": "YEAR",
+}
+_REGION_BY_COUNTRY = {
+    "AE": "Asia",
+    "AU": "Oceania",
+    "CA": "North America",
+    "CN": "Asia",
+    "DE": "Europe",
+    "FR": "Europe",
+    "GB": "Europe",
+    "HK": "Asia",
+    "ID": "Asia",
+    "IN": "Asia",
+    "JP": "Asia",
+    "KR": "Asia",
+    "MY": "Asia",
+    "NZ": "Oceania",
+    "PH": "Asia",
+    "PK": "Asia",
+    "SA": "Asia",
+    "SG": "Asia",
+    "TH": "Asia",
+    "TW": "Asia",
+    "US": "North America",
+    "VN": "Asia",
+}
+_COUNTRY_NAME_TO_ISO = {
+    "japan": "JP",
+    "日本": "JP",
+    "singapore": "SG",
+    "シンガポール": "SG",
+    "united arab emirates": "AE",
+    "uae": "AE",
+    "アラブ首長国連邦": "AE",
+}
+_REMOTE_RE = re.compile(r"(?:full[ -]?remote|remote|フルリモート|完全在宅)", re.I)
+
+
+@ScraperRegistry.register(ATSType.TALENTIO)
+class TalentioScraper(BaseScraper):
+    """Scrape one public Talentio recruitment home."""
+
+    ats = ATSType.TALENTIO
+
+    default_headers: ClassVar[dict[str, str]] = {
+        "User-Agent": "Mozilla/5.0",
+        "Accept": "text/html,application/xhtml+xml",
+    }
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        include_descriptions: bool = True,
+        proxy: str | None = None,
+        company_name: str | None = None,
+    ) -> None:
+        super().__init__(
+            company_slug,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        self.portal_url, self.namespace, self.home_id = _parse_home_url(company_slug)
+        self.company_name = company_name.strip() if company_name and company_name.strip() else None
+
+    async def afetch(self) -> list[Job]:
+        async with self.make_fetcher() as fetch:
+            html = await fetch.get_text(self.portal_url)
+            jobs = self._parse_listing(html)
+            if self.include_descriptions and jobs:
+                semaphore = asyncio.Semaphore(_DETAIL_CONCURRENCY)
+                keep = await asyncio.gather(
+                    *(self._enrich_detail(fetch, semaphore, job) for job in jobs)
+                )
+                jobs = [job for job, retained in zip(jobs, keep, strict=True) if retained]
+        return jobs
+
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+
+        async def run() -> str | None:
+            async with self.make_fetcher() as fetch:
+                await self._enrich_detail(fetch, asyncio.Semaphore(1), job)
+            return job.description
+
+        return self._run_sync(run())
+
+    def _parse_listing(self, html: str) -> list[Job]:
+        payload = _react_payload(html, "RecruitmentOpenPageHomeView")
+        company = _required_dict(payload, "openAtsCompany", "home")
+        home = _required_dict(payload, "recruitmentOpenPageHome", "home")
+        if company.get("openAtsNamespace") != self.namespace:
+            raise ScraperError(
+                f"Talentio ({self.namespace}/{self.home_id}) returned a namespace mismatch"
+            )
+        if _positive_int(home.get("id")) != self.home_id:
+            raise ScraperError(
+                f"Talentio ({self.namespace}/{self.home_id}) returned a home ID mismatch"
+            )
+
+        company_name = self.company_name or _company_name_from_html(html) or self.namespace
+        language = _language(home.get("language"))
+        groups = home.get("recruitmentPageGroups")
+        if not isinstance(groups, list):
+            raise ScraperError(
+                f"Talentio ({self.namespace}/{self.home_id}) omitted recruitment groups"
+            )
+
+        jobs: list[Job] = []
+        jobs_by_id: dict[str, Job] = {}
+        fetched_at = datetime.now(UTC)
+        for group_index, group in enumerate(groups):
+            if not isinstance(group, dict):
+                raise ScraperError(
+                    f"Talentio ({self.namespace}/{self.home_id}) group "
+                    f"{group_index} was not an object"
+                )
+            pages = group.get("recruitmentOpenPages")
+            if not isinstance(pages, list):
+                raise ScraperError(
+                    f"Talentio ({self.namespace}/{self.home_id}) group "
+                    f"{group_index} omitted recruitment pages"
+                )
+            department = _optional_text(group.get("name"))
+            for page_index, page in enumerate(pages):
+                if not isinstance(page, dict):
+                    raise ScraperError(
+                        f"Talentio ({self.namespace}/{self.home_id}) page "
+                        f"{group_index}:{page_index} was not an object"
+                    )
+                page_id = _positive_int(page.get("id"))
+                title = _optional_text(page.get("name"))
+                if page_id is None or title is None:
+                    raise ScraperError(
+                        f"Talentio ({self.namespace}/{self.home_id}) page "
+                        f"{group_index}:{page_index} omitted its ID or title"
+                    )
+                ats_id = str(page_id)
+                job_url = _validate_page_url(
+                    page.get("publishedUrl"),
+                    namespace=self.namespace,
+                    page_id=page_id,
+                    suffix="",
+                )
+                apply_url = _validate_page_url(
+                    page.get("publishedApplyUrl"),
+                    namespace=self.namespace,
+                    page_id=page_id,
+                    suffix="/apply",
+                )
+                requisition_id = _positive_int(page.get("requisitionId"))
+                form_id = _positive_int(page.get("formId"))
+                existing = jobs_by_id.get(ats_id)
+                if existing is not None:
+                    if (
+                        existing.title != title
+                        or str(existing.url) != job_url
+                        or str(existing.apply_url) != apply_url
+                        or existing.requisition_id
+                        != (str(requisition_id) if requisition_id else None)
+                    ):
+                        raise ScraperError(
+                            f"Talentio ({self.namespace}/{self.home_id}) returned "
+                            f"conflicting page data for ID {ats_id}"
+                        )
+                    existing.department = _merge_labels(existing.department, department)
+                    continue
+                job = Job(
+                    url=job_url,
+                    title=title,
+                    company=company_name,
+                    ats_type=ATSType.TALENTIO,
+                    ats_id=ats_id,
+                    department=department,
+                        requisition_id=str(requisition_id) if requisition_id else None,
+                        apply_url=apply_url,
+                        language=language,
+                    fetched_at=fetched_at,
+                    raw={
+                        "namespace": self.namespace,
+                        "home_id": self.home_id,
+                        "form_id": form_id,
+                    },
+                )
+                jobs_by_id[ats_id] = job
+                jobs.append(job)
+        return jobs
+
+    async def _enrich_detail(
+        self,
+        fetch: Fetcher,
+        semaphore: asyncio.Semaphore,
+        job: Job,
+    ) -> bool:
+        async with semaphore:
+            try:
+                response = await fetch.request(
+                    "GET",
+                    str(job.url),
+                    handled=_DETAIL_HANDLED,
+                )
+            except ScraperError:
+                return True
+        if response.status_code in _DETAIL_HANDLED:
+            return False
+        detail = _job_posting_json_ld(response.text)
+        if detail is not None:
+            _apply_detail(job, detail, namespace=self.namespace)
+        else:
+            return _apply_react_detail(job, response.text, namespace=self.namespace)
+        return True
+
+
+def _parse_home_url(value: str) -> tuple[str, str, int]:
+    parsed = urlparse(value)
+    if (
+        parsed.scheme != "https"
+        or (parsed.hostname or "").lower() not in _ALLOWED_HOSTS
+        or parsed.username
+        or parsed.password
+        or parsed.port is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ScraperError(
+            "TalentioScraper requires an HTTPS Talentio /r/1/c/{namespace}/homes/{id} URL"
+        )
+    match = _HOME_PATH_RE.fullmatch(parsed.path.rstrip("/"))
+    if match is None:
+        raise ScraperError(
+            "TalentioScraper requires an HTTPS Talentio /r/1/c/{namespace}/homes/{id} URL"
+        )
+    namespace, home_id = match.groups()
+    canonical = parsed._replace(path=parsed.path.rstrip("/")).geturl()
+    return canonical, namespace, int(home_id)
+
+
+def _react_payload(html: str, component: str) -> dict[str, Any]:
+    soup = BeautifulSoup(html, "html.parser")
+    element = soup.select_one(f'[data-react-class*="{component}"][data-react-props]')
+    if element is None:
+        raise ScraperError(f"Talentio response omitted {component} bootstrap")
+    try:
+        payload = json.loads(unescape(str(element["data-react-props"])))
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ScraperError(f"Talentio {component} bootstrap was malformed") from exc
+    if not isinstance(payload, dict):
+        raise ScraperError(f"Talentio {component} bootstrap was not an object")
+    return payload
+
+
+def _required_dict(payload: dict[str, Any], key: str, context: str) -> dict[str, Any]:
+    value = payload.get(key)
+    if not isinstance(value, dict):
+        raise ScraperError(f"Talentio {context} bootstrap omitted {key}")
+    return value
+
+
+def _company_name_from_html(html: str) -> str | None:
+    soup = BeautifulSoup(html, "html.parser")
+    title = soup.title.get_text(" ", strip=True) if soup.title else ""
+    if " / " not in title:
+        return None
+    return _optional_text(title.rsplit(" / ", 1)[-1])
+
+
+def _validate_page_url(
+    value: object,
+    *,
+    namespace: str,
+    page_id: int,
+    suffix: str,
+) -> str:
+    if not isinstance(value, str):
+        raise ScraperError(f"Talentio page {page_id} omitted its published URL")
+    parsed = urlparse(value.strip())
+    expected_path = f"/r/1/c/{namespace}/pages/{page_id}{suffix}"
+    if not _valid_official_url(parsed) or parsed.path.rstrip("/") != expected_path.rstrip("/"):
+        raise ScraperError(f"Talentio page {page_id} returned an invalid published URL")
+    if suffix:
+        return parsed._replace(path=expected_path).geturl()
+    match = _PAGE_PATH_RE.fullmatch(parsed.path.rstrip("/"))
+    if match is None or match.groups() != (namespace, str(page_id)):
+        raise ScraperError(f"Talentio page {page_id} returned an identity mismatch")
+    return parsed._replace(path=expected_path).geturl()
+
+
+def _valid_official_url(parsed: ParseResult) -> bool:
+    return (
+        parsed.scheme == "https"
+        and (parsed.hostname or "").lower() in _ALLOWED_HOSTS
+        and parsed.username is None
+        and parsed.password is None
+        and parsed.port is None
+        and not parsed.query
+        and not parsed.fragment
+    )
+
+
+def _job_posting_json_ld(html: str) -> dict[str, Any] | None:
+    soup = BeautifulSoup(html, "html.parser")
+    for script in soup.select('script[type="application/ld+json"]'):
+        try:
+            payload = json.loads(script.get_text())
+        except (TypeError, ValueError):
+            continue
+        candidates: list[Any]
+        if isinstance(payload, list):
+            candidates = payload
+        elif isinstance(payload, dict) and isinstance(payload.get("@graph"), list):
+            candidates = payload["@graph"]
+        else:
+            candidates = [payload]
+        for candidate in candidates:
+            if isinstance(candidate, dict) and candidate.get("@type") == "JobPosting":
+                return candidate
+    return None
+
+
+def _apply_detail(job: Job, detail: dict[str, Any], *, namespace: str) -> None:
+    identifier = detail.get("identifier")
+    if (
+        not isinstance(identifier, dict)
+        or str(identifier.get("value") or "") != job.ats_id
+    ):
+        raise ScraperError(f"Talentio detail {job.ats_id} returned an ID mismatch")
+    _validate_page_url(
+        detail.get("url"),
+        namespace=namespace,
+        page_id=int(job.ats_id),
+        suffix="",
+    )
+
+    title = _optional_text(detail.get("title"))
+    if title is None or title != job.title:
+        raise ScraperError(f"Talentio detail {job.ats_id} returned a title mismatch")
+    description = _optional_text(detail.get("description"))
+    if description:
+        job.description = description[:25_000]
+
+    organization = detail.get("hiringOrganization")
+    if isinstance(organization, dict):
+        company = _optional_text(organization.get("name"))
+        if company:
+            job.company = company
+
+    location, country_iso = _location(detail.get("jobLocation"))
+    if location:
+        job.location = location
+        if _REMOTE_RE.search(location):
+            job.is_remote = True
+    if country_iso:
+        job.country_iso = country_iso
+        job.region = _REGION_BY_COUNTRY.get(country_iso)
+
+    posted_at = _parse_datetime(detail.get("datePosted"))
+    if posted_at is not None:
+        job.posted_at = posted_at
+
+    employment = detail.get("employmentType")
+    if isinstance(employment, list):
+        employment = next((value for value in employment if isinstance(value, str)), None)
+    commitment = _optional_text(employment)
+    if commitment:
+        job.commitment = commitment
+        normalized = commitment.upper()
+        job.employment_type = _EMPLOYMENT_TYPE_MAP.get(normalized) or next(
+            (
+                mapped
+                for marker, mapped in _EMPLOYMENT_TYPE_MAP.items()
+                if marker in commitment
+            ),
+            None,
+        )
+
+    _apply_salary(job, detail.get("baseSalary"))
+
+
+def _apply_react_detail(job: Job, html: str, *, namespace: str) -> bool:
+    payload = _react_payload(html, "RecruitmentOpenPageView")
+    company = _required_dict(payload, "openAtsCompany", "detail")
+    page = _required_dict(payload, "recruitmentOpenPage", "detail")
+    if company.get("openAtsNamespace") != namespace:
+        raise ScraperError(f"Talentio detail {job.ats_id} returned a namespace mismatch")
+    page_id = _positive_int(page.get("id"))
+    if page_id is None or str(page_id) != job.ats_id:
+        raise ScraperError(f"Talentio detail {job.ats_id} returned an ID mismatch")
+    title = _optional_text(page.get("name"))
+    if title is None or title != job.title:
+        raise ScraperError(f"Talentio detail {job.ats_id} returned a title mismatch")
+    _validate_page_url(
+        page.get("publishedUrl"),
+        namespace=namespace,
+        page_id=page_id,
+        suffix="",
+    )
+    apply_url = _validate_page_url(
+        page.get("publishedApplyUrl"),
+        namespace=namespace,
+        page_id=page_id,
+        suffix="/apply",
+    )
+    if str(job.apply_url) != apply_url:
+        raise ScraperError(f"Talentio detail {job.ats_id} returned an apply URL mismatch")
+    requisition_id = _positive_int(page.get("requisitionId"))
+    if requisition_id is not None and job.requisition_id != str(requisition_id):
+        raise ScraperError(
+            f"Talentio detail {job.ats_id} returned a requisition ID mismatch"
+        )
+
+    description = _react_description(page)
+    if description is None:
+        return False
+    job.description = description[:25_000]
+    company_name = _company_name_from_html(html)
+    if company_name:
+        job.company = company_name
+    requisition = page.get("requisition")
+    requisition_language = (
+        requisition.get("language") if isinstance(requisition, dict) else None
+    )
+    language = _language(payload.get("language")) or _language(requisition_language)
+    if language:
+        job.language = language
+    location = _react_location(page)
+    if location:
+        job.location = location
+        if _REMOTE_RE.search(location):
+            job.is_remote = True
+    return True
+
+
+def _react_description(page: dict[str, Any]) -> str | None:
+    sections: list[str] = []
+    for key in (
+        "requisitionDetails",
+        "jobDescriptionDetails",
+        "requisitionCompanyAttributes",
+    ):
+        values = page.get(key)
+        if not isinstance(values, list):
+            raise ScraperError(f"Talentio detail omitted {key}")
+        for field in values:
+            if not isinstance(field, dict):
+                raise ScraperError(f"Talentio detail {key} contained a malformed field")
+            if field.get("selected") is False:
+                continue
+            name = _optional_text(field.get("name"))
+            rendered = _render_react_value(field.get("value"))
+            if rendered is None:
+                continue
+            heading = f"<h2>{escape(name)}</h2>" if name else ""
+            sections.append(f"{heading}<p>{rendered}</p>")
+    embedded = page.get("embeddedNote")
+    if isinstance(embedded, dict):
+        tags = embedded.get("htmlTags")
+        if isinstance(tags, list):
+            for tag in tags:
+                rendered = _render_react_value(tag)
+                if rendered:
+                    sections.append(f"<p>{rendered}</p>")
+    return "".join(sections) or None
+
+
+def _render_react_value(value: object) -> str | None:
+    if isinstance(value, str):
+        text = value.strip()
+        return escape(text).replace("\n", "<br>") if text else None
+    if isinstance(value, list):
+        rendered = [_render_react_value(item) for item in value]
+        return "<br>".join(item for item in rendered if item) or None
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        text = json.dumps(value, ensure_ascii=False, sort_keys=True)
+    else:
+        text = str(value)
+    return escape(text.strip()) or None
+
+
+def _react_location(page: dict[str, Any]) -> str | None:
+    locations: list[str] = []
+    for key in (
+        "requisitionDetails",
+        "jobDescriptionDetails",
+        "requisitionCompanyAttributes",
+    ):
+        values = page.get(key)
+        if not isinstance(values, list):
+            continue
+        for field in values:
+            if not isinstance(field, dict) or field.get("selected") is False:
+                continue
+            name = _optional_text(field.get("name"))
+            if name is None or not re.search(
+                r"(?:勤務地|勤務場所|就業場所|location|workplace)",
+                name,
+                re.I,
+            ):
+                continue
+            value = field.get("value")
+            if isinstance(value, list):
+                locations.extend(
+                    text
+                    for item in value
+                    if (text := _optional_text(item))
+                )
+            elif text := _optional_text(value):
+                locations.append(text)
+    return "; ".join(dict.fromkeys(locations)) or None
+
+
+def _apply_salary(job: Job, value: object) -> None:
+    if not isinstance(value, dict):
+        return
+    currency = _optional_text(value.get("currency"))
+    amount = value.get("value")
+    if not isinstance(amount, dict) or currency is None or len(currency) != 3:
+        return
+    minimum = _number(amount.get("minValue"))
+    maximum = _number(amount.get("maxValue"))
+    if minimum is None and maximum is None:
+        scalar = _number(amount.get("value"))
+        minimum = scalar
+        maximum = scalar
+    if minimum is None and maximum is None:
+        return
+    period = _SALARY_PERIOD_MAP.get(str(amount.get("unitText") or "").upper(), "YEAR")
+    job.salary_currency = currency.upper()
+    job.salary_period = period
+    job.salary_min = minimum
+    job.salary_max = maximum
+
+
+def _location(value: object) -> tuple[str | None, str | None]:
+    if isinstance(value, list):
+        locations = [_location(item) for item in value]
+        texts = [text for text, _ in locations if text]
+        countries = {country for _, country in locations if country}
+        country_iso = next(iter(countries)) if len(countries) == 1 else None
+        return "; ".join(dict.fromkeys(texts)) or None, country_iso
+    if not isinstance(value, dict):
+        return None, None
+    address = value.get("address")
+    if isinstance(address, str):
+        return _optional_text(address), None
+    if not isinstance(address, dict):
+        return None, None
+    parts = [
+        str(address[key]).strip()
+        for key in (
+            "streetAddress",
+            "addressLocality",
+            "addressRegion",
+            "postalCode",
+            "addressCountry",
+        )
+        if address.get(key)
+    ]
+    return ", ".join(parts) or None, _country_iso(address.get("addressCountry"))
+
+
+def _country_iso(value: object) -> str | None:
+    if isinstance(value, dict):
+        value = value.get("name")
+    text = _optional_text(value)
+    if text is None:
+        return None
+    upper = text.upper()
+    if re.fullmatch(r"[A-Z]{2}", upper):
+        return upper
+    return _COUNTRY_NAME_TO_ISO.get(text.casefold())
+
+
+def _parse_datetime(value: object) -> datetime | None:
+    text = _optional_text(value)
+    if text is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+
+
+def _positive_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 and str(value).strip() == str(parsed) else None
+
+
+def _number(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed
+
+
+def _optional_text(value: object) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _language(value: object) -> str | None:
+    text = _optional_text(value)
+    return text.lower() if text and re.fullmatch(r"[A-Za-z]{2}", text) else None
+
+
+def _merge_labels(first: str | None, second: str | None) -> str | None:
+    labels = [
+        label.strip()
+        for value in (first, second)
+        if value
+        for label in value.split(";")
+        if label.strip()
+    ]
+    return "; ".join(dict.fromkeys(labels)) or None

--- a/tests/e2e/test_live_scrapers.py
+++ b/tests/e2e/test_live_scrapers.py
@@ -34,6 +34,7 @@ from ats_scrapers.scrapers import (
     RemoteOKScraper,
     SmartRecruitersScraper,
     SoftgardenScraper,
+    TalentioScraper,
     TeamtailorScraper,
     TheHubScraper,
     UberScraper,
@@ -73,6 +74,14 @@ CASES = [
     ("smartrecruiters-10pearls",
      lambda: SmartRecruitersScraper("10pearls", include_descriptions=False), False),
     ("softgarden-abeking", lambda: SoftgardenScraper("abeking"), True),
+    (
+        "talentio-viewn",
+        lambda: TalentioScraper(
+            "https://open.talentio.com/r/1/c/viewn/homes/2635",
+            include_descriptions=False,
+        ),
+        True,
+    ),
     ("workable-0x", lambda: WorkableScraper("0x", include_descriptions=False), False),
     ("recruitee-12build",
      lambda: RecruiteeScraper("12build", include_descriptions=False), False),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,7 +22,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         "icims", "join_com", "jobvite", "keka", "lever", "mercor", "moka", "oracle", "pageup", "paycom", "paylocity",
         "personio", "phenom",
         "pinpoint", "recruiterbox", "rippling", "smartrecruiters", "softgarden",
-        "successfactors", "ukg", "workable", "workday",
+        "successfactors", "talentio", "ukg", "workable", "workday",
         # Big-tech custom careers systems
         "amazon", "apple", "bytedance", "google", "meta",
         "tesla", "tiktok", "uber", "usajobs",

--- a/tests/test_talentio.py
+++ b/tests/test_talentio.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import html
+import json
+
+import pytest
+
+from ats_scrapers import get_scraper_for_url
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType
+from ats_scrapers.scrapers import TalentioScraper
+from ats_scrapers.scrapers.base import ScraperRegistry
+
+PORTAL_URL = "https://open.talentio.com/r/1/c/viewn/homes/2635"
+JOB_URL = "https://open.talentio.com/r/1/c/viewn/pages/21394"
+APPLY_URL = f"{JOB_URL}/apply"
+
+
+def _page(group: str = "WEBサービス開発") -> dict[str, object]:
+    return {
+        "id": 21394,
+        "name": "サーバーサイドエンジニア",
+        "requisitionId": 21991,
+        "formId": 1718,
+        "publishedUrl": JOB_URL,
+        "publishedApplyUrl": APPLY_URL,
+        "_group": group,
+    }
+
+
+def _home_html(*, duplicate: bool = False, page_url: str = JOB_URL) -> str:
+    first = _page()
+    first["publishedUrl"] = page_url
+    groups: list[dict[str, object]] = [
+        {
+            "id": 4241,
+            "name": first.pop("_group"),
+            "recruitmentOpenPages": [first],
+        }
+    ]
+    if duplicate:
+        second = _page("エンジニア")
+        groups.append(
+            {
+                "id": 4242,
+                "name": second.pop("_group"),
+                "recruitmentOpenPages": [second],
+            }
+        )
+    payload = {
+        "openAtsCompany": {"id": 1668, "openAtsNamespace": "viewn"},
+        "recruitmentOpenPageHome": {
+            "id": 2635,
+            "name": "募集ポジション",
+            "language": "ja",
+            "recruitmentPageGroups": groups,
+        },
+    }
+    props = html.escape(json.dumps(payload, ensure_ascii=False), quote=True)
+    return (
+        "<html><head><title>募集ポジション / 株式会社ビューン</title></head>"
+        '<body><div data-react-class="RecruitmentOpenPageHomeView/index.'
+        f'RecruitmentOpenPageHomeView" data-react-props="{props}"></div></body></html>'
+    )
+
+
+def _detail_html(*, identifier: str = "21394") -> str:
+    payload = {
+        "@context": "https://schema.org/",
+        "@type": "JobPosting",
+        "title": "サーバーサイドエンジニア",
+        "description": "<h1>職務内容</h1><p>サービスを開発します。</p>",
+        "datePosted": "2026-07-29",
+        "url": JOB_URL,
+        "hiringOrganization": {
+            "@type": "Organization",
+            "name": "株式会社ビューン",
+        },
+        "identifier": {
+            "@type": "PropertyValue",
+            "name": "株式会社ビューン",
+            "value": identifier,
+        },
+        "jobLocation": {
+            "@type": "Place",
+            "address": {
+                "@type": "PostalAddress",
+                "streetAddress": "神田錦町3-13-7",
+                "addressLocality": "千代田区",
+                "addressRegion": "東京都",
+                "addressCountry": "JP",
+            },
+        },
+        "employmentType": "FULL_TIME",
+        "baseSalary": {
+            "@type": "MonetaryAmount",
+            "currency": "JPY",
+            "value": {
+                "@type": "QuantitativeValue",
+                "minValue": 4500000,
+                "maxValue": 7000000,
+                "unitText": "YEAR",
+            },
+        },
+    }
+    return (
+        '<html><body><script type="application/ld+json">'
+        f"{json.dumps(payload, ensure_ascii=False)}"
+        "</script></body></html>"
+    )
+
+
+def _react_detail_html(*, include_description: bool = True) -> str:
+    payload = {
+        "openAtsCompany": {"id": 1668, "openAtsNamespace": "viewn"},
+        "recruitmentOpenPage": {
+            "id": 21394,
+            "name": "サーバーサイドエンジニア",
+            "requisitionId": 21991,
+            "formId": 1718,
+            "requisition": {"language": "ja"},
+            "publishedApplyUrl": APPLY_URL,
+            "publishedUrl": JOB_URL,
+            "requisitionDetails": (
+                [
+                    {
+                        "id": 1,
+                        "type": "optional_field",
+                        "name": "職務内容",
+                        "value": "サービスを開発します。\nAPIも設計します。",
+                        "selected": True,
+                    },
+                    {
+                        "id": 2,
+                        "type": "optional_field",
+                        "name": "勤務地",
+                        "value": ["東京都千代田区", "フルリモート可"],
+                        "selected": True,
+                    },
+                ]
+                if include_description
+                else []
+            ),
+            "jobDescriptionDetails": [],
+            "requisitionCompanyAttributes": [],
+            "embeddedNote": {"htmlTags": []},
+        },
+        "language": "ja",
+    }
+    props = html.escape(json.dumps(payload, ensure_ascii=False), quote=True)
+    return (
+        "<html><head><title>サーバーサイドエンジニア / 株式会社ビューン"
+        "</title></head><body><div data-react-class=\"RecruitmentOpenPageView/"
+        f'index.RecruitmentOpenPageView" data-react-props="{props}"></div>'
+        "</body></html>"
+    )
+
+
+def test_registry_resolves_talentio() -> None:
+    assert ScraperRegistry.get(ATSType.TALENTIO) is TalentioScraper
+
+
+def test_fetches_active_jobs_with_full_detail(httpx_mock) -> None:
+    httpx_mock.add_response(url=PORTAL_URL, text=_home_html(duplicate=True))
+    httpx_mock.add_response(url=JOB_URL, text=_detail_html())
+
+    jobs = TalentioScraper(PORTAL_URL).fetch()
+
+    assert len(jobs) == 1
+    job = jobs[0]
+    assert job.ats_type is ATSType.TALENTIO
+    assert job.ats_id == "21394"
+    assert job.global_id == "talentio:21394"
+    assert str(job.url) == JOB_URL
+    assert str(job.apply_url) == APPLY_URL
+    assert job.title == "サーバーサイドエンジニア"
+    assert job.company == "株式会社ビューン"
+    assert job.department == "WEBサービス開発; エンジニア"
+    assert job.requisition_id == "21991"
+    assert job.description == "<h1>職務内容</h1><p>サービスを開発します。</p>"
+    assert job.location == "神田錦町3-13-7, 千代田区, 東京都, JP"
+    assert job.country_iso == "JP"
+    assert job.region == "Asia"
+    assert job.language == "ja"
+    assert job.employment_type == "FULL_TIME"
+    assert job.commitment == "FULL_TIME"
+    assert job.salary_currency == "JPY"
+    assert job.salary_period == "YEAR"
+    assert job.salary_min == 4500000
+    assert job.salary_max == 7000000
+    assert job.posted_at is not None
+    assert job.posted_at.isoformat() == "2026-07-29T00:00:00+00:00"
+    assert job.raw == {"namespace": "viewn", "home_id": 2635, "form_id": 1718}
+
+
+def test_listing_only_uses_catalog_company_name(httpx_mock) -> None:
+    httpx_mock.add_response(url=PORTAL_URL, text=_home_html())
+
+    job = TalentioScraper(
+        PORTAL_URL,
+        include_descriptions=False,
+        company_name="Viewn",
+    ).fetch()[0]
+
+    assert job.company == "Viewn"
+    assert job.description is None
+    assert job.location is None
+    assert job.country_iso is None
+    assert job.region is None
+
+
+def test_detail_country_is_not_forced_to_japan(httpx_mock) -> None:
+    detail = _detail_html().replace(
+        '"addressCountry": "JP"',
+        '"addressCountry": "SG"',
+    )
+    httpx_mock.add_response(url=PORTAL_URL, text=_home_html())
+    httpx_mock.add_response(url=JOB_URL, text=detail)
+
+    job = TalentioScraper(PORTAL_URL).fetch()[0]
+
+    assert job.country_iso == "SG"
+    assert job.region == "Asia"
+
+
+def test_react_detail_fallback_preserves_legacy_jobs(httpx_mock) -> None:
+    httpx_mock.add_response(url=PORTAL_URL, text=_home_html())
+    httpx_mock.add_response(url=JOB_URL, text=_react_detail_html())
+
+    job = TalentioScraper(PORTAL_URL).fetch()[0]
+
+    assert job.company == "株式会社ビューン"
+    assert job.language == "ja"
+    assert job.location == "東京都千代田区; フルリモート可"
+    assert job.is_remote is True
+    assert job.description == (
+        "<h2>職務内容</h2><p>サービスを開発します。<br>APIも設計します。</p>"
+        "<h2>勤務地</h2><p>東京都千代田区<br>フルリモート可</p>"
+    )
+
+
+def test_react_detail_without_content_is_dropped(httpx_mock) -> None:
+    httpx_mock.add_response(url=PORTAL_URL, text=_home_html())
+    httpx_mock.add_response(
+        url=JOB_URL,
+        text=_react_detail_html(include_description=False),
+    )
+
+    assert TalentioScraper(PORTAL_URL).fetch() == []
+
+
+def test_stale_detail_is_dropped(httpx_mock) -> None:
+    httpx_mock.add_response(url=PORTAL_URL, text=_home_html())
+    httpx_mock.add_response(url=JOB_URL, status_code=404)
+
+    assert TalentioScraper(PORTAL_URL).fetch() == []
+
+
+def test_transient_detail_failure_preserves_listing(httpx_mock) -> None:
+    httpx_mock.add_response(url=PORTAL_URL, text=_home_html())
+    for _ in range(3):
+        httpx_mock.add_response(url=JOB_URL, status_code=500)
+
+    job = TalentioScraper(PORTAL_URL).fetch()[0]
+
+    assert job.ats_id == "21394"
+    assert job.description is None
+
+
+def test_detail_identity_mismatch_fails_closed(httpx_mock) -> None:
+    httpx_mock.add_response(url=PORTAL_URL, text=_home_html())
+    httpx_mock.add_response(url=JOB_URL, text=_detail_html(identifier="999"))
+
+    with pytest.raises(ScraperError, match="ID mismatch"):
+        TalentioScraper(PORTAL_URL).fetch()
+
+
+def test_unrecognized_home_fails_closed(httpx_mock) -> None:
+    httpx_mock.add_response(url=PORTAL_URL, text="<html>maintenance</html>")
+
+    with pytest.raises(ScraperError, match="omitted RecruitmentOpenPageHomeView"):
+        TalentioScraper(PORTAL_URL).fetch()
+
+
+def test_untrusted_published_url_fails_closed(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=PORTAL_URL,
+        text=_home_html(page_url="https://evil.example/r/1/c/viewn/pages/21394"),
+    )
+
+    with pytest.raises(ScraperError, match="invalid published URL"):
+        TalentioScraper(PORTAL_URL, include_descriptions=False).fetch()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "viewn",
+        "http://open.talentio.com/r/1/c/viewn/homes/2635",
+        "https://evil.example/r/1/c/viewn/homes/2635",
+        "https://open.talentio.com/r/1/c/viewn/pages/21394",
+        "https://open.talentio.com/r/1/c/viewn/homes/not-a-number",
+        "https://open.talentio.com/r/1/c/viewn/homes/2635?redirect=https://evil.example",
+        "https://open.talentio.com.evil.example/r/1/c/viewn/homes/2635",
+    ],
+)
+def test_rejects_invalid_portal_urls(url: str) -> None:
+    with pytest.raises(ScraperError, match="TalentioScraper"):
+        TalentioScraper(url)
+
+
+def test_resolver_builds_talentio_scraper() -> None:
+    scraper = get_scraper_for_url(f"{PORTAL_URL}/")
+
+    assert isinstance(scraper, TalentioScraper)
+    assert scraper.company_slug == PORTAL_URL
+
+
+def test_resolver_rejects_detail_url() -> None:
+    with pytest.raises(ScraperError, match="Could not recognize"):
+        get_scraper_for_url(JOB_URL)

--- a/tests/test_talentio_contracts.py
+++ b/tests/test_talentio_contracts.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from ats_scrapers.scrapers import TalentioScraper
+from pipeline.publisher import ATS_DEDUP_PRIORITY
+from scripts.run_pipeline import CONFIGS, _bounded_concurrency
+
+
+def test_talentio_pipeline_uses_validated_tenant_catalog() -> None:
+    config = CONFIGS["talentio"]
+    row = {
+        "name": "株式会社ビューン",
+        "url": "https://open.talentio.com/r/1/c/viewn/homes/2635",
+    }
+
+    assert config["scraper"] is TalentioScraper
+    assert config["slug"](row) == row["url"]
+    assert config["kwargs"](row) == {"company_name": "株式会社ビューン"}
+    assert config["csv"] == "ats-companies/talentio.csv"
+    assert config["output"] == "talentio/jobs.csv"
+    assert config["dedupe_by_ats_id"] is True
+    assert config["max_concurrency"] == 2
+    assert config["tenant_delay_seconds"] == 0.25
+    assert config["fail_closed_on_any_error"] is True
+    assert config["fail_closed_on_empty"] is True
+
+
+def test_talentio_concurrency_cap_is_enforced() -> None:
+    assert _bounded_concurrency(CONFIGS["talentio"], 24) == 2
+
+
+def test_talentio_is_a_direct_employer_ats_for_deduplication() -> None:
+    assert ATS_DEDUP_PRIORITY["talentio"] == ATS_DEDUP_PRIORITY["workday"]
+
+
+def test_talentio_catalog_contains_only_validated_nonempty_portals() -> None:
+    with Path("ats-companies/talentio.csv").open(newline="") as handle:
+        rows = list(csv.DictReader(handle))
+
+    assert rows
+    assert len({row["url"] for row in rows}) == len(rows)
+    assert all(row["name"].strip() for row in rows)
+    assert all(
+        row["url"].startswith(
+            (
+                "https://open.talentio.com/r/1/c/",
+                "https://recruit.talentio.co.jp/r/1/c/",
+            )
+        )
+        and "/homes/" in row["url"]
+        for row in rows
+    )


### PR DESCRIPTION
## Summary
- add a credential-free Talentio scraper for official `open.talentio.com` and `recruit.talentio.co.jp` employer portals
- add 633 validated direct-employer career homes
- preserve structured JSON-LD details and verified legacy React fallback data

## Live validation
- 633/633 tenants succeeded; 0 not-found; 0 errors
- 4,917 unique jobs, all with titles, companies, descriptions, and stable global IDs
- 3,699 jobs have explicit Japan country data; 1,218 remain unforced when location metadata is absent
- 0 exact URL overlaps and 0 normalized company/title/location overlaps against the immutable 4,245,280-job baseline

## Tests
- 1,856 passed, 2 skipped, 36 deselected
- Ruff passed
- live E2E passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `talentio` ATS provider with a credential-free scraper and a catalog of 633 validated employer portals, producing 4,917 net-new jobs with stable IDs and JSON-LD-backed details. Improves pipeline dedupe and routing for Talentio portals.

- New Features
  - Introduced `TalentioScraper` for `open.talentio.com` and `recruit.talentio.co.jp`.
  - Parses JSON-LD `JobPosting`; falls back to React bootstrap when JSON-LD is missing.
  - Added `ats-companies/talentio.csv` (633 portals) and wired into `scripts/run_pipeline.py` with dedupe-by-ATS-ID, max concurrency 2, and fail-closed flags.
  - Marked `talentio` as a direct-employer ATS in `pipeline/publisher.py` for deduplication priority.
  - Updated resolver and models to recognize `talentio` homes; docs matrix now lists 53 providers.
  - Added targeted unit and E2E tests for listing, details, fallback, and URL validation.

<sup>Written for commit 4025f126975b72bb366c76875968fa4b454d3263. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a credential-free Talentio provider across URL resolution, scraping, publication, documentation, tests, and the employer catalog.

Live validation of Viewn’s public Talentio portal returned three active positions with canonical official URLs. Detail enrichment retained all three jobs and populated descriptions, Japanese locations, country codes, and posting dates. The dedicated live scraper test also passed. No defects were found.

<h3>Confidence Score: 5/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The review-authored Python harness was run against Viewn’s public Talentio portal with descriptions disabled and then enabled, followed by the repo’s talentio-viewn live pytest case.
- The listing returned three jobs with canonical official detail and application URLs, and enrichment retained all three jobs with descriptions, locations, country codes, and posting dates, without URL, identity, or detail errors.
- The live pytest case passed, confirming that the production scraper can retrieve and enrich the exercised public Talentio portal.
- Plain-language evidence record shows three active Viewn positions and that turning on detail enrichment kept all three and supplied descriptions and Japanese locations, with no exceptions or invalid/mismatched URLs.
- Fixture and runtime validation completed against the same portal, with the repository fixture passing as described in the live evidence set.

<a href="https://app.greptile.com/trex/runs/16604813/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Add Talentio provider scraper"](https://github.com/kalil0321/ats-scrapers/commit/4025f126975b72bb366c76875968fa4b454d3263) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48737135)</sub>

<!-- /greptile_comment -->