### PR TITLE
feat: create `cli.py` with command-line scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ dev = [
     "types-boto3",
 ]
 
+[project.scripts]
+ats-scraper-search = "src.ats_scrapers.cli:search"
+
 [project.urls]
 Homepage = "https://github.com/kalil0321/ats-scrapers"
 Documentation = "https://github.com/kalil0321/ats-scrapers#readme"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,8 @@ dev = [
 
 [project.scripts]
 ats-scraper-search = "ats_scrapers.cli:search"
+ats-scraper-fetch = "ats_scrapers.cli:fetch"
+ats-scraper-fetch-url = "ats_scrapers.cli:fetch_for_url"
 
 [project.urls]
 Homepage = "https://github.com/kalil0321/ats-scrapers"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ dev = [
 
 [project.scripts]
 ats-scraper-search = "ats_scrapers.cli:search"
+ats-scraper-find = "ats_scrapers.cli:find"
 ats-scraper-fetch = "ats_scrapers.cli:fetch"
 ats-scraper-fetch-url = "ats_scrapers.cli:fetch_for_url"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ dev = [
 ]
 
 [project.scripts]
-ats-scraper-search = "src.ats_scrapers.cli:search"
+ats-scraper-search = "ats_scrapers.cli:search"
 
 [project.urls]
 Homepage = "https://github.com/kalil0321/ats-scrapers"

--- a/src/ats_scrapers/cli.py
+++ b/src/ats_scrapers/cli.py
@@ -20,7 +20,7 @@ def search():
     args.add_argument(
         '--ats-type', dest='ats',
         type=str, default=None, nargs='?',
-        choices=[e.name for e in ATSType],
+        choices=[e.name.lower() for e in ATSType],
     )
     args.add_argument(
         '--remote', dest='remote',

--- a/src/ats_scrapers/cli.py
+++ b/src/ats_scrapers/cli.py
@@ -1,4 +1,5 @@
-from ats_scrapers import client
+from ats_scrapers import client, find_company, get_scraper_for_url
+from ats_scrapers.scrapers import get_scraper
 from ats_scrapers.models import ATSType
 import argparse
 import pandas as pd
@@ -42,9 +43,22 @@ def search():
         '--limit', dest='limit',
         type=int, default=None, nargs='?',
     )
-    with pd.option_context(
-        'display.max_rows', None,
-        'display.max_columns', None,
-        'display.precision', 3,
-    ):
-        print(client.search(**args.parse_args().__dict__))
+    jobs = client.search(**args.parse_args().__dict__)
+    print(jobs.to_json(indent=4))
+
+def fetch():
+    args = argparse.ArgumentParser()
+    args.add_argument(
+        'company', dest='company', type=str,
+    )
+    company = find_company(args.parse_args().company)
+    jobs = get_scraper(company.ats, company.slug).fetch()
+    print(jobs.to_json(indent=4))
+
+def fetch_for_url():
+    args = argparse.ArgumentParser()
+    args.add_argument(
+        'url', dest='url', type=str,
+    )
+    jobs = get_scraper_for_url(args.parse_args().url).fetch()
+    print(jobs.to_json(indent=4))

--- a/src/ats_scrapers/cli.py
+++ b/src/ats_scrapers/cli.py
@@ -1,6 +1,7 @@
 from ats_scrapers import client
 from ats_scrapers.models import ATSType
 import argparse
+import pandas as pd
 
 def search():
     args = argparse.ArgumentParser()

--- a/src/ats_scrapers/cli.py
+++ b/src/ats_scrapers/cli.py
@@ -49,7 +49,7 @@ def search():
 def fetch():
     args = argparse.ArgumentParser()
     args.add_argument(
-        'company', dest='company', type=str,
+        'company', type=str,
     )
     company = find_company(args.parse_args().company)
     jobs = get_scraper(company.ats, company.slug).fetch()
@@ -58,7 +58,7 @@ def fetch():
 def fetch_for_url():
     args = argparse.ArgumentParser()
     args.add_argument(
-        'url', dest='url', type=str,
+        'url', type=str,
     )
     jobs = get_scraper_for_url(args.parse_args().url).fetch()
     print(jobs.to_json(indent=4))

--- a/src/ats_scrapers/cli.py
+++ b/src/ats_scrapers/cli.py
@@ -6,6 +6,10 @@ import pandas as pd
 def search():
     args = argparse.ArgumentParser()
     args.add_argument(
+        '--query', dest='query',
+        type=str, default=None, nargs='?',
+    )
+    args.add_argument(
         '--location', dest='location',
         type=str, default=None, nargs='?',
     )

--- a/src/ats_scrapers/cli.py
+++ b/src/ats_scrapers/cli.py
@@ -22,7 +22,7 @@ def search():
     )
     args.add_argument(
         '--remote', dest='remote',
-        action='store_true',
+        action='store_true', default=None,
     )
     args.add_argument(
         '--salary-min', dest='salary_min',

--- a/src/ats_scrapers/cli.py
+++ b/src/ats_scrapers/cli.py
@@ -1,8 +1,5 @@
-from ats_scrapers import client, find_company, get_scraper_for_url
-from ats_scrapers.scrapers import get_scraper
 from ats_scrapers.models import ATSType
 import argparse
-import pandas as pd
 
 def search():
     args = argparse.ArgumentParser()
@@ -43,6 +40,8 @@ def search():
         '--limit', dest='limit',
         type=int, default=None, nargs='?',
     )
+
+    from ats_scrapers import client
     jobs = client.search(**args.parse_args().__dict__)
     print(jobs.to_json(orient='records', indent=4))
 
@@ -51,6 +50,8 @@ def find():
     args.add_argument(
         'company', type=str,
     )
+    
+    from ats_scrapers import find_company
     company = find_company(args.parse_args().company)
     print(company.to_json(orient='records', indent=4))
 
@@ -61,14 +62,21 @@ def fetch():
     )
     args.add_argument(
         'ats', type=str,
+        choices=[e.name.lower() for e in ATSType],
     )
