### PR TITLE
Fix TheHub v2 job discovery

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -855,9 +855,10 @@ CONFIGS: dict[str, dict[str, Any]] = {
         "output": "remoteok/jobs.csv",
     },
     "thehub": {
-        # The Hub — Nordic startups, ships lat/lon. ~1k live.
+        # The Hub — Nordic startups, ships lat/lon.
         "scraper": TheHubScraper, "singleton": True,
         "output": "thehub/jobs.csv",
+        "fail_closed_on_empty": True,
     },
     "wanted": {
         # Wanted — Korea + Japan tech roles. ~10k live.

--- a/src/ats_scrapers/fetch.py
+++ b/src/ats_scrapers/fetch.py
@@ -68,6 +68,10 @@ class MalformedJSONError(ScraperError, ValueError):
     written against either contract keep working.
     """
 
+
+class RetryExhaustedError(ScraperError):
+    """A retryable HTTP or network failure exhausted its attempt budget."""
+
 # Total attempts per request (first try included). Module-level so the
 # suite-wide conftest fixture can dial them down in one place; a
 # Fetcher constructed with explicit values ignores these.
@@ -290,7 +294,7 @@ class Fetcher:
             except Exception as exc:  # network layer (httpx transport, cloak)
                 last_error = str(exc)
                 if attempt == retries:
-                    raise ScraperError(
+                    raise RetryExhaustedError(
                         f"{self.label}: {method} {url} failed after "
                         f"{retries} attempts: {exc}"
                     ) from exc
@@ -335,7 +339,7 @@ class Fetcher:
             if status in _RETRYABLE_STATUSES:
                 last_error = f"HTTP {status}"
                 if attempt == retries:
-                    raise ScraperError(
+                    raise RetryExhaustedError(
                         f"{self.label}: {url} returned {status} after "
                         f"{retries} attempts"
                     )

--- a/src/ats_scrapers/scrapers/thehub.py
+++ b/src/ats_scrapers/scrapers/thehub.py
@@ -91,15 +91,32 @@ class TheHubScraper(BaseScraper):
             for payload in remaining:
                 summaries.extend(payload.get("docs") or [])
 
-            job_ids = list(dict.fromkeys(
-                str(item.get("id") or item.get("_id") or "").strip()
-                for item in summaries
-                if item.get("id") or item.get("_id")
-            ))
+            job_ids: list[str] = []
+            seen_ids: set[str] = set()
+            for item in summaries:
+                status = str(item.get("status") or "").strip().upper()
+                if status and status != "ACTIVE":
+                    continue
+                job_id = str(item.get("id") or item.get("_id") or "").strip()
+                if not job_id or job_id in seen_ids:
+                    continue
+                seen_ids.add(job_id)
+                job_ids.append(job_id)
             details = await asyncio.gather(
                 *(self._fetch_detail(fetch, sem, job_id=job_id) for job_id in job_ids),
                 return_exceptions=True,
             )
+            for index, detail in enumerate(details):
+                if not isinstance(detail, Exception):
+                    continue
+                try:
+                    details[index] = await self._fetch_detail(
+                        fetch,
+                        sem,
+                        job_id=job_ids[index],
+                    )
+                except Exception as exc:
+                    details[index] = exc
 
         failures = [item for item in details if isinstance(item, Exception)]
         allowed_failures = max(1, int(len(job_ids) * MAX_DETAIL_FAILURE_RATIO))
@@ -142,7 +159,10 @@ class TheHubScraper(BaseScraper):
                 payload = await fetch.get_json(DETAIL_API_URL_TEMPLATE.format(job_id=job_id))
         except CompanyNotFoundError:
             return None
-        return payload.get("doc") or {}
+        detail = payload.get("doc")
+        if not isinstance(detail, dict) or not detail:
+            raise ScraperError(f"The Hub detail response for {job_id} has no job document")
+        return detail
 
     def _parse(self, item: dict[str, Any]) -> Job | None:
         ats_id = (item.get("id") or item.get("_id") or "").strip()

--- a/src/ats_scrapers/scrapers/thehub.py
+++ b/src/ats_scrapers/scrapers/thehub.py
@@ -16,10 +16,12 @@ from __future__ import annotations
 
 import asyncio
 import html
+import logging
 import re
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, ClassVar
 
+from ats_scrapers.exceptions import CompanyNotFoundError, ScraperError
 from ats_scrapers.models import ATSType, Job
 from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
 
@@ -33,8 +35,10 @@ DETAIL_API_URL_TEMPLATE = "https://thehub.io/api/jobs/{job_id}"
 JOB_URL_TEMPLATE = "https://thehub.io/jobs/{job_id}"
 PER_PAGE = 15  # Hard-coded by the API; ?limit=… is ignored.
 MAX_CONCURRENCY = 4
+MAX_DETAIL_FAILURE_RATIO = 0.10
 
 _TAG_RE = re.compile(r"<[^>]+>")
+log = logging.getLogger(__name__)
 
 
 @ScraperRegistry.register(ATSType.THEHUB)
@@ -93,10 +97,28 @@ class TheHubScraper(BaseScraper):
                 if item.get("id") or item.get("_id")
             ))
             details = await asyncio.gather(
-                *(self._fetch_detail(fetch, sem, job_id=job_id) for job_id in job_ids)
+                *(self._fetch_detail(fetch, sem, job_id=job_id) for job_id in job_ids),
+                return_exceptions=True,
             )
 
-        return [job for item in details if (job := self._parse(item)) is not None]
+        failures = [item for item in details if isinstance(item, Exception)]
+        allowed_failures = max(1, int(len(job_ids) * MAX_DETAIL_FAILURE_RATIO))
+        if len(failures) > allowed_failures:
+            raise ScraperError(
+                f"The Hub detail hydration failed for {len(failures)}/{len(job_ids)} jobs"
+            ) from failures[0]
+        if failures:
+            log.warning(
+                "The Hub skipped %d/%d jobs whose details failed to load",
+                len(failures),
+                len(job_ids),
+            )
+
+        return [
+            job
+            for item in details
+            if isinstance(item, dict) and (job := self._parse(item)) is not None
+        ]
 
     async def _fetch_page(
         self,
@@ -114,9 +136,12 @@ class TheHubScraper(BaseScraper):
         sem: asyncio.Semaphore,
         *,
         job_id: str,
-    ) -> dict[str, Any]:
-        async with sem:
-            payload = await fetch.get_json(DETAIL_API_URL_TEMPLATE.format(job_id=job_id))
+    ) -> dict[str, Any] | None:
+        try:
+            async with sem:
+                payload = await fetch.get_json(DETAIL_API_URL_TEMPLATE.format(job_id=job_id))
+        except CompanyNotFoundError:
+            return None
         return payload.get("doc") or {}
 
     def _parse(self, item: dict[str, Any]) -> Job | None:

--- a/src/ats_scrapers/scrapers/thehub.py
+++ b/src/ats_scrapers/scrapers/thehub.py
@@ -22,6 +22,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, ClassVar
 
 from ats_scrapers.exceptions import CompanyNotFoundError, ScraperError
+from ats_scrapers.fetch import RetryExhaustedError
 from ats_scrapers.models import ATSType, Job
 from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
 
@@ -106,17 +107,26 @@ class TheHubScraper(BaseScraper):
                 *(self._fetch_detail(fetch, sem, job_id=job_id) for job_id in job_ids),
                 return_exceptions=True,
             )
-            for index, detail in enumerate(details):
-                if not isinstance(detail, Exception):
-                    continue
-                try:
-                    details[index] = await self._fetch_detail(
-                        fetch,
-                        sem,
-                        job_id=job_ids[index],
+            retry_indexes = [
+                index
+                for index, detail in enumerate(details)
+                if isinstance(detail, RetryExhaustedError)
+            ]
+            if retry_indexes:
+                async with self.make_fetcher(retries=1) as recovery_fetch:
+                    recovered = await asyncio.gather(
+                        *(
+                            self._fetch_detail(
+                                recovery_fetch,
+                                sem,
+                                job_id=job_ids[index],
+                            )
+                            for index in retry_indexes
+                        ),
+                        return_exceptions=True,
                     )
-                except Exception as exc:
-                    details[index] = exc
+                for index, detail in zip(retry_indexes, recovered, strict=True):
+                    details[index] = detail
 
         failures = [item for item in details if isinstance(item, Exception)]
         allowed_failures = max(1, int(len(job_ids) * MAX_DETAIL_FAILURE_RATIO))

--- a/src/ats_scrapers/scrapers/thehub.py
+++ b/src/ats_scrapers/scrapers/thehub.py
@@ -1,14 +1,13 @@
 """The Hub (https://thehub.io) — Nordic startup jobs scraper.
 
-The Hub is the leading direct-posting tech / startup job platform
-for the Nordics (DK, SE, NO, FI). Companies pay to list — not
-syndicated from LinkedIn / Indeed. ~1,000 active postings at any one
-time, all developer- or growth-focused, all with structured
-location + lat/lon + apply URL data.
+The Hub is a direct-posting tech / startup job platform for the
+Nordics (DK, SE, NO, FI). Companies pay to list — not syndicated
+from LinkedIn / Indeed. Listings include structured location +
+lat/lon + apply URL data.
 
-Public REST at ``https://thehub.io/api/jobs`` — no auth, no key.
-Pagination via ``?page=N`` (15 docs per page; page count is in the
-response envelope).
+Public REST at ``https://thehub.io/api/v2/jobs`` with details from
+``https://thehub.io/api/jobs/{id}`` — no auth, no key. Pagination via
+``?page=N`` (15 docs per page; page count is in the response envelope).
 
 Single-source scraper: ``company_slug`` is informational and ignored.
 """
@@ -29,7 +28,8 @@ if TYPE_CHECKING:
 
     from ats_scrapers.fetch import Fetcher
 
-API_URL = "https://thehub.io/api/jobs"
+LIST_API_URL = "https://thehub.io/api/v2/jobs"
+DETAIL_API_URL_TEMPLATE = "https://thehub.io/api/jobs/{job_id}"
 JOB_URL_TEMPLATE = "https://thehub.io/jobs/{job_id}"
 PER_PAGE = 15  # Hard-coded by the API; ?limit=… is ignored.
 MAX_CONCURRENCY = 4
@@ -46,7 +46,7 @@ class TheHubScraper(BaseScraper):
 
     Knobs:
     - ``max_pages`` — pagination cap (default 200, far above the
-      ~70 pages currently in the active board).
+      current active board).
     """
 
     ats = ATSType.THEHUB
@@ -73,37 +73,30 @@ class TheHubScraper(BaseScraper):
         self.max_pages = max_pages
 
     async def afetch(self) -> list[Job]:
-        seen: set[str] = set()
-        jobs: list[Job] = []
-        lock = asyncio.Lock()
-
-        async def absorb(items: list[dict[str, Any]]) -> None:
-            async with lock:
-                for it in items:
-                    job = self._parse(it)
-                    if job is None or job.ats_id in seen:
-                        continue
-                    seen.add(job.ats_id)
-                    jobs.append(job)
-
         async with self.make_fetcher() as fetch:
             sem = asyncio.Semaphore(MAX_CONCURRENCY)
 
-            # Probe page 1 to learn ``pages`` count.
             first = await self._fetch_page(fetch, sem, page=1)
             pages_total = int(first.get("pages") or 1)
-            await absorb(first.get("docs") or [])
-
             page_count = min(pages_total, self.max_pages)
-            if page_count <= 1:
-                return jobs
+            remaining = await asyncio.gather(
+                *(self._fetch_page(fetch, sem, page=page) for page in range(2, page_count + 1))
+            )
 
-            async def one(page: int) -> None:
-                payload = await self._fetch_page(fetch, sem, page=page)
-                await absorb(payload.get("docs") or [])
+            summaries = list(first.get("docs") or [])
+            for payload in remaining:
+                summaries.extend(payload.get("docs") or [])
 
-            await asyncio.gather(*(one(p) for p in range(2, page_count + 1)))
-        return jobs
+            job_ids = list(dict.fromkeys(
+                str(item.get("id") or item.get("_id") or "").strip()
+                for item in summaries
+                if item.get("id") or item.get("_id")
+            ))
+            details = await asyncio.gather(
+                *(self._fetch_detail(fetch, sem, job_id=job_id) for job_id in job_ids)
+            )
+
+        return [job for item in details if (job := self._parse(item)) is not None]
 
     async def _fetch_page(
         self,
@@ -113,7 +106,18 @@ class TheHubScraper(BaseScraper):
         page: int,
     ) -> dict[str, Any]:
         async with sem:
-            return await fetch.get_json(API_URL, params={"page": page})
+            return await fetch.get_json(LIST_API_URL, params={"page": page})
+
+    async def _fetch_detail(
+        self,
+        fetch: Fetcher,
+        sem: asyncio.Semaphore,
+        *,
+        job_id: str,
+    ) -> dict[str, Any]:
+        async with sem:
+            payload = await fetch.get_json(DETAIL_API_URL_TEMPLATE.format(job_id=job_id))
+        return payload.get("doc") or {}
 
     def _parse(self, item: dict[str, Any]) -> Job | None:
         ats_id = (item.get("id") or item.get("_id") or "").strip()

--- a/tests/test_thehub.py
+++ b/tests/test_thehub.py
@@ -256,6 +256,11 @@ def test_keeps_good_jobs_when_one_detail_fetch_fails(httpx_mock) -> None:
     )
 
     assert [job.ats_id for job in TheHubScraper("any").fetch()] == ["good"]
+    requests = httpx_mock.get_requests()
+    failed_requests = [
+        request for request in requests if str(request.url).endswith("/failed")
+    ]
+    assert len(failed_requests) == DEFAULT_RETRIES + 1
 
 
 def test_recovers_detail_after_initial_retry_budget_is_exhausted(httpx_mock) -> None:
@@ -319,6 +324,10 @@ def test_empty_detail_documents_count_toward_failure_threshold(httpx_mock) -> No
 
     with pytest.raises(ScraperError, match="detail hydration failed for 2/3 jobs"):
         TheHubScraper("any").fetch()
+
+    requests = httpx_mock.get_requests()
+    assert sum(str(request.url).endswith("/empty-1") for request in requests) == 1
+    assert sum(str(request.url).endswith("/empty-2") for request in requests) == 1
 
 
 def test_persistent_500_raises(httpx_mock) -> None:

--- a/tests/test_thehub.py
+++ b/tests/test_thehub.py
@@ -13,6 +13,7 @@ from typing import Any
 import pytest
 
 from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.fetch import DEFAULT_RETRIES
 from ats_scrapers.models import ATSType
 from ats_scrapers.scrapers import ScraperRegistry, TheHubScraper
 
@@ -73,10 +74,12 @@ def _mock_page(httpx_mock, docs: list[dict], *, page: int = 1, pages: int = 1) -
         json=_envelope(docs, pages=pages),
     )
     for doc in docs:
