### PR TITLE
Add Ninehire provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ on a worker thread.
 
 Scraper adapters include:
 
-- Major ATS platforms: ADP Workforce Now, Greenhouse, Lever, Ashby, Workday, SmartRecruiters,
+- Major ATS platforms: ADP Workforce Now, Greenhouse, Lever, Ashby, Workday, Ninehire, SmartRecruiters,
   SuccessFactors, Oracle, iCIMS, HERP Hire, HRMOS, Keka, Paycom, Softgarden, Workable, Personio,
   and more.
 - First-party company APIs: Amazon, Apple, Google, TikTok, and Uber.

--- a/ats-companies/ninehire.csv
+++ b/ats-companies/ninehire.csv
@@ -1,0 +1,30 @@
+name,slug,url
+데이원컴퍼니,day1company,https://day1company.ninehire.site/
+삼양라운드스퀘어,samyangroundsquare,https://samyangroundsquare.ninehire.site/
+신성통상 / 에이션패션,ssts,https://ssts.ninehire.site/
+미소,miso,https://miso.ninehire.site/
+Telechips,telechipscareer,https://telechipscareer.ninehire.site/
+AITRICS,aitrics,https://aitrics.ninehire.site/
+바이트랩,bitelab,https://bitelab.ninehire.site/
+커넥트웨이브,connectwave,https://connectwave.ninehire.site/
+TYM,tym,https://tym.ninehire.site/
+한화비전,hanwhavision,https://hanwhavision.ninehire.site/
+로보티즈,robotisrecruiter,https://robotisrecruiter.ninehire.site/
+메라키플레이스,merakiplace,https://merakiplace.ninehire.site/
+넵튠,ug6h08u8,https://ug6h08u8.ninehire.site/
+네비웍스,naviworks,https://naviworks.ninehire.site/
+TVING,tving,https://tving.ninehire.site/
+페이히어,payhere,https://payhere.ninehire.site/
+테크타카(ARGO),techtaka,https://techtaka.ninehire.site/
+위대한상상 (요기요),wesangcareer,https://wesangcareer.ninehire.site/
+Tibero,tibero,https://tibero.ninehire.site/
+테헤란컴퍼니그룹,teherancompanygroup,https://teherancompanygroup.ninehire.site/
+비모소프트,vimosoft,https://vimosoft.ninehire.site/
+빌드코퍼레이션,vuildcorp,https://vuildcorp.ninehire.site/
+STARMED,starmed,https://starmed.ninehire.site/
+데카트론코리아,decathlon,https://decathlon.ninehire.site/
+레블코퍼레이션,rebelcorp,https://rebelcorp.ninehire.site/
+화이트큐브,whitecube,https://whitecube.ninehire.site/
+홈앤코,homeco,https://homeco.ninehire.site/
+메뉴잇,menuit,https://menuit.ninehire.site/
+오뚜기라면,otokirm,https://otokirm.ninehire.site/

