### PR TITLE
Fix Uber careers API scraper

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -772,6 +772,7 @@ CONFIGS: dict[str, dict[str, Any]] = {
     "uber": {
         "scraper": UberScraper, "singleton": True,
         "output": "uber/jobs.csv",
+        "fail_closed_on_empty": True,
     },
     "bundesagentur": {
         # German federal employment agency — official, public, ~1M+ jobs.

--- a/src/ats_scrapers/scrapers/uber.py
+++ b/src/ats_scrapers/scrapers/uber.py
@@ -1,42 +1,37 @@
 """Uber careers scraper.
 
-    POST https://www.uber.com/api/loadSearchJobsResults?localeCode=en
-
-Returns a paginated payload. The endpoint accepts a placeholder CSRF token.
-
-**Important payload shape**: ``limit`` and ``page`` MUST be at the top level
-of the request body — *not* inside ``params``. If they're nested under
-``params``, the API silently ignores them and returns its default page
-(1000 results) regardless of pagination, producing the same listings on
-every call. We hit this bug pre-fix: 11K "jobs" returned for a tenant
-with 1,077 actual openings, all duplicates.
-
-Field names inside ``params``: ``lineOfBusinessName`` and ``programAndPlatform``
-(NOT ``lineOfBusiness`` / ``program`` — empty arrays mask the typo).
+Uber retired its legacy ``/api/loadSearchJobsResults`` RPC in August 2026.
+Its replacement careers site exposes the live catalogue through the public
+``/api/jobs/search/`` route used by the browser. Cloudflare blocks plain HTTP
+clients on that route, so the scraper uses the project's existing
+TLS-impersonating ``httpcloak`` transport rather than a browser runtime.
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
+from urllib.parse import urljoin
 
-from ats_scrapers.models import ATSType, Job
+from pydantic import HttpUrl
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType, EmploymentType, Job, SalaryPeriod
 from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
 
 if TYPE_CHECKING:
-    from typing import Any, ClassVar
+    from typing import Any
 
     from ats_scrapers.fetch import Fetcher
 
-API_URL = "https://www.uber.com/api/loadSearchJobsResults"
-PAGE_SIZE = 100
+API_URL = "https://jobs.uber.com/api/jobs/search/"
+JOBS_ORIGIN = "https://jobs.uber.com"
+PAGE_SIZE = 1000
 
-_EMPLOYMENT_TYPE_PATTERNS = {
+_EMPLOYMENT_TYPE_PATTERNS: dict[str, EmploymentType] = {
     "intern": "INTERN",
-    "internship": "INTERN",
     "trainee": "INTERN",
     "contract": "CONTRACT",
-    "contractor": "CONTRACT",
     "fixed-term": "CONTRACT",
     "fixed term": "CONTRACT",
     "temporary": "TEMPORARY",
@@ -51,146 +46,259 @@ _EMPLOYMENT_TYPE_PATTERNS = {
     "permanent": "FULL_TIME",
 }
 
+_SALARY_PERIODS: dict[str, SalaryPeriod] = {
+    "hour": "HOUR",
+    "hourly": "HOUR",
+    "day": "DAY",
+    "daily": "DAY",
+    "week": "WEEK",
+    "weekly": "WEEK",
+    "month": "MONTH",
+    "monthly": "MONTH",
+    "year": "YEAR",
+    "yearly": "YEAR",
+    "annual": "YEAR",
+    "annually": "YEAR",
+}
+
 
 @ScraperRegistry.register(ATSType.UBER)
 class UberScraper(BaseScraper):
-    """Uber scraper — `company_slug` is informational; jobs are global."""
+    """Uber scraper — ``company_slug`` is informational; jobs are global."""
 
     ats = ATSType.UBER
+    fetch_engine = "cloak"
 
     default_headers: ClassVar[dict[str, str]] = {
-        "User-Agent": "Mozilla/5.0",
-        "Content-Type": "application/json",
-        "x-csrf-token": "x",  # placeholder — the endpoint accepts any value
+        "Accept": "application/json",
+        "Referer": "https://jobs.uber.com/en/jobs/",
     }
 
     async def afetch(self) -> list[Job]:
-        seen: set[str] = set()
-        all_jobs: list[Job] = []
-        page = 0
         async with self.make_fetcher() as fetch:
-            while True:
-                data = await self._fetch_page(fetch, page=page)
-                results = data.get("results") or []
-                if not results:
-                    break
-                for item in results:
-                    job = self._parse_job(item)
-                    if job.ats_id in seen:
-                        continue
-                    seen.add(job.ats_id)
-                    all_jobs.append(job)
-                total = _extract_total(data)
-                if (page + 1) * PAGE_SIZE >= total or len(results) < PAGE_SIZE:
-                    break
-                page += 1
-        return all_jobs
+            first_page = await self._fetch_page(fetch, page=1)
+            total = _positive_int(first_page.get("totalJobs"), "totalJobs")
+            total_pages = _positive_int(first_page.get("totalPages"), "totalPages")
+            items = list(first_page["jobs"])
+
+            for page in range(2, total_pages + 1):
+                payload = await self._fetch_page(fetch, page=page)
+                page_total = _positive_int(payload.get("totalJobs"), "totalJobs")
+                if page_total != total:
+                    raise ScraperError(
+                        f"Uber careers total changed during pagination: "
+                        f"{total} -> {page_total}"
+                    )
+                items.extend(payload["jobs"])
+
+        jobs_by_id: dict[str, Job] = {}
+        for item in items:
+            job = self._parse_job(item)
+            job_id = job.ats_id
+            if not job_id:
+                raise ScraperError("Uber careers parsed a job without an ID")
+            if job_id in jobs_by_id:
+                raise ScraperError(f"Uber careers returned duplicate job ID {job_id}")
+            jobs_by_id[job_id] = job
+
+        if len(jobs_by_id) != total:
+            raise ScraperError(
+                f"Uber careers advertised {total} jobs but returned "
+                f"{len(jobs_by_id)} unique IDs"
+            )
+        return list(jobs_by_id.values())
 
     async def _fetch_page(self, fetch: Fetcher, *, page: int) -> dict[str, Any]:
-        payload = {
-            # `limit` and `page` MUST be at the top level — see module docstring.
-            "limit": PAGE_SIZE,
-            "page": page,
-            "params": {
-                "department": [],
-                "lineOfBusinessName": [],
-                "location": [],
-                "programAndPlatform": [],
-                "team": [],
-            },
+        payload = await fetch.get_json(
+            API_URL,
+            params={"page": page, "pagesize": PAGE_SIZE},
+        )
+        if not isinstance(payload, dict) or not isinstance(payload.get("jobs"), list):
+            raise ScraperError("Uber careers returned an invalid jobs payload")
+        if not payload["jobs"]:
+            raise ScraperError(f"Uber careers page {page} returned no jobs")
+        return payload
+
+    def _parse_job(self, item: Any) -> Job:
+        if not isinstance(item, dict):
+            raise ScraperError("Uber careers returned a non-object job")
+
+        job_id = _text(item.get("Id"))
+        title = _text(item.get("Title"))
+        if not job_id or not title:
+            raise ScraperError("Uber careers returned a job without an ID or title")
+
+        locations = item.get("Locations")
+        location_items = (
+            [value for value in locations if isinstance(value, dict)]
+            if isinstance(locations, list)
+            else []
+        )
+        first_location = location_items[0] if location_items else {}
+        location_parts = [
+            value for value in (_location_text(item) for item in location_items) if value
+        ]
+        location = "; ".join(dict.fromkeys(location_parts)) or None
+        country_iso = _text(first_location.get("CountryCode"))
+        if country_iso and len(country_iso) != 2:
+            country_iso = None
+
+        coordinates = None
+        point = first_location.get("LocationPoint")
+        if isinstance(point, dict) and isinstance(point.get("coordinates"), list):
+            coordinates = point["coordinates"]
+        lon = _number(coordinates[0]) if coordinates and len(coordinates) >= 2 else None
+        lat = _number(coordinates[1]) if coordinates and len(coordinates) >= 2 else None
+
+        teams_value = item.get("Teams")
+        teams = (
+            [value for value in (_text(team) for team in teams_value) if value]
+            if isinstance(teams_value, list)
+            else []
+        )
+        contract_type = _text(item.get("ContractType"))
+        work_pattern = _text(item.get("WorkPattern"))
+        commitment_parts = list(dict.fromkeys(filter(None, (contract_type, work_pattern))))
+        commitment = " / ".join(commitment_parts) or None
+
+        salary_value = item.get("Salary")
+        salary: dict[str, Any] = salary_value if isinstance(salary_value, dict) else {}
+        currency = _text(salary.get("Currency"))
+        if currency:
+            currency = currency.upper()
+            if len(currency) != 3:
+                currency = None
+
+        url = _job_url(item.get("Urls"), job_id)
+        raw = {
+            key: value
+            for key, value in item.items()
+            if key
+            in {
+                "AdditionalText",
+                "ContractType",
+                "ExperienceLevel",
+                "Locations",
+                "Remote",
+                "Salary",
+                "Summary",
+                "Teams",
+                "WorkPattern",
+            }
+            and value not in (None, "", [], {})
         }
-        data = await fetch.post_json(
-            API_URL, params={"localeCode": "en"}, json=payload
-        )
-        return data.get("data") or {}
-
-    def _parse_job(self, item: dict[str, Any]) -> Job:
-        ats_id = str(item.get("id") or "")
-        all_locations = item.get("allLocations") or []
-        first_loc = all_locations[0] if all_locations else (item.get("location") or {})
-        location = None
-        if isinstance(first_loc, dict):
-            # Prefer ``countryName`` ("United Kingdom") over the
-            # ISO-3 ``country`` code ("GBR") for human readability.
-            parts = [
-                first_loc.get("city"),
-                first_loc.get("region"),
-                first_loc.get("countryName") or first_loc.get("country"),
-            ]
-            location = ", ".join(p for p in parts if p) or None
-        elif isinstance(first_loc, str):
-            location = first_loc
-
-        # Description is markdown — kept verbatim, capped at 25k chars.
-        description_raw = item.get("description")
-        description = (
-            description_raw.strip()[:25_000] or None
-            if isinstance(description_raw, str)
-            else None
-        )
-
-        # ``timeType`` ships as ``"Full-Time"`` / ``"Part-Time"`` /
-        # ``"Intern"`` / ``"Contract"``. Map to the canonical enum.
-        time_type = item.get("timeType")
-        commitment = (
-            time_type.strip() if isinstance(time_type, str) and time_type.strip()
-            else None
-        )
-        employment_type: str | None = None
-        if commitment:
-            norm = commitment.lower()
-            for needle, mapped in _EMPLOYMENT_TYPE_PATTERNS.items():
-                if needle in norm:
-                    employment_type = mapped
-                    break
-
-        raw: dict[str, Any] = {}
-        for k in ("department", "team", "category", "subCategory",
-                  "level", "otherLevels", "remote", "allLocations",
-                  "programAndPlatform", "type", "timeType", "uniqueSkills"):
-            v = item.get(k)
-            if v:
-                raw[k] = v
 
         return Job(
-            url=f"https://www.uber.com/global/en/careers/list/{ats_id}/",
-            title=item.get("title") or "Untitled",
+            url=url,
+            title=title,
             company="Uber",
             ats_type=ATSType.UBER,
-            ats_id=ats_id,
+            ats_id=job_id,
             location=location,
-            department=item.get("department") if isinstance(item.get("department"), str) else None,
-            team=item.get("team") if isinstance(item.get("team"), str) else None,
-            employment_type=employment_type,
+            country_iso=country_iso.upper() if country_iso else None,
+            region=None,
+            lat=lat,
+            lon=lon,
+            is_remote=item.get("Remote") if isinstance(item.get("Remote"), bool) else None,
+            salary_currency=currency,
+            salary_period=_salary_period(salary.get("Period")),
+            salary_summary=_text(salary.get("Description")),
+            salary_min=_number(salary.get("MinValue")),
+            salary_max=_number(salary.get("MaxValue")),
+            employment_type=_employment_type(commitment),
+            department=_text(item.get("AdditionalText")),
+            team=", ".join(teams) or None,
+            requisition_id=_text(item.get("Reference")) or job_id,
             commitment=commitment,
-            description=description,
-            requisition_id=ats_id if ats_id else None,
-            posted_at=_parse_iso(
-                item.get("creationDate")
-                or item.get("createdDate")
-                or item.get("updatedDate")
+            description=(
+                _html_to_text(item.get("Description"))
+                if self.include_descriptions
+                else None
             ),
+            posted_at=_parse_iso(item.get("DisplayDate")),
             fetched_at=datetime.now(UTC),
+            language="en",
             raw=raw or None,
         )
 
 
-def _extract_total(data: dict[str, Any]) -> int:
-    """Uber's `totalResults` is a 64-bit `{"low", "high", "unsigned"}`
-    envelope. The 32-bit ``low`` field is enough — Uber doesn't have 4B+
-    job postings."""
-    envelope = data.get("totalResults")
-    if isinstance(envelope, dict):
-        return int(envelope.get("low") or 0)
-    if isinstance(envelope, (int, float)):
-        return int(envelope)
-    return 0
+def _positive_int(value: Any, field: str) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ScraperError(f"Uber careers returned invalid {field}") from exc
+    if parsed <= 0:
+        raise ScraperError(f"Uber careers returned invalid {field}")
+    return parsed
 
 
-def _parse_iso(value: str | None) -> datetime | None:
-    if not value:
+def _text(value: Any) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool):
         return None
     try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return float(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _location_text(location: dict[str, Any]) -> str | None:
+    address = _text(location.get("Address"))
+    if address:
+        return address
+    parts = [
+        _text(location.get("City")),
+        _text(location.get("Region")),
+        _text(location.get("Country")),
+    ]
+    return ", ".join(dict.fromkeys(part for part in parts if part)) or None
+
+
+def _job_url(urls: Any, job_id: str) -> HttpUrl:
+    if isinstance(urls, list):
+        candidates = [value for value in urls if isinstance(value, dict)]
+        default = next((value for value in candidates if value.get("IsDefault") is True), None)
+        selected = default or (candidates[0] if candidates else None)
+        path = _text(selected.get("Url")) if selected else None
+        if path:
+            return HttpUrl(urljoin(JOBS_ORIGIN, path))
+    return HttpUrl(f"{JOBS_ORIGIN}/en/jobs/{job_id}/")
+
+
+def _employment_type(commitment: str | None) -> EmploymentType | None:
+    normalized = commitment.lower() if commitment else ""
+    return next(
+        (mapped for needle, mapped in _EMPLOYMENT_TYPE_PATTERNS.items() if needle in normalized),
+        None,
+    )
+
+
+def _salary_period(value: Any) -> SalaryPeriod | None:
+    normalized = _text(value)
+    return _SALARY_PERIODS.get(normalized.lower()) if normalized else None
+
+
+def _html_to_text(value: Any) -> str | None:
+    raw = _text(value)
+    if not raw:
+        return None
+    try:
+        from bs4 import BeautifulSoup
+    except ImportError as exc:
+        raise ScraperError(
+            "Uber scraping requires beautifulsoup4; install ats-scrapers[scrapers]"
+        ) from exc
+    return BeautifulSoup(raw, "html.parser").get_text("\n", strip=True)[:25_000] or None
+
+
+def _parse_iso(value: Any) -> datetime | None:
+    raw = _text(value)
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
     except ValueError:
         return None

--- a/tests/test_uber.py
+++ b/tests/test_uber.py
@@ -1,0 +1,168 @@
+"""Tests for Uber's current careers JSON API."""
+
+from __future__ import annotations
+
+import pytest
+
+from ats_scrapers.exceptions import ScraperError
+from ats_scrapers.models import ATSType
+from ats_scrapers.scrapers import UberScraper
+
+API_URL = "https://jobs.uber.com/api/jobs/search/"
+
+
+def _job(job_id: str) -> dict[str, object]:
+    return {
+        "Id": job_id,
+        "Title": f"Job {job_id}",
+        "Reference": f"R-{job_id}",
+        "Description": "<p>Hello <strong>world</strong></p>",
+        "DisplayDate": "2026-08-22T23:48:24Z",
+        "AdditionalText": "University Operations",
+        "Teams": ["University"],
+        "ContractType": "Full time",
+        "WorkPattern": "Intern",
+        "Remote": False,
+        "Salary": {
+            "MinValue": 50_000,
+            "MaxValue": 70_000,
+            "Currency": "usd",
+            "Period": "Year",
+            "Description": "$50,000-$70,000",
+        },
+        "Locations": [
+            {
+                "Address": "Paris, France",
+                "City": "Paris",
+                "Region": "Ile-de-France",
+                "Country": "France",
+                "CountryCode": "FR",
+                "LocationPoint": {"coordinates": [2.3522, 48.8566]},
+            },
+            {
+                "Address": "Amsterdam, Netherlands",
+                "City": "Amsterdam",
+                "Region": "North Holland",
+                "Country": "Netherlands",
+                "CountryCode": "NL",
+                "LocationPoint": {"coordinates": [4.9041, 52.3676]},
+            },
+        ],
+        "Urls": [{"Culture": "en-us", "Url": f"/en/jobs/{job_id}/", "IsDefault": True}],
+    }
+
+
+def _payload(
+    jobs: list[dict[str, object]],
+    *,
+    total_jobs: int | None = None,
+    total_pages: int = 1,
+    page: int = 1,
+) -> dict[str, object]:
+    return {
+        "jobs": jobs,
+        "totalJobs": len(jobs) if total_jobs is None else total_jobs,
+        "totalPages": total_pages,
+        "page": page,
+        "pageSize": 1000,
+    }
+
+
+def _use_mock_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(UberScraper, "fetch_engine", "httpx")
+
+
+def test_parses_current_api_fields(httpx_mock, monkeypatch) -> None:
+    _use_mock_transport(monkeypatch)
+    httpx_mock.add_response(
+        url=f"{API_URL}?page=1&pagesize=1000",
+        json=_payload([_job("300886")]),
+    )
+
+    jobs = UberScraper("uber").fetch()
+
+    assert len(jobs) == 1
+    job = jobs[0]
+    assert job.ats_type is ATSType.UBER
+    assert job.ats_id == "300886"
+    assert job.title == "Job 300886"
+    assert job.location == "Paris, France; Amsterdam, Netherlands"
+    assert job.country_iso == "FR"
+    assert job.region is None
+    assert (job.lat, job.lon) == (48.8566, 2.3522)
+    assert job.is_remote is False
+    assert job.department == "University Operations"
+    assert job.team == "University"
+    assert job.employment_type == "INTERN"
+    assert job.commitment == "Full time / Intern"
+    assert job.requisition_id == "R-300886"
+    assert job.salary_currency == "USD"
+    assert job.salary_period == "YEAR"
+    assert job.description == "Hello\nworld"
+    assert str(job.url) == "https://jobs.uber.com/en/jobs/300886/"
+
+
+def test_can_omit_descriptions(httpx_mock, monkeypatch) -> None:
+    _use_mock_transport(monkeypatch)
+    httpx_mock.add_response(
+        url=f"{API_URL}?page=1&pagesize=1000",
+        json=_payload([_job("1")]),
+    )
+
+    assert UberScraper("uber", include_descriptions=False).fetch()[0].description is None
+
+
+def test_paginates_to_advertised_total(httpx_mock, monkeypatch) -> None:
+    _use_mock_transport(monkeypatch)
+    httpx_mock.add_response(
+        url=f"{API_URL}?page=1&pagesize=1000",
+        json=_payload([_job("1")], total_jobs=2, total_pages=2),
+    )
+    httpx_mock.add_response(
+        url=f"{API_URL}?page=2&pagesize=1000",
+        json=_payload([_job("2")], total_jobs=2, total_pages=2, page=2),
+    )
+
+    assert len(UberScraper("uber").fetch()) == 2
+
+
+def test_rejects_partial_catalogue(httpx_mock, monkeypatch) -> None:
+    _use_mock_transport(monkeypatch)
+    httpx_mock.add_response(
+        url=f"{API_URL}?page=1&pagesize=1000",
+        json=_payload([_job("1")], total_jobs=2),
+    )
+
+    with pytest.raises(
+        ScraperError,
+        match="advertised 2 jobs but returned 1 unique IDs",
+    ):
+        UberScraper("uber").fetch()
+
+
+def test_rejects_duplicate_job_ids(httpx_mock, monkeypatch) -> None:
+    _use_mock_transport(monkeypatch)
+    httpx_mock.add_response(
+        url=f"{API_URL}?page=1&pagesize=1000",
+        json=_payload([_job("1"), _job("1")]),
+    )
+
+    with pytest.raises(ScraperError, match="duplicate job ID 1"):
+        UberScraper("uber").fetch()
+
+
+def test_rejects_invalid_payload(httpx_mock, monkeypatch) -> None:
+    _use_mock_transport(monkeypatch)
+    httpx_mock.add_response(
+        url=f"{API_URL}?page=1&pagesize=1000",
+        json={"message": "blocked"},
+    )
+
+    with pytest.raises(ScraperError, match="invalid jobs payload"):
+        UberScraper("uber").fetch()
+
+
+def test_pipeline_fails_closed_on_empty() -> None:
+    from scripts.run_pipeline import CONFIGS
+
+    assert CONFIGS["uber"]["fail_closed_on_empty"] is True


### PR DESCRIPTION
## Summary
- replace Uber’s retired legacy RPC with the current official `/api/jobs/search/` catalogue
- use the existing `httpcloak` transport for Cloudflare-compatible TLS fingerprinting
- map descriptions, locations, coordinates, teams, employment type, salary, and posting dates
- reject partial or duplicate catalogues and preserve the previous CSV on empty output

## Validation
- `8 passed, 30 deselected`
- Ruff passed
- local full live probe: 710 jobs / 710 unique IDs, 710 descriptions, 710 locations
- VPS exact-head probe (`2515088`): 710 jobs / 710 unique IDs, 710 descriptions, 710 locations

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces Uber’s retired careers RPC with the public `https://jobs.uber.com/api/jobs/search/`, restoring coverage behind Cloudflare and enforcing complete pagination. Fixes region semantics by no longer populating continent-level `region` with sub‑national values; `region` is now unset and `country_iso` is populated to prevent continent filters from dropping jobs.

- Uses `httpcloak`; paginates via `totalJobs`/`totalPages`; rejects invalid payloads, empty pages, duplicate IDs, and changing totals.
- Maps job URL, locations (address/city/country), `country_iso`, lat/lon, remote, teams, commitment and canonical employment type, salary currency/period/min/max/summary, requisition ID, posted date, and language; converts HTML descriptions to text when enabled (requires `beautifulsoup4` or install `ats-scrapers[scrapers]`).
- Sets pipeline `fail_closed_on_empty=True` for Uber.
- Migration: consumers filtering by continent must derive it from `country_iso`; do not use `region`.

<sup>Written for commit b41d2bf38afa5b9ae488ec24b19cdd5253d4a70d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates Uber job collection to use the current catalogue API, adds transport and completeness handling, and expands normalized job fields. Runtime validation reproduced an incorrect geographic mapping: a French job whose Uber location has `Region='Ile-de-France'` is stored outside the canonical Europe grouping, so Europe-filtered consumers omit it. Normalize `country_iso` to a continent before populating `Job.region`, or leave that field unset when normalization is unavailable.

<h3>Confidence Score: 4/5</h3>

The change should not merge until Uber location regions are normalized to the canonical continent-level field.

A focused runtime check reproduced the incorrect filtering and grouping behavior using a representative Uber payload and a continent-level control.

**Files Needing Attention:** src/ats_scrapers/scrapers/uber.py line 188 needs to derive the canonical continent from the country rather than copy Uber's administrative region.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding and linked to the review comment for details.
- T-Rex produced a second proof for another posted P1 finding, with no additional artifacts attached.
- T-Rex validated the general-contract proof regarding Uber region handling, noting how Europe-region control passes the Europe filter while Ile-de-France is treated as a sub-national item, and drafted a final comment recommending continent derivation from country\_iso or leaving region unset when normalization fails.

<a href="https://app.greptile.com/trex/runs/20256502/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Uber stores a sub-national location in the continent-level region field**

   - **Bug**
     - A representative Uber job with `CountryCode='FR'` and `Region='Ile-de-France'` parses successfully with `Job.region='Ile-de-France'`. A consumer filtering `region == 'Europe'` excludes that French job, while grouping creates an `Ile-de-France` bucket instead of the documented Europe bucket.
   - **Cause**
     - `UberScraper._parse_job` assigns `Locations[0].Region` directly to `Job.region`; Uber's Region is an administrative subdivision, while the canonical model defines this field as continent-level. The model type is unconstrained `str | None`, so it does not reject the semantic mismatch.
   - **Fix**
     - Normalize the structured country to its continent (for `FR`, `Europe`) before assigning `Job.region`, or leave it `None` if normalization is unavailable; retain Uber's raw subdivision in `location`/`raw` rather than the canonical region field.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/ats_scrapers/scrapers/uber.py:188
**Sub-national value breaks region semantics**

`Locations[0].Region` is a sub-national administrative area (for example, `Ile-de-France`), while `Job.region` is the continent-level grouping field. A French job is therefore emitted with `region='Ile-de-France'`, excluded from consumers filtering for `region == 'Europe'`, and grouped under an unexpected region. Normalize the country to its continent before assigning this field, or leave it unset when it cannot be normalized.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: [2515088](https://github.com/kalil0321/ats-scrapers/commit/25150883975046111293c7511c8c9b31219b3075) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56024607)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->