-        if not doc.get("id"):
+        status = str(doc.get("status") or "").strip().upper()
+        job_id = str(doc.get("id") or "").strip()
+        if not job_id or (status and status != "ACTIVE"):
             continue
         httpx_mock.add_response(
-            url=f"https://thehub.io/api/jobs/{doc['id']}",
+            url=f"https://thehub.io/api/jobs/{job_id}",
             json={"doc": doc, "related": []},
         )
 
@@ -212,6 +215,8 @@ def test_drops_doc_missing_id_or_title(httpx_mock) -> None:
         _doc(job_id="ok"),
         {"title": "no id", "status": "ACTIVE", "company": {"name": "X"},
          "location": {}, "geoLocation": {}},
+        {"id": "   ", "title": "blank id", "status": "ACTIVE", "company": {"name": "X"},
+         "location": {}, "geoLocation": {}},
         {"id": "no title", "status": "ACTIVE", "company": {"name": "X"},
          "location": {}, "geoLocation": {}},
     ])
@@ -253,6 +258,29 @@ def test_keeps_good_jobs_when_one_detail_fetch_fails(httpx_mock) -> None:
     assert [job.ats_id for job in TheHubScraper("any").fetch()] == ["good"]
 
 
+def test_recovers_detail_after_initial_retry_budget_is_exhausted(httpx_mock) -> None:
+    docs = [_doc(job_id="good"), _doc(job_id="recovered")]
+    httpx_mock.add_response(
+        url="https://thehub.io/api/v2/jobs?page=1",
+        json=_envelope(docs),
+    )
+    httpx_mock.add_response(
+        url="https://thehub.io/api/jobs/good",
+        json={"doc": docs[0], "related": []},
+    )
+    for _ in range(DEFAULT_RETRIES):
+        httpx_mock.add_response(
+            url="https://thehub.io/api/jobs/recovered",
+            status_code=500,
+        )
+    httpx_mock.add_response(
+        url="https://thehub.io/api/jobs/recovered",
+        json={"doc": docs[1], "related": []},
+    )
+
+    assert [job.ats_id for job in TheHubScraper("any").fetch()] == ["good", "recovered"]
+
+
 def test_raises_when_detail_failures_exceed_threshold(httpx_mock) -> None:
     docs = [_doc(job_id="good"), _doc(job_id="failed-1"), _doc(job_id="failed-2")]
     httpx_mock.add_response(
@@ -266,6 +294,26 @@ def test_raises_when_detail_failures_exceed_threshold(httpx_mock) -> None:
     httpx_mock.add_response(
         url=re.compile(r"^https://thehub\.io/api/jobs/failed-"),
         status_code=500,
+        is_reusable=True,
+    )
+
+    with pytest.raises(ScraperError, match="detail hydration failed for 2/3 jobs"):
+        TheHubScraper("any").fetch()
+
+
+def test_empty_detail_documents_count_toward_failure_threshold(httpx_mock) -> None:
+    docs = [_doc(job_id="good"), _doc(job_id="empty-1"), _doc(job_id="empty-2")]
+    httpx_mock.add_response(
+        url="https://thehub.io/api/v2/jobs?page=1",
+        json=_envelope(docs),
+    )
+    httpx_mock.add_response(
+        url="https://thehub.io/api/jobs/good",
+        json={"doc": docs[0], "related": []},
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://thehub\.io/api/jobs/empty-"),
+        json={"doc": None, "related": []},
         is_reusable=True,
     )
 

--- a/tests/test_thehub.py
+++ b/tests/test_thehub.py
@@ -219,6 +219,60 @@ def test_drops_doc_missing_id_or_title(httpx_mock) -> None:
     assert [j.ats_id for j in jobs] == ["ok"]
 
 
+def test_skips_job_that_vanishes_before_detail_fetch(httpx_mock) -> None:
+    docs = [_doc(job_id="good"), _doc(job_id="vanished")]
+    httpx_mock.add_response(
+        url="https://thehub.io/api/v2/jobs?page=1",
+        json=_envelope(docs),
+    )
+    httpx_mock.add_response(
+        url="https://thehub.io/api/jobs/good",
+        json={"doc": docs[0], "related": []},
+    )
+    httpx_mock.add_response(url="https://thehub.io/api/jobs/vanished", status_code=404)
+
+    assert [job.ats_id for job in TheHubScraper("any").fetch()] == ["good"]
+
+
+def test_keeps_good_jobs_when_one_detail_fetch_fails(httpx_mock) -> None:
+    docs = [_doc(job_id="good"), _doc(job_id="failed")]
+    httpx_mock.add_response(
+        url="https://thehub.io/api/v2/jobs?page=1",
+        json=_envelope(docs),
+    )
+    httpx_mock.add_response(
+        url="https://thehub.io/api/jobs/good",
+        json={"doc": docs[0], "related": []},
+    )
+    httpx_mock.add_response(
+        url="https://thehub.io/api/jobs/failed",
+        status_code=500,
+        is_reusable=True,
+    )
+
+    assert [job.ats_id for job in TheHubScraper("any").fetch()] == ["good"]
+
+
+def test_raises_when_detail_failures_exceed_threshold(httpx_mock) -> None:
+    docs = [_doc(job_id="good"), _doc(job_id="failed-1"), _doc(job_id="failed-2")]
+    httpx_mock.add_response(
+        url="https://thehub.io/api/v2/jobs?page=1",
+        json=_envelope(docs),
+    )
+    httpx_mock.add_response(
+        url="https://thehub.io/api/jobs/good",
+        json={"doc": docs[0], "related": []},
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"^https://thehub\.io/api/jobs/failed-"),
+        status_code=500,
+        is_reusable=True,
+    )
+
+    with pytest.raises(ScraperError, match="detail hydration failed for 2/3 jobs"):
+        TheHubScraper("any").fetch()
+
+
 def test_persistent_500_raises(httpx_mock) -> None:
     httpx_mock.add_response(url=_API_RE, status_code=500, is_reusable=True)
     with pytest.raises(ScraperError):

