### PR TITLE
Fix BambooHR multiline widget parsing

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -524,6 +524,7 @@ CONFIGS: dict[str, dict[str, Any]] = {
         "slug": lambda r: _slug_col(r) or (r.get("name") or "").strip() or None,
         "csv": "ats-companies/bamboohr.csv",
         "output": "bamboohr/jobs.csv",
+        "fail_closed_on_empty": True,
     },
     "dayforce": {
         "scraper": DayforceScraper,

--- a/src/ats_scrapers/scrapers/bamboohr.py
+++ b/src/ats_scrapers/scrapers/bamboohr.py
@@ -163,7 +163,7 @@ class BambooHRScraper(BaseScraper):
                 WIDGET_TEMPLATE.format(slug=self.company_slug)
             )
             jobs = self._parse_widget(widget_html)
-            if "bhrPositionID_" in widget_html and not jobs:
+            if re.search(r"bhrPositionID_", widget_html, re.IGNORECASE) and not jobs:
                 raise ScraperError(
                     f"BambooHR widget for {self.company_slug} contains jobs "
                     "but none matched the parser"

--- a/src/ats_scrapers/scrapers/bamboohr.py
+++ b/src/ats_scrapers/scrapers/bamboohr.py
@@ -81,10 +81,10 @@ _EMPLOYMENT_TYPE_MAP = {
 # Each department block is wrapped in a <li class="BambooHR-ATS-Department-Item">.
 # Inside, the header div carries the department name and the <ul> holds jobs.
 _DEPARTMENT_BLOCK_RE = re.compile(
-    r'<li id="bhrDepartmentID_(?P<dept_id>\d+)"[^>]*'
+    r'<li\s+id="bhrDepartmentID_(?P<dept_id>\d+)"[^>]*'
     r'class="BambooHR-ATS-Department-Item"[^>]*>'
     r'(?P<body>.*?)'
-    r'(?=<li id="bhrDepartmentID_|\Z)',
+    r'(?=<li\s+id="bhrDepartmentID_|\Z)',
     re.DOTALL | re.IGNORECASE,
 )
 _DEPARTMENT_NAME_RE = re.compile(
@@ -92,7 +92,7 @@ _DEPARTMENT_NAME_RE = re.compile(
     re.DOTALL | re.IGNORECASE,
 )
 _POSITION_RE = re.compile(
-    r'<li id="bhrPositionID_(?P<id>\d+)"[^>]*'
+    r'<li\s+id="bhrPositionID_(?P<id>\d+)"[^>]*'
     r'class="BambooHR-ATS-Jobs-Item"[^>]*>'
     r'(?P<body>.*?)</li>',
     re.DOTALL | re.IGNORECASE,
@@ -163,6 +163,11 @@ class BambooHRScraper(BaseScraper):
                 WIDGET_TEMPLATE.format(slug=self.company_slug)
             )
             jobs = self._parse_widget(widget_html)
+            if "bhrPositionID_" in widget_html and not jobs:
+                raise ScraperError(
+                    f"BambooHR widget for {self.company_slug} contains jobs "
+                    "but none matched the parser"
+                )
             if self.include_descriptions and jobs:
                 await self._enrich_from_detail_api(fetch, jobs)
             return jobs

--- a/tests/test_bamboohr.py
+++ b/tests/test_bamboohr.py
@@ -106,6 +106,69 @@ def test_parses_basic_widget(httpx_mock) -> None:
     assert jobs[0].company == "acme"
 
 
+def test_parses_current_multiline_widget_markup(httpx_mock) -> None:
+    html = """
+    <li
+        id="bhrDepartmentID_100"
+        class="BambooHR-ATS-Department-Item"
+    >
+        <div id="department_100" class="BambooHR-ATS-Department-Header">
+            Engineering
+        </div>
+        <ul class="BambooHR-ATS-Jobs-List">
+            <li
+                id="bhrPositionID_1"
+                class="BambooHR-ATS-Jobs-Item"
+            >
+                <a href="//acme.bamboohr.com/careers/1">Backend Engineer</a>
+                <span class="BambooHR-ATS-Location">Berlin</span>
+            </li>
+        </ul>
+    </li>
+    <li
+        id="bhrDepartmentID_200"
+        class="BambooHR-ATS-Department-Item"
+    >
+        <div id="department_200" class="BambooHR-ATS-Department-Header">
+            Sales
+        </div>
+        <ul class="BambooHR-ATS-Jobs-List">
+            <li
+                id="bhrPositionID_2"
+                class="BambooHR-ATS-Jobs-Item"
+            >
+                <a href="//acme.bamboohr.com/careers/2">Account Executive</a>
+                <span class="BambooHR-ATS-Location">Paris</span>
+            </li>
+        </ul>
+    </li>
+    """
+    httpx_mock.add_response(url=WIDGET_URL, text=html)
+
+    jobs = BambooHRScraper("acme", include_descriptions=False).fetch()
+
+    assert [(job.ats_id, job.title, job.department) for job in jobs] == [
+        ("1", "Backend Engineer", "Engineering"),
+        ("2", "Account Executive", "Sales"),
+    ]
+
+
+def test_raises_when_job_markers_do_not_match_parser(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=WIDGET_URL,
+        text='<article data-position="bhrPositionID_1">Job</article>',
+    )
+
+    with pytest.raises(ScraperError, match="contains jobs but none matched"):
+        BambooHRScraper("acme", include_descriptions=False).fetch()
+
+
+def test_pipeline_fails_closed_on_empty() -> None:
+    from scripts.run_pipeline import CONFIGS
+
+    assert CONFIGS["bamboohr"]["fail_closed_on_empty"] is True
+
+
 def test_returns_empty_for_widget_with_no_departments(httpx_mock) -> None:
     httpx_mock.add_response(url=WIDGET_URL, text='<div class="BambooHR-ATS-board"></div>')
     assert BambooHRScraper("acme").fetch() == []

--- a/tests/test_bamboohr.py
+++ b/tests/test_bamboohr.py
@@ -163,10 +163,14 @@ def test_raises_when_job_markers_do_not_match_parser(httpx_mock) -> None:
         BambooHRScraper("acme", include_descriptions=False).fetch()
 
 
-def test_pipeline_fails_closed_on_empty() -> None:
-    from scripts.run_pipeline import CONFIGS
+def test_raises_for_case_variant_unparsed_job_marker(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=WIDGET_URL,
+        text='<article data-position="bhrpositionid_1">Job</article>',
+    )
 
-    assert CONFIGS["bamboohr"]["fail_closed_on_empty"] is True
+    with pytest.raises(ScraperError, match="contains jobs but none matched"):
+        BambooHRScraper("acme", include_descriptions=False).fetch()
 
 
 def test_returns_empty_for_widget_with_no_departments(httpx_mock) -> None:

--- a/tests/test_run_pipeline_guards.py
+++ b/tests/test_run_pipeline_guards.py
@@ -12,6 +12,10 @@ from ats_scrapers.exceptions import CompanyNotFoundError
 from ats_scrapers.models import ATSType, Job
 
 
+def test_bamboohr_pipeline_fails_closed_on_empty() -> None:
+    assert runner.CONFIGS["bamboohr"]["fail_closed_on_empty"] is True
+
+
 def test_jobs_output_root_defaults_to_repository_root(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- accept whitespace/newlines between `<li` and BambooHR position IDs
- fail loudly when live position markers exist but no rows parse
- preserve the previous provider CSV when a required run returns empty

## Validation
- `29 passed, 30 deselected`
- Ruff passed
- local live probe: `4thdimension` returned 6 jobs / 6 unique IDs
- VPS exact-head probe (`bd257b7`): 6 jobs / 6 unique IDs, all with locations

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes BambooHR widget parsing for multiline `<li>` attributes and makes BambooHR runs fail closed to prevent data loss. Previously, multiline department or position `<li>` elements could be skipped and scrapes could return 0 jobs without error; now the parser accepts whitespace/newlines, correctly splits departments, and raises when job markers exist but nothing parses.

- Department and position regexes accept whitespace between `<li` and `id`, and the department-block lookahead uses the same whitespace-tolerant opener to split departments correctly.
- `BambooHRScraper` raises `ScraperError` when the widget contains `bhrPositionID_` markers but no jobs parse (case-insensitive).
- Pipeline config sets `fail_closed_on_empty=True` for `bamboohr`, preserving the prior CSV when a required run would otherwise be empty.

<sup>Written for commit 0c072354f7d849b18a69dc1f55c2daf5fde97605. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change broadens BambooHR widget parsing for whitespace-formatted markup and preserves prior output when a required scrape returns no jobs. A focused reproduction found that a multiline second department block is absorbed into the first department, causing its jobs to be published with the wrong department name.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until multiline department boundaries are parsed consistently, because later departments can be mislabeled as the first department.

A focused executable reproduction directly exercised two whitespace-formatted department blocks and observed the second job receive the first department's name.

**Files Needing Attention:** src/ats_scrapers/scrapers/bamboohr.py needs the department-block lookahead updated to accept whitespace between `<li` and `id`.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding, including reproduction source and reproduction output artifacts.
- T-Rex produced a proof for a posted P1 finding (second finding) with no artifacts attached.
- T-Rex performed general contract validation, noting observed=\[('1', 'Backend Engineer', 'Engineering'), ('2', 'Account Executive', 'Engineering')\] vs expected second department 'Sales', and that the BambooHR suite passed 27 tests.

<a href="https://app.greptile.com/trex/runs/20256489/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Whitespace-formatted next department opener is not recognized by department-block lookahead**

   - **Bug**
     - With two multiline department openers, the first `_DEPARTMENT_BLOCK_RE` match consumes the second department block, so its position inherits the first department name.
   - **Cause**
     - The opener accepts `<li\s+id`, but the terminating lookahead only accepts the literal `<li id="bhrDepartmentID_`, which does not match `<li` followed by newline/indentation before `id`.
   - **Fix**
     - Make the lookahead use the same whitespace-tolerant opener form, such as `(?=<li\s+id="bhrDepartmentID_|\Z)`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/ats_scrapers/scrapers/bamboohr.py:87
**Multiline department boundary is not recognized**

The department opener accepts whitespace between `<li` and `id`, but this terminating lookahead still requires the literal `<li id`. When a later department uses the newly supported multiline formatting, the first department match consumes it and its positions are emitted with the first department's name. Use the same whitespace-tolerant form in the lookahead, such as `(?=<li\s+id="bhrDepartmentID_|\Z)`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: [bd257b7](https://github.com/kalil0321/ats-scrapers/commit/bd257b798ac333ee9cc025ac3cf7a5e806043728) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56024559)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->