### PR TITLE
feat(successfactors): expose application deadline

### DIFF
--- a/docs/JOB_SCHEMA.md
+++ b/docs/JOB_SCHEMA.md
@@ -274,11 +274,12 @@ When ats-scrapers last saw this posting. UTC.
 
 ### `application_deadline` &nbsp;`datetime | None`
 
-Explicit application deadline the ATS exposes, when the source
-provides one. Examples: SuccessFactors `g:expiration_date` (Google
-Merchant namespace), schema.org JobPosting `validThrough`. Parsed as
-ISO-8601 via `datetime.fromisoformat` (date-only `YYYY-MM-DD` or a
-full datetime, optionally ending in `Z`).
+Source-provided date after which the posting should no longer be treated
+as open. Examples: SuccessFactors `g:expiration_date` (Google Merchant
+namespace), schema.org JobPosting `validThrough`. It may be an
+employer-stated application deadline or a platform-generated validity
+horizon. Parsed as ISO-8601 via `datetime.fromisoformat` (date-only
+`YYYY-MM-DD` or a full datetime, optionally ending in `Z`).
 
 The timezone depends on what the source ships: values that carry an
 offset or `Z` are preserved as timezone-aware (e.g. `Z` → UTC-aware),

--- a/docs/JOB_SCHEMA.md
+++ b/docs/JOB_SCHEMA.md
@@ -277,7 +277,13 @@ When ats-scrapers last saw this posting. UTC.
 Explicit application deadline the ATS exposes, when the source
 provides one. Examples: SuccessFactors `g:expiration_date` (Google
 Merchant namespace), schema.org JobPosting `validThrough`. Parsed as
-ISO-8601 (date or full datetime with `Z`), UTC.
+ISO-8601 via `datetime.fromisoformat` (date-only `YYYY-MM-DD` or a
+full datetime, optionally ending in `Z`).
+
+The timezone depends on what the source ships: values that carry an
+offset or `Z` are preserved as timezone-aware (e.g. `Z` → UTC-aware),
+while **date-only values parse to a timezone-naive** datetime (`00:00`
+local, no offset). Consumers should not assume the value is always UTC.
 
 `None` when the source does not provide an explicit deadline — it is
 **never** inferred from `posted_at`, `fetched_at`, or any arbitrary

--- a/docs/JOB_SCHEMA.md
+++ b/docs/JOB_SCHEMA.md
@@ -19,10 +19,10 @@ the Pydantic descriptions are the source of truth; please update both.
 | **Location** | `location`, `country_iso`, `region`, `lat`, `lon`, `is_remote` |
 | **Compensation** | `salary_currency`, `salary_period`, `salary_summary`, `salary_min`, `salary_max` |
 | **Classification** | `experience`, `employment_type`, `department`, `team`, `requisition_id`, `apply_url`, `commitment` |
-| **Content & timing** | `description`, `posted_at`, `fetched_at`, `language` |
+| **Content & timing** | `description`, `posted_at`, `fetched_at`, `application_deadline`, `language` |
 | **Provider overflow** | `raw` |
 