--- a/tests/test_thehub.py
+++ b/tests/test_thehub.py
@@ -16,7 +16,7 @@ from ats_scrapers.exceptions import ScraperError
 from ats_scrapers.models import ATSType
 from ats_scrapers.scrapers import ScraperRegistry, TheHubScraper
 
-_API_RE = re.compile(r"^https://thehub\.io/api/jobs")
+_API_RE = re.compile(r"^https://thehub\.io/api/v2/jobs")
 
 
 def _doc(
@@ -67,6 +67,20 @@ def _envelope(docs: list[dict], pages: int = 1, total: int | None = None) -> dic
     }
 
 
+def _mock_page(httpx_mock, docs: list[dict], *, page: int = 1, pages: int = 1) -> None:
+    httpx_mock.add_response(
+        url=f"https://thehub.io/api/v2/jobs?page={page}",
+        json=_envelope(docs, pages=pages),
+    )
+    for doc in docs:
+        if not doc.get("id"):
+            continue
+        httpx_mock.add_response(
+            url=f"https://thehub.io/api/jobs/{doc['id']}",
+            json={"doc": doc, "related": []},
+        )
+
+
 # --- registry / wiring ------------------------------------------------------
 
 
@@ -80,7 +94,7 @@ def test_registry_resolves_thehub() -> None:
 def test_parses_full_doc_with_geo_swap(httpx_mock) -> None:
     """The Hub ships ``geoLocation.center.coordinates`` as GeoJSON
     ``[lon, lat]``; our model uses lat-first. The scraper must swap."""
