### PR TITLE
Migrate Bundesagentur listings to v6

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -779,6 +779,12 @@ CONFIGS: dict[str, dict[str, Any]] = {
         # (job category) to bypass the 10k pagination cap.
         "scraper": BundesagenturScraper, "singleton": True,
         "output": "bundesagentur/jobs.csv",
+        "fail_closed_on_empty": True,
+        # The listing API already provides the fields needed for the public
+        # index. Fetching ~1M individual detail pages would take days and put
+        # unnecessary load on the federal service; preserve cached bodies for
+        # existing rows and leave new descriptions for a separate backfill.
+        "skip_description_enrichment": True,
     },
     "arbetsformedlingen": {
         # Sweden's federal employment service — public JSON API. ~46k
@@ -1508,7 +1514,14 @@ async def run(ats: str, concurrency: int, max_tenants: int | None, timeout: floa
             # today — its ~2.7 M-row pan-EU catalog would peak at ~10 GB
             # RSS in legacy mode, exceeding the VPS RAM budget.
             if uses_streaming:
-                scraper = cfg["scraper"](ats, timeout=timeout)
+                skip_description_enrichment = bool(
+                    cfg.get("skip_description_enrichment")
+                )
+                scraper = cfg["scraper"](
+                    ats,
+                    timeout=timeout,
+                    include_descriptions=not skip_description_enrichment,
+                )
                 pending_descriptions: set[asyncio.Task[Job]] = set()
 
                 def write_streamed_job(job: Job) -> None:
@@ -1546,7 +1559,11 @@ async def run(ats: str, concurrency: int, max_tenants: int | None, timeout: floa
                 try:
                     async for job in scraper.fetch_stream():
                         cached = _cached_description(job, description_cache)
-                        if cached:
+                        if skip_description_enrichment:
+                            if cached:
+                                job.description = cached
+                            write_streamed_job(job)
+                        elif cached:
                             job.description = cached
                             write_streamed_job(job)
                         elif job.description:

--- a/src/ats_scrapers/scrapers/bundesagentur.py
+++ b/src/ats_scrapers/scrapers/bundesagentur.py
@@ -494,7 +494,7 @@ class BundesagenturScraper(BaseScraper):
             ats_id=ats_id,
             location=location,
             country_iso=country_iso,
-            region=None,
+            region="Europe" if country_iso else None,
             lat=_number(coordinate_location.get("breite")),
             lon=_number(coordinate_location.get("laenge")),
             is_remote=is_remote,

--- a/src/ats_scrapers/scrapers/bundesagentur.py
+++ b/src/ats_scrapers/scrapers/bundesagentur.py
@@ -425,10 +425,15 @@ class BundesagenturScraper(BaseScraper):
         ).strip()
         if not ats_id or not title:
             return None
-        location_data = _first_location(item)
-        location = _format_location(location_data)
-        address = location_data.get("adresse") if isinstance(location_data, dict) else None
-        address = address if isinstance(address, dict) else {}
+        location_items = _locations(item)
+        location = _format_locations(location_items)
+        country_codes = {
+            country_iso
+            for location_item in location_items
+            if (country_iso := _country_iso(_location_address(location_item).get("land")))
+        }
+        country_iso = next(iter(country_codes)) if len(country_codes) == 1 else None
+        coordinate_location = location_items[0] if len(location_items) == 1 else {}
         company = str(
             item.get("firma") or item.get("arbeitgeber") or "Bundesagentur"
         ).strip() or "Bundesagentur"
@@ -441,7 +446,7 @@ class BundesagenturScraper(BaseScraper):
         remote_value = item.get("homeofficemoeglich")
         is_remote = remote_value if isinstance(remote_value, bool) else None
 
-        department = _text(item.get("hauptberuf") or item.get("berufsfeld"))
+        department = _text(item.get("berufsfeld"))
         team = _text(item.get("branche"))
         if team == department:
             team = None
@@ -461,6 +466,7 @@ class BundesagenturScraper(BaseScraper):
             "arbeitszeitTeilzeitNachmittag",
             "arbeitszeitTeilzeitVormittag",
             "arbeitszeitVollzeit",
+            "berufsfeld",
             "branche",
             "chiffrenummer",
             "hauptberuf",
@@ -468,6 +474,7 @@ class BundesagenturScraper(BaseScraper):
             "istGeringfuegigeBeschaeftigung",
             "quereinstiegGeeignet",
             "stellenangebotsart",
+            "stellenlokationen",
             "vertragsdauer",
         ):
             v = item.get(k)
@@ -486,10 +493,10 @@ class BundesagenturScraper(BaseScraper):
             ats_type=ATSType.BUNDESAGENTUR,
             ats_id=ats_id,
             location=location,
-            country_iso=_country_iso(address.get("land")),
-            region=_region_name(address.get("region")),
-            lat=_number(location_data.get("breite")),
-            lon=_number(location_data.get("laenge")),
+            country_iso=country_iso,
+            region=None,
+            lat=_number(coordinate_location.get("breite")),
+            lon=_number(coordinate_location.get("laenge")),
             is_remote=is_remote,
             salary_currency="EUR" if salary_min is not None or salary_max is not None else None,
             salary_period=salary_period,
@@ -620,12 +627,14 @@ def _employment_details(
     return ", ".join(labels) or None, employment_type
 
 
-def _first_location(item: dict[str, Any]) -> dict[str, Any]:
+def _locations(item: dict[str, Any]) -> list[dict[str, Any]]:
     locations = item.get("stellenlokationen")
-    if isinstance(locations, list) and locations and isinstance(locations[0], dict):
-        return locations[0]
+    if isinstance(locations, list):
+        parsed = [value for value in locations if isinstance(value, dict)]
+        if parsed:
+            return parsed
     legacy = item.get("arbeitsort")
-    return {"adresse": legacy} if isinstance(legacy, dict) else {}
+    return [{"adresse": legacy}] if isinstance(legacy, dict) else []
 
 
 def _bucket_counts(facets: dict[str, Any], facet_name: str) -> dict[str, int]:
@@ -685,6 +694,20 @@ def _format_location(value: object) -> str | None:
         _display_enum(value.get("land")),
     ]
     return ", ".join(dict.fromkeys(part for part in parts if part)) or None
+
+
+def _format_locations(values: list[dict[str, Any]]) -> str | None:
+    locations = [
+        location
+        for value in values
+        if (location := _format_location(value)) is not None
+    ]
+    return " | ".join(dict.fromkeys(locations)) or None
+
+
+def _location_address(value: dict[str, Any]) -> dict[str, Any]:
+    address = value.get("adresse")
+    return address if isinstance(address, dict) else {}
 
 
 def _text(value: object) -> str | None:

--- a/src/ats_scrapers/scrapers/bundesagentur.py
+++ b/src/ats_scrapers/scrapers/bundesagentur.py
@@ -5,9 +5,13 @@ every German employer that lists with the agency. The portal at
 ``arbeitsagentur.de`` exposes a public unauthenticated JSON API that
 the official frontend consumes:
 
-    GET https://rest.arbeitsagentur.de/jobboerse/jobsuche-service/pc/v4/jobs
+    GET https://rest.arbeitsagentur.de/jobboerse/jobsuche-service/pc/v6/jobs
         ?size=100&page={1..100}
     Header: X-API-Key: jobboerse-jobsuche
+
+The official frontend moved listings from v4 to v6 in August 2026. The v6
+response uses ``ergebnisliste`` and renamed German field keys, while job
+details remain on the v4 endpoint.
 
 The API caps pagination at ``size × page = 10,000`` results per query
 (``size=100, page=100``). Past that limit, the server returns 400.
@@ -42,24 +46,19 @@ from __future__ import annotations
 
 import asyncio
 import base64
-import logging
 import random
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import Any
 
 import httpx
+from pydantic import HttpUrl
 
 from ats_scrapers.exceptions import ScraperError
-from ats_scrapers.models import ATSType, Job
+from ats_scrapers.models import ATSType, EmploymentType, Job, SalaryPeriod
 from ats_scrapers.scrapers.base import BaseScraper, ScraperRegistry
 
-if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Awaitable, Callable
-    from typing import Any
-
-logger = logging.getLogger(__name__)
-
-API_URL = "https://rest.arbeitsagentur.de/jobboerse/jobsuche-service/pc/v4/jobs"
+API_URL = "https://rest.arbeitsagentur.de/jobboerse/jobsuche-service/pc/v6/jobs"
 DETAIL_URL_TEMPLATE = (
     "https://rest.arbeitsagentur.de/jobboerse/jobsuche-service/pc/v4/jobdetails/{encoded_ref}"
 )
@@ -78,26 +77,26 @@ RETRY_BASE_DELAY = 2.0
 RETRY_JITTER = 0.5  # ± fraction added to each backoff so concurrent
 # retries don't synchronize and re-trigger the WAF in lockstep.
 
-# Subdivision facets in priority order. Each facet's ``counts`` dict
-# enumerates the available values for that filter — we read those at
-# query time so the scraper survives taxonomy churn.
-#
-# Facet ordering matters: API responses cap at 10k results, so we want
-# the highest-cardinality / least-skewed facets applied first. The
-# tail (arbeitszeit/zeitarbeit/befristung) is heavily skewed (~84% in
-# the dominant bucket each), which is why berufsfeld + the original
-# 4 facets weren't enough — the worst leaf (Verkauf+vz+false+
-# befristung=3) still held 56k jobs. eintrittsdatum (24 monthly start
-# windows + a "10_01_01-now" catch-all) and arbeitgeber (top-100
-# employers per leaf) are the levers that finally crack the dominant
-# leaves.
+# Candidate subdivision facets. At each node we only use a facet when its
+# bucket counts sum exactly to that node's total, then pick the candidate
+# whose largest bucket is smallest. This matters in v6: ``berufsfeld`` omits
+# 7.9k uncategorized Ausbildung records at the root, while multi-valued facets
+# such as ``arbeitszeit`` overlap. Treating either as an unconditional
+# partition silently loses or double-counts jobs. Once ``angebotsart`` and
+# ``ausbildungsart`` narrow the relevant branches, ``berufsfeld`` becomes
+# exhaustive and is safe to use.
 _SUBDIVISION_FACETS = (
-    "berufsfeld",      # 144 buckets, full coverage
-    "eintrittsdatum",  # 24 month windows; multi-tag (sum > total) so dedup is essential
-    "arbeitszeit",     # 5 work-time codes, multi-tag
-    "befristung",      # 3 contract types
-    "zeitarbeit",      # 2 (temp work y/n)
-    "arbeitgeber",     # top-100 employers per leaf — last-resort partition
+    "angebotsart",
+    "ausbildungsart",
+    "berufsfeld",
+    "befristung",
+    "zeitarbeit",
+    "pav",
+    "quereinstieg",
+    "externestellenboersen",
+    "behinderung",
+    "branche",
+    "arbeitgeber",
 )
 MAX_SUBDIVISION_DEPTH = len(_SUBDIVISION_FACETS)
 
@@ -107,11 +106,9 @@ class _PageFetchExhaustedError(ScraperError):
     a *transient* failure class (persistent 403 / 429 / 5xx, or a network
     error that didn't resolve before MAX_RETRIES).
 
-    Distinguished from ``ScraperError`` because the soft-fail callers
-    (``_exhaust_query`` / ``_fan_out_pages``) only want to swallow this
-    specific case — not contract breaks (401, 404, non-retryable status,
-    malformed JSON), which still raise plain ``ScraperError`` and crash
-    the scrape so an operator notices instead of silently undercounting.
+    Distinguished from ``ScraperError`` so logs preserve the retry-exhausted
+    failure class. It is deliberately not swallowed: publishing a partial
+    federal catalogue is less safe than preserving the previous complete run.
     """
 
 
@@ -215,7 +212,7 @@ class BundesagenturScraper(BaseScraper):
             async with lock:
                 for it in items:
                     job = self._parse(it)
-                    if job is None or job.ats_id in seen:
+                    if job is None or not job.ats_id or job.ats_id in seen:
                         continue
                     seen.add(job.ats_id)
                     new_jobs.append(job)
@@ -277,7 +274,7 @@ class BundesagenturScraper(BaseScraper):
         *,
         base_params: dict[str, Any],
         depth: int,
-        absorb,
+        absorb: Callable[[list[dict[str, Any]]], Awaitable[None]],
     ) -> None:
         """Recursively pull all jobs matching ``base_params``.
 
@@ -285,33 +282,14 @@ class BundesagenturScraper(BaseScraper):
         unused subdivision facet and split. ``depth`` bounds the
         recursion: berufsfeld → arbeitszeit → zeitarbeit → befristung.
         """
-        try:
-            first = await self._fetch_page(
-                client, sem, params={**base_params, "size": 1, "page": 1},
-            )
-        except _PageFetchExhaustedError as exc:
-            # Probe exhausted retries on a transient class (persistent WAF
-            # block or a network error that didn't resolve in time). We
-            # soft-fail this *one* subtree only — sibling buckets keep
-            # going. Probe failures must never silently look like
-            # ``maxErgebnisse=0`` (that would drop the whole subtree and
-            # at depth=0 the entire scrape) so we log loudly.
-            #
-            # Non-transient failures (401/404 contract breaks, malformed
-            # JSON, etc.) raise plain ``ScraperError`` from ``_fetch_page``
-            # and propagate up here uncaught — those crash the scrape
-            # rather than produce a silent undercount.
-            logger.warning(
-                "Bundesagentur probe failed for params=%s depth=%d — "
-                "subtree skipped, output will undercount: %s",
-                base_params, depth, exc,
-            )
-            return
+        first = await self._fetch_page(
+            client, sem, params={**base_params, "size": 1, "page": 1},
+        )
         total = int(first.get("maxErgebnisse") or 0)
         if total == 0:
             return
         # Page-1 hits are already paid for — absorb them rather than re-fetch.
-        await absorb(first.get("stellenangebote") or [])
+        await absorb(_result_items(first))
 
         if total <= PAGINATION_CAP:
             await self._fan_out_pages(
@@ -320,31 +298,14 @@ class BundesagenturScraper(BaseScraper):
             )
             return
 
-        # Above the cap — pick a subdivision facet not already in
-        # base_params, then split.
         applied = set(base_params.keys())
-        facet_name: str | None = None
-        for f in _SUBDIVISION_FACETS:
-            if f not in applied:
-                facet_name = f
-                break
-
-        if facet_name is None or depth >= MAX_SUBDIVISION_DEPTH:
-            # Out of facets — fall through and accept the 10k cap.
-            await self._fan_out_pages(
-                client, sem,
-                base_params=base_params, total=PAGINATION_CAP, absorb=absorb,
+        partition = _select_partition(first, total=total, applied=applied)
+        if partition is None or depth >= MAX_SUBDIVISION_DEPTH:
+            raise ScraperError(
+                f"Bundesagentur cannot losslessly partition {total} jobs "
+                f"for params={base_params}"
             )
-            return
-
-        facets = first.get("facetten") or {}
-        bucket_counts = _bucket_counts(facets, facet_name)
-        if not bucket_counts:
-            await self._fan_out_pages(
-                client, sem,
-                base_params=base_params, total=PAGINATION_CAP, absorb=absorb,
-            )
-            return
+        facet_name, bucket_counts = partition
 
         async def child_bucket(value: str, count: int) -> None:
             if count == 0:
@@ -366,7 +327,7 @@ class BundesagenturScraper(BaseScraper):
         *,
         base_params: dict[str, Any],
         total: int,
-        absorb,
+        absorb: Callable[[list[dict[str, Any]]], Awaitable[None]],
     ) -> None:
         # We can fetch ``ceil(total / PAGE_SIZE)`` pages, capped at PAGE_LIMIT.
         page_count = min((total + PAGE_SIZE - 1) // PAGE_SIZE, PAGE_LIMIT)
@@ -377,26 +338,8 @@ class BundesagenturScraper(BaseScraper):
         # saw at concurrency=3.
         for page in range(1, page_count + 1):
             params = {**base_params, "size": PAGE_SIZE, "page": page}
-            try:
-                payload = await self._fetch_page(client, sem, params=params)
-            except _PageFetchExhaustedError as exc:
-                # Page-level soft-fail: lose at most ``PAGE_SIZE`` jobs from
-                # this one page; keep working on the rest of the leaf and
-                # the rest of the tree. Bounded loss from transient WAF /
-                # network exhaustion is acceptable. (Probe failures hit
-                # the same class but ``_exhaust_query`` handles them
-                # separately because they affect a whole subtree.)
-                #
-                # Non-transient failures (contract breaks, bad JSON) raise
-                # plain ``ScraperError`` and propagate uncaught — better
-                # to crash than to silently undercount.
-                logger.warning(
-                    "Bundesagentur page %d/%d failed for params=%s — "
-                    "page skipped (~%d jobs lost): %s",
-                    page, page_count, base_params, PAGE_SIZE, exc,
-                )
-                continue
-            await absorb(payload.get("stellenangebote") or [])
+            payload = await self._fetch_page(client, sem, params=params)
+            await absorb(_result_items(payload))
 
     async def _fetch_page(
         self,
@@ -424,27 +367,27 @@ class BundesagenturScraper(BaseScraper):
                     continue
             if r.status_code == 200:
                 try:
-                    return r.json()
+                    payload = r.json()
                 except ValueError as exc:
                     raise ScraperError(
                         f"Bundesagentur returned non-JSON for {params}: {exc}"
                     ) from exc
+                if not isinstance(payload, dict):
+                    raise ScraperError(
+                        f"Bundesagentur returned a non-object payload for {params}"
+                    )
+                return payload
             if r.status_code == 400:
-                # Past pagination cap — return empty so caller stops.
-                return {"stellenangebote": [], "maxErgebnisse": 0}
+                raise ScraperError(
+                    f"Bundesagentur rejected query {params}: {r.text[:120]}"
+                )
             # 403 here is a transient Akamai/WAF rate-limit, not a real
             # auth failure (the API key never expires); back off and retry.
             if r.status_code in (403, 429) or 500 <= r.status_code < 600:
                 if attempt == MAX_RETRIES:
-                    # Persistent WAF/server failure — raise the *narrowed*
-                    # ``_PageFetchExhaustedError`` so callers can soft-fail it
-                    # specifically. ``_exhaust_query`` treats this as a
-                    # subtree-loss (logs + skips); ``_fan_out_pages`` treats
-                    # it as a page-loss (logs + continues). We must NOT
-                    # silently return an empty payload here: that would be
-                    # indistinguishable from a real ``maxErgebnisse=0``
-                    # response and would silently abandon the whole subtree
-                    # whenever a probe gets WAF-blocked.
+                    # Persistent WAF/server failure aborts the scrape. The
+                    # pipeline removes its temporary CSV and preserves the
+                    # previous complete provider output.
                     raise _PageFetchExhaustedError(
                         f"Bundesagentur returned {r.status_code} for {params} "
                         f"after {MAX_RETRIES} retries"
@@ -462,107 +405,110 @@ class BundesagenturScraper(BaseScraper):
             # Non-retryable status (401 auth break, 404 endpoint moved,
             # 4xx other than 403/429, etc.) — these are contract breaks,
             # not transient. Raise plain ``ScraperError`` so callers do
-            # NOT swallow it as a soft-fail; the scrape crashes loudly
-            # rather than silently producing a wholesale undercount.
+            # The scrape crashes loudly rather than producing an undercount.
             raise ScraperError(
                 f"Bundesagentur returned {r.status_code} for {params}: "
                 f"{r.text[:120]}"
             )
-        # Network errors exhausted the retry budget — same transient class
-        # as persistent WAF, so callers can soft-fail just this fetch.
+        # Network errors exhausted the retry budget; preserve the old output.
         raise _PageFetchExhaustedError(
             f"Bundesagentur exhausted retries for {params}: {last_exc}"
         )
 
     def _parse(self, item: dict[str, Any]) -> Job | None:
-        ats_id = str(item.get("refnr") or "").strip()
-        title = (item.get("titel") or item.get("beruf") or "").strip()
+        ats_id = str(item.get("referenznummer") or item.get("refnr") or "").strip()
+        title = str(
+            item.get("stellenangebotsTitel")
+            or item.get("titel")
+            or item.get("hauptberuf")
+            or ""
+        ).strip()
         if not ats_id or not title:
             return None
-        location = _format_location(item.get("arbeitsort"))
-        company = (item.get("arbeitgeber") or "Bundesagentur").strip() or "Bundesagentur"
+        location_data = _first_location(item)
+        location = _format_location(location_data)
+        address = location_data.get("adresse") if isinstance(location_data, dict) else None
+        address = address if isinstance(address, dict) else {}
+        company = str(
+            item.get("firma") or item.get("arbeitgeber") or "Bundesagentur"
+        ).strip() or "Bundesagentur"
 
         # Each posting has a deterministic public URL on jobsuche.arbeitsagentur.de.
         # The detail endpoint expects base64(refnr); the human URL accepts refnr.
         url = f"https://www.arbeitsagentur.de/jobsuche/jobdetail/{ats_id}"
 
-        # Bundesagentur exposes ``arbeitszeit`` as the work-time bucket
-        # — ``vz`` (Vollzeit / full-time), ``tz`` (Teilzeit / part-time),
-        # ``mj`` (Minijob / contract-style), ``ho`` (Home office),
-        # ``saison`` (Seasonal), ``ne`` (Nebenjob / side gig),
-        # ``selb`` (Selbständig / self-employed). Map the canonical ones.
-        arbeitszeit = item.get("arbeitszeit")
-        commitment: str | None = None
-        employment_type: str | None = None
-        if isinstance(arbeitszeit, str) and arbeitszeit.strip():
-            commitment = _ARBEITSZEIT_LABELS.get(
-                arbeitszeit.strip().lower(), arbeitszeit.strip(),
-            )
-            employment_type = _ARBEITSZEIT_TO_EMPLOYMENT_TYPE.get(
-                arbeitszeit.strip().lower(),
-            )
-        # ``zeitarbeit=true`` (temp-agency placement) is unambiguous —
-        # surface as TEMPORARY when the time-type doesn't disambiguate.
-        if not employment_type and item.get("zeitarbeit") is True:
-            employment_type = "TEMPORARY"
-        # ``befristung=2`` indicates fixed-term in the BA taxonomy.
-        if not employment_type and str(item.get("befristung") or "") == "2":
-            employment_type = "CONTRACT"
+        commitment, employment_type = _employment_details(item)
+        remote_value = item.get("homeofficemoeglich")
+        is_remote = remote_value if isinstance(remote_value, bool) else None
 
-        # ``ho`` (Home office) is the only explicit remote signal.
-        is_remote = True if isinstance(arbeitszeit, str) and arbeitszeit.lower() == "ho" else None
+        department = _text(item.get("hauptberuf") or item.get("berufsfeld"))
+        team = _text(item.get("branche"))
+        if team == department:
+            team = None
 
-        # ``berufsfeld`` is a high-level domain (Pedagogik / IT / Sales)
-        # — closest match to a department facet.
-        berufsfeld = item.get("berufsfeld")
-        department = (
-            berufsfeld.strip()
-            if isinstance(berufsfeld, str) and berufsfeld.strip()
-            else None
-        )
-
-        # Industry / sector → ``team`` (the closest analog the API exposes).
-        branche = item.get("branche")
-        team = (
-            branche.strip()
-            if isinstance(branche, str) and branche.strip()
-            and branche.strip() != department
-            else None
-        )
+        salary_min = _number(item.get("gehaltsspanneVon"))
+        salary_max = _number(item.get("gehaltsspanneBis"))
+        salary_period = _salary_period(item.get("verguetungsangabe"))
 
         raw: dict[str, Any] = {}
-        for k in ("branche", "berufsfeld", "befristung", "zeitarbeit",
-                  "arbeitgeberHashId", "kundennummerHash", "externeUrl",
-                  "arbeitszeit", "modifikationsTimestamp"):
+        for k in (
+            "aenderungsdatum",
+            "alleBerufe",
+            "arbeitgeberKundennummerHash",
+            "arbeitszeitSchichtNachtWochenende",
+            "arbeitszeitTeilzeitAbend",
+            "arbeitszeitTeilzeitFlexibel",
+            "arbeitszeitTeilzeitNachmittag",
+            "arbeitszeitTeilzeitVormittag",
+            "arbeitszeitVollzeit",
+            "branche",
+            "chiffrenummer",
+            "hauptberuf",
+            "istArbeitnehmerUeberlassung",
+            "istGeringfuegigeBeschaeftigung",
+            "quereinstiegGeeignet",
+            "stellenangebotsart",
+            "vertragsdauer",
+        ):
             v = item.get(k)
-            if v not in (None, ""):
+            if v not in (None, "", [], {}):
                 raw[k] = v
 
-        externe_url = item.get("externeUrl")
+        externe_url = item.get("externeURL") or item.get("externeUrl")
         apply_url = externe_url if isinstance(externe_url, str) and externe_url.startswith("http") else None
 
+        description = _text(item.get("stellenangebotsBeschreibung"))
+
         return Job(
-            url=url,
+            url=HttpUrl(url),
             title=title,
             company=company,
             ats_type=ATSType.BUNDESAGENTUR,
             ats_id=ats_id,
             location=location,
+            country_iso=_country_iso(address.get("land")),
+            region=_region_name(address.get("region")),
+            lat=_number(location_data.get("breite")),
+            lon=_number(location_data.get("laenge")),
             is_remote=is_remote,
+            salary_currency="EUR" if salary_min is not None or salary_max is not None else None,
+            salary_period=salary_period,
+            salary_min=salary_min,
+            salary_max=salary_max,
             department=department,
             team=team,
             employment_type=employment_type,
             commitment=commitment,
-            apply_url=apply_url,
-            requisition_id=item.get("hashId") or None,
-            description=(
-                item.get("stellenangebotsBeschreibung").strip()[:25_000]
-                if isinstance(item.get("stellenangebotsBeschreibung"), str)
-                and item.get("stellenangebotsBeschreibung").strip()
-                else None
+            apply_url=HttpUrl(apply_url) if apply_url else None,
+            requisition_id=_text(item.get("chiffrenummer") or item.get("hashId")),
+            description=description[:25_000] if description else None,
+            posted_at=_parse_iso(
+                item.get("datumErsteVeroeffentlichung")
+                or _nested_value(item.get("veroeffentlichungszeitraum"), "von")
+                or item.get("aktuelleVeroeffentlichungsdatum")
             ),
-            posted_at=_parse_iso(item.get("eintrittsdatum") or item.get("aktuelleVeroeffentlichungsdatum")),
             fetched_at=datetime.now(UTC),
+            language="de",
             raw=raw or None,
         )
 
@@ -579,7 +525,7 @@ _ARBEITSZEIT_LABELS = {
     "selb": "Selbständig",
     "snw": "Schicht/Nacht/Wochenende",
 }
-_ARBEITSZEIT_TO_EMPLOYMENT_TYPE = {
+_ARBEITSZEIT_TO_EMPLOYMENT_TYPE: dict[str, EmploymentType] = {
     "vz": "FULL_TIME",
     "tz": "PART_TIME",
     "ho": "FULL_TIME",
@@ -588,6 +534,98 @@ _ARBEITSZEIT_TO_EMPLOYMENT_TYPE = {
     "saison": "TEMPORARY",
     "selb": "CONTRACT",
 }
+
+_COUNTRY_ISO = {
+    "DEUTSCHLAND": "DE",
+    "OESTERREICH": "AT",
+    "ÖSTERREICH": "AT",
+    "SCHWEIZ": "CH",
+    "FRANKREICH": "FR",
+    "NIEDERLANDE": "NL",
+    "BELGIEN": "BE",
+    "LUXEMBURG": "LU",
+    "POLEN": "PL",
+    "TSCHECHIEN": "CZ",
+    "DÄNEMARK": "DK",
+    "DAENEMARK": "DK",
+}
+
+_SALARY_PERIODS: dict[str, SalaryPeriod] = {
+    "STUNDENLOHN": "HOUR",
+    "TAGESENTGELT": "DAY",
+    "WOCHENENTGELT": "WEEK",
+    "MONATSENTGELT": "MONTH",
+    "MONATSGEHALT": "MONTH",
+    "JAHRESGEHALT": "YEAR",
+}
+
+
+def _result_items(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    items = payload.get("ergebnisliste")
+    if not isinstance(items, list):
+        raise ScraperError("Bundesagentur v6 response is missing ergebnisliste")
+    if not all(isinstance(item, dict) for item in items):
+        raise ScraperError("Bundesagentur v6 returned a non-object job")
+    return items
+
+
+def _employment_details(
+    item: dict[str, Any],
+) -> tuple[str | None, EmploymentType | None]:
+    legacy = _text(item.get("arbeitszeit"))
+    if legacy:
+        code = legacy.lower()
+        commitment = _ARBEITSZEIT_LABELS.get(code, legacy)
+        legacy_employment_type = _ARBEITSZEIT_TO_EMPLOYMENT_TYPE.get(code)
+        if legacy_employment_type is None and item.get("zeitarbeit") is True:
+            legacy_employment_type = "TEMPORARY"
+        if (
+            legacy_employment_type is None
+            and str(item.get("befristung") or "") == "2"
+        ):
+            legacy_employment_type = "CONTRACT"
+        return commitment, legacy_employment_type
+
+    labels: list[str] = []
+    is_full_time = item.get("arbeitszeitVollzeit") is True
+    is_part_time = any(
+        item.get(key) is True
+        for key in (
+            "arbeitszeitTeilzeitAbend",
+            "arbeitszeitTeilzeitFlexibel",
+            "arbeitszeitTeilzeitNachmittag",
+            "arbeitszeitTeilzeitVormittag",
+        )
+    )
+    is_minijob = item.get("istGeringfuegigeBeschaeftigung") is True
+    if is_full_time:
+        labels.append("Vollzeit")
+    if is_part_time:
+        labels.append("Teilzeit")
+    if is_minijob:
+        labels.append("Minijob")
+    if item.get("arbeitszeitSchichtNachtWochenende") is True:
+        labels.append("Schicht/Nacht/Wochenende")
+
+    if item.get("istArbeitnehmerUeberlassung") is True:
+        employment_type: EmploymentType | None = "TEMPORARY"
+    elif is_full_time:
+        employment_type = "FULL_TIME"
+    elif is_part_time or is_minijob:
+        employment_type = "PART_TIME"
+    elif item.get("vertragsdauer") == "BEFRISTET":
+        employment_type = "CONTRACT"
+    else:
+        employment_type = None
+    return ", ".join(labels) or None, employment_type
+
+
+def _first_location(item: dict[str, Any]) -> dict[str, Any]:
+    locations = item.get("stellenlokationen")
+    if isinstance(locations, list) and locations and isinstance(locations[0], dict):
+        return locations[0]
+    legacy = item.get("arbeitsort")
+    return {"adresse": legacy} if isinstance(legacy, dict) else {}
 
 
 def _bucket_counts(facets: dict[str, Any], facet_name: str) -> dict[str, int]:
@@ -603,15 +641,86 @@ def _bucket_counts(facets: dict[str, Any], facet_name: str) -> dict[str, int]:
     return {str(k): int(v) for k, v in counts.items() if int(v) > 0}
 
 
+def _select_partition(
+    payload: dict[str, Any],
+    *,
+    total: int,
+    applied: set[str],
+) -> tuple[str, dict[str, int]] | None:
+    facets = payload.get("facetten")
+    if not isinstance(facets, dict):
+        return None
+
+    candidates: list[tuple[int, int, str, dict[str, int]]] = []
+    for priority, facet_name in enumerate(_SUBDIVISION_FACETS):
+        if facet_name in applied:
+            continue
+        counts = _bucket_counts(facets, facet_name)
+        if len(counts) < 2 or sum(counts.values()) != total:
+            continue
+        largest_bucket = max(counts.values())
+        if largest_bucket >= total:
+            continue
+        candidates.append((largest_bucket, priority, facet_name, counts))
+
+    if not candidates:
+        return None
+    _, _, facet_name, counts = min(candidates)
+    return facet_name, counts
+
+
 def _format_location(value: object) -> str | None:
     if not isinstance(value, dict):
         return None
+    address = value.get("adresse")
+    if isinstance(address, dict):
+        value = address
+
+    postal_code = _text(value.get("plz"))
+    city = _text(value.get("ort"))
+    locality = " ".join(part for part in (postal_code, city) if part) or None
     parts = [
-        str(value[k]).strip()
-        for k in ("ort", "region", "land")
-        if isinstance(value.get(k), str) and value.get(k).strip() and value.get(k) != "null"
+        locality,
+        _region_name(value.get("region")),
+        _display_enum(value.get("land")),
     ]
-    return ", ".join(parts) or None
+    return ", ".join(dict.fromkeys(part for part in parts if part)) or None
+
+
+def _text(value: object) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _number(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _display_enum(value: object) -> str | None:
+    raw = _text(value)
+    return raw.replace("_", " ").title() if raw else None
+
+
+def _region_name(value: object) -> str | None:
+    return _display_enum(value)
+
+
+def _country_iso(value: object) -> str | None:
+    raw = _text(value)
+    return _COUNTRY_ISO.get(raw.upper()) if raw else None
+
+
+def _salary_period(value: object) -> SalaryPeriod | None:
+    raw = _text(value)
+    return _SALARY_PERIODS.get(raw.upper()) if raw else None
+
+
+def _nested_value(value: object, key: str) -> object:
+    return value.get(key) if isinstance(value, dict) else None
 
 
 def _parse_iso(value: object) -> datetime | None:

--- a/tests/test_bundesagentur.py
+++ b/tests/test_bundesagentur.py
@@ -1,24 +1,19 @@
-"""Tests for the Bundesagentur scraper.
-
-Focused on the failure-mode contract: probe failures must skip the affected
-subtree (and shout about it), page failures must skip just one page, and
-neither may silently look like a clean ``maxErgebnisse=0`` response.
-"""
+"""Tests for the Bundesagentur v6 scraper and fail-closed contract."""
 
 from __future__ import annotations
 
 import asyncio
-import logging
 import re
 from urllib.parse import parse_qs, urlparse
 
 import httpx
 import pytest
 
+from ats_scrapers.exceptions import ScraperError
 from ats_scrapers.scrapers import BundesagenturScraper
 
 _API_RE = re.compile(
-    r"^https://rest\.arbeitsagentur\.de/jobboerse/jobsuche-service/pc/v4/jobs"
+    r"^https://rest\.arbeitsagentur\.de/jobboerse/jobsuche-service/pc/v6/jobs"
 )
 
 
@@ -32,12 +27,29 @@ def _fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def _job(refnr: str, titel: str, ort: str | None = None) -> dict:
     return {
-        "refnr": refnr,
-        "titel": titel,
+        "referenznummer": refnr,
+        "stellenangebotsTitel": titel,
         "stellenangebotsBeschreibung": "Build public services.",
-        "arbeitsort": {"ort": ort or "Berlin", "land": "Deutschland"},
-        "arbeitgeber": "ACME",
-        "aktuelleVeroeffentlichungsdatum": "2026-05-01",
+        "stellenlokationen": [
+            {
+                "adresse": {
+                    "plz": "10115",
+                    "ort": ort or "Berlin",
+                    "region": "BERLIN",
+                    "land": "DEUTSCHLAND",
+                },
+                "breite": 52.532,
+                "laenge": 13.384,
+            }
+        ],
+        "firma": "ACME",
+        "datumErsteVeroeffentlichung": "2026-05-01",
+        "hauptberuf": "Softwareentwicklung und Programmierung",
+        "arbeitszeitVollzeit": True,
+        "homeofficemoeglich": False,
+        "verguetungsangabe": "JAHRESGEHALT",
+        "gehaltsspanneVon": 50_000,
+        "gehaltsspanneBis": 70_000,
     }
 
 
@@ -48,62 +60,72 @@ def test_simple_run_under_pagination_cap(httpx_mock) -> None:
     """A small dataset (≤10k) just paginates and returns everything."""
     httpx_mock.add_response(
         url=_API_RE,
-        json={"stellenangebote": [_job("1", "Probe")], "maxErgebnisse": 1},
+        json={"ergebnisliste": [_job("1", "Probe")], "maxErgebnisse": 1},
         is_reusable=True,
     )
     jobs = BundesagenturScraper("any").fetch()
     assert {j.ats_id for j in jobs} == {"1"}
     assert jobs[0].description == "Build public services."
+    assert jobs[0].company == "ACME"
+    assert jobs[0].location == "10115 Berlin, Berlin, Deutschland"
+    assert jobs[0].country_iso == "DE"
+    assert jobs[0].employment_type == "FULL_TIME"
+    assert jobs[0].salary_currency == "EUR"
+    assert jobs[0].salary_period == "YEAR"
+    assert jobs[0].salary_min == 50_000
 
 
-# --- Probe failure: must NOT silently look like maxErgebnisse=0 -------------
+def test_partition_ignores_non_exhaustive_facets() -> None:
+    from ats_scrapers.scrapers.bundesagentur import _select_partition
+
+    payload = {
+        "facetten": {
+            "angebotsart": {"counts": {"1": 9, "4": 1}},
+            "befristung": {"counts": {"1": 6, "2": 4}},
+            "berufsfeld": {"counts": {"IT": 6, "Sales": 3}},
+        }
+    }
+
+    assert _select_partition(payload, total=10, applied=set()) == (
+        "befristung",
+        {"1": 6, "2": 4},
+    )
 
 
-def test_root_probe_persistent_403_skips_subtree(httpx_mock, caplog) -> None:
-    """If the very first probe (no facets) keeps returning 403 the entire
-    scrape must NOT just return an empty list silently — that would publish
-    a wholesale undercount as a successful run. We log loudly and return
-    whatever was collected (here: nothing)."""
+def test_oversize_query_without_lossless_partition_crashes(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_API_RE,
+        json={
+            "ergebnisliste": [_job("1", "Probe")],
+            "maxErgebnisse": 10_001,
+            "facetten": {"berufsfeld": {"counts": {"IT": 9_000}}},
+        },
+        is_reusable=True,
+    )
+
+    with pytest.raises(ScraperError, match="cannot losslessly partition"):
+        BundesagenturScraper("any").fetch()
+
+
+# --- Retry exhaustion: abort rather than publish a partial catalogue --------
+
+
+def test_root_probe_persistent_403_crashes(httpx_mock) -> None:
     httpx_mock.add_response(url=_API_RE, status_code=403, is_reusable=True)
-    with caplog.at_level(logging.WARNING, logger="ats_scrapers.scrapers.bundesagentur"):
-        jobs = BundesagenturScraper("any").fetch()
-    assert jobs == []
-    # The warning must say "subtree skipped" so an operator can spot the
-    # undercount in the logs. The previous soft-fail returned a fake
-    # ``maxErgebnisse=0`` payload that produced no warning at all.
-    assert any(
-        "subtree skipped" in rec.getMessage().lower()
-        for rec in caplog.records
-    ), "expected 'subtree skipped' warning, got: " + "\n".join(
-        rec.getMessage() for rec in caplog.records
-    )
+    with pytest.raises(ScraperError, match="returned 403"):
+        BundesagenturScraper("any").fetch()
 
 
-def test_probe_500_after_retries_skips_with_warning(
-    httpx_mock, caplog
-) -> None:
-    """Same pattern for 500 — the previous code returned empty and looked
-    like a clean zero-result query. Now the failure is logged."""
+def test_probe_500_after_retries_crashes(httpx_mock) -> None:
     httpx_mock.add_response(url=_API_RE, status_code=500, is_reusable=True)
-    with caplog.at_level(logging.WARNING, logger="ats_scrapers.scrapers.bundesagentur"):
-        jobs = BundesagenturScraper("any").fetch()
-    assert jobs == []
-    assert any(
-        "subtree skipped" in rec.getMessage().lower()
-        for rec in caplog.records
-    )
+    with pytest.raises(ScraperError, match="returned 500"):
+        BundesagenturScraper("any").fetch()
 
 
-# --- Page failure: skip just the page, keep going ---------------------------
+# --- Page failure: abort rather than omit one page --------------------------
 
 
-def test_page_failure_logs_page_skip_not_subtree_skip(
-    httpx_mock, monkeypatch, caplog
-) -> None:
-    """A page-level failure inside ``_fan_out_pages`` must log a *page*
-    skip (bounded loss) — not a subtree skip — and must not silently
-    look like a clean response.
-    """
+def test_page_failure_crashes(httpx_mock, monkeypatch) -> None:
     import ats_scrapers.scrapers.bundesagentur as ba
     # Tiny page size so a 3-row dataset spans 3 pages and we can exercise
     # the per-page failure path deterministically.
@@ -119,30 +141,15 @@ def test_page_failure_logs_page_skip_not_subtree_skip(
         return httpx.Response(
             200,
             json={
-                "stellenangebote": [_job(str(page), f"Page-{page} row")],
+                "ergebnisliste": [_job(str(page), f"Page-{page} row")],
                 "maxErgebnisse": 3,
             },
         )
 
     httpx_mock.add_callback(serve, url=_API_RE, is_reusable=True)
 
-    with caplog.at_level(logging.WARNING, logger="ats_scrapers.scrapers.bundesagentur"):
-        jobs = BundesagenturScraper("any").fetch()
-
-    # Pages 1 and 3 made it through; page 2 was lost. The leaf and the
-    # subtree both kept going.
-    ats_ids = {j.ats_id for j in jobs}
-    assert "1" in ats_ids and "3" in ats_ids
-    assert "2" not in ats_ids
-
-    page_warnings = [
-        r for r in caplog.records if "page skipped" in r.getMessage().lower()
-    ]
-    subtree_warnings = [
-        r for r in caplog.records if "subtree skipped" in r.getMessage().lower()
-    ]
-    assert page_warnings, "expected page-level warning"
-    assert not subtree_warnings, "page failure must NOT escalate to subtree skip"
+    with pytest.raises(ScraperError, match="returned 403"):
+        BundesagenturScraper("any").fetch()
 
 
 # --- Contract-break failures: must crash, not soft-fail --------------------
@@ -260,3 +267,11 @@ def test_fetch_stream_yields_same_jobs_as_legacy(monkeypatch) -> None:
 
     streamed = asyncio.run(collect_stream())
     assert sorted(j.ats_id for j in streamed) == sorted(f"R-{i}" for i in range(7))
+
+
+def test_pipeline_config_fails_closed_without_bulk_detail_requests() -> None:
+    from scripts.run_pipeline import CONFIGS
+
+    config = CONFIGS["bundesagentur"]
+    assert config["fail_closed_on_empty"] is True
+    assert config["skip_description_enrichment"] is True

--- a/tests/test_bundesagentur.py
+++ b/tests/test_bundesagentur.py
@@ -44,6 +44,7 @@ def _job(refnr: str, titel: str, ort: str | None = None) -> dict:
         ],
         "firma": "ACME",
         "datumErsteVeroeffentlichung": "2026-05-01",
+        "berufsfeld": "IT",
         "hauptberuf": "Softwareentwicklung und Programmierung",
         "arbeitszeitVollzeit": True,
         "homeofficemoeglich": False,
@@ -69,10 +70,40 @@ def test_simple_run_under_pagination_cap(httpx_mock) -> None:
     assert jobs[0].company == "ACME"
     assert jobs[0].location == "10115 Berlin, Berlin, Deutschland"
     assert jobs[0].country_iso == "DE"
+    assert jobs[0].region is None
+    assert jobs[0].department == "IT"
     assert jobs[0].employment_type == "FULL_TIME"
     assert jobs[0].salary_currency == "EUR"
     assert jobs[0].salary_period == "YEAR"
     assert jobs[0].salary_min == 50_000
+
+
+def test_preserves_multiple_locations_without_ambiguous_coordinates() -> None:
+    item = _job("multi", "Multi-location role")
+    item["stellenlokationen"].append(
+        {
+            "adresse": {
+                "plz": "80331",
+                "ort": "München",
+                "region": "BAYERN",
+                "land": "DEUTSCHLAND",
+            },
+            "breite": 48.137,
+            "laenge": 11.575,
+        }
+    )
+
+    job = BundesagenturScraper("any")._parse(item)
+
+    assert job is not None
+    assert job.location == (
+        "10115 Berlin, Berlin, Deutschland | "
+        "80331 München, Bayern, Deutschland"
+    )
+    assert job.country_iso == "DE"
+    assert job.region is None
+    assert (job.lat, job.lon) == (None, None)
+    assert len(job.raw["stellenlokationen"]) == 2
 
 
 def test_partition_ignores_non_exhaustive_facets() -> None:

--- a/tests/test_bundesagentur.py
+++ b/tests/test_bundesagentur.py
@@ -70,7 +70,7 @@ def test_simple_run_under_pagination_cap(httpx_mock) -> None:
     assert jobs[0].company == "ACME"
     assert jobs[0].location == "10115 Berlin, Berlin, Deutschland"
     assert jobs[0].country_iso == "DE"
-    assert jobs[0].region is None
+    assert jobs[0].region == "Europe"
     assert jobs[0].department == "IT"
     assert jobs[0].employment_type == "FULL_TIME"
     assert jobs[0].salary_currency == "EUR"
@@ -101,7 +101,7 @@ def test_preserves_multiple_locations_without_ambiguous_coordinates() -> None:
         "80331 München, Bayern, Deutschland"
     )
     assert job.country_iso == "DE"
-    assert job.region is None
+    assert job.region == "Europe"
     assert (job.lat, job.lon) == (None, None)
     assert len(job.raw["stellenlokationen"]) == 2
 

--- a/tests/test_run_pipeline_guards.py
+++ b/tests/test_run_pipeline_guards.py
@@ -952,6 +952,54 @@ def test_streaming_pipeline_reuses_sqlite_description_cache(
     assert rows[0]["description"] == "cached"
 
 
+def test_streaming_pipeline_can_skip_description_enrichment(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    out_dir = tmp_path / "stream"
+    out_dir.mkdir()
+    out_path = out_dir / "jobs.csv"
+
+    class StreamingScraper:
+        include_descriptions: bool | None = None
+        description_calls = 0
+
+        def __init__(self, *_args, include_descriptions=True, **_kwargs) -> None:
+            self.__class__.include_descriptions = include_descriptions
+
+        async def fetch_stream(self):
+            yield Job(
+                url="https://example.com/jobs/1",
+                title="Engineer",
+                company="Acme",
+                ats_type=ATSType.CUSTOM,
+                ats_id="1",
+            )
+
+        def get_description(self, _job):
+            self.__class__.description_calls += 1
+            raise AssertionError("description endpoint must not be called")
+
+    monkeypatch.setattr(runner, "DATA_ROOT", tmp_path)
+    monkeypatch.setitem(
+        runner.CONFIGS,
+        "stream",
+        {
+            "scraper": StreamingScraper,
+            "singleton": True,
+            "output": "stream/jobs.csv",
+            "skip_description_enrichment": True,
+        },
+    )
+
+    rc = asyncio.run(runner.run("stream", concurrency=1, max_tenants=None, timeout=1))
+
+    assert rc == 0
+    rows = list(csv.DictReader(out_path.open(newline="")))
+    assert rows[0]["description"] == ""
+    assert StreamingScraper.include_descriptions is False
+    assert StreamingScraper.description_calls == 0
+
+
 def test_streaming_failure_preserves_previous_jobs_csv(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- move listings from the retired `pc/v4/jobs` endpoint to the official frontend’s live `pc/v6/jobs` endpoint
- map v6 salary, coordinates, remote/work-time, contract, employer, profession, apply URL, and publication fields
- choose only facet partitions whose bucket counts exactly cover the current subtree
- abort on page/subtree failure or an unsplittable >10k leaf, preserving the previous complete CSV
- reuse cached descriptions but skip roughly one million uncached detail requests during the bulk listing run; the official v4 detail endpoint remains supported and live-tested

## Validation
- `20 passed, 26 deselected` across provider and affected streaming guards
- focused provider suite: 13 passed
- Ruff passed; focused mypy passed
- local exact-head probe: 100/100 unique parsed jobs, live total 996,421, lossless root partition, live detail body
- VPS exact-head probe (`5a16f35`): 100/100 unique parsed jobs, live total 996,422, partition sum exactly 996,422, live detail body
- v6 pagination probe: page 100 works; page 101 still returns the documented 10,000-result cap error

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates Bundesagentur listings from `pc/v4/jobs` to `pc/v6/jobs` and switches the scraper to fail-closed to prevent publishing partial datasets. Corrects geography by deriving continent-level `region` from the structured country and avoiding ambiguous coordinates.

- Parse v6 `ergebnisliste` and renamed fields: map salary min/max and period, coordinates, remote flag, employment/contract type, employer, department/team, posting dates, language, and build public/apply URLs from `referenznummer`/`externeURL`.
- Preserve location semantics: join multiple locations with postal code/city/region/country, set `country_iso` from the structured country and `region='Europe'` when known (e.g., `DE`, `AT`, `CH`; else `None`), do not write Bundesländer into `region`, and only set `lat/lon` when a single location is present.
- Partition only on facets whose bucket counts exactly equal the current total, then pick the facet with the smallest largest bucket; raise when a leaf above 10k cannot be split losslessly.
- Fail-closed error handling: 400 is an error; persistent 403/429/5xx or network retry exhaustion aborts the run instead of emitting a partial dataset.
- Pipeline: set `fail_closed_on_empty: true` and `skip_description_enrichment: true`; the streaming runner passes `include_descriptions=False`, reuses cached descriptions, and avoids ~1M detail requests during the bulk listing run.

<sup>Written for commit 4109af9d5abca2d80869a225494a485ce293c538. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change moves Bundesagentur collection to the v6 listings endpoint, adds lossless facet partitioning, and preserves the prior output when retrieval fails. A reproduced data-normalization defect remains: German state values such as `BERLIN` are written into the continent-level `Job.region` field, which makes continent filtering and grouping inconsistent across providers. The focused Bundesagentur and Job model tests pass but do not cover this field contract.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until Bundesagentur’s geographic field mapping preserves the canonical continent-level meaning of `Job.region`.

An executable parser check reproduced the incorrect mapping using a fixture-shaped v6 Berlin listing, and the model contract explicitly distinguishes continent regions from sub-national locations.

**Files Needing Attention:** src/ats_scrapers/scrapers/bundesagentur.py needs its `region` mapping corrected and tests should assert the canonical value for v6 listings containing a Bundesland.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and attached supporting artifacts.
- T-Rex produced a second P1 finding proof documenting the additional review commentary.
- T-Rex executed the region-check contract validation; the failure-path command exited with an assertion about continent-level region, while the baseline test suite passed.

<a href="https://app.greptile.com/trex/runs/20256524/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Bundesagentur v6 parser writes a German Bundesland into continent-level Job.region**

   - **Bug**
     - For a v6 listing whose `stellenlokationen[0].adresse.region` is `BERLIN`, the parser emits `Job.region='Berlin'`. The canonical model defines this field exclusively as a continent (`Europe`, `Asia`, etc.) and expressly assigns German Bundesländer to `location`. This creates inconsistent cross-provider region data and makes continent grouping unreliable.
   - **Cause**
     - `BundesagenturScraper._parse` at `src/ats_scrapers/scrapers/bundesagentur.py:490` passes the provider's sub-national `address.region` through `_region_name`, which only title-cases it at lines 708-709, directly into the canonical `Job.region` field.
   - **Fix**
     - At line 490, derive the canonical continent from the structured country (`DE` → `Europe`) or leave `region=None` when no authoritative continent mapping is available. Preserve `Berlin` through `_format_location`, then add a regression assertion that the BERLIN v6 fixture produces `location` containing Berlin and `region == 'Europe'` (or `None`, if that is the chosen policy).

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/ats_scrapers/scrapers/bundesagentur.py:490
**Sub-national location is written to the continent field**

A v6 listing with `stellenlokationen[].adresse.region = "BERLIN"` is parsed as `Job.region = "Berlin"`. `Job.region` is the canonical continent-level field, while German Bundesländer belong in `location`; this makes continent-based filtering and grouping inconsistent with jobs from other providers. Set `region` to the country’s canonical continent or to `None` when it cannot be derived, and retain the Bundesland in `location`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Migrate Bundesagentur listings to v6"](https://github.com/kalil0321/ats-scrapers/commit/5a16f35d303d990d91dc53bbe274274d117e5b5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56024651)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->