### PR TITLE
Fix Job Bank repeated final page

### DIFF
--- a/src/ats_scrapers/scrapers/jobbankca.py
+++ b/src/ats_scrapers/scrapers/jobbankca.py
@@ -219,9 +219,12 @@ class JobBankCAScraper(BaseScraper):
                 )
                 repeated_pages = repeated_pages + 1 if added == 0 else 0
                 if repeated_pages >= 2:
-                    raise ScraperError(
-                        "Job Bank repeated only known jobs on consecutive pages"
+                    logger.info(
+                        "Job Bank repeated only known jobs on consecutive "
+                        "pages; treating the catalogue as exhausted"
                     )
+                    exhausted = True
+                    break
                 page += 1
         if self._full_catalogue and not jobs:
             raise ScraperError(

--- a/tests/test_jobbankca.py
+++ b/tests/test_jobbankca.py
@@ -320,6 +320,27 @@ def test_fetch_deduplicates_repeated_ats_id(httpx_mock) -> None:
     assert [j.ats_id for j in jobs] == ["9999"]
 
 
+def test_fetch_treats_consecutive_repeated_pages_as_exhausted(
+    httpx_mock,
+) -> None:
+    """Job Bank clamps pages past the end to its final result page."""
+    httpx_mock.add_response(
+        url="https://www.jobbank.gc.ca/jobsearch/jobsearch",
+        match_params={"searchstring": "", "sort": "M", "page": "1"},
+        html=_page([_article(job_id="9999")]),
+    )
+    for page in ("2", "3"):
+        httpx_mock.add_response(
+            url="https://www.jobbank.gc.ca/jobsearch/jobsearch",
+            match_params={"searchstring": "", "sort": "M", "page": page},
+            html=_page([_article(job_id="9999")]),
+        )
+
+    jobs = JobBankCAScraper("any").fetch()
+
+    assert [job.ats_id for job in jobs] == ["9999"]
+
+
 def test_fetch_respects_max_pages_cap(httpx_mock) -> None:
     """``max_pages=1`` stops after a single page even if more remain."""
     httpx_mock.add_response(


### PR DESCRIPTION
## Summary
- treat two consecutive duplicate-only pages as catalogue exhaustion
- preserve the accumulated full-catalogue jobs instead of failing closed
- cover Job Bank's live final-page clamping behavior

## Validation
- `uv run --extra test pytest tests/test_jobbankca.py -q` (45 passed)
- `uv run --extra dev ruff check src/ats_scrapers/scrapers/jobbankca.py tests/test_jobbankca.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle Job Bank’s final-page clamping by treating two consecutive duplicate-only pages as catalogue exhaustion. This stops pagination, avoids failing closed in full-catalogue runs, and returns the gathered jobs.

<sup>Written for commit 1d81bc0ec890ffaaa13ec106e971b5406d4333fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change changes Job Bank pagination so repeated known-job pages are treated as catalogue exhaustion instead of raising an error. A deterministic pagination check reproduced a data-loss case: when two duplicate-only pages precede a later page with a new job, the scraper returns successfully before requesting that later page. The focused Job Bank test suite passed, but it does not cover this overlapping-page sequence.

<h3>Confidence Score: 3/5</h3>

Not safe to merge until T-Rex findings are addressed.

The reproduced pagination sequence causes the scraper to omit later valid postings while returning a successful result, affecting the completeness of downstream job data.

T-Rex reproduced 2 failing behaviors at runtime in src/ats_scrapers/scrapers/jobbankca.py; the change needs fixes before it is safe to merge.

**Files Needing Attention:** src/ats_scrapers/scrapers/jobbankca.py needs revised exhaustion handling, and tests/test_jobbankca.py needs coverage for duplicate-only pages followed by a page containing a new job.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and linked it to the review comment.
- T-Rex produced a second proof for another posted P1 finding.
- A general-contract-validation-proof shows the before/after behavior change, where before raised on two duplicate-only pages and after returns a partial list, with two\_duplicates\_then\_new\_id: ids=\['100'\]; calls=\[1, 2, 3\], and the exact authored probe source and outputs were uploaded.

<a href="https://app.greptile.com/trex/runs/16692441/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Two duplicate-only pages can silently truncate later valid Job Bank results**

   - **Bug**
     - The runtime scenario pages `[100]`, `[100]`, `[100]`, `[200]`, `[]` returned only `['100']` and made requests only through page 3. Page 4, which contained valid new ID `200`, was never fetched. This converts an ambiguous pagination condition into successful full-catalogue completion and loses data.
   - **Cause**
     - `repeated_pages` is incremented for every page adding zero unseen IDs; when it reaches two, the loop treats the catalogue as exhausted despite having no authoritative empty-page/end-of-results indication.
   - **Fix**
     - Do not treat duplicate-only pages as authoritative exhaustion. Continue until an empty valid results page or an explicit pagination/end marker is observed; alternatively, retain a bounded duplicate guard but raise a fail-closed `ScraperError` rather than return a partial full catalogue.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/ats_scrapers/scrapers/jobbankca.py:220-227
**Duplicate-page exhaustion silently truncates results**

Two pages that contain only IDs already seen are not an authoritative end-of-catalogue signal. In the exercised sequence `[100]`, `[100]`, `[100]`, `[200]`, `[]`, this branch stops after page 3 and returns only `100`, never requesting page 4 containing valid job `200`. Because this scraper represents a full catalogue, returning the partial list successfully is worse than the prior fail-closed error. Continue until an empty result page or a server-provided end marker is observed; if a bounded duplicate guard is necessary, it should preserve the error rather than claim successful completion.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Job Bank repeated final page"](https://github.com/kalil0321/ats-scrapers/commit/1d81bc0ec890ffaaa13ec106e971b5406d4333fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48896239)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->