-    httpx_mock.add_response(url=_API_RE, json=_envelope([_doc()]))
+    _mock_page(httpx_mock, [_doc()])
     j = TheHubScraper("any").fetch()[0]
     assert j.ats_type is ATSType.THEHUB
     assert j.ats_id == "abc123"
@@ -103,11 +117,11 @@ def test_parses_full_doc_with_geo_swap(httpx_mock) -> None:
 
 
 def test_drops_non_active_postings(httpx_mock) -> None:
-    httpx_mock.add_response(url=_API_RE, json=_envelope([
+    _mock_page(httpx_mock, [
         _doc(job_id="active", status="ACTIVE"),
         _doc(job_id="expired", status="EXPIRED"),
         _doc(job_id="draft", status="DRAFT"),
-    ]))
+    ])
     jobs = TheHubScraper("any").fetch()
     assert [j.ats_id for j in jobs] == ["active"]
 
@@ -116,9 +130,9 @@ def test_drops_non_active_postings(httpx_mock) -> None:
 
 
 def test_location_falls_back_to_locality_country_when_no_address(httpx_mock) -> None:
-    httpx_mock.add_response(url=_API_RE, json=_envelope([
+    _mock_page(httpx_mock, [
         _doc(job_id="x", address="", locality="Stockholm", country="Sweden"),
-    ]))
+    ])
     assert TheHubScraper("any").fetch()[0].location == "Stockholm, Sweden"
 
 