-29 columns total in the published CSV.
+30 columns total in the published CSV.
 
 > **Heuristic vs LLM split.** The publisher's hardcoded inference is
 > intentionally narrow: title-only `is_remote` (returns `True` or
@@ -271,6 +271,17 @@ legacy ATSes.
 ### `fetched_at` &nbsp;`datetime | None`
 
 When ats-scrapers last saw this posting. UTC.
+
+### `application_deadline` &nbsp;`datetime | None`
+
+Explicit application deadline the ATS exposes, when the source
+provides one. Examples: SuccessFactors `g:expiration_date` (Google
+Merchant namespace), schema.org JobPosting `validThrough`. Parsed as
+ISO-8601 (date or full datetime with `Z`), UTC.
+
+`None` when the source does not provide an explicit deadline — it is
+**never** inferred from `posted_at`, `fetched_at`, or any arbitrary
+number of days.
 
 ### `language` &nbsp;`str | None`
 

--- a/src/ats_scrapers/models.py
+++ b/src/ats_scrapers/models.py
@@ -479,11 +479,13 @@ class Job(BaseModel):
     application_deadline: datetime | None = Field(
         default=None,
         description=(
-            "Explicit application deadline the ATS exposes (e.g. "
+            "Source-provided date after which the posting should no longer be "
+            "treated as open (e.g. "
             "SuccessFactors ``g:expiration_date`` in the Google Merchant "
-            "namespace, schema.org JobPosting ``validThrough``). ``None`` "
-            "when the source does not provide one — never inferred from "
-            "``posted_at`` or ``fetched_at``."
+            "namespace, schema.org JobPosting ``validThrough``). This may be "
+            "an employer-stated application deadline or a platform-generated "
+            "validity horizon. ``None`` when unavailable — never inferred "
+            "locally from ``posted_at`` or ``fetched_at``."
         ),
     )
     language: str | None = Field(

--- a/src/ats_scrapers/models.py
+++ b/src/ats_scrapers/models.py
@@ -473,6 +473,16 @@ class Job(BaseModel):
         default=None,
         description="When ats-scrapers last saw this posting (UTC).",
     )
+    application_deadline: datetime | None = Field(
+        default=None,
+        description=(
+            "Explicit application deadline the ATS exposes (e.g. "
+            "SuccessFactors ``g:expiration_date`` in the Google Merchant "
+            "namespace, schema.org JobPosting ``validThrough``). ``None`` "
+            "when the source does not provide one — never inferred from "
+            "``posted_at`` or ``fetched_at``."
+        ),
+    )
     language: str | None = Field(
         default=None,
         description=(

--- a/src/ats_scrapers/models.py
+++ b/src/ats_scrapers/models.py
@@ -187,8 +187,11 @@ class Job(BaseModel):
        them, ``None`` otherwise.
 
     5. **Content & timing** (``description``, ``posted_at``,
-       ``fetched_at``, ``language``). ``language`` is the listing's
-       locale code (ISO 639-1, e.g. ``en`` / ``fr``).
+       ``fetched_at``, ``application_deadline``, ``language``).
+       ``application_deadline`` is an explicit deadline the ATS exposes
+       (``None`` when unavailable, never inferred from other timestamps).
+       ``language`` is the listing's locale code (ISO 639-1, e.g.
+       ``en`` / ``fr``).
 
     6. **Provider-specific overflow** (``raw``): a JSON dict captured
        at scrape-time so we don't lose ATS-specific fields the

--- a/src/ats_scrapers/scrapers/successfactors.py
+++ b/src/ats_scrapers/scrapers/successfactors.py
@@ -372,6 +372,16 @@ class SuccessFactorsScraper(BaseScraper):
                     employment_type = mapped
                     break
 
+        # ``g:expiration_date`` (Google Merchant namespace) is the explicit
+        # application deadline. Tenants ship it as ``YYYY-MM-DD`` (date-only)
+        # or ISO 8601. Parse with ``datetime.fromisoformat`` (accepts both
+        # date-only and full ISO 8601 with offset/``Z``) — NOT ``_parse_pubdate``
+        # which is RFC 822 for ``pubDate``. ``None`` on absence/invalid; never
+        # fall back to ``posted_at``.
+        application_deadline = _parse_expiration_date(
+            item.findtext("g:expiration_date", namespaces=_GOOGLE_NS),
+        )
+
         return Job(
             url=link,
             title=title,
@@ -384,6 +394,7 @@ class SuccessFactorsScraper(BaseScraper):
             employment_type=employment_type,
             commitment=commitment,
             posted_at=posted_at,
+            application_deadline=application_deadline,
             fetched_at=datetime.now(UTC),
         )
 
@@ -572,6 +583,27 @@ def _parse_pubdate(value: object) -> datetime | None:
     try:
         return parsedate_to_datetime(value)
     except (TypeError, ValueError):
+        return None
+
+
+def _parse_expiration_date(value: object) -> datetime | None:
+    """Parse ``g:expiration_date`` (SuccessFactors application deadline).
+
+    Tenants ship this as date-only ``YYYY-MM-DD`` or full ISO 8601 (optionally
+    ending in ``Z``). Use ``datetime.fromisoformat`` — NOT ``_parse_pubdate``
+    (RFC 822, for ``pubDate``). Return ``None`` on absence or invalid input; the
+    caller never falls back to ``posted_at``.
+    """
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
         return None
 
 

--- a/src/ats_scrapers/scrapers/successfactors.py
+++ b/src/ats_scrapers/scrapers/successfactors.py
@@ -372,12 +372,13 @@ class SuccessFactorsScraper(BaseScraper):
                     employment_type = mapped
                     break
 
-        # ``g:expiration_date`` (Google Merchant namespace) is the explicit
-        # application deadline. Tenants ship it as ``YYYY-MM-DD`` (date-only)
-        # or ISO 8601. Parse with ``datetime.fromisoformat`` (accepts both
-        # date-only and full ISO 8601 with offset/``Z``) — NOT ``_parse_pubdate``
-        # which is RFC 822 for ``pubDate``. ``None`` on absence/invalid; never
-        # fall back to ``posted_at``.
+        # ``g:expiration_date`` (Google Merchant namespace) is the source's
+        # posting-expiration / valid-through value. Tenants ship it as
+        # ``YYYY-MM-DD`` (date-only) or ISO 8601. Parse with
+        # ``datetime.fromisoformat`` (accepts both date-only and full ISO 8601
+        # with offset/``Z``) — NOT ``_parse_pubdate`` which is RFC 822 for
+        # ``pubDate``. ``None`` on absence/invalid; never fall back to
+        # ``posted_at``.
         application_deadline = _parse_expiration_date(
             item.findtext("g:expiration_date", namespaces=_GOOGLE_NS),
         )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,7 +5,7 @@ Field renames here are breaking changes — these tests pin the contract.
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from pydantic import ValidationError
@@ -168,6 +168,24 @@ def test_job_posted_at_accepts_datetime() -> None:
 def test_job_posted_at_accepts_iso_string() -> None:
     job = _minimal_job(posted_at="2026-01-15T12:00:00")
     assert job.posted_at == datetime(2026, 1, 15, 12, 0, 0)
+
+
+def test_job_application_deadline_defaults_to_none() -> None:
+    job = _minimal_job()
+    assert job.application_deadline is None
+
+
+def test_job_application_deadline_accepts_datetime() -> None:
+    when = datetime(2026, 9, 14, 23, 59, 59, tzinfo=UTC)
+    job = _minimal_job(application_deadline=when)
+    assert job.application_deadline == when
+
+
+def test_job_application_deadline_round_trips() -> None:
+    job = _minimal_job(application_deadline="2026-09-14T23:59:59Z")
+    payload = job.model_dump(mode="json")
+    restored = Job.model_validate(payload)
+    assert restored.application_deadline == job.application_deadline
 
 
 def test_job_accepts_ats_type_via_alias() -> None:

--- a/tests/test_successfactors.py
+++ b/tests/test_successfactors.py
@@ -45,14 +45,21 @@ def _item(
     pubdate: str = "Fri, 20 Mar 2026 09:30:04 +0100",
     description: str = "<![CDATA[<p>Manage things.</p>]]>",
     gid: str | None = "86101",
+    expiration: str | None = None,
 ) -> str:
     g_id = f"<g:id>{gid}</g:id>" if gid else ""
+    g_expiration = (
+        f"<g:expiration_date>{expiration}</g:expiration_date>"
+        if expiration is not None
+        else ""
+    )
     return f"""<item>
 <title>{title}</title>
 <link>{link}</link>
 <pubDate>{pubdate}</pubDate>
 <description>{description}</description>
 {g_id}
+{g_expiration}
 </item>"""
 
 
@@ -194,6 +201,48 @@ def test_parses_basic_rss(httpx_mock) -> None:
     assert job.ats_type is ATSType.SUCCESSFACTORS
     assert str(job.url).startswith("https://job.acme.com")
     assert job.posted_at is not None and job.posted_at.year == 2026
+
+
+def test_expiration_date_present_date_only(httpx_mock) -> None:
+    """g:expiration_date shipped as YYYY-MM-DD maps to application_deadline."""
+    httpx_mock.add_response(url=FEED_URL, text=_rss([_item(expiration="2026-09-14")]))
+    job = SuccessFactorsScraper("job.acme.com").fetch()[0]
+    assert job.application_deadline is not None
+    assert job.application_deadline.isoformat() == "2026-09-14T00:00:00"
+
+
+def test_expiration_date_absent_is_none(httpx_mock) -> None:
+    """No g:expiration_date -> application_deadline is None (never fabricated)."""
+    httpx_mock.add_response(url=FEED_URL, text=_rss([_item()]))
+    job = SuccessFactorsScraper("job.acme.com").fetch()[0]
+    assert job.application_deadline is None
+
+
+def test_expiration_date_invalid_is_none(httpx_mock) -> None:
+    """Malformed g:expiration_date degrades gracefully to None."""
+    httpx_mock.add_response(url=FEED_URL, text=_rss([_item(expiration="not-a-date")]))
+    job = SuccessFactorsScraper("job.acme.com").fetch()[0]
+    assert job.application_deadline is None
+
+
+def test_expiration_date_iso_with_z(httpx_mock) -> None:
+    """Full ISO 8601 with trailing Z is parsed as UTC-aware."""
+    httpx_mock.add_response(
+        url=FEED_URL, text=_rss([_item(expiration="2026-09-14T23:59:59Z")]),
+    )
+    job = SuccessFactorsScraper("job.acme.com").fetch()[0]
+    assert job.application_deadline is not None
+    assert job.application_deadline.isoformat() == "2026-09-14T23:59:59+00:00"
+
+
+def test_posted_at_not_used_as_deadline(httpx_mock) -> None:
+    """A real pubDate populates posted_at but NOT application_deadline."""
+    httpx_mock.add_response(
+        url=FEED_URL, text=_rss([_item(expiration=None)]),
+    )
+    job = SuccessFactorsScraper("job.acme.com").fetch()[0]
+    assert job.posted_at is not None and job.posted_at.year == 2026
+    assert job.application_deadline is None
 
 
 def test_dedupes_by_ats_id(httpx_mock) -> None:


### PR DESCRIPTION
## Summary

- add `application_deadline` to the canonical `Job` model
- expose SuccessFactors `g:expiration_date` as `application_deadline`
- add focused model and SuccessFactors tests

## Motivation

SuccessFactors RSS feeds expose `g:expiration_date`, but the current scraper discards it. This change preserves that existing upstream data as a first-class optional field.

Missing or invalid values remain `None`; the deadline is never inferred from `posted_at` or other timestamps.

## Parsing

`g:expiration_date` is parsed using `datetime.fromisoformat` because SuccessFactors uses date/ISO-8601 semantics rather than RFC-822 `pubDate` semantics.

## Tests

Verified locally against `main` (`40e49f0`):

- `tests/test_successfactors.py` — 46 passed (41 existing + 5 new)
- `tests/test_models.py` — 62 passed (59 existing + 3 new)
- collectible suite — 1733 passed, 2 skipped (live e2e), 0 failures
- 8/8 new tests passed

New tests:
- `test_expiration_date_present_date_only` — `YYYY-MM-DD` maps to `application_deadline`
- `test_expiration_date_absent_is_none` — no element -> `None` (never fabricated)
- `test_expiration_date_invalid_is_none` — malformed -> `None` (graceful)
- `test_expiration_date_iso_with_z` — full ISO 8601 with `Z` -> UTC-aware
- `test_posted_at_not_used_as_deadline` — `posted_at` populated, `application_deadline` stays `None`
- `test_job_application_deadline_defaults_to_none`
- `test_job_application_deadline_accepts_datetime`
- `test_job_application_deadline_round_trips`

Note: 15 `*contracts`/`publisher`/`r2` tests fail only at collection time because `polars` is not installed in the local environment; this is pre-existing (reproduced on the unmodified baseline via `git stash`) and unrelated to this change. No dependencies are added or changed.

---

_This pull request was created by an AI agent (OpenHands) on behalf of the contributor._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose SuccessFactors application deadlines and add optional `application_deadline` to the canonical `Job` export so consumers can display apply-by dates. Previously we dropped `g:expiration_date`; now we parse and surface it without changing behavior when the feed omits it.

- SuccessFactors: parse `g:expiration_date` with `datetime.fromisoformat` (accepts `YYYY-MM-DD` and ISO‑8601). Preserve offsets; treat trailing `Z` as UTC; date‑only values remain timezone‑naive. Never infer from `posted_at`; invalid or absent stays `None`.
- `Job`: new `application_deadline: datetime | None`.
- Docs: add `application_deadline` to Content & timing and bump published CSV columns from 29 to 30. Clarify that timezone depends on the source; do not assume UTC.

**Migration**
- CSV consumers must accept a 30th column and handle nullable `application_deadline` values.

<sup>Written for commit ae0ad533c49f148874c1b359a4eefdf75a7e3ba1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds optional application deadlines to the canonical Job model and populates them from SuccessFactors expiration dates. The public Job schema reference was verified to be out of sync: it omits `application_deadline` from the timing fields, provides no field description, and still reports 29 CSV columns although the model now exports 30. Update the documentation before merge so consumers can discover and use the complete public contract.

<h3>Confidence Score: 4/5</h3>

The parsing and model change should be accompanied by an updated public schema reference before merging.

An executable comparison against both the parent revision and this change confirmed that the model gained a public field while the mirrored documentation and column total were not updated.

**Files Needing Attention:** `docs/JOB_SCHEMA.md` needs to document `application_deadline` and correct the published column count.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced proof for a posted P2 finding and prepared related artifacts for review.
- T-Rex produced proof for a posted P1 finding.
- T-Rex validated contract details by comparing model fields and documentation segments, noting a new application\_deadline field in code but not yet reflected in docs.

<a href="https://app.greptile.com/trex/runs/19087854/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `docs/JOB_SCHEMA.md`, line 22 ([link](https://github.com/kalil0321/ats-scrapers/blob/7dde3911cbd29357f6475d70e11b6733277495e4/docs/JOB_SCHEMA.md#L22)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Ran a revision-aware Python comparison script that introspected Job.modelfields and com...**

   - **Bug**
     - Ran a revision-aware Python comparison script that introspected Job.modelfields and compared the model's Content & timing fields and total field count with assertions derived from docs/JOBSCHEMA.md. The script passed against HEAD^, where 29 model fields matched four documented timing fields and a 29-column total. The same script failed against this change: the model has 30 fields including applicationdeadline, while the documentation still has four timing fields and declares 29 columns. This confirms that the public schema reference drifted when the new field was added.
   - **Cause**
     - T-Rex reproduced this while running the changed behavior, but it did not return a separate root-cause sentence.
   - **Fix**
     - Update the changed code so this failing path is handled, then rerun the same T-Rex check to confirm it passes.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Executable documentation-drift check source](https://app.greptile.com/trex/artifacts/4585587a-eac2-438d-8dc7-4cc2e88dfc3b)**

   - Captured output of the command that printed the exact authored Python comparison script; it introspects Job.model\_fields and compares model-derived Content & timing fields and total columns with structured JOB\_SCHEMA.md assertions, proving the check scope.

   **[Baseline schema documentation comparison before application\_deadline](https://app.greptile.com/trex/artifacts/8ab3f417-af83-4fd9-90cf-b3b43668710e)**

   - Captured execution of the comparison script against HEAD^; all three assertions pass with four Content & timing fields and 29 columns, establishing the pre-change baseline.

   **[Schema documentation comparison after application\_deadline](https://app.greptile.com/trex/artifacts/2c39e7c3-b43a-4fce-920f-e4a3765faf8a)**

   - Captured execution of the comparison script against the working tree; it finds application\_deadline in the 30-field model and fails all three documentation assertions, confirming consumer-facing drift.

   <a href="https://app.greptile.com/trex/runs/19087854/artifacts?artifact=4585587a-eac2-438d-8dc7-4cc2e88dfc3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Public Job schema documentation omits application_deadline**

   - **Bug**
     - `Job.application_deadline` is a public model/export column, but `docs/JOB_SCHEMA.md` does not list it in Content & timing, provides no field section for it, and still declares 29 CSV columns instead of the model's 30.
   - **Cause**
     - The feature commit added the model field but did not update the mirrored public schema document.
   - **Fix**
     - Add `application_deadline` after `fetched_at` in the Content & timing overview and field sections, describe its nullable UTC deadline semantics, and update the published CSV total to 30.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(successfactors): expose application..."](https://github.com/kalil0321/ats-scrapers/commit/7dde3911cbd29357f6475d70e11b6733277495e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53730289)</sub>

<!-- /greptile_comment -->