-    jobs = get_scraper(args.parse_args().ats, args.parse_args().company).fetch()
-    print(jobs.to_json(orient='records', indent=4))
+    a = args.parse_args()
+
+    from ats_scrapers.scrapers import get_scraper
+    import json
+    jobs = get_scraper(a.ats, a.company).fetch()
+    print(json.dumps(jobs, indent=4))
 
 def fetch_for_url():
     args = argparse.ArgumentParser()
     args.add_argument(
         'url', type=str,
     )
+
+    from ats_scrapers import get_scraper_for_url
     jobs = get_scraper_for_url(args.parse_args().url).fetch()
     print(jobs.to_json(orient='records', indent=4))

--- a/src/ats_scrapers/cli.py
+++ b/src/ats_scrapers/cli.py
@@ -46,13 +46,23 @@ def search():
     jobs = client.search(**args.parse_args().__dict__)
     print(jobs.to_json(indent=4))
 
-def fetch():
+def find():
     args = argparse.ArgumentParser()
     args.add_argument(
         'company', type=str,
     )
     company = find_company(args.parse_args().company)
-    jobs = get_scraper(company.ats, company.slug).fetch()
+    print(company.to_json(indent=4))
+
+def fetch():
+    args = argparse.ArgumentParser()
+    args.add_argument(
+        'company', type=str,
+    )
+    args.add_argument(
+        'ats', type=str,
+    )
+    jobs = get_scraper(args.parse_args().ats, args.parse_args().company).fetch()
     print(jobs.to_json(indent=4))
 
 def fetch_for_url():

--- a/src/ats_scrapers/cli.py
+++ b/src/ats_scrapers/cli.py
@@ -67,9 +67,9 @@ def fetch():
     a = args.parse_args()
 
     from ats_scrapers.scrapers import get_scraper
-    import json
     jobs = get_scraper(a.ats, a.company).fetch()
-    print(json.dumps(jobs, indent=4))
+    from pydantic import RootModel
+    print(RootModel(jobs).model_dump_json(indent=4))
 
 def fetch_for_url():
     args = argparse.ArgumentParser()
@@ -79,4 +79,5 @@ def fetch_for_url():
 
     from ats_scrapers import get_scraper_for_url
     jobs = get_scraper_for_url(args.parse_args().url).fetch()
-    print(jobs.to_json(orient='records', indent=4))
+    from pydantic import RootModel
+    print(RootModel(jobs).model_dump_json(indent=4))

--- a/src/ats_scrapers/cli.py
+++ b/src/ats_scrapers/cli.py
@@ -44,7 +44,7 @@ def search():
         type=int, default=None, nargs='?',
     )
     jobs = client.search(**args.parse_args().__dict__)
-    print(jobs.to_json(indent=4))
+    print(jobs.to_json(orient='records', indent=4))
 
 def find():
     args = argparse.ArgumentParser()
@@ -52,7 +52,7 @@ def find():
         'company', type=str,
     )
     company = find_company(args.parse_args().company)