@@ -128,9 +142,9 @@ def test_location_falls_back_to_locality_country_when_no_address(httpx_mock) -> 
 def test_no_salary_when_only_label_is_competitive(httpx_mock) -> None:
     """The free-text ``salary`` field ('competitive', 'undisclosed') is
     not numeric — don't synthesize salary fields from it."""
-    httpx_mock.add_response(url=_API_RE, json=_envelope([
+    _mock_page(httpx_mock, [
         _doc(job_id="x", salary_label="competitive", salary_range={}),
-    ]))
+    ])
     j = TheHubScraper("any").fetch()[0]
     assert j.salary_currency is None
     assert j.salary_min is None
@@ -138,9 +152,9 @@ def test_no_salary_when_only_label_is_competitive(httpx_mock) -> None:
 
 
 def test_salary_range_with_structured_object(httpx_mock) -> None:
-    httpx_mock.add_response(url=_API_RE, json=_envelope([
+    _mock_page(httpx_mock, [
         _doc(job_id="x", salary_range={"from": 60000, "to": 90000, "currency": "EUR"}),
-    ]))
+    ])
     j = TheHubScraper("any").fetch()[0]
     assert j.salary_min == 60000
     assert j.salary_max == 90000
@@ -154,18 +168,9 @@ def test_paginates_until_pages_count(httpx_mock) -> None:
     """Page 1 carries ``pages`` count; the scraper fans out the
     remaining N-1 pages in parallel."""
     # Probe (page=1) → pages=3