--- a/pipeline/publisher.py
+++ b/pipeline/publisher.py
@@ -540,7 +540,7 @@ ATS_DEDUP_PRIORITY: dict[str, int] = {
     "darwinbox": 1, "dayforce": 1,
     "greenhouse": 1, "gupy": 1, "herp": 1, "hrmos": 1, "icims": 1, "jazzhr": 1, "join_com": 1, "jobvite": 1, "keka": 1,
     "lever": 1,
-    "moka": 1, "oracle": 1, "pageup": 1, "paycom": 1, "paylocity": 1, "personio": 1, "phenom": 1, "pinpoint": 1,
+    "moka": 1, "ninehire": 1, "oracle": 1, "pageup": 1, "paycom": 1, "paylocity": 1, "personio": 1, "phenom": 1, "pinpoint": 1,
     "recruitee": 1,
     "recruiterbox": 1, "rippling": 1, "smartrecruiters": 1, "softgarden": 1,
     "successfactors": 1, "taleo": 1, "teamtailor": 1, "ukg": 1, "workable": 1,

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -76,6 +76,7 @@ from ats_scrapers.scrapers import (
     MercorScraper,
     MetaScraper,
     MokaScraper,
+    NinehireScraper,
     OracleScraper,
     PageUpScraper,
     PaycomScraper,
@@ -640,6 +641,19 @@ CONFIGS: dict[str, dict[str, Any]] = {
         "slug": _moka_slug,
         "csv": "ats-companies/moka.csv",
         "output": "moka/jobs.csv",
+    },
+    "ninehire": {
+        "scraper": NinehireScraper,
+        "slug": lambda r: _slug_col(r) or (r.get("name") or "").strip() or None,
+        "kwargs": lambda r: {
+            "company_name": (r.get("name") or "").strip() or None,
+        },
+        "csv": "ats-companies/ninehire.csv",
+        "output": "ninehire/jobs.csv",
+        "dedupe_by_ats_id": True,
+        "max_concurrency": 6,
+        "fail_closed_on_empty": True,
+        "fail_closed_on_any_error": True,
     },
     "darwinbox": {
         "scraper": DarwinboxScraper,

--- a/src/ats_scrapers/models.py
+++ b/src/ats_scrapers/models.py
@@ -54,6 +54,7 @@ class ATSType(StrEnum):
     LEVER = "lever"
     MERCOR = "mercor"
     MOKA = "moka"
+    NINEHIRE = "ninehire"
     ORACLE = "oracle"
     PAGEUP = "pageup"
     PAYCOM = "paycom"

--- a/src/ats_scrapers/resolve.py
+++ b/src/ats_scrapers/resolve.py
@@ -77,6 +77,7 @@ _SUBDOMAIN_SUFFIXES: dict[str, ATSType] = {
     ".breezy.hr": ATSType.BREEZY,
     ".bamboohr.com": ATSType.BAMBOOHR,
     ".gupy.io": ATSType.GUPY,
+    ".ninehire.site": ATSType.NINEHIRE,
     ".jobs.personio.com": ATSType.PERSONIO,
     ".jobs.personio.de": ATSType.PERSONIO,
     ".pinpointhq.com": ATSType.PINPOINT,

--- a/src/ats_scrapers/scrapers/__init__.py
+++ b/src/ats_scrapers/scrapers/__init__.py
@@ -48,6 +48,7 @@ from ats_scrapers.scrapers.manfred import ManfredScraper
 from ats_scrapers.scrapers.mercor import MercorScraper
 from ats_scrapers.scrapers.meta import MetaScraper
 from ats_scrapers.scrapers.moka import MokaScraper
+from ats_scrapers.scrapers.ninehire import NinehireScraper
 from ats_scrapers.scrapers.oracle import OracleScraper
 from ats_scrapers.scrapers.pageup import PageUpScraper
 from ats_scrapers.scrapers.paycom import PaycomScraper
@@ -120,6 +121,7 @@ __all__ = [
     "MercorScraper",
     "MetaScraper",
     "MokaScraper",
+    "NinehireScraper",
     "OracleScraper",
     "PageUpScraper",
     "PaycomScraper",

--- a/src/ats_scrapers/scrapers/ninehire.py
+++ b/src/ats_scrapers/scrapers/ninehire.py
@@ -1,0 +1,647 @@
+"""Ninehire multi-tenant ATS scraper."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+import re
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from bs4 import BeautifulSoup
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType, EmploymentType, Job
+from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
+
+if TYPE_CHECKING:
+    from ats_scrapers.fetch import Fetcher
+
+API_URL = "https://api.ninehire.com/identity-access/homepage/recruitments"
+PAGE_SIZE = 100
+DESCRIPTION_CONCURRENCY = 4
+MAX_PAGES = 10_000
+
+_TENANT_RE = re.compile(
+    r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?",
+    re.IGNORECASE,
+)
+_UUID_RE = re.compile(
+    r"[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-"
+    r"[a-f0-9]{4}-[a-f0-9]{12}",
+    re.IGNORECASE,
+)
+_ADDRESS_KEY_RE = re.compile(r"[A-Za-z0-9_-]{4,64}")
+_NON_JOB_TITLE_MARKERS = (
+    "커피챗",
+    "coffee chat",
+    "talent pool",
+    "인재풀",
+    "최종 합격 발표",
+    "합격자 발표",
+)
+
+_EMPLOYMENT_TYPES: dict[str, EmploymentType] = {
+    "full_time": "FULL_TIME",
+    "part_time": "PART_TIME",
+    "contractor": "CONTRACT",
+    "contract": "CONTRACT",
+    "intern": "INTERN",
+    "internship": "INTERN",
+    "temporary": "TEMPORARY",
+}
+
+
+@ScraperRegistry.register(ATSType.NINEHIRE)
+class NinehireScraper(BaseScraper):
+    """Scrape one employer homepage hosted by Ninehire."""
+
+    ats = ATSType.NINEHIRE
+    default_headers: ClassVar[dict[str, str]] = {
+        "User-Agent": "Mozilla/5.0",
+        "Accept-Language": "ko-KR,ko;q=0.9,en;q=0.8",
+    }
+
+    def __init__(
+        self,
+        company_slug: str,
+        *,
+        timeout: float = 30.0,
+        include_descriptions: bool = True,
+        proxy: str | None = None,
+        company_name: str | None = None,
+    ) -> None:
+        tenant = company_slug.strip().casefold()
+        if not _TENANT_RE.fullmatch(tenant):
+            raise ScraperError(
+                "NinehireScraper requires a safe ninehire.site tenant slug"
+            )
+        super().__init__(
+            tenant,
+            timeout=timeout,
+            include_descriptions=include_descriptions,
+            proxy=proxy,
+        )
+        self.tenant = tenant
+        self.base_url = f"https://{tenant}.ninehire.site"
+        self.company_name = _clean_text(company_name)
+        self.company_id: str | None = None
+
+    async def afetch(self) -> list[Job]:
+        async with self.make_fetcher() as fetch:
+            await self._bootstrap(fetch)
+            jobs = await self._fetch_jobs(fetch)
+            if self.include_descriptions:
+                await self._hydrate_descriptions(fetch, jobs)
+            return jobs
+
+    def get_description(self, job: Job) -> str | None:
+        if job.description:
+            return job.description
+
+        async def run() -> str | None:
+            async with self.make_fetcher() as fetch:
+                return await self._fetch_description(fetch, job)
+
+        return self._run_sync(run())
+
+    async def _bootstrap(self, fetch: Fetcher) -> None:
+        html = await fetch.get_text(f"{self.base_url}/")
+        page_props = _next_page_props(
+            html,
+            provider=f"Ninehire ({self.tenant}) homepage",
+        )
+        homepage_props = page_props.get("homepageProps")
+        if not isinstance(homepage_props, dict):
+            raise ScraperError(
+                f"Ninehire ({self.tenant}) homepage has no homepageProps"
+            )
+        homepage = homepage_props.get("homepage")
+        info = homepage_props.get("info")
+        domain = homepage_props.get("domain")
+        if not isinstance(homepage, dict) or not isinstance(info, dict):
+            raise ScraperError(
+                f"Ninehire ({self.tenant}) homepage metadata is malformed"
+            )
+        company_id = _required_uuid(
+            homepage.get("companyId"),
+            field="companyId",
+            tenant=self.tenant,
+        )
+        info_company_id = _required_uuid(
+            info.get("companyId"),
+            field="info.companyId",
+            tenant=self.tenant,
+        )
+        if company_id != info_company_id:
+            raise ScraperError(
+                f"Ninehire ({self.tenant}) company IDs do not match"
+            )
+        if str(info.get("status")).casefold() != "published":
+            raise ScraperError(
+                f"Ninehire ({self.tenant}) homepage is not published"
+            )
+        if isinstance(domain, dict):
+            site_url = _clean_text(domain.get("siteUrl"))
+            if site_url is not None and site_url.casefold() != self.tenant:
+                raise ScraperError(
+                    f"Ninehire ({self.tenant}) resolved to tenant {site_url!r}"
+                )
+        self.company_id = company_id
+        self.company_name = (
+            self.company_name
+            or _required_text(
+                info.get("companyName"),
+                field="companyName",
+                tenant=self.tenant,
+            )
+        )
+
+    async def _fetch_jobs(self, fetch: Fetcher) -> list[Job]:
+        if self.company_id is None or self.company_name is None:
+            raise ScraperError(
+                f"Ninehire ({self.tenant}) was not bootstrapped"
+            )
+        expected_total: int | None = None
+        total_pages: int | None = None
+        raw_count = 0
+        seen: set[str] = set()
+        jobs: list[Job] = []
+        for page in range(1, MAX_PAGES + 1):
+            payload = await fetch.get_json(
+                API_URL,
+                params={
+                    "companyId": self.company_id,
+                    "page": page,
+                    "countPerPage": PAGE_SIZE,
+                    "order": "created_at_desc",
+                },
+                headers={"Referer": f"{self.base_url}/"},
+            )
+            if not isinstance(payload, dict):
+                raise ScraperError(
+                    f"Ninehire ({self.tenant}) API returned a non-object"
+                )
+            page_total = _required_nonnegative_int(
+                payload.get("count"),
+                field="count",
+                tenant=self.tenant,
+            )
+            results = payload.get("results")
+            if not isinstance(results, list):
+                raise ScraperError(
+                    f"Ninehire ({self.tenant}) API returned no results list"
+                )
+            if len(results) > PAGE_SIZE:
+                raise ScraperError(
+                    f"Ninehire ({self.tenant}) returned {len(results)} "
+                    f"rows for page size {PAGE_SIZE}"
+                )
+            if expected_total is None:
+                expected_total = page_total
+                total_pages = math.ceil(expected_total / PAGE_SIZE)
+                if expected_total == 0:
+                    if results:
+                        raise ScraperError(
+                            f"Ninehire ({self.tenant}) returned rows with "
+                            "count=0"
+                        )
+                    return []
+            elif page_total != expected_total:
+                raise ScraperError(
+                    f"Ninehire ({self.tenant}) count changed while paginating"
+                )
+            if not results:
+                raise ScraperError(
+                    f"Ninehire ({self.tenant}) pagination stopped at "
+                    f"{raw_count} of {expected_total}"
+                )
+            for item in results:
+                if not isinstance(item, dict):
+                    raise ScraperError(
+                        f"Ninehire ({self.tenant}) returned a malformed job"
+                    )
+                raw_count += 1
+                job = self._parse_job(item)
+                if job.ats_id in seen:
+                    raise ScraperError(
+                        f"Ninehire ({self.tenant}) returned duplicate job "
+                        f"ID {job.ats_id}"
+                    )
+                seen.add(str(job.ats_id))
+                if _is_real_job(job.title):
+                    jobs.append(job)
+            if total_pages is not None and page >= total_pages:
+                break
+        else:
+            raise ScraperError(
+                f"Ninehire ({self.tenant}) reached the {MAX_PAGES}-page "
+                "safety cap"
+            )
+        if expected_total is None or raw_count != expected_total:
+            raise ScraperError(
+                f"Ninehire ({self.tenant}) expected {expected_total} jobs, "
+                f"parsed {raw_count}"
+            )
+        return jobs
+
+    def _parse_job(self, item: dict[str, Any]) -> Job:
+        if self.company_name is None or self.company_id is None:
+            raise ScraperError(
+                f"Ninehire ({self.tenant}) was not bootstrapped"
+            )
+        item_company_id = _required_uuid(
+            item.get("companyId"),
+            field="job.companyId",
+            tenant=self.tenant,
+        )
+        if item_company_id != self.company_id:
+            raise ScraperError(
+                f"Ninehire ({self.tenant}) returned another company's job"
+            )
+        recruitment_id = _required_uuid(
+            item.get("recruitmentId"),
+            field="recruitmentId",
+            tenant=self.tenant,
+        )
+        address_key = _required_address_key(
+            item.get("addressKey"),
+            tenant=self.tenant,
+        )
+        title = _required_text(
+            item.get("title") or item.get("externalTitle"),
+            field="title",
+            tenant=self.tenant,
+        )
+        locations = _parse_locations(item.get("jobLocations"))
+        location = ", ".join(locations["names"]) or None
+        country_iso, region = _location_geography(location)
+        employment_values = _string_list(item.get("employmentType"))
+        career = item.get("career")
+        career_range = (
+            career.get("range")
+            if isinstance(career, dict)
+            and isinstance(career.get("range"), dict)
+            else None
+        )
+        job_group = item.get("jobGroup")
+        job_task = item.get("jobTask")
+        affiliation = item.get("affiliation")
+        canonical_url = f"{self.base_url}/job_posting/{address_key}"
+        return Job(
+            url=canonical_url,
+            title=title,
+            company=self.company_name,
+            ats_type=ATSType.NINEHIRE,
+            ats_id=recruitment_id,
+            location=location,
+            country_iso=country_iso,
+            region=region,
+            lat=locations["lat"],
+            lon=locations["lon"],
+            is_remote=_is_remote(title, location),
+            experience=(
+                _coerce_int(career_range.get("over"))
+                if career_range is not None
+                else None
+            ),
+            employment_type=_employment_type(employment_values),
+            department=_nested_text(job_group, "title"),
+            team=_nested_text(job_task, "title"),
+            apply_url=canonical_url,
+            commitment=", ".join(employment_values) or None,
+            posted_at=_parse_datetime(item.get("createdAt")),
+            fetched_at=datetime.now(UTC),
+            language=_language_for_text(title),
+            raw={
+                "address_key": address_key,
+                "company_id": self.company_id,
+                "status": item.get("status"),
+                "deadline_type": item.get("deadlineType"),
+                "deadline_value": item.get("deadlineValue"),
+                "career": career,
+                "affiliation": _nested_text(affiliation, "title"),
+                "tags": _tag_values(item.get("tags")),
+                "always_exposure": item.get("alwaysExposure"),
+            },
+        )
+
+    async def _hydrate_descriptions(
+        self,
+        fetch: Fetcher,
+        jobs: list[Job],
+    ) -> None:
+        semaphore = asyncio.Semaphore(DESCRIPTION_CONCURRENCY)
+
+        async def hydrate(job: Job) -> None:
+            async with semaphore:
+                try:
+                    description = await self._fetch_description(fetch, job)
+                except ScraperError:
+                    return
+                if description:
+                    job.description = description[:25_000]
+
+        await asyncio.gather(*(hydrate(job) for job in jobs))
+
+    async def _fetch_description(
+        self,
+        fetch: Fetcher,
+        job: Job,
+    ) -> str | None:
+        html = await fetch.get_text(str(job.url))
+        page_props = _next_page_props(
+            html,
+            provider=f"Ninehire job {job.ats_id}",
+        )
+        recruitment = page_props.get("recruitment")
+        job_posting = page_props.get("jobPosting")
+        if not isinstance(recruitment, dict) or not isinstance(
+            job_posting,
+            dict,
+        ):
+            raise ScraperError(
+                f"Ninehire job {job.ats_id} has malformed detail metadata"
+            )
+        detail_id = _required_uuid(
+            recruitment.get("recruitmentId"),
+            field="detail.recruitmentId",
+            tenant=self.tenant,
+        )
+        if detail_id != job.ats_id:
+            raise ScraperError(
+                f"Ninehire job {job.ats_id} detail returned ID {detail_id}"
+            )
+        detail_key = _required_address_key(
+            recruitment.get("addressKey"),
+            tenant=self.tenant,
+        )
+        if detail_key != job.raw.get("address_key"):
+            raise ScraperError(
+                f"Ninehire job {job.ats_id} detail address key changed"
+            )
+        if job_posting.get("isActive") is not True:
+            return None
+        return _clean_multiline(job_posting.get("content"))
+
+
+def _next_page_props(html: str, *, provider: str) -> dict[str, Any]:
+    soup = BeautifulSoup(html, "html.parser")
+    script = soup.find("script", id="__NEXT_DATA__")
+    if script is None or not script.string:
+        raise ScraperError(f"{provider} has no Next.js bootstrap data")
+    try:
+        payload = json.loads(script.string)
+        page_props = payload["props"]["pageProps"]
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise ScraperError(
+            f"{provider} has malformed Next.js bootstrap data"
+        ) from exc
+    if not isinstance(page_props, dict):
+        raise ScraperError(f"{provider} has no pageProps object")
+    return page_props
+
+
+def _parse_locations(value: object) -> dict[str, Any]:
+    if not isinstance(value, list):
+        return {"names": [], "lat": None, "lon": None}
+    names: list[str] = []
+    coordinates: list[tuple[float, float]] = []
+    for location in value:
+        if not isinstance(location, dict):
+            continue
+        name = (
+            _clean_text(location.get("addressName"))
+            or _clean_text(location.get("placeName"))
+        )
+        if name and name not in names:
+            names.append(name)
+        lat = _coerce_float(location.get("y"))
+        lon = _coerce_float(location.get("x"))
+        if (
+            lat is not None
+            and lon is not None
+            and -90 <= lat <= 90
+            and -180 <= lon <= 180
+        ):
+            coordinates.append((lat, lon))
+    return {
+        "names": names,
+        "lat": coordinates[0][0] if len(coordinates) == 1 else None,
+        "lon": coordinates[0][1] if len(coordinates) == 1 else None,
+    }
+
+
+def _required_uuid(value: object, *, field: str, tenant: str) -> str:
+    cleaned = _clean_text(value)
+    if cleaned is None or not _UUID_RE.fullmatch(cleaned):
+        raise ScraperError(
+            f"Ninehire ({tenant}) returned malformed {field}={value!r}"
+        )
+    return cleaned.casefold()
+
+
+def _required_address_key(value: object, *, tenant: str) -> str:
+    cleaned = _clean_text(value)
+    if cleaned is None or not _ADDRESS_KEY_RE.fullmatch(cleaned):
+        raise ScraperError(
+            f"Ninehire ({tenant}) returned malformed addressKey={value!r}"
+        )
+    return cleaned
+
+
+def _required_text(
+    value: object,
+    *,
+    field: str,
+    tenant: str,
+) -> str:
+    cleaned = _clean_text(value)
+    if cleaned is None:
+        raise ScraperError(f"Ninehire ({tenant}) returned no {field}")
+    return cleaned
+
+
+def _required_nonnegative_int(
+    value: object,
+    *,
+    field: str,
+    tenant: str,
+) -> int:
+    parsed = _coerce_int(value)
+    if parsed is None or parsed < 0:
+        raise ScraperError(
+            f"Ninehire ({tenant}) returned malformed {field}={value!r}"
+        )
+    return parsed
+
+
+def _coerce_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        return float(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _clean_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = BeautifulSoup(str(value), "html.parser").get_text(" ", strip=True)
+    normalized = re.sub(r"\s+", " ", text).strip()
+    return normalized or None
+
+
+def _clean_multiline(value: object) -> str | None:
+    if value is None:
+        return None
+    text = BeautifulSoup(str(value), "html.parser").get_text(
+        "\n",
+        strip=True,
+    )
+    lines = [
+        re.sub(r"[^\S\r\n]+", " ", line).strip()
+        for line in text.splitlines()
+    ]
+    return "\n".join(line for line in lines if line) or None
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [
+        cleaned
+        for item in value
+        if (cleaned := _clean_text(item)) is not None
+    ]
+
+
+def _nested_text(value: object, field: str) -> str | None:
+    return (
+        _clean_text(value.get(field))
+        if isinstance(value, dict)
+        else None
+    )
+
+
+def _tag_values(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [
+        cleaned
+        for tag in value
+        if isinstance(tag, dict)
+        and (cleaned := _clean_text(tag.get("content"))) is not None
+    ]
+
+
+def _employment_type(values: list[str]) -> EmploymentType | None:
+    return next(
+        (
+            normalized
+            for value in values
+            if (normalized := _EMPLOYMENT_TYPES.get(value.casefold()))
+            is not None
+        ),
+        None,
+    )
+
+
+def _location_geography(
+    location: str | None,
+) -> tuple[str | None, str | None]:
+    normalized = (location or "").casefold()
+    if any(
+        marker in normalized
+        for marker in (
+            "대한민국",
+            "서울",
+            "부산",
+            "대구",
+            "인천",
+            "광주",
+            "대전",
+            "울산",
+            "세종",
+            "경기",
+            "강원",
+            "충북",
+            "충남",
+            "전북",
+            "전남",
+            "경북",
+            "경남",
+            "제주",
+            "south korea",
+            "korea",
+        )
+    ):
+        return "KR", "Asia"
+    if any(
+        marker in normalized
+        for marker in ("일본", "japan", "tokyo", "osaka")
+    ):
+        return "JP", "Asia"
+    if any(
+        marker in normalized
+        for marker in (
+            "united states",
+            "usa",
+            "california",
+            "new york",
+            "massachusetts",
+        )
+    ):
+        return "US", "North America"
+    return None, None
+
+
+def _is_remote(title: str, location: str | None) -> bool | None:
+    combined = f"{title} {location or ''}".casefold()
+    if any(
+        marker in combined
+        for marker in ("remote", "재택", "원격", "리모트")
+    ):
+        return True
+    return None
+
+
+def _parse_datetime(value: object) -> datetime | None:
+    cleaned = _clean_text(value)
+    if cleaned is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(cleaned.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return (
+        parsed.replace(tzinfo=UTC)
+        if parsed.tzinfo is None
+        else parsed.astimezone(UTC)
+    )
+
+
+def _language_for_text(value: str) -> str | None:
+    if re.search(r"[\uac00-\ud7af]", value):
+        return "ko"
+    if re.search(r"[A-Za-z]", value):
+        return "en"
+    return None
+
+
+def _is_real_job(title: str) -> bool:
+    normalized = title.casefold()
+    return not any(
+        marker in normalized for marker in _NON_JOB_TITLE_MARKERS
+    )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -19,7 +19,7 @@ def test_ats_type_includes_every_supported_platform() -> None:
         # Multi-tenant ATS systems
         "adp", "ashby", "avature", "beisen", "beisen_legacy", "cornerstone",
         "darwinbox", "dayforce", "eightfold", "gem", "greenhouse", "gupy", "herp", "hrmos",
-        "icims", "join_com", "jobvite", "keka", "lever", "mercor", "moka", "oracle", "pageup", "paycom", "paylocity",
+        "icims", "join_com", "jobvite", "keka", "lever", "mercor", "moka", "ninehire", "oracle", "pageup", "paycom", "paylocity",
         "personio", "phenom",
         "pinpoint", "recruiterbox", "rippling", "smartrecruiters", "softgarden",
         "successfactors", "ukg", "workable", "workday",

--- a/tests/test_ninehire.py
+++ b/tests/test_ninehire.py
@@ -1,0 +1,376 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType
+from ats_scrapers.scrapers import NinehireScraper
+from ats_scrapers.scrapers.base import ScraperRegistry
+
+TENANT = "day1company"
+BASE_URL = f"https://{TENANT}.ninehire.site"
+COMPANY_ID = "70683bd0-612b-11ec-bd23-6b2cabce5a2f"
+OTHER_COMPANY_ID = "11111111-2222-3333-4444-555555555555"
+RECRUITMENT_ID = "fab5ece0-8bee-11f1-9802-bf2fa0054e80"
+API_URL = "https://api.ninehire.com/identity-access/homepage/recruitments"
+
+
+def _next_html(page_props: dict) -> str:
+    payload = {"props": {"pageProps": page_props}}
+    return (
+        "<html><body><script id=\"__NEXT_DATA__\" "
+        f"type=\"application/json\">{json.dumps(payload)}</script></body></html>"
+    )
+
+
+def _homepage(
+    *,
+    company_id: str = COMPANY_ID,
+    info_company_id: str | None = None,
+    status: str = "published",
+    site_url: str = TENANT,
+) -> str:
+    return _next_html(
+        {
+            "homepageProps": {
+                "homepage": {"companyId": company_id},
+                "info": {
+                    "companyId": info_company_id or company_id,
+                    "companyName": "데이원컴퍼니",
+                    "status": status,
+                },
+                "domain": {"siteUrl": site_url},
+            }
+        }
+    )
+
+
+def _job(
+    index: int = 1,
+    *,
+    recruitment_id: str = RECRUITMENT_ID,
+    company_id: str = COMPANY_ID,
+    title: str = "[계약직] 세일즈 매니저",
+    address_key: str = "7a0UlD8L",
+) -> dict:
+    return {
+        "companyId": company_id,
+        "recruitmentId": recruitment_id,
+        "status": "in_progress",
+        "title": title,
+        "externalTitle": title,
+        "addressKey": address_key,
+        "deadlineValue": None,
+        "deadlineType": "until_filled",
+        "employmentType": ["contractor"],
+        "career": {"type": "experienced", "range": {"over": 1, "below": 0}},
+        "jobLocations": [
+            {
+                "x": 127.041154766578,
+                "y": 37.5026496860008,
+                "placeName": "센터필드 West",
+                "addressName": "서울 강남구 테헤란로 231",
+            }
+        ],
+        "jobGroup": {"title": "세일즈"},
+        "jobTask": {"title": "B2C 세일즈"},
+        "affiliation": {"title": "포도"},
+        "tags": [{"content": "계약직"}, {"content": f"job-{index}"}],
+        "createdAt": "2026-07-30T08:31:42.000Z",
+        "alwaysExposure": False,
+    }
+
+
+def _page(results: list[dict], *, count: int | None = None) -> dict:
+    return {
+        "count": len(results) if count is None else count,
+        "results": results,
+    }
+
+
+def _api_url(page: int = 1) -> str:
+    return (
+        f"{API_URL}?companyId={COMPANY_ID}&page={page}"
+        "&countPerPage=100&order=created_at_desc"
+    )
+
+
+def _detail(
+    *,
+    recruitment_id: str = RECRUITMENT_ID,
+    address_key: str = "7a0UlD8L",
+    active: bool = True,
+    content: str = "<h3>담당 업무</h3><p>고객 상담과 세일즈</p>",
+) -> str:
+    return _next_html(
+        {
+            "recruitment": {
+                "recruitmentId": recruitment_id,
+                "addressKey": address_key,
+            },
+            "jobPosting": {
+                "isActive": active,
+                "content": content,
+            },
+        }
+    )
+
+
+def _add_homepage(httpx_mock, html: str | None = None) -> None:
+    httpx_mock.add_response(
+        url=f"{BASE_URL}/",
+        text=html or _homepage(),
+    )
+
+
+def test_registry_resolves_ninehire() -> None:
+    assert ScraperRegistry.get(ATSType.NINEHIRE) is NinehireScraper
+
+
+def test_fetches_structured_jobs(httpx_mock) -> None:
+    _add_homepage(httpx_mock)
+    httpx_mock.add_response(
+        url=_api_url(),
+        json=_page([_job()]),
+    )
+
+    job = NinehireScraper(
+        TENANT,
+        include_descriptions=False,
+    ).fetch()[0]
+
+    assert job.ats_type is ATSType.NINEHIRE
+    assert job.ats_id == RECRUITMENT_ID
+    assert job.title == "[계약직] 세일즈 매니저"
+    assert job.company == "데이원컴퍼니"
+    assert str(job.url) == f"{BASE_URL}/job_posting/7a0UlD8L"
+    assert str(job.apply_url) == f"{BASE_URL}/job_posting/7a0UlD8L"
+    assert job.location == "서울 강남구 테헤란로 231"
+    assert job.country_iso == "KR"
+    assert job.region == "Asia"
+    assert job.lat == pytest.approx(37.5026496860008)
+    assert job.lon == pytest.approx(127.041154766578)
+    assert job.experience == 1
+    assert job.employment_type == "CONTRACT"
+    assert job.commitment == "contractor"
+    assert job.department == "세일즈"
+    assert job.team == "B2C 세일즈"
+    assert job.posted_at == datetime(
+        2026, 7, 30, 8, 31, 42, tzinfo=UTC
+    )
+    assert job.fetched_at is not None
+    assert job.language == "ko"
+    assert job.raw["affiliation"] == "포도"
+    assert job.raw["tags"] == ["계약직", "job-1"]
+
+
+def test_catalog_company_name_overrides_homepage(httpx_mock) -> None:
+    _add_homepage(httpx_mock)
+    httpx_mock.add_response(url=_api_url(), json=_page([_job()]))
+
+    job = NinehireScraper(
+        TENANT,
+        company_name="Day 1 Company",
+        include_descriptions=False,
+    ).fetch()[0]
+
+    assert job.company == "Day 1 Company"
+
+
+def test_filters_non_job_postings(httpx_mock) -> None:
+    _add_homepage(httpx_mock)
+    httpx_mock.add_response(
+        url=_api_url(),
+        json=_page(
+            [
+                _job(),
+                _job(
+                    2,
+                    recruitment_id="11111111-2222-3333-4444-555555555551",
+                    title="☕️ 커피챗 신청하기",
+                    address_key="coffee01",
+                ),
+                _job(
+                    3,
+                    recruitment_id="11111111-2222-3333-4444-555555555552",
+                    title="Talent Pool(상시 인재풀 등록)",
+                    address_key="talent01",
+                ),
+                _job(
+                    4,
+                    recruitment_id="11111111-2222-3333-4444-555555555553",
+                    title="최종 합격 발표 안내",
+                    address_key="result01",
+                ),
+            ]
+        ),
+    )
+
+    jobs = NinehireScraper(
+        TENANT,
+        include_descriptions=False,
+    ).fetch()
+
+    assert [job.ats_id for job in jobs] == [RECRUITMENT_ID]
+
+
+def test_paginates_to_exact_advertised_count(httpx_mock) -> None:
+    _add_homepage(httpx_mock)
+    first_page = [
+        _job(
+            index,
+            recruitment_id=f"00000000-0000-4000-8000-{index:012x}",
+            address_key=f"job{index:04d}",
+        )
+        for index in range(100)
+    ]
+    last = _job(
+        100,
+        recruitment_id="00000000-0000-4000-8000-000000000100",
+        address_key="job0100",
+    )
+    httpx_mock.add_response(
+        url=_api_url(1),
+        json=_page(first_page, count=101),
+    )
+    httpx_mock.add_response(
+        url=_api_url(2),
+        json=_page([last], count=101),
+    )
+
+    jobs = NinehireScraper(
+        TENANT,
+        include_descriptions=False,
+    ).fetch()
+
+    assert len(jobs) == 101
+
+
+def test_count_change_fails_closed(httpx_mock) -> None:
+    _add_homepage(httpx_mock)
+    first_page = [
+        _job(
+            index,
+            recruitment_id=f"00000000-0000-4000-8000-{index:012x}",
+            address_key=f"job{index:04d}",
+        )
+        for index in range(100)
+    ]
+    httpx_mock.add_response(
+        url=_api_url(1),
+        json=_page(first_page, count=101),
+    )
+    httpx_mock.add_response(
+        url=_api_url(2),
+        json=_page([], count=102),
+    )
+
+    with pytest.raises(ScraperError, match="count changed"):
+        NinehireScraper(TENANT, include_descriptions=False).fetch()
+
+
+def test_duplicate_ids_fail_closed(httpx_mock) -> None:
+    _add_homepage(httpx_mock)
+    httpx_mock.add_response(
+        url=_api_url(),
+        json=_page([_job(), _job(2)]),
+    )
+
+    with pytest.raises(ScraperError, match="duplicate job ID"):
+        NinehireScraper(TENANT, include_descriptions=False).fetch()
+
+
+def test_cross_company_job_fails_closed(httpx_mock) -> None:
+    _add_homepage(httpx_mock)
+    httpx_mock.add_response(
+        url=_api_url(),
+        json=_page([_job(company_id=OTHER_COMPANY_ID)]),
+    )
+
+    with pytest.raises(ScraperError, match="another company's job"):
+        NinehireScraper(TENANT, include_descriptions=False).fetch()
+
+
+def test_default_fetch_hydrates_description(httpx_mock) -> None:
+    _add_homepage(httpx_mock)
+    httpx_mock.add_response(url=_api_url(), json=_page([_job()]))
+    httpx_mock.add_response(
+        url=f"{BASE_URL}/job_posting/7a0UlD8L",
+        text=_detail(),
+    )
+
+    job = NinehireScraper(TENANT).fetch()[0]
+
+    assert job.description == "담당 업무\n고객 상담과 세일즈"
+
+
+def test_inactive_detail_returns_no_description(httpx_mock) -> None:
+    _add_homepage(httpx_mock)
+    httpx_mock.add_response(url=_api_url(), json=_page([_job()]))
+    scraper = NinehireScraper(TENANT, include_descriptions=False)
+    job = scraper.fetch()[0]
+    httpx_mock.add_response(
+        url=f"{BASE_URL}/job_posting/7a0UlD8L",
+        text=_detail(active=False),
+    )
+
+    assert scraper.get_description(job) is None
+
+
+def test_detail_identity_change_fails_closed(httpx_mock) -> None:
+    _add_homepage(httpx_mock)
+    httpx_mock.add_response(url=_api_url(), json=_page([_job()]))
+    scraper = NinehireScraper(TENANT, include_descriptions=False)
+    job = scraper.fetch()[0]
+    httpx_mock.add_response(
+        url=f"{BASE_URL}/job_posting/7a0UlD8L",
+        text=_detail(
+            recruitment_id="11111111-2222-3333-4444-555555555555"
+        ),
+    )
+
+    with pytest.raises(ScraperError, match="detail returned ID"):
+        scraper.get_description(job)
+
+
+@pytest.mark.parametrize(
+    ("homepage", "message"),
+    [
+        (_homepage(status="draft"), "not published"),
+        (
+            _homepage(info_company_id=OTHER_COMPANY_ID),
+            "company IDs do not match",
+        ),
+        (_homepage(site_url="other"), "resolved to tenant"),
+        ("<html>maintenance</html>", "no Next.js bootstrap"),
+    ],
+)
+def test_rejects_invalid_homepage(
+    httpx_mock,
+    homepage: str,
+    message: str,
+) -> None:
+    _add_homepage(httpx_mock, homepage)
+
+    with pytest.raises(ScraperError, match=message):
+        NinehireScraper(TENANT).fetch()
+
+
+@pytest.mark.parametrize(
+    "slug",
+    [
+        "",
+        "bad_slug",
+        "../tenant",
+        "tenant.ninehire.site",
+        "https://tenant.ninehire.site",
+        "a" * 64,
+        "trailing-",
+    ],
+)
+def test_rejects_untrusted_tenant_slugs(slug: str) -> None:
+    with pytest.raises(ScraperError, match="NinehireScraper"):
+        NinehireScraper(slug)

--- a/tests/test_ninehire_contracts.py
+++ b/tests/test_ninehire_contracts.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from ats_scrapers.scrapers import NinehireScraper
+from pipeline.publisher import ATS_DEDUP_PRIORITY
+from scripts.run_pipeline import CONFIGS, _bounded_concurrency
+
+
+def test_ninehire_pipeline_is_fail_closed() -> None:
+    config = CONFIGS["ninehire"]
+    row = {
+        "name": "데이원컴퍼니",
+        "slug": "day1company",
+        "url": "https://day1company.ninehire.site/",
+    }
+
+    assert config["scraper"] is NinehireScraper
+    assert config["slug"](row) == "day1company"
+    assert config["kwargs"](row) == {"company_name": "데이원컴퍼니"}
+    assert config["csv"] == "ats-companies/ninehire.csv"
+    assert config["output"] == "ninehire/jobs.csv"
+    assert config["dedupe_by_ats_id"] is True
+    assert config["max_concurrency"] == 6
+    assert config["fail_closed_on_empty"] is True
+    assert config["fail_closed_on_any_error"] is True
+
+
+def test_ninehire_concurrency_cap_is_enforced() -> None:
+    assert _bounded_concurrency(CONFIGS["ninehire"], 24) == 6
+
+
+def test_ninehire_is_a_direct_employer_ats() -> None:
+    assert ATS_DEDUP_PRIORITY["ninehire"] == ATS_DEDUP_PRIORITY["workday"]
+
+
+def test_ninehire_catalog_contains_only_selected_direct_employers() -> None:
+    with Path("ats-companies/ninehire.csv").open(
+        newline="",
+        encoding="utf-8",
+    ) as handle:
+        rows = list(csv.DictReader(handle))
+
+    assert len(rows) == 29
+    assert len({row["slug"] for row in rows}) == len(rows)
+    assert len({row["url"] for row in rows}) == len(rows)
+    assert all(row["name"].strip() for row in rows)
+    assert all(
+        row["url"] == f"https://{row['slug']}.ninehire.site/"
+        for row in rows
+    )
+
+    slugs = {row["slug"] for row in rows}
+    assert "ezrecruit" not in slugs
+    assert "aknac1" not in slugs
+    assert "classting" not in slugs
+    assert "dealmakers" not in slugs
+    assert "ddv6dme7" not in slugs

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -20,6 +20,7 @@ from ats_scrapers.scrapers import (
     JobviteScraper,
     KekaScraper,
     MokaScraper,
+    NinehireScraper,
     PageUpScraper,
     PaycomScraper,
     PaylocityScraper,
@@ -162,6 +163,11 @@ RESOLVES = [
     ("https://bloomberg.avature.net/careers", ATSType.AVATURE, "bloomberg"),
     ("https://nvidia.eightfold.ai/careers", ATSType.EIGHTFOLD, "nvidia"),
     ("https://petz.gupy.io/jobs/123", ATSType.GUPY, "petz"),
+    (
+        "https://day1company.ninehire.site/job_posting/7a0UlD8L",
+        ATSType.NINEHIRE,
+        "day1company",
+    ),
     # Scheme-less input is tolerated
     ("jobs.ashbyhq.com/openai", ATSType.ASHBY, "openai"),
     ("www.jobs.lever.co/acme", ATSType.LEVER, "acme"),
@@ -327,6 +333,12 @@ def test_get_scraper_for_url_builds_scraper() -> None:
     assert isinstance(
         get_scraper_for_url("https://amer.zhiye.com/Social/?PageIndex=1"),
         BeisenLegacyScraper,
+    )
+    assert isinstance(
+        get_scraper_for_url(
+            "https://day1company.ninehire.site/job_posting/7a0UlD8L"
+        ),
+        NinehireScraper,
     )
     workday = get_scraper_for_url(
         "https://2020companies.wd1.myworkdayjobs.com/external_careers"


### PR DESCRIPTION
## Summary

- add a credential-free Ninehire scraper using the public homepage bootstrap and anonymous recruitment API
- add 29 validated direct-employer portals in Korea
- preserve UUID job IDs, structured employment, experience, department, team, location, coordinates, dates, tags, and full text descriptions where available
- filter coffee chats, talent pools, and result announcements while failing closed on cross-company jobs, duplicate IDs, and incomplete pagination
- wire Ninehire into URL resolution, the pipeline, direct-ATS dedup priority, exports, and model contracts

## Yield and quality

- 37/37 discovered tenants passed the finished scraper
- 661 advertised rows were reduced by 19 non-job rows
- excluded the `ezrecruit` staffing portal, three tenants containing no real jobs after filtering, and four fragile one-job portals
- the production catalog keeps 29 direct employers and contributes 624 exact unique jobs
- against the immutable 4,245,280-row baseline: 0 URL overlaps, 0 normalized company/title/location overlaps, and 0 company/requisition overlaps
- conservative net-new yield: 624 jobs, including 593 identified as Korea and 5 as Japan

## Validation

- live catalog census: 29 employers, 624 unique jobs, 0 tenant failures
- live text-description probe: 1,954 characters
- `ruff check .`
- focused contracts: 176 passed
- broad suite excluding the unavailable Moka crypto dependency: 1,839 passed, 2 skipped

The parent validation environment lacks `pycryptodome`, so the unrelated Moka crypto tests remain excluded locally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a credential-free `ninehire` provider and wire it into URL resolution, the pipeline, and dedup for 29 direct employers in Korea. The scraper preserves structured fields, filters non-jobs, and hydrates descriptions from the public site.

- **New Features**
  - Added `NinehireScraper` using public homepage bootstrap and anonymous recruitment API; keeps UUID IDs, employment type, experience, department/team, location/coords, dates, tags; filters coffee chats, talent pools, and result announcements; hydrates descriptions.
  - Pipeline: added `ninehire` config with `dedupe_by_ats_id: true`, output `ninehire/jobs.csv`, max concurrency 6, fail-closed on empty and any error; added to dedup priority in publisher.
  - URL resolution: map `.ninehire.site` to `ATSType.NINEHIRE`; added enum to models; exported in scrapers `__init__`.
  - Catalog: added `ats-companies/ninehire.csv` with 29 validated direct-employer tenants.
  - Docs/tests: README lists Ninehire; added comprehensive scraper, resolve, and contract tests.

<sup>Written for commit 42f996ac6cb0e62c62a8b433bd8aa46ee9a15d8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