-    print(company.to_json(indent=4))
+    print(company.to_json(orient='records', indent=4))
 
 def fetch():
     args = argparse.ArgumentParser()
@@ -63,7 +63,7 @@ def fetch():
         'ats', type=str,
     )
     jobs = get_scraper(args.parse_args().ats, args.parse_args().company).fetch()
-    print(jobs.to_json(indent=4))
+    print(jobs.to_json(orient='records', indent=4))
 
 def fetch_for_url():
     args = argparse.ArgumentParser()
@@ -71,4 +71,4 @@ def fetch_for_url():
         'url', type=str,
     )
     jobs = get_scraper_for_url(args.parse_args().url).fetch()
-    print(jobs.to_json(indent=4))
+    print(jobs.to_json(orient='records', indent=4))

--- a/src/ats_scrapers/cli.py
+++ b/src/ats_scrapers/cli.py
@@ -1,0 +1,45 @@
+from ats_scrapers import client
+from ats_scrapers.models import ATSType
+import argparse
+
+def search():
+    args = argparse.ArgumentParser()
+    args.add_argument(
+        '--location', dest='location',
+        type=str, default=None, nargs='?',
+    )
+    args.add_argument(
+        '--company', dest='company',
+        type=str, default=None, nargs='?',
+    )
+    args.add_argument(
+        '--ats-type', dest='ats',
+        type=str, default=None, nargs='?',
+        choices=[e.name for e in ATSType],
+    )
+    args.add_argument(
+        '--remote', dest='remote',
+        action='store_true',
+    )
+    args.add_argument(
+        '--salary-min', dest='salary_min',
+        type=float, default=None, nargs='?',
+    )
+    args.add_argument(
+        '--salary-max', dest='salary_max',
+        type=float, default=None, nargs='?',
+    )
+    args.add_argument(
+        '--experience-max', dest='experience_max',
+        type=int, default=None, nargs='?',
+    )
+    args.add_argument(
+        '--limit', dest='limit',
+        type=int, default=None, nargs='?',
+    )
+    with pd.option_context(
+        'display.max_rows', None,
+        'display.max_columns', None,
+        'display.precision', 3,
+    ):
+        print(client.search(**args.parse_args().__dict__))


### PR DESCRIPTION
Documentation is not yet written as of 2026-07-31 05:11 UTC.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CLI for `ats_scrapers` with four commands to search, find, and fetch job postings. Scripts are exposed via `pyproject.toml` and print JSON for easy piping.

- **New Features**
  - `ats-scraper-search`: filter by `--query`, `--location`, `--company`, `--ats-type`, `--remote`, salary (`--salary-min`, `--salary-max`), experience (`--experience-max`), `--limit`.
  - `ats-scraper-find`: find ATS info for a company name.
  - `ats-scraper-fetch`: fetch jobs for `company` and `ats` (choices from ATSType).
  - `ats-scraper-fetch-url`: fetch jobs for a given `url`.

- **Bug Fixes**
  - `--remote` is truly optional; omitting it no longer excludes remote jobs.

<sup>Written for commit 379ce0851a13271fb15eb406e974ee3d2b421a4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds four command-line entry points for searching the hosted dataset, finding companies, and fetching live jobs.
- Registers the commands through `pyproject.toml`.
- Serializes search and company results as JSON records.
- Serializes live scraper results through Pydantic.
- Preserves the absence of a remote-work filter when `--remote` is omitted.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; omitting `--remote` now passes `None`, which the client correctly interprets as no remote-work filter.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pyproject.toml | Registers four package console scripts backed by the new CLI module. |
| src/ats_scrapers/cli.py | Implements search, company lookup, direct provider fetch, and URL-based fetch commands with JSON output; the prior optional-remote-filter issue is fixed. |

<sub>Reviews (2): Last reviewed commit: ["Update src/ats\_scrapers/cli.py"](https://github.com/kalil0321/ats-scrapers/commit/379ce0851a13271fb15eb406e974ee3d2b421a4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48945538)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Public client API](https://app.greptile.com/kalil0321/-/custom-context/knowledge-base/kalil0321/ats-scrapers/-/docs/public-client-api.md)
- Knowledge Base — [Client retrieval workflow](https://app.greptile.com/kalil0321/-/custom-context/knowledge-base/kalil0321/ats-scrapers/-/docs/client-retrieval-workflow.md)
- Knowledge Base — [Provider resolution](https://app.greptile.com/kalil0321/-/custom-context/knowledge-base/kalil0321/ats-scrapers/-/docs/provider-resolution.md)
</details>


<!-- /greptile_comment -->