-    httpx_mock.add_response(
-        url="https://thehub.io/api/jobs?page=1",
-        json=_envelope([_doc(job_id=f"a{i}") for i in range(15)], pages=3),
-    )
-    httpx_mock.add_response(
-        url="https://thehub.io/api/jobs?page=2",
-        json=_envelope([_doc(job_id=f"b{i}") for i in range(15)], pages=3),
-    )
-    httpx_mock.add_response(
-        url="https://thehub.io/api/jobs?page=3",
-        json=_envelope([_doc(job_id=f"c{i}") for i in range(10)], pages=3),
-    )
+    _mock_page(httpx_mock, [_doc(job_id=f"a{i}") for i in range(15)], page=1, pages=3)
+    _mock_page(httpx_mock, [_doc(job_id=f"b{i}") for i in range(15)], page=2, pages=3)
+    _mock_page(httpx_mock, [_doc(job_id=f"c{i}") for i in range(10)], page=3, pages=3)
     jobs = TheHubScraper("any").fetch()
     assert len(jobs) == 40  # 15 + 15 + 10 distinct ats_ids
 
@@ -173,21 +178,15 @@ def test_paginates_until_pages_count(httpx_mock) -> None:
 def test_max_pages_caps_pagination(httpx_mock) -> None:
     """Even if envelope says 1000 pages, ``max_pages=2`` must stop after 2
     page requests (probe + 1 fan-out)."""
