### PR TITLE
Keep README dataset metrics synchronized

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,17 @@ sources.
 [![PyPI version](https://img.shields.io/pypi/v/ats-scrapers)](https://pypi.org/project/ats-scrapers/)
 [![Python versions](https://img.shields.io/pypi/pyversions/ats-scrapers)](https://pypi.org/project/ats-scrapers/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](https://github.com/kalil0321/ats-scrapers/blob/main/LICENSE)
+[![Live jobs](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fstorage.stapply.ai%2Fjobhive%2Fv1%2Fmanifest.json&query=%24.stats.total_jobs&label=live%20jobs&cacheSeconds=300)](https://storage.stapply.ai/jobhive/v1/manifest.json)
+[![Companies](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fstorage.stapply.ai%2Fjobhive%2Fv1%2Fmanifest.json&query=%24.stats.total_companies&label=companies&cacheSeconds=300)](https://storage.stapply.ai/jobhive/v1/manifest.json)
+[![Sources](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fstorage.stapply.ai%2Fjobhive%2Fv1%2Fmanifest.json&query=%24.stats.ats_count&label=sources&cacheSeconds=300)](https://storage.stapply.ai/jobhive/v1/manifest.json)
+[![Dataset snapshot](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fstorage.stapply.ai%2Fjobhive%2Fv1%2Fmanifest.json&query=%24.generated_at&label=snapshot&cacheSeconds=300)](https://storage.stapply.ai/jobhive/v1/manifest.json)
 
 `ats-scrapers` provides two layers:
 
-- A free, hosted dataset with **4.2M+ live jobs** from **63,000+ companies**
-  across **49 sources**.
-- More than 50 reusable scraper adapters, including Workday, Greenhouse, Lever,
+- A free, hosted dataset of live jobs from company career sites, ATS
+  platforms, and public job feeds. The badges above read current counts and
+  snapshot time directly from the live manifest.
+- Reusable scraper adapters for Workday, Greenhouse, Lever,
   Ashby, SmartRecruiters, and SuccessFactors.
 
 Jobs are collected from ATS endpoints, company career sites, and public job
@@ -80,7 +85,7 @@ scraper = get_scraper_for_url("https://jobs.ashbyhq.com/openai")
 jobs = scraper.fetch()
 ```
 
-Or look it up by name in the hosted companies directory (63,000+ tenants):
+Or look it up by name in the hosted companies directory:
 
 ```python
 from ats_scrapers import find_company

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+README = Path(__file__).parents[1] / "README.md"
+_NUMBER = r"\d[\d,.]*(?:\s*(?:[KMB]|thousand|million|billion))?\+?"
+_METRIC = r"(?:jobs?|job\s+(?:postings?|listings?)|companies|tenants|sources|adapters?)"
+_HARD_CODED_DATASET_STAT = re.compile(
+    rf"(?:\b{_NUMBER}(?:\s+(?:live|active|open|hosted|public|reusable|scraper))*"
+    rf"\s+{_METRIC}\b|\b{_METRIC}\s*(?:count|total)?\s*[:=]\s*{_NUMBER}\b)",
+    flags=re.IGNORECASE,
+)
+
+
+def _readme_prose(content: str) -> str:
+    lines: list[str] = []
+    in_code_fence = False
+    for line in content.splitlines():
+        if line.strip().startswith("```"):
+            in_code_fence = not in_code_fence
+            continue
+        if not in_code_fence and "img.shields.io/badge/dynamic/json" not in line:
+            lines.append(line)
+    return "\n".join(lines)
+
+
+def test_readme_uses_live_manifest_for_mutable_dataset_stats() -> None:
+    content = README.read_text()
+
+    for query in (
+        "%24.stats.total_jobs",
+        "%24.stats.total_companies",
+        "%24.stats.ats_count",
+        "%24.generated_at",
+    ):
+        assert query in content
+
+    assert _HARD_CODED_DATASET_STAT.search(_readme_prose(content)) is None
+
+
+def test_hard_coded_dataset_stat_guard_is_wording_independent() -> None:
+    claims = (
+        "**4.2M+ live jobs**",
+        "**1,200+ active job postings**",
+        "4.2 million jobs",
+        "79,906 companies",
+        "(63,000+ tenants)",
+        "**49 sources**",
+        "More than 50 reusable scraper adapters",
+        "jobs total: 4.2M",
+    )
+
+    for claim in claims:
+        assert _HARD_CODED_DATASET_STAT.search(claim) is not None


### PR DESCRIPTION
## Summary
- replace hard-coded job, company, and source totals with live manifest-backed badges
- expose the public snapshot timestamp in the README
- remove the duplicated hard-coded tenant count
- add a network-free regression test preventing mutable dataset totals from being hard-coded again

## Validation
- `pytest tests/test_readme.py -q`
- `ruff check tests/test_readme.py`
- live Shields probes resolve all four manifest fields

Operational monitoring remains private on the VPS and is intentionally outside this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps README dataset metrics in sync with the live manifest to prevent drift. Previously the README hard‑coded job, company, source, and tenant counts; now it renders dynamic badges and the snapshot timestamp.

- Uses Shields dynamic JSON badges for `stats.total_jobs`, `stats.total_companies`, `stats.ats_count`, and `generated_at` (cacheSeconds=300).
- Removes the duplicated hard‑coded tenant count from the companies directory line.
- Adds a network‑free test that requires these manifest queries and forbids hard‑coded, wording‑variant dataset totals in README prose.
- No runtime or packaging changes; only README and tests.

<sup>Written for commit 60bcc53fc6b89fc8e298815be329f4c0e6380ac7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change replaces static README dataset totals with manifest-backed badges and adds a regression test for the prior hard-coded wording. The test still permits alternate hard-coded numeric totals, allowing README statistics to drift from the hosted dataset without CI detecting it. Merge is not recommended until the guard covers equivalent dataset-stat phrasing.

<h3>Confidence Score: 4/5</h3>

Not merge-safe as written because the documentation regression guard does not enforce its intended invariant across common wording variants.

One verified, non-security P2 finding remains. The score is 4 under the required scoring table for P2-only findings.

**Files Needing Attention:** tests/test_readme.py needs a more general assertion that prevents hard-coded mutable dataset totals regardless of their surrounding prose.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P2 finding and ran a regression experiment to validate the finding.

<a href="https://app.greptile.com/trex/runs/20257284/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
tests/test_readme.py:20-25
**Hard-coded metric patterns are narrow**

The regression guard only rejects the former wording of these metrics. It allows alternate hard-coded totals such as `**49 sources**` and `**4.2 million jobs**`, so mutable dataset counts can be added back to the README without a test failure. Match hard-coded numeric totals independently of the old sentence forms, or assert that dataset-stat claims use the manifest-backed badges.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Keep README dataset stats live"](https://github.com/kalil0321/ats-scrapers/commit/158af3324ec0a35e6edbc89d4a757685a24d400a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56026420)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->