### PR TITLE
Workday: capture startDate/endDate from detail payload into Job.raw

### DIFF
--- a/src/ats_scrapers/scrapers/workday.py
+++ b/src/ats_scrapers/scrapers/workday.py
@@ -294,7 +294,7 @@ class WorkdayScraper(BaseScraper):
             except ValueError:
                 return
             jpi = payload.get("jobPostingInfo") or {}
-            updates: dict[str, str] = {}
+            updates: dict[str, object] = {}
 
             description = _extract_description(jpi)
             if description and not job.description:
@@ -306,6 +306,20 @@ class WorkdayScraper(BaseScraper):
                 resolved = _format_locations(primary, additional)
                 if resolved:
                     updates["location"] = resolved
+ 
+            # Capture posting dates from the detail payload. Workday sends
+            # bare 'YYYY-MM-DD' strings with no time or timezone. Merge into
+            # raw rather than replacing it, so listing-sourced keys
+            # (externalPath, bullet_fields) survive the model_copy update below.
+            start_date = jpi.get("startDate")
+            end_date = jpi.get("endDate")
+            if start_date or end_date:
+                merged_raw = dict(updates.get("raw") or job.raw or {})
+                if start_date:
+                    merged_raw["startDate"] = start_date
+                if end_date:
+                    merged_raw["endDate"] = end_date
+                updates["raw"] = merged_raw
 
             if updates:
                 jobs[i] = job.model_copy(update=updates)

--- a/src/ats_scrapers/scrapers/workday.py
+++ b/src/ats_scrapers/scrapers/workday.py
@@ -294,7 +294,7 @@ class WorkdayScraper(BaseScraper):
             except ValueError:
                 return
             jpi = payload.get("jobPostingInfo") or {}
-            updates: dict[str, object] = {}
+            updates: dict[str, Any] = {}
 
             description = _extract_description(jpi)
             if description and not job.description:
@@ -306,7 +306,7 @@ class WorkdayScraper(BaseScraper):
                 resolved = _format_locations(primary, additional)
                 if resolved:
                     updates["location"] = resolved
- 
+
             # Capture posting dates from the detail payload. Workday sends
             # bare 'YYYY-MM-DD' strings with no time or timezone. Merge into
             # raw rather than replacing it, so listing-sourced keys
@@ -314,7 +314,7 @@ class WorkdayScraper(BaseScraper):
             start_date = jpi.get("startDate")
             end_date = jpi.get("endDate")
             if start_date or end_date:
-                merged_raw = dict(updates.get("raw") or job.raw or {})
+                merged_raw = dict(job.raw or {})
                 if start_date:
                     merged_raw["startDate"] = start_date
                 if end_date:

--- a/tests/test_scrapers_extra.py
+++ b/tests/test_scrapers_extra.py
@@ -452,6 +452,8 @@ def test_workday_enriches_description_from_detail_endpoint(httpx_mock) -> None:
         json={
             "jobPostingInfo": {
                 "jobDescription": "<div><p>Build <strong>search</strong>.</p></div>",
+                "startDate": "2026-08-23",
+                "endDate": "2026-09-30",
             }
         },
     )
@@ -460,6 +462,12 @@ def test_workday_enriches_description_from_detail_endpoint(httpx_mock) -> None:
 
     assert len(jobs) == 1
     assert jobs[0].description == "Build search ."
+    assert jobs[0].raw == {
+        "bullet_fields": ["R-1"],
+        "externalPath": "/job/USA/Engineer_R-1",
+        "startDate": "2026-08-23",
+        "endDate": "2026-09-30",
+    }
 
 
 def test_workday_rollup_resolution_failure_is_silent(httpx_mock) -> None:


### PR DESCRIPTION
## What

`WorkdayScraper._enrich_details()` already fetches each job's detail
payload (`jobPostingInfo`) to pull `jobDescription` and resolve
multi-location rollups. This captures two more fields from that same
already-fetched payload, `startDate` and `endDate`, into `Job.raw`.

## Why

Workday's listing-level `postedOn` is only a relative bucket ("Posted
30+ Days Ago"), so `startDate` is the sole source of an absolute posting
date. `endDate` is the employer-stated application close date. Both are
useful for downstream age/freshness tracking.

## Notes

- **Zero new requests.** The values come from the `payload` the detail
  fetch already retrieved; no additional HTTP call is made.
- Merged into `raw` rather than replacing it, so listing-sourced keys
  (`externalPath`, `bullet_fields`) survive the `model_copy(update=...)`.
- Both nullable: many tenants omit `endDate`, and `startDate` may reflect
  a re-post rather than original publication.
- Bumped the `updates` annotation from `dict[str, str]` to
  `dict[str, object]` since the `raw` value is a dict.

Verified against a live Workday tenant: 10/10 jobs returned both
`startDate` and `endDate`, with location resolution intact.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Capture Workday startDate and endDate from the job detail payload and merge them into Job.raw. This adds an absolute posting date and an employer close date for downstream freshness tracking without extra requests.

- Reuses the existing jobPostingInfo detail fetch; zero additional HTTP calls.
- Adds startDate/endDate only when present and merges into raw without clobbering listing-sourced keys (externalPath, bullet_fields); tolerates missing fields and bare YYYY-MM-DD strings.
- Broadens the local updates annotation to dict[str, Any] to carry the raw dict.

<sup>Written for commit d25286e459b9c176ed58a25f75531354e2582363. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds Workday posting start and end dates from the job-detail response to each job’s raw metadata while preserving metadata collected from the listing response.

The date-enrichment path was exercised with both dates and pre-existing nested raw metadata. Existing keys were retained, both dates were added, and the enriched job serialized successfully to JSON. The focused Workday guard tests also passed.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised Workday detail-enrichment behavior and focused regression coverage.

No defects remain: the tested detail response preserved listing metadata, added both requested dates, and serialized successfully.

**Files Needing Attention:** No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a review-authored fake-client pytest reproducer against the parent revision and the PR revision to validate the enrichment added startDate and endDate to Job.raw, and confirmed JSON serialization via model\_dump\_json().
- Ran the focused Workday guard suite and confirmed all tests passed (6/6).
- Compared pre-PR and post-PR behavior with a targeted enrichment reproducer, finding that the parent commit lacks startDate and endDate while the PR includes them.
- Reviewed the end-to-end validation artifacts to confirm the PR passes enrichment and serialization checks.

<a href="https://app.greptile.com/trex/runs/20176030/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Workday: capture startDate/endDate from ..."](https://github.com/kalil0321/ats-scrapers/commit/6a476974eb183106065443fda775784338ce5776) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55866355)</sub>

<!-- /greptile_comment -->