-    httpx_mock.add_response(
-        url="https://thehub.io/api/jobs?page=1",
-        json=_envelope([_doc(job_id=f"a{i}") for i in range(15)], pages=1000),
-    )
-    httpx_mock.add_response(
-        url="https://thehub.io/api/jobs?page=2",
-        json=_envelope([_doc(job_id=f"b{i}") for i in range(15)], pages=1000),
-    )
+    _mock_page(httpx_mock, [_doc(job_id=f"a{i}") for i in range(15)], page=1, pages=1000)
+    _mock_page(httpx_mock, [_doc(job_id=f"b{i}") for i in range(15)], page=2, pages=1000)
     # Page 3 must NOT be requested — httpx_mock will error if it is.
     jobs = TheHubScraper("any", max_pages=2).fetch()
     assert len(jobs) == 30
 
 
 def test_no_fanout_when_one_page(httpx_mock) -> None:
-    httpx_mock.add_response(url=_API_RE, json=_envelope([_doc(job_id="solo")], pages=1))
+    _mock_page(httpx_mock, [_doc(job_id="solo")])
     assert len(TheHubScraper("any").fetch()) == 1
 
 
@@ -199,23 +198,23 @@ def test_empty_link_drops_apply_url_not_whole_job(httpx_mock) -> None:
     ``HttpUrl`` validator on Job.apply_url rejects empty strings, so
     blindly passing the field crashes the whole scrape. Regression
     for the live-verify ValidationError."""
-    httpx_mock.add_response(url=_API_RE, json=_envelope([
+    _mock_page(httpx_mock, [
         _doc(job_id="empty-link", apply_url=""),
         _doc(job_id="weird-link", apply_url="javascript:void(0)"),
-    ]))
+    ])
     jobs = TheHubScraper("any").fetch()
     assert len(jobs) == 2
     assert all(j.apply_url is None for j in jobs)
 
 
 def test_drops_doc_missing_id_or_title(httpx_mock) -> None:
-    httpx_mock.add_response(url=_API_RE, json=_envelope([
+    _mock_page(httpx_mock, [
         _doc(job_id="ok"),
         {"title": "no id", "status": "ACTIVE", "company": {"name": "X"},
          "location": {}, "geoLocation": {}},
         {"id": "no title", "status": "ACTIVE", "company": {"name": "X"},
          "location": {}, "geoLocation": {}},
-    ]))
+    ])
     jobs = TheHubScraper("any").fetch()
     assert [j.ats_id for j in jobs] == ["ok"]
 
@@ -224,3 +223,9 @@ def test_persistent_500_raises(httpx_mock) -> None:
     httpx_mock.add_response(url=_API_RE, status_code=500, is_reusable=True)
     with pytest.raises(ScraperError):
         TheHubScraper("any").fetch()
+
+
+def test_pipeline_fails_closed_on_empty() -> None:
+    from scripts.run_pipeline import CONFIGS
+
+    assert CONFIGS["thehub"]["fail_closed_on_empty"] is True


### PR DESCRIPTION
## What changed
- switch discovery to the live `/api/v2/jobs` endpoint
- hydrate all summaries through the existing detail endpoint to preserve descriptions, locations, and apply URLs
- fail closed on unexpected zero-job runs

## Validation
- 15 focused tests pass
- Ruff passes
- live scrape: 48 unique jobs, 48 descriptions, 37 apply URLs, 26 locations

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches TheHub discovery to the v2 listing API and isolates detail-hydration failures so successful jobs still publish. Previously any exhausted detail retry aborted the scrape; now we skip only failed jobs unless failures exceed 10%, and we fail closed on unexpected zero-job runs.

- Lists via https://thehub.io/api/v2/jobs; hydrates via https://thehub.io/api/jobs/{id}; filters ACTIVE; de-dupes IDs; fetches concurrently (semaphore-capped).
- Handles partial detail failures: uses gather with return_exceptions, retries each exhausted detail exactly once, skips 404 “vanished” jobs, counts empty detail docs as failures, and logs skipped jobs.
- Raises when failed details exceed 10% of requested (floor 1); otherwise returns parsed jobs from successful details.
- Fetcher: adds `RetryExhaustedError`; TheHub uses it to target a single extra detail retry.
- Pipeline: sets `fail_closed_on_empty: true` for `thehub`.
- Tests cover v2 list+detail, pagination, vanished 404s, single-retry recovery after exhaustion, failure-threshold and empty-detail cases, and apply-link edge cases.

<sup>Written for commit 840d80b9a76b8bc75804cadaa248a9b7c2f6977a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

TheHub now discovers job IDs from the v2 listing API and hydrates each listing through the detail endpoint. A reproduced failure remains in the detail-hydration path: if one job detail request keeps failing, the scraper discards successfully fetched jobs by raising instead of returning the available results. The singleton publisher then keeps the previous output, leaving the feed stale even when most listings were available.

<h3>Confidence Score: 4/5</h3>

This change should not merge until individual detail-request failures can be isolated so available TheHub listings continue to publish.

A focused mocked run exercised both successful hydration and a mixed successful/failing detail response. It demonstrated that one exhausted request prevents all successfully fetched jobs from being returned.

**Files Needing Attention:** src/ats_scrapers/scrapers/thehub.py needs failure isolation around concurrent detail hydration; tests/test_thehub.py should cover a successful detail request alongside an exhausted failing request.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and linked the review comment detailing the finding.
- The focused The Hub mixed-detail failure harness was executed to reproduce the issue and generate focused outputs for validation.
- Contract validation was performed, detailing the scraper location, retry policy, and pipeline consequences that led to an empty job list after failures.
- Artifacts supporting the proofs were organized for reviewer inspection, including the harness outputs and related logs.

<a href="https://app.greptile.com/trex/runs/17781016/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **A single exhausted The Hub detail request prevents all available jobs from being returned**

   - **Bug**
     - `afetch()` concurrently fetches every detail document. In the focused mocked run, the `good` detail endpoint succeeded once while `bad` returned HTTP 500 for all three fetch attempts. Instead of returning the available `good` job, `afetch()` raised `ScraperError`. The pipeline wrapper consequently produced an empty job list and an error for this singleton scraper.
   - **Cause**
     - `src/ats_scrapers/scrapers/thehub.py:95-97` uses default `asyncio.gather`, which propagates a child exception; the parsing/return expression at line 99 is therefore never reached. Fetcher converts the exhausted retryable 500 into `ScraperError` at `src/ats_scrapers/fetch.py:335-341`.
   - **Fix**
     - Fetch detail tasks with per-task exception handling or `asyncio.gather(..., return_exceptions=True)`, discard/log only failed detail payloads, and parse successful detail payloads. Retain a separate failure threshold if a wholly failed scrape must still fail closed.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/ats_scrapers/scrapers/thehub.py:95-97
**Detail hydration aborts the complete scrape**

The default `asyncio.gather` propagates a failure from any one detail request before line 99 can return the successfully hydrated jobs. In the reproduced mixed response, the `good` job detail succeeded while `bad` returned 500 until retries were exhausted; `afetch()` raised `ScraperError` rather than returning `good`. The singleton publisher consequently receives an empty errored result and preserves stale output despite available listings. Collect detail failures independently (for example with `return_exceptions=True`) and parse successful detail responses, while retaining an explicit threshold for a wholly failed scrape.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix TheHub v2 job discovery"](https://github.com/kalil0321/ats-scrapers/commit/d0a5353b7bd49bc015b1b54350d57a6b970a45d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51